### PR TITLE
Automatically create tt-mlir uplift PR every night

### DIFF
--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -1,0 +1,64 @@
+# This workflow runs a schedule and uses the latest version of tt-mlir (origin/main branch)
+# to check if the latest version of tt-mlir is compatible with the current codebase.
+
+name: Nighty Uplift PR
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+  push:
+
+jobs:    
+  uplift-pr:    
+    runs-on: ubuntu-latest    
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0 # Fetch all history and tags
+
+      - name: Set env variable
+        run: |
+          echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+      - name: Create uplift PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          UPLIFT_BRANCH: uplift-${{ env.TODAY }}
+          SUBMODULE_PATH: third_party/tt-mlir
+          SUBMODULE_VERSION: origin/main
+        run: |
+            git config --global user.email ci@tenstorrent.com
+            git config --global user.name "Tenstorrent CI"
+            
+            if git branch -a | grep -q "remotes/origin/$UPLIFT_BRANCH"; then
+              echo "### Branch already exists on remote ###"
+              exit 0
+            fi
+
+            git checkout main
+            git checkout -b $UPLIFT_BRANCH
+            cd $SUBMODULE_PATH
+            git fetch origin
+            git checkout $SUBMODULE_VERSION
+            echo "### Latest commit in $SUBMODULE_PATH ###"
+            git log -1
+            cd ../..
+
+            if [ -z "$(git status --porcelain)" ]; then
+              echo "### No changes in $SUBMODULE_PATH ###"
+              exit 0
+            fi
+            echo "### Commit change and create PR ###"
+            git add $SUBMODULE_PATH
+            git commit -m "Uplift $SUBMODULE_PATH to $SUBMODULE_VERSION $TODAY"
+            git push origin $UPLIFT_BRANCH --force
+
+            gh pr create \
+            --title "Uplift $SUBMODULE_PATH to $SUBMODULE_VERSION $TODAY" \
+            --body "This PR uplifts the $SUBMODULE_PATH submodule to the $SUBMODULE_VERSION." \
+            --base main \
+            --head $UPLIFT_BRANCH \
+            --label uplift \
+            --reviewer ${{ vars.INTEGRATION_OWNER }}

--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -30,7 +30,7 @@ jobs:
             git config --global user.email ci@tenstorrent.com
             git config --global user.name "Tenstorrent CI"
             
-            if git branch -a | grep -q "remotes/origin/$UPLIFT_BRANCH"; then
+            if git branch -a | grep -q "remotes/origin/uplift-"; then
               echo "### Branch already exists on remote ###"
               exit 0
             fi

--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -1,13 +1,11 @@
-# This workflow runs a schedule and uses the latest version of tt-mlir (origin/main branch)
-# to check if the latest version of tt-mlir is compatible with the current codebase.
+# This workflow automates creation of uplift pull requests.
+# Uplift PR is created daily to uplift the submodule to the latest version.
 
 name: Nighty Uplift PR
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 0 * * *'
-  push:
 
 jobs:    
   uplift-pr:    


### PR DESCRIPTION
Workflow will automatically create uplift PR every night and assign it to the reviewer. 
Uplift PR workflow creates a change on top of main branch and thirdparty/tt-mlir submodule is updated to the latest version (origin/main on tt-mlir repo).
Change is pushed into branch "uplift-YYYY-MM-DD" and PR is created and assigned to the reviewer for approval.
This change only creates PR. We can later add step to out PR workflow to automatically accept change if branch name starts with "uplift" and all tests pass.

Issue: #214