### PR TITLE
Fix reciprocal op in TVM relay PyTorch frontend

### DIFF
--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -354,7 +354,7 @@ def test_sqrt(x_shape, y_shape):
 @pytest.mark.parametrize("token_num", [12])
 @pytest.mark.parametrize("embedding_dim", [3200])
 def test_embedding(vocab_size, token_num, embedding_dim):
-    compiler_cfg = pyforge.config._get_global_compiler_config()
+    compiler_cfg = forge.config._get_global_compiler_config()
     compiler_cfg.enable_tvm_cpu_fallback = False
 
     class Embedding(nn.Module):
@@ -372,14 +372,13 @@ def test_embedding(vocab_size, token_num, embedding_dim):
     framework_model = Embedding()
     fw_out = framework_model(*inputs)
 
-    compiled_model = pyforge.compile(framework_model, sample_inputs=inputs)
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
     co_out = compiled_model(*inputs)
 
     co_out = [co.to("cpu") for co in co_out]
     assert compare_with_golden_pcc(golden=fw_out, calculated=co_out[0], pcc=0.99)
 
 
-@pytest.mark.xfail(reason="Program expects 2 inputs, found 1 in input tensors vector")
 @pytest.mark.parametrize("shape", [
     (7,),           # 1D tensor
     (32,),          # 1D tensor
@@ -405,7 +404,7 @@ def test_reciprocal(shape):
     framework_model = Reciprocal()
     fw_out = framework_model(*inputs)
     
-    compiled_model = pyforge.compile(framework_model, sample_inputs=inputs)
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
     co_out = compiled_model(*inputs)
     
     co_out = [co.to("cpu") for co in co_out]


### PR DESCRIPTION
Fixes [https://github.com/tenstorrent/tt-forge-fe/issues/112](https://github.com/tenstorrent/tt-forge-fe/issues/112)
1) In TVM pytorch frontend conversion, the aten::reciprocal is mapped to divide op.
<img width="1103" alt="Screenshot 2024-09-09 at 12 41 27 PM" src="https://github.com/user-attachments/assets/427750c1-9fcb-4ff2-99bb-1af6880fcd1f">


2) In TVM forge passes, we have decomposed divide op into reciprocal and multiply.
<img width="1065" alt="Screenshot 2024-09-09 at 12 41 41 PM" src="https://github.com/user-attachments/assets/19a11022-8dd2-4c7c-a1c9-ebcae0572d42">

3) Below is the initial graph for single reciprocal in Forge
<img width="1046" alt="Screenshot 2024-09-09 at 12 36 49 PM" src="https://github.com/user-attachments/assets/cf0542c5-7e08-4170-a578-763f9516abd1">



In the intial graph, we doesn't need the multplication of reciprocal output with ones constant tensor which was instroduced from TVM. So mapped aten::reciprocal with tvm.relay.reciprocal directly


4) Intial graph after mapping aten::reciprocal with tvm.relay.reciprocal directly.
<img width="1460" alt="Screenshot 2024-09-09 at 12 37 17 PM" src="https://github.com/user-attachments/assets/11900bf9-6f8c-429a-8a31-e6d2c71876c4">

