### PR TITLE
Fix forge types missing formatter

### DIFF
--- a/forge/csrc/backend_api/device_config.hpp
+++ b/forge/csrc/backend_api/device_config.hpp
@@ -452,3 +452,13 @@ inline std::ostream& operator<<(std::ostream& os, DeviceConfig const& device_con
 }
 
 }  // namespace tt
+
+template<> struct fmt::formatter<tt::DeviceConfig> : fmt::formatter<std::string_view>
+{
+    inline auto format(const tt::DeviceConfig& device_config, fmt::format_context& ctx) const -> decltype(ctx.out())
+    {
+        std::ostringstream oss;
+        oss << device_config;
+        return fmt::formatter<std::string_view>::format(oss.str(), ctx);
+    }
+};

--- a/forge/csrc/graph_lib/node_types.hpp
+++ b/forge/csrc/graph_lib/node_types.hpp
@@ -655,3 +655,13 @@ inline std::string to_string(InputNodeType t)
 
 }  // namespace graphlib
 }  // namespace tt
+
+template<> struct fmt::formatter<tt::graphlib::OpType> : fmt::formatter<std::string_view>
+{
+    inline auto format(const tt::graphlib::OpType& op_type, fmt::format_context& ctx) const -> decltype(ctx.out())
+    {
+        std::ostringstream oss;
+        oss << op_type;
+        return fmt::formatter<std::string_view>::format(oss.str(), ctx);
+    }
+};

--- a/forge/csrc/passes/nd_slice.hpp
+++ b/forge/csrc/passes/nd_slice.hpp
@@ -296,3 +296,13 @@ inline std::ostream& operator<<(std::ostream& out, NDSlice::Slice const& c)
     return out;
 }
 }  // namespace tt::passes
+
+template<> struct fmt::formatter<tt::passes::NDSlice> : fmt::formatter<std::string_view>
+{
+    inline auto format(const tt::passes::NDSlice& nd_slice, fmt::format_context& ctx) const -> decltype(ctx.out())
+    {
+        std::ostringstream oss;
+        oss << nd_slice;
+        return fmt::formatter<std::string_view>::format(oss.str(), ctx);
+    }
+};

--- a/forge/csrc/tt_torch_device/torch_device_impl.cpp
+++ b/forge/csrc/tt_torch_device/torch_device_impl.cpp
@@ -554,3 +554,23 @@ TORCH_LIBRARY_IMPL(_, PrivateUse1, m)
     m.fallback(torch::CppFunction::makeFromBoxedFunction<&tt::fallback>());
 }
 
+template<> struct fmt::formatter<c10::Device> : fmt::formatter<std::string_view>
+{
+    inline auto format(const c10::Device& device, fmt::format_context& ctx) const -> decltype(ctx.out())
+    {
+        std::ostringstream oss;
+        oss << device;
+        return fmt::formatter<std::string_view>::format(oss.str(), ctx);
+    }
+};
+
+template<> struct fmt::formatter<c10::OperatorName> : fmt::formatter<std::string_view>
+{
+    inline auto format(const c10::OperatorName& operator_name, fmt::format_context& ctx) const -> decltype(ctx.out())
+    {
+        std::ostringstream oss;
+        oss << operator_name;
+        return fmt::formatter<std::string_view>::format(oss.str(), ctx);
+    }
+};
+


### PR DESCRIPTION
Adding formatter for forge types to enable debug build without any hacks.
I tried several different approaches to "catch all" types with single templated struct but it seems that everyone is doing it this way (torch/scylladb)