### PR TITLE
Adding context option to print mlir stack trace on error

### DIFF
--- a/pybuda/csrc/passes/mlir_compiler.cpp
+++ b/pybuda/csrc/passes/mlir_compiler.cpp
@@ -42,6 +42,12 @@ namespace tt::passes
 
         // Create a context with all registered dialects.
         mlir::MLIRContext context(registry);
+
+#ifdef DEBUG
+        // Context setting to have mlir print out stacktrace whenever errors occur
+        context.printStackTraceOnDiagnostic(true);
+#endif
+
         // Load all available dialects
         context.loadAllAvailableDialects();
 


### PR DESCRIPTION
Adding context option to print MLIR stack trace on error. It can be useful during debugging.