### PR TITLE
Update forge embedding op argument order with respect to TTIR

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -486,6 +486,8 @@ class MLIRGenerator
                     return builder_.getBF16Type();
                 case tt::DataFormat::Float16:
                     return builder_.getF16Type();
+                case tt::DataFormat::Int32:
+                    return builder_.getI32Type();
                 case tt::DataFormat::Int8:
                     return builder_.getI8Type();
                 default:

--- a/forge/csrc/passes/pre_lowering_passes.cpp
+++ b/forge/csrc/passes/pre_lowering_passes.cpp
@@ -187,7 +187,7 @@ void bypass_embedding_input_nops(Graph *graph)
 
         graphlib::PyOpNode *embedding = node->as<graphlib::PyOpNode>();
 
-        Node *input_ids = graph->data_operands(embedding)[1];
+        Node *input_ids = graph->data_operands(embedding)[0];
         if (input_ids->node_type() == NodeType::kInput)
             continue;
 

--- a/forge/forge/op/common.py
+++ b/forge/forge/op/common.py
@@ -66,7 +66,7 @@ class ForgeOp:
             else:
                 data_format = self.operands[0].data_format
         elif len(self.operands) > 0:
-            if self.op_type == "where":
+            if self.op_type in ["where", "embedding"]:
                 data_format = self.operands[1].data_format
             else:
                 data_format = self.operands[0].data_format

--- a/forge/forge/op/embedding.py
+++ b/forge/forge/op/embedding.py
@@ -9,8 +9,8 @@ from .common import ForgeOp as op
 
 def Embedding(
         name: str, 
-        embedding_table: Union[Tensor, Parameter],
-        indices: Tensor) -> Tensor:
+        indices: Tensor,
+        embedding_table: Union[Tensor, Parameter]) -> Tensor:
     """
     Embedding lookup
 
@@ -26,4 +26,4 @@ def Embedding(
         Dictionary of embeddings
     """
 
-    return op("embedding", name, embedding_table, indices).get_tensor()
+    return op("embedding", name, indices, embedding_table).get_tensor()

--- a/forge/forge/op/eval/forge/embedding.py
+++ b/forge/forge/op/eval/forge/embedding.py
@@ -12,14 +12,14 @@ def eval(type, attr, ops):
     assert type == "embedding"
     assert len(ops) == 2
     t_ops = to_torch_operands(*ops)
-    return torch.embedding(t_ops[0], t_ops[1].to(torch.int32))
+    return torch.embedding(t_ops[1], t_ops[0].to(torch.int32))
 
 
 def shape(type, attr, ops):
     assert type == "embedding"
     assert len(ops) == 2
-    shape = list(ops[1])
-    shape.append(ops[0][-1])
+    shape = list(ops[0])
+    shape.append(ops[1][-1])
     return shape, []
 
 
@@ -27,18 +27,18 @@ def lower(type, attr, lc, ops, outputs):
     assert type == "embedding"
     assert len(ops) == 2
 
-    lc.set_output_df(ops[1], DataFormat.RawUInt32)
-    lc.set_runtime_tensor_transform(ops[1], RuntimeTensorTransform.EmbeddingIndex(ops[1].shape))
+    lc.set_output_df(ops[0], DataFormat.RawUInt32)
+    lc.set_runtime_tensor_transform(ops[0], RuntimeTensorTransform.EmbeddingIndex(ops[0].shape))
 
-    embedding_dim = ops[0].shape.as_list()
+    embedding_dim = ops[1].shape.as_list()
     while len(embedding_dim) < 4:
         embedding_dim = [1] + embedding_dim
 
     forge_attrs = {
-        "num_indices": ops[1].shape[-1],
+        "num_indices": ops[0].shape[-1],
     }
 
-    lc.op(type, ops, (ops[1].shape[-1],), forge_attrs, "", TILE_DIM, TILE_DIM)
+    lc.op(type, ops, (ops[0].shape[-1],), forge_attrs, "", TILE_DIM, TILE_DIM)
 
 
 def decompose(type, attr, dc, inputs):

--- a/forge/forge/op/eval/lforge/embedding.py
+++ b/forge/forge/op/eval/lforge/embedding.py
@@ -12,8 +12,8 @@ def eval(type, attr, ops):
     assert len(ops) == 2
     t_ops = to_torch_operands(*ops)
     num_indices = attr[0]
-    indices = t_ops[1].reshape(-1).narrow(0, 0, num_indices)
-    table = t_ops[0].squeeze(0).squeeze(0)
+    indices = t_ops[0].reshape(-1).narrow(0, 0, num_indices)
+    table = t_ops[1].squeeze(0).squeeze(0)
     r = torch.embedding(table, indices)
     return pad_pytorch_tensor_to_forge(r, [])
 
@@ -22,7 +22,7 @@ def shape(type, attr, ops, tile_height, tile_width):
     assert type == "embedding"
     assert len(ops) == 2
     num_indices = align_up_tile(attr[0])
-    embedding_dim = ops[0][-1]
+    embedding_dim = ops[1][-1]
     shape = [1, 1, num_indices, embedding_dim]
     return shape, []
 

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1964,6 +1964,9 @@ def compile_tvm_to_python(framework_mod, graph_name, inputs, module_name=None, c
                     if inp_shape[:2] == out_shape[:2] and inp_shape[2] * 2 == out_shape[2]:
                         input_names = [input_names[0], input_names[0]]
 
+                if json_graph["device"] == "tt" and node["name"] == "embedding":
+                    input_names = [input_names[1], input_names[0]]
+
                 ops[node["nid"]] = Operation(
                     function_name=function_name,
                     # node_name=node["forge_name"],

--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -468,7 +468,7 @@ def test_sqrt(x_shape, y_shape):
 # @pytest.mark.parametrize("vocab_size", [2048, 16384, 32000])
 # @pytest.mark.parametrize("token_num", [1, 7, 32])
 # @pytest.mark.parametrize("embedding_dim", [128, 512, 3200])
-@pytest.mark.xfail(reason="L1 allocation issue on Metal")
+@pytest.mark.xfail(reason="ttnn.embedding op fails while reshaping the input_tensor in TILE_LAYOUT")
 @pytest.mark.parametrize("vocab_size", [32000])
 @pytest.mark.parametrize("token_num", [12])
 @pytest.mark.parametrize("embedding_dim", [3200])
@@ -485,7 +485,7 @@ def test_embedding(vocab_size, token_num, embedding_dim):
             return self.embedding(x)
 
     inputs = [
-        torch.randint(0, vocab_size, (1, token_num)),
+        torch.randint(0, vocab_size, (1, token_num)).to(torch.int32),
     ]
 
     framework_model = Embedding()


### PR DESCRIPTION

- In TVM and Forge, for the embedding op, the first argument is weight tensor and the second argument is input tensor (i.e indices) but the TTIR expect the input tensor as the first argument and weight tensor as the second argument so updating the argument order in forge embedding op.

- Add int32 datatype in lowering Forge to MLIR


Fixes #295 

TTIR before fix:
```
module @Embedding attributes {tt.system_desc = #tt.system_desc<[{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 0, erisc_l1_unreserved_base = 0, dram_unreserved_base = 0, dram_unreserved_end = 1073741824, physical_cores = {worker = [(0, 0), (0, 1), (0, 2), (0, 3), (0, 4), (0, 5), (0, 6), (0, 7), (1, 0), (1, 1), (1, 2), (1, 3), (1, 4), (1, 5), (1, 6), (1, 7), (2, 0), (2, 1), (2, 2), (2, 3), (2, 4), (2, 5), (2, 6), (2, 7), (3, 0), (3, 1), (3, 2), (3, 3), (3, 4), (3, 5), (3, 6), (3, 7), (4, 0), (4, 1), (4, 2), (4, 3), (4, 4), (4, 5), (4, 6), (4, 7), (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6), (5, 7), (6, 0), (6, 1), (6, 2), (6, 3), (6, 4), (6, 5), (6, 6), (6, 7), (7, 0), (7, 1), (7, 2), (7, 3), (7, 4), (7, 5), (7, 6), (7, 7)] dram = [(8, 0), (9, 0), (10, 0), (8, 1), (9, 1), (10, 1), (8, 2), (9, 2), (10, 2), (8, 3), (9, 3), (10, 3)]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>], supported_tile_sizes = [(4 x 16), (16 x 16), (32 x 16), (4 x 32), (16 x 32), (32 x 32)]}], [0], [3 : i32], [<0, 0, 0, 0>]>} {
  func.func @forward(%arg0: tensor<1x12xi8> {ttir.name = "input"}, %arg1: tensor<32000x3200xf32> {ttir.name = "embedding.weight"}) -> tensor<1x12x3200xf32> {
    %0 = tensor.empty() : tensor<1x12x3200xf32>
    %1 = "ttir.embedding"(%arg1, %arg0, %0) <{operand_constraints = [#tt.operand_constraint<dram|l1|scalar|tile|none_layout|interleaved|single_bank|height_sharded|width_sharded|block_sharded|any_layout|any_device|any_device_tile|l1_block_sharded>, #tt.operand_constraint<dram|l1|scalar|tile|none_layout|interleaved|single_bank|height_sharded|width_sharded|block_sharded|any_layout|any_device|any_device_tile|l1_block_sharded>, #tt.operand_constraint<dram|l1|scalar|tile|none_layout|interleaved|single_bank|height_sharded|width_sharded|block_sharded|any_layout|any_device|any_device_tile|l1_block_sharded>]}> : (tensor<32000x3200xf32>, tensor<1x12xi8>, tensor<1x12x3200xf32>) -> tensor<1x12x3200xf32>
    return %1 : tensor<1x12x3200xf32>
  }
} 
```
TTIR after fix:
```
module @Embedding attributes {tt.system_desc = #tt.system_desc<[{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_cores = {worker = [(0, 0), (0, 1), (0, 2), (0, 3), (0, 4), (0, 5), (0, 6), (0, 7), (1, 0), (1, 1), (1, 2), (1, 3), (1, 4), (1, 5), (1, 6), (1, 7), (2, 0), (2, 1), (2, 2), (2, 3), (2, 4), (2, 5), (2, 6), (2, 7), (3, 0), (3, 1), (3, 2), (3, 3), (3, 4), (3, 5), (3, 6), (3, 7), (4, 0), (4, 1), (4, 2), (4, 3), (4, 4), (4, 5), (4, 6), (4, 7), (5, 0), (5, 1), (5, 2), (5, 3), (5, 4), (5, 5), (5, 6), (5, 7), (6, 0), (6, 1), (6, 2), (6, 3), (6, 4), (6, 5), (6, 6), (6, 7), (7, 0), (7, 1), (7, 2), (7, 3), (7, 4), (7, 5), (7, 6), (7, 7)] dram = [(8, 0), (9, 0), (10, 0), (8, 1), (9, 1), (10, 1), (8, 2), (9, 2), (10, 2), (8, 3), (9, 3), (10, 3)]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>], supported_tile_sizes = [(4 x 16), (16 x 16), (32 x 16), (4 x 32), (16 x 32), (32 x 32)]}], [0], [3 : i32], [<0, 0, 0, 0>]>} {
  func.func @forward(%arg0: tensor<1x12xi32> {ttir.name = "input"}, %arg1: tensor<32000x3200xf32> {ttir.name = "embedding.weight"}) -> tensor<1x12x3200xf32> {
    %0 = tensor.empty() : tensor<1x12x3200xf32>
    %1 = "ttir.embedding"(%arg0, %arg1, %0) <{operand_constraints = [#tt.operand_constraint<dram|l1|scalar|tile|none|interleaved|single_bank|height_sharded|width_sharded|block_sharded|any_layout|any_device|any_device_tile|l1_block_sharded>, #tt.operand_constraint<dram|l1|scalar|tile|none|interleaved|single_bank|height_sharded|width_sharded|block_sharded|any_layout|any_device|any_device_tile|l1_block_sharded>, #tt.operand_constraint<dram|l1|scalar|tile|none|interleaved|single_bank|height_sharded|width_sharded|block_sharded|any_layout|any_device|any_device_tile|l1_block_sharded>]}> : (tensor<1x12xi32>, tensor<32000x3200xf32>, tensor<1x12x3200xf32>) -> tensor<1x12x3200xf32>
    return %1 : tensor<1x12x3200xf32>
  }
} 
```