### PR TITLE
Use runner instead of self-hosted

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - runs-on: self-hosted        
+          - runs-on: runner
 
     runs-on: ${{ matrix.build.runs-on }}
 


### PR DESCRIPTION
Use runner instead of self-hosted

Our workflow requires silicon runners, so we need to be more specific in selecting worker labels.
