### PR TITLE
[lower_to_mlir] Lower reduce op from tt-forge to mlir

### DIFF
--- a/pybuda/csrc/passes/lower_to_mlir.cpp
+++ b/pybuda/csrc/passes/lower_to_mlir.cpp
@@ -134,6 +134,12 @@ class MLIRGenerator
                     return builder_.getSI32IntegerAttr(arg);
                 } else if constexpr (std::is_same_v<T, float>) {
                     return builder_.getF32FloatAttr(arg);
+                } else if constexpr (std::is_same_v<T, std::vector<int>>) {
+                    llvm::SmallVector<mlir::Attribute> attributes;
+                    for (auto& element : arg) {
+                        attributes.push_back(builder_.getI32IntegerAttr(element));
+                    }
+                    return builder_.getArrayAttr(attributes);
                 } else {
                     // If type not handled, throw an exception or handle it appropriately
                     throw std::runtime_error("Unhandled attribute type");
@@ -445,6 +451,8 @@ class MLIRGenerator
             lowering_handler_map["relu"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ReluOp>;
             lowering_handler_map["matmul"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MatmulOp>;
             lowering_handler_map["softmax"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::SoftmaxOp>;
+            lowering_handler_map["reduce_sum"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::SumOp>;
+            lowering_handler_map["reduce_avg"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MeanOp>;
         }
 };
 }

--- a/pybuda/pybuda/op/reduce.py
+++ b/pybuda/pybuda/op/reduce.py
@@ -7,7 +7,8 @@ from .common import PyBudaOp as op
 def ReduceSum(
         name: str,
         operandA: Tensor,
-        dim: int) -> Tensor:
+        dim: int,
+        keep_dim: bool = True) -> Tensor:
     """
     Reduce by summing along the given dimension
 
@@ -32,12 +33,13 @@ def ReduceSum(
     # if dim < 0:
     #     dim += 4
 
-    return op("reduce_sum", name, operandA, attrs=(dim,)).get_tensor()
+    return op("reduce_sum", name, operandA, attrs=(dim,), dim_arg=[dim], keep_dim= keep_dim).get_tensor()
 
 def ReduceAvg(
         name: str,
         operandA: Tensor,
-        dim: int) -> Tensor:
+        dim: int,
+        keep_dim: bool = True) -> Tensor:
     """
     Reduce by averaging along the given dimension
 
@@ -62,7 +64,7 @@ def ReduceAvg(
     # if dim < 0:
     #     dim += 4
 
-    return op("reduce_avg", name, operandA, attrs=(dim,)).get_tensor()
+    return op("reduce_avg", name, operandA, attrs=(dim,), dim_arg=[dim], keep_dim= keep_dim).get_tensor()
 
 def GroupedReduceAvg(
         name: str,

--- a/pybuda/test/mlir/mnist/test_inference.py
+++ b/pybuda/test/mlir/mnist/test_inference.py
@@ -5,6 +5,7 @@
 import torch
 from .utils import *
 import pybuda
+from pybuda.op.eval.common import compare_with_golden_pcc
 
 def test_mnist_inference():
     inputs = [torch.rand(1, 784)]
@@ -16,4 +17,4 @@ def test_mnist_inference():
     co_out = compiled_model(*[i.to("tt") for i in inputs])
 
     co_out = [co.to("cpu") for co in co_out]
-    assert [torch.allclose(fo, co) for fo, co in zip(fw_out, co_out)]
+    assert [compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)]


### PR DESCRIPTION
Lowering reduce sum and mean ops from tt-forge to mlir. Adding end to end tests for those ops. Adding method for pcc comparison with torch golden instead of using torch.allclose since it fails on reduce ops when data format is float32. 

I checked on metal reduce tests (tests/ttnn/unit_
tests/operations/test_mean.py::test_mean) and using bfloat16 gives output that matches on fourth decimal with golden, while float32 has differences on third and fourth decimal. 
