### PR TITLE
Lowering input and weight names into the MLIR argument attributes

### DIFF
--- a/pybuda/csrc/passes/lower_to_mlir.cpp
+++ b/pybuda/csrc/passes/lower_to_mlir.cpp
@@ -174,6 +174,15 @@ class MLIRGenerator
             auto funcType = builder_.getType<mlir::FunctionType>(mlir::TypeRange(argument_types), mlir::TypeRange(returns));
             auto func = builder_.create<mlir::func::FuncOp>(graphModule_.getLoc(), "main", funcType);
             
+            // Set the function argument names
+            for(size_t i = 0; i < argument_nodes.size(); i++)
+            {
+                graphlib::Node* argument_node = argument_nodes[i];
+                llvm::SmallVector<mlir::NamedAttribute, 1> named_attributes;
+                named_attributes.push_back(builder_.getNamedAttr("ttir.name", builder_.getStringAttr(argument_node->name())));
+                func.setArgAttrs(i, named_attributes);
+            }
+
             // Start the body of the function by creating an entry block.
             mlir::Block *entryBlock = func.addEntryBlock();
 


### PR DESCRIPTION
Lowering input and weight names into the MLIR function argument attribute names:
```
func.func @main(%arg0: tensor<1x784xf32> {ttir.name = "input_1"} loc("MNISTLinear":4294967295:0), %arg1: tensor<1x10xf32> {ttir.name = "b2"} loc("MNISTLinear":4294967295:0), %arg2: tensor<256x10xf32> {ttir.name = "l2.weight"} loc("MNISTLinear":4294967295:0), %arg3: tensor<1x256xf32> {ttir.name = "b1"} loc("MNISTLinear":4294967295:0), %arg4: tensor<784x256xf32> {ttir.name = "l1.weight"} loc("MNISTLinear":4294967295:0)) -> tensor<1x10xf32>
```
Added attributes:
**{ttir.name = "input_1"}**
**{ttir.name = "b2"}**
**{ttir.name = "l2.weight"}**
**{ttir.name = "b1"}**
**{ttir.name = "l1.weight"}**

Solves: https://github.com/tenstorrent/tt-forge/issues/91