### PR TITLE
[Model] Placeholder for ResNet 50 (initial planing & stats)

### DIFF
--- a/pybuda/test/mlir/resnet/test_resnet_inference.py
+++ b/pybuda/test/mlir/resnet/test_resnet_inference.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from torchvision.models.resnet import resnet50
+
+import pybuda
+
+
+def test_resnet_inference():
+    # Compiler configurations
+    compiler_cfg = pybuda.config._get_global_compiler_config()
+    compiler_cfg.enable_tvm_cpu_fallback = False
+
+    # Load ResNet50 model
+    framework_model = resnet50()
+    framework_model.eval()
+
+    input_image = torch.rand(1, 3, 224, 224)
+
+    # Sanity run
+    generation_output = framework_model(input_image)
+    print(generation_output)
+
+    # Compile the model
+    compiled_model = pybuda.compile(framework_model, input_image)


### PR DESCRIPTION
List of ops that are currently lowered through tt-forge (up to emit to TTIR):
- add - already supported
- hstack - potentially not needed, part of conv2d
- matmul - potentially not needed, part of conv2d
- narrow - potentially not needed, part of conv2d
- pad_tile - potentially not needed, part of conv2d
- reduce_avg - required support on Forge, MLIR has it
- reduce_max - required support on Forge and MLIR
- relu - required support on Forge, MLIR has it
- sparse_matmul - potentially not needed, part of conv2d
- squeeze - potentially not needed, used after avg poll to reduce dim to the appropriate output
- transpose - Currently WIP
- vslice - potentially not needed

Whole model has around 300 ops before MLIR emitting. However, once we remove conv2d decompositions, this number will be drastically reduced.

Most of the ops are coming from conv2d decompositions. Therefore, bringup for them is probably redundant. Some of them are:
- hstack
- matmul
- narrow
- pad_tile
- vslice