### PR TITLE
[ci] cleanup submodules when running CI

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -26,11 +26,6 @@ jobs:
         - /lib/modules:/lib/modules
         - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
     steps:
-    - uses: actions/checkout@v4
-      with:
-          submodules: recursive
-          fetch-depth: 0 # Fetch all history and tags
-
     - name: Set reusable strings
       id: strings
       shell: bash
@@ -40,6 +35,18 @@ jobs:
 
     - name: Git safe dir
       run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
+
+    - uses: actions/checkout@v4
+      with:
+          submodules: recursive
+          fetch-depth: 0 # Fetch all history and tags
+
+    # Clean everything from submodules (needed to avoid issues
+    # with cmake generated files leftover from previous builds)
+    - name: Cleanup submodules
+      run: |
+          git submodule foreach --recursive git clean -ffdx
+          git submodule foreach --recursive git reset --hard
 
     - name: ccache
       uses: hendrikmuhs/ccache-action@v1.2
@@ -51,8 +58,14 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        cmake -G Ninja -B build .
-        cmake --build build
+        cmake -G Ninja \
+        -B ${{ steps.strings.outputs.build-output-dir }} \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER=clang \
+        -DCMAKE_CXX_COMPILER=clang++ \
+        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        cmake --build ${{ steps.strings.outputs.build-output-dir }}
 
     - name: Run Test
       shell: bash

--- a/third_party/build_mlir.sh
+++ b/third_party/build_mlir.sh
@@ -10,6 +10,6 @@ c_compiler=${C_COMPILER:-clang}
 cxx_compiler=${CXX_COMPILER:-clang++}
 
 source env/activate
-cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=$build_type -DCMAKE_C_COMPILER=$c_compiler -DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DTTMLIR_ENABLE_RUNTIME=ON -DTT_RUNTIME_ENABLE_TTNN=ON
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=$build_type -DCMAKE_C_COMPILER=$c_compiler -DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DTTMLIR_ENABLE_RUNTIME=ON
 
 cmake --build build


### PR DESCRIPTION
We've hit build issues when bumping tt-mlir version and to resolve those #190 was merged. This is a follow up change with a cleaner fix.

Github runner will reuse the same folder for repo checkout between jobs. The checkout action from github cleans leftover files, but not for git submodules within a repo. This creates a problem, since it can happen that cmake doesn't regenerate build files, but incorrectly, reuse ones that were left over.

This change enforces cleanup of git submodules, resulting in correct, but slower builds.

Also, the build command is rewritten to be more explicit.