### PR TITLE
[Op] Further support for reciprocal #112

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -500,6 +500,7 @@ class MLIRGenerator
             lowering_handler_map["embedding"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::EmbeddingOp>;
             lowering_handler_map["matmul"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MatmulOp>;
             lowering_handler_map["multiply"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MultiplyOp>;
+            lowering_handler_map["reciprocal"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ReciprocalOp>;
             lowering_handler_map["reduce_avg"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MeanOp>;
             lowering_handler_map["reduce_sum"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::SumOp>;
             lowering_handler_map["relu"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ReluOp>;


### PR DESCRIPTION
Uncovered new blocker related to the invalid setup of reciprocal on MLIR side. More precisely, it requires 2 attributes instead of 1 due to limitation of being defined as elementwise binary op on TTIR to TTNN op conversion.

Potential root cause (enforces eltwise binary checks):
```
third_party/tt-mlir/lib/Conversion/TTIRToTTNN/TTIRToTTNN.cpp::populateTTIRToTTNNPatterns
```