### PR TITLE
[compile] introduce forge graph module

### DIFF
--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -17,6 +17,7 @@ namespace py = pybind11;
 #include "autograd/python_bindings.hpp"
 #include "backend_api/device_config.hpp"
 #include "forge_passes.hpp"
+#include "forge_graph_module.hpp"
 #include "graph_lib/graph.hpp"
 #include "graph_lib/python_bindings.hpp"
 #include "lower_to_forge/common.hpp"
@@ -110,6 +111,16 @@ PYBIND11_MODULE(_C, m) {
 
     py::module_ m_graph = m.def_submodule("graph", "Submodule defining forge graph functions");
     GraphModule(m_graph);
+
+    py::enum_<tt::GraphType>(m, "GraphType")
+        .value("Forward", tt::GraphType::Forward)
+        .value("Backward", tt::GraphType::Backward)
+        .value("Optimizer", tt::GraphType::Optimizer)
+        .export_values();
+
+    py::class_<tt::ForgeGraphModule>(m, "ForgeGraphModule")
+        .def(py::init<std::string, tt::graphlib::Graph *>(), py::arg("name"), py::arg("forward_graph"))
+        .def("set_graph", &tt::ForgeGraphModule::set_graph);
 
     py::module_ m_autograd = m.def_submodule("autograd", "Submodule defining autograd_engine.");
     AutogradModule(m_autograd);

--- a/forge/csrc/forge_graph_module.hpp
+++ b/forge/csrc/forge_graph_module.hpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <type_traits>
+
+#include "utils/assert.hpp"
+
+namespace tt
+{
+
+namespace graphlib
+{
+    class Graph;
+}
+
+enum class GraphType : std::uint8_t
+{
+    Forward = 0,
+    Backward = 1,
+    Loss = 2,
+    Optimizer = 3,
+    GraphTypeCount = 4,
+};
+
+template <typename T>
+constexpr std::underlying_type_t<T> to_underlying(T e) noexcept
+{
+    return static_cast<std::underlying_type_t<T>>(e);
+}
+
+constexpr std::uint8_t GRAPH_TYPE_COUNT = to_underlying(GraphType::GraphTypeCount);
+using StaticGraphArray = std::array<graphlib::Graph*, GRAPH_TYPE_COUNT>;
+
+/**
+ * @brief ForgeGraphModule is a container for all the graphs that are part of a module.
+ * The graphs are stored in an array by their type (enum GraphType).
+ * ForgeGraphModule is initialized with a Forward graph,
+ * while the other graphs can be set later (if the module is compiled for training).
+ */
+class ForgeGraphModule
+{
+public:
+    ForgeGraphModule(std::string name, graphlib::Graph* forward_graph) : name_(name), graphs_{nullptr}
+    {
+        TT_ASSERT(forward_graph != nullptr);
+        graphs_[to_underlying(GraphType::Forward)] = forward_graph;
+    }
+
+    void set_graph(GraphType type, graphlib::Graph* graph)
+    {
+        TT_ASSERT(graph != nullptr);
+        graphs_[to_underlying(type)] = graph;
+    }
+
+    graphlib::Graph* get_graph(GraphType type) const
+    {
+        return graphs_[to_underlying(type)];
+    }
+
+    /**
+     * @brief Get all existing graphs in the module.
+     * @return A vector of pointers to the graphs.
+     */
+    std::vector<graphlib::Graph*> graphs() const
+    {
+        std::vector<graphlib::Graph*> res;
+        res.reserve(graphs_.size());
+        for (auto graph : graphs_) {
+            if (graph != nullptr) {
+                res.push_back(graph);
+            }
+        }
+        return res;
+    }
+
+    std::string name() const { return name_; }
+
+private:
+    std::string name_;
+    
+    // Static array of graphs, indexed by GraphType.
+    StaticGraphArray graphs_;
+};
+
+} // namespace tt

--- a/forge/csrc/passes/lower_to_mlir.hpp
+++ b/forge/csrc/passes/lower_to_mlir.hpp
@@ -2,9 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
-namespace tt::graphlib
+
+namespace tt
 {
-class Graph;
+class ForgeGraphModule;
 }
 
 namespace mlir {
@@ -15,7 +16,7 @@ namespace mlir {
 
 namespace tt::passes 
 {
-    // Public API for generating MLIR from the TT-Forge graph.
-    mlir::OwningOpRef<mlir::ModuleOp> lower_to_mlir(tt::graphlib::Graph * graph, mlir::MLIRContext& context);
+    // Public API for generating MLIR from a Forge module (set of graphs).
+    mlir::OwningOpRef<mlir::ModuleOp> lower_to_mlir(tt::ForgeGraphModule& module, mlir::MLIRContext& context);
 } // namespace tt:passes
 

--- a/forge/csrc/passes/mlir_compiler.cpp
+++ b/forge/csrc/passes/mlir_compiler.cpp
@@ -35,7 +35,7 @@
 namespace tt::passes
 {
     /// Public API for lowering to MLIR, running MLIR passes and generate runtime binary.
-    runtime::Binary run_mlir_compiler(tt::graphlib::Graph *graph)
+    runtime::Binary run_mlir_compiler(tt::ForgeGraphModule& module)
     {
         // Register all the required dialects.
         mlir::DialectRegistry registry;
@@ -58,9 +58,7 @@ namespace tt::passes
         context.loadAllAvailableDialects();
 
         // Generate MLIR from the Forge graph.
-        mlir::OwningOpRef<mlir::ModuleOp> mlir_module = lower_to_mlir(graph, context);
-
-        tt::log_info(LogMLIRCompiler, "MLIR module generated successfully.");
+        mlir::OwningOpRef<mlir::ModuleOp> mlir_module = lower_to_mlir(module, context);
 
         // Run MLIR registered passes.
         run_mlir_passes(mlir_module);

--- a/forge/csrc/passes/mlir_compiler.hpp
+++ b/forge/csrc/passes/mlir_compiler.hpp
@@ -2,20 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
-#include <memory>
 
 #include "tt/runtime/types.h"
 
 namespace tt
 {
-    namespace graphlib
-    {
-        class Graph;
-    }
+    class ForgeGraphModule;
 }
 
 namespace tt::passes
 {
     /// Public API for running MLIR passes and generating binary.
-    runtime::Binary run_mlir_compiler(tt::graphlib::Graph *graph);
+    runtime::Binary run_mlir_compiler(tt::ForgeGraphModule& module);
 }


### PR DESCRIPTION
For the purpose of encapsulating multiple graphs for a given module, `ForgeGraphModule` class is introduced.

The class for now simply stores pointers to graphs by the type of the graph. Graph type can be one of the following: `Forward`, `Backward`, `Loss`, `Optimizer`.

When lowering to mlir, we will iterate through all the graphs inside the `ForgeGraphModule` and lower them as mlir functions.

This is a first change in a set of changes needed for separating forward and backward graphs (for training) - Issue #100.

Closes #222