### PR TITLE
Fix for reshape/transpose optimization passes to support change rank ops

### DIFF
--- a/forge/csrc/graph_lib/node_types.hpp
+++ b/forge/csrc/graph_lib/node_types.hpp
@@ -418,10 +418,13 @@ class OpNode : public TaggedNode
 public:
     OpNode(const std::string &name, const std::string &op_type, NodeType node_type) : TaggedNode(name, node_type), op_type_(op_type), gradient_op_(false) {}
     OpNode(const std::string &name, OpType op_type, NodeType node_type) : TaggedNode(name, node_type), op_type_(op_type), gradient_op_(false) {}
+    void change_op_type(OpType const &new_op_type) { op_type_ = new_op_type; }
     void change_op_type(const std::string &new_op_type, std::vector<OpType::Attr> attrs = {}) {
         op_type_ = OpType(new_op_type, attrs);
     }
-    void change_op_type(OpType const &new_op_type) { op_type_ = new_op_type; }
+    void change_op_type(const std::string &new_op_type, std::vector<OpType::Attr> attrs, OpType::Attrs named_attrs) {
+        op_type_ = OpType(new_op_type, attrs, {}, named_attrs);
+    }
     OpType const& op_type() const { return op_type_; }
     OpType &op_type() { return op_type_; }
     OpType const* op_type_ptr() const { return &op_type_; }

--- a/forge/csrc/graph_lib/utils.cpp
+++ b/forge/csrc/graph_lib/utils.cpp
@@ -1372,7 +1372,9 @@ void handle_change_rank(graphlib::Graph *graph, graphlib::Edge edge)
         TT_ASSERT(change_rank);
         auto attr = (op == "squeeze") ? std::vector<graphlib::OpType::Attr>{0}
                                       : std::vector<graphlib::OpType::Attr>{0, ((int)rank - 1)};
-        change_rank->change_op_type(graphlib::OpType(op, attr));
+        change_rank->change_op_type(op, attr, graphlib::OpType::Attrs{
+            {"dim", attr[0]}
+        });
         change_rank->set_shape(producer->shape().as_rank(rank));
         change_rank->tag("dont_erase", true);
         auto [incoming_edge, outgoing_edge] = insert_node_on_edge(graph, edge, change_rank);

--- a/forge/csrc/passes/erase_inverse_ops.cpp
+++ b/forge/csrc/passes/erase_inverse_ops.cpp
@@ -264,12 +264,15 @@ void commute_and_bypass(graphlib::Graph *graph, std::vector<graphlib::Node *> co
 
             // Operand commute clones for squeeze/unsqueeze need to be swapped to the opposite op
             if (first->op_name() == "unsqueeze") {
-                op->change_op_type("squeeze");
-                op->overwrite_op_attrs({first->op_attrs()[0]});
+                op->change_op_type("squeeze", {first->op_attrs()[0]}, graphlib::OpType::Attrs{
+                    {"dim", first->op_attrs()[0]}
+                });
             }
             else if (first->op_name() == "squeeze") {
                 op->change_op_type("unsqueeze");
-                op->overwrite_op_attrs({first->op_attrs()[0], (int)graph->node_by_id(operand_edge.producer_node_id)->shape().size()});
+                op->change_op_type("unsqueeze", {first->op_attrs()[0], (int)graph->node_by_id(operand_edge.producer_node_id)->shape().size()}, graphlib::OpType::Attrs{
+                    {"dim", first->op_attrs()[0]}
+                });
             }
 
             // Inputs can have mismatched number of dims and still function corretly to the consuming op

--- a/forge/csrc/passes/explicate_unsqueeze.cpp
+++ b/forge/csrc/passes/explicate_unsqueeze.cpp
@@ -47,7 +47,10 @@ void explicate_unsqueeze(graphlib::Graph *graph)
                     auto rank = current_node->shape().size();
                     std::string name = to_be_unsqueeze->name() + "_" + eltwise->name() + "_unsqueeze_" + std::to_string(rank) + "_operand_0";
                     auto attr = std::vector<graphlib::OpType::Attr>{0, ((int)rank)};
-                    auto op_type = graphlib::OpType("unsqueeze", attr);
+                    auto named_attr = graphlib::OpType::Attrs{
+                        {"dim", ((int)rank)}
+                    };
+                    auto op_type = graphlib::OpType("unsqueeze", attr, {}, named_attr);
                     auto change_rank = graph->add_node(
                         std::make_unique<graphlib::PyOpNode>(name, op_type), graph->get_subgraph_id_for_node(current_node->id()));
 


### PR DESCRIPTION
This fix includes:
- Adding a new function to enable named attributes for change rank ops (e.g. squeeze)
- Updating a few occurrences in the mentioned optimization passes to set named attributes as well

_Note: Cleaner fix would be to eliminate the usage of ordered attributes and named attributes together. However, this requires more architectural changes to how we handle attributes of each op and should be covered separately._

Fixes #274