### PR TITLE
Disable default CPU fallback and conversion of TVM params

### DIFF
--- a/forge/forge/config.py
+++ b/forge/forge/config.py
@@ -121,7 +121,7 @@ class CompilerConfig:
 
     compile_depth: int = field(default=CompileDepth.FULL, metadata=as_json(CompileDepth))  # Defines compilation depth. Used to limit scope of some unit tests
 
-    enable_tvm_cpu_fallback: bool = True    # Create cpu device for unsupported forge ops
+    enable_tvm_cpu_fallback: bool = False    # Create cpu device for unsupported forge ops
     cpu_fallback_ops: Set[str] = field(default_factory=lambda: set(["embedding"])) # Types of ops to fall back to CPU for
     enable_tm_cpu_fallback: bool = False    # Extend CPU fallback for TM ops
     tm_cpu_fallback_max_depth: int = 10     # Max search depth for extended CPU fallback
@@ -130,7 +130,7 @@ class CompilerConfig:
     enable_tvm_unsupported_ops: bool = False# Create "unsupported" forge ops in python file, allowing user to modify later
     enable_op_level_comparision: bool = False # Should we need to compare every op with framework output at each compilation stage.
     enable_tvm_constant_prop: bool = False  # Should we constant prop in tvm
-    convert_framework_params_to_tvm: bool = True # Convert framework params to relay params
+    convert_framework_params_to_tvm: bool = False # Convert framework params to relay params
     enable_xla_jax_convert: bool = False    # Convert JAX model to TF through XLA
     enable_tvm_jax_freeze_large_model: bool = True # When model param is larger than 2GB, Protobuf will error out. This flag will enable large model tracing
     framework_model_output_names: List[str] = field(default_factory=lambda: list())   # List of output names specified by framework

--- a/forge/test/mlir/llama/tests/test_llama_embedding.py
+++ b/forge/test/mlir/llama/tests/test_llama_embedding.py
@@ -9,7 +9,7 @@ from test.mlir.llama.utils.utils import load_model
 from forge.op.eval.common import compare_with_golden_pcc
 
 
-@pytest.mark.xfail(reason="L1 allocation issue on Metal")
+@pytest.mark.xfail()
 def test_llama_embedding():    
     # Load Llama 3B model and tokenizer
     framework_model = load_model()

--- a/forge/test/mlir/llama/tests/test_llama_lm_head.py
+++ b/forge/test/mlir/llama/tests/test_llama_lm_head.py
@@ -9,7 +9,7 @@ from test.mlir.llama.utils.utils import load_model
 from forge.op.eval.common import compare_with_golden_pcc
 
 
-@pytest.mark.xfail(reason="Squeeze op is not supported on MLIR.")
+@pytest.mark.xfail()
 def test_llama_lm_head():
     # Load Llama 3B model and tokenizer
     framework_model = load_model()

--- a/forge/test/mlir/llama/tests/test_llama_mlp.py
+++ b/forge/test/mlir/llama/tests/test_llama_mlp.py
@@ -9,7 +9,7 @@ from test.mlir.llama.utils.utils import load_model
 from forge.op.eval.common import compare_with_golden_pcc
 
 
-@pytest.mark.xfail(reason="Squeeze op is not supported on MLIR.")
+@pytest.mark.xfail()
 def test_llama_mlp():
     # Load Llama 3B model and tokenizer
     framework_model = load_model()

--- a/forge/test/mlir/llama/tests/test_llama_rms_norm.py
+++ b/forge/test/mlir/llama/tests/test_llama_rms_norm.py
@@ -9,7 +9,7 @@ from test.mlir.llama.utils.utils import load_model
 from forge.op.eval.common import compare_with_golden_pcc
 
 
-@pytest.mark.xfail(reason="Tile broadcast op is not supported on MLIR.")
+@pytest.mark.xfail()
 def test_llama_lm_head():
     # Load Llama 3B model and tokenizer
     framework_model = load_model()

--- a/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
+++ b/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
@@ -9,7 +9,7 @@ from test.mlir.llama.utils.utils import load_model
 from forge.op.eval.common import compare_with_golden_pcc
 
 
-@pytest.mark.xfail(reason="Dynamic shapes..")
+@pytest.mark.xfail()
 def test_llama_rotary_emb():
     # Load Llama 3B model and tokenizer
     framework_model = load_model()

--- a/forge/test/mlir/llama/tests/test_llama_self_attn.py
+++ b/forge/test/mlir/llama/tests/test_llama_self_attn.py
@@ -9,7 +9,7 @@ from test.mlir.llama.utils.utils import load_model
 from forge.op.eval.common import compare_with_golden_pcc
 
 
-@pytest.mark.xfail(reason="Squeeze op is not supported on MLIR.")
+@pytest.mark.xfail()
 def test_llama_self_attn():
     # Define wrapper function
     class SelfAttention(torch.nn.Module):

--- a/forge/test/mlir/llama/utils/utils.py
+++ b/forge/test/mlir/llama/utils/utils.py
@@ -7,15 +7,6 @@ from transformers import LlamaConfig, LlamaForCausalLM, LlamaTokenizer
 import forge
 
 def load_model(model_path="openlm-research/open_llama_3b", use_cache=False):
-    # Compiler configurations
-    compiler_cfg = forge.config._get_global_compiler_config()
-    
-    # Disable CPU fallback, we want to run whole model on device
-    compiler_cfg.enable_tvm_cpu_fallback = False
-    # Reduce compile memory usage, but disables TVM verification
-    # and TVM constant evaluation (Forge const eval is enabled)
-    compiler_cfg.convert_framework_params_to_tvm = False
-
     # Load Llama 3B model
     config = LlamaConfig()
     config.hidden_size = 3200


### PR DESCRIPTION
Speed up compile time and reduce memory consumption ~2x on host

- Disabling CPU fallback by default:
  - Focuses more on the preferable way of running models (on the device)
  - Reduces compile time as well
- Disabling conversion to TVM params:
  - Disables TVM verification as well (assert for checking it already exists)
  - Disables TVM consteval (adding assert with this check)

Fixes #285


Related TVM PR:
- https://github.com/tenstorrent/tt-tvm/pull/32