### PR TITLE
Added support for named attrs in DecomposingContext.

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - runs-on: self-hosted        
+          - runs-on: runner
 
     runs-on: ${{ matrix.build.runs-on }}
 

--- a/forge/forge/op/eval/forge/nn.py
+++ b/forge/forge/op/eval/forge/nn.py
@@ -476,7 +476,7 @@ def decompose_post_autograd(op_type, attr, dc, inputs):
         assert len(out_shape) > dim and dim >= -len(out_shape), "Given dimension is out of the shape"
 
         grad_out = dc.op("multiply", (grad, output), ())
-        gout_sum = dc.op("reduce_sum", (grad_out, ), (dim, ))
+        gout_sum = dc.op_with_named_attrs("reduce_sum", (grad_out, ), {"keep_dim": True}, (dim, ))
         gout_sub = dc.op("subtract", (grad, gout_sum), ())
         result = dc.op("multiply", (gout_sub, output), ())
         dc.fuse(result)


### PR DESCRIPTION
Added support for named attrs in DecomposingContext, since they are needed for lowering to MLIR. 
Currently using it only in softmax_bw, as an example. As we find more uses for it (as training matures), we will add it at other locations.

Solves #183 