### PR TITLE
[Llama 3B] CPU samples of running model without using .generative() API. #185

### DIFF
--- a/pybuda/test/mlir/llama/test_llama_inference.py
+++ b/pybuda/test/mlir/llama/test_llama_inference.py
@@ -2,12 +2,12 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import torch
 import pytest
-
-from test.mlir.llama.utils.utils import load_model
 from transformers import LlamaConfig, LlamaForCausalLM, LlamaTokenizer
 
 import pybuda
+from test.mlir.llama.utils.utils import load_model
 
 
 @pytest.mark.xfail(reason="Tile broadcast op is not supported on MLIR.")
@@ -26,3 +26,102 @@ def test_llama_inference():
 
     # Compile the model
     compiled_model = pybuda.compile(framework_model, input_ids)
+
+@pytest.mark.skip(reason="No need to run in CI, this is PoC that should be mapped to work on device.")
+def test_llama_inference_no_cache_cpu():
+    """
+    This function tests the inference of the Llama 3B model without using a past-cache (KV cache).
+    It generates text token by token, which can slow down over time as the model has to compute
+    all key-value (KV) pairs for each new token. The function demonstrates how to load the model
+    and tokenizer, prepare an input prompt, and generate a sequence of tokens until a specified
+    maximum number of new tokens is reached or an end-of-sequence token is encountered.
+    """
+    # Load Llama 3B model and tokenizer
+    model_path = "openlm-research/open_llama_3b"
+    framework_model = load_model(model_path)
+    tokenizer = LlamaTokenizer.from_pretrained(model_path)
+
+    # Prepare input sentence
+    prompt = "Q: What is the largest animal?\nA:"
+    input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+
+    max_new_tokens = 46
+    generated_tokens = input_ids
+    for i in range(max_new_tokens):
+        logits = framework_model(input_ids)
+        next_token_logits = logits[0][:, -1, :]
+        next_token_id = torch.argmax(next_token_logits, dim=-1)
+
+        if next_token_id == tokenizer.eos_token_id:
+            break
+
+        input_ids = torch.cat([input_ids, next_token_id.unsqueeze(0)], dim=-1)
+
+    # Generated text
+    generated_text = tokenizer.decode(input_ids[0], skip_special_tokens=True)
+    print(generated_text)
+
+
+@pytest.mark.skip(reason="No need to run in CI, this is PoC that should be mapped to work on device.")
+def test_llama_inference_cache_cpu():
+    """
+    This function tests the inference of the Llama 3B model using a past-cache (KV cache).
+    By utilizing cached key-value (KV) pairs, the model can generate text more efficiently
+    as it doesn't need to recompute KV pairs for previously generated tokens. The function
+    demonstrates how to load the model and tokenizer, prepare an input prompt, and generate
+    a sequence of tokens until a specified maximum number of new tokens is reached or an
+    end-of-sequence token is encountered.
+
+    Steps:
+    1. Load the Llama 3B model and tokenizer with caching enabled.
+    2. Prepare an input prompt and convert it to input IDs.
+    3. Initialize past key-values and other necessary inputs.
+    4. Perform a prefill step to get the initial logits and past key-values.
+    5. Generate tokens iteratively, updating the past key-values and input IDs.
+    6. Decode the generated tokens into text and print the result.
+    """
+    # Load Llama 3B model and tokenizer
+    model_path = "openlm-research/open_llama_3b"
+    framework_model = load_model(model_path, use_cache=True)
+    tokenizer = LlamaTokenizer.from_pretrained(model_path)
+
+    # Prepare input sentence
+    prompt = "Q: What is the largest animal?\nA:"
+    input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+    seq_length = input_ids.size(-1)
+
+    # Prepare other inputs
+    past_key_values = None
+    pkv_length = len(past_key_values[0][0].shape[2]) if past_key_values else 0
+    attention_mask = torch.ones_like(input_ids)
+    position_ids = torch.arange(
+        pkv_length, seq_length + pkv_length, dtype=torch.long
+    ).unsqueeze(0)
+
+    inputs = (input_ids, attention_mask, position_ids, past_key_values)
+
+    # Prefill
+    logits, past_key_values = framework_model(*inputs)
+
+    # Fetch token for 0 iteration
+    next_token_logits = logits[:, -1, :]
+    next_token = torch.argmax(next_token_logits, dim=-1)
+
+    max_new_tokens = 46
+    generated_tokens = input_ids
+    for i in range(max_new_tokens):
+        logits, past_key_values = framework_model(
+            input_ids=next_token.unsqueeze(0), past_key_values=past_key_values
+        )
+        next_token_logits = logits[:, -1, :]
+        next_token = torch.argmax(next_token_logits, dim=-1)
+
+        if next_token == tokenizer.eos_token_id:
+            break
+        generated_tokens = torch.cat(
+            [generated_tokens, next_token.unsqueeze(0)], dim=-1
+        )
+
+    # Generated text
+    generated_text = tokenizer.decode(generated_tokens[0], skip_special_tokens=True)
+    print(generated_text)

--- a/pybuda/test/mlir/llama/tests/test_llama_self_attn.py
+++ b/pybuda/test/mlir/llama/tests/test_llama_self_attn.py
@@ -12,7 +12,7 @@ from pybuda.op.eval.common import compare_with_golden_pcc
 @pytest.mark.xfail(reason="Squeeze op is not supported on MLIR.")
 def test_llama_self_attn():
     # Define wrapper function
-    class Wrapper(torch.nn.Module):
+    class SelfAttention(torch.nn.Module):
         def __init__(self, model):
             super().__init__()
             self.model = model
@@ -24,7 +24,7 @@ def test_llama_self_attn():
     
     # Load Llama 3B model and tokenizer
     framework_model = load_model()
-    framework_model = Wrapper(framework_model.model.layers[0].self_attn)
+    framework_model = SelfAttention(framework_model.model.layers[0].self_attn)
 
     # Input samples
     inputs = [

--- a/pybuda/test/mlir/llama/utils/utils.py
+++ b/pybuda/test/mlir/llama/utils/utils.py
@@ -2,7 +2,7 @@ from transformers import LlamaConfig, LlamaForCausalLM, LlamaTokenizer
 
 import pybuda
 
-def load_model(model_path="openlm-research/open_llama_3b"):
+def load_model(model_path="openlm-research/open_llama_3b", use_cache=False):
     # Compiler configurations
     compiler_cfg = pybuda.config._get_global_compiler_config()
     compiler_cfg.enable_tvm_cpu_fallback = False
@@ -14,6 +14,7 @@ def load_model(model_path="openlm-research/open_llama_3b"):
     config.num_hidden_layers = 26
     config.pad_token_id = 0
     config.return_dict = False
+    config.use_cache = use_cache
     framework_model = LlamaForCausalLM.from_pretrained(
         model_path, device_map="auto", config=config
     )


### PR DESCRIPTION
Main purpose of this change is to demonstrate how to perform inference on the Llama 3B model on CPU without using the `.generate` function from the transformers library.

Also, keep in mind that tests are marked to be skipped in CI as they are proof-of-concept (PoC) and should be mapped to work on the actual device.

Note: The actual implementation when running end-to-end (E2E) on the device might differ depending on various constraints.