### PR TITLE
[training] splitting forward and backward graphs

### DIFF
--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -29,6 +29,7 @@ namespace py = pybind11;
 #include "passes/passes_utils.hpp"
 #include "passes/python_bindings.hpp"
 #include "passes/mlir_compiler.hpp"
+#include "passes/split_graph.hpp"
 #include "python_bindings_common.hpp"
 #include "reportify/reportify.hpp"
 #include "runtime/python_bindings.hpp"
@@ -120,7 +121,8 @@ PYBIND11_MODULE(_C, m) {
 
     py::class_<tt::ForgeGraphModule>(m, "ForgeGraphModule")
         .def(py::init<std::string, tt::graphlib::Graph *>(), py::arg("name"), py::arg("forward_graph"))
-        .def("set_graph", &tt::ForgeGraphModule::set_graph);
+        .def("set_graph", &tt::ForgeGraphModule::set_graph)
+        .def("get_graph", &tt::ForgeGraphModule::get_graph);
 
     py::module_ m_autograd = m.def_submodule("autograd", "Submodule defining autograd_engine.");
     AutogradModule(m_autograd);
@@ -202,6 +204,7 @@ PYBIND11_MODULE(_C, m) {
         py::arg("graph"),
         py::arg("default_df_override") = std::optional<DataFormat>{});
     m.def("run_mlir_compiler", &passes::run_mlir_compiler);
+    m.def("split_graph", &passes::split_graph);
 
     m.def(
         "dump_graph",

--- a/forge/csrc/graph_lib/graph.hpp
+++ b/forge/csrc/graph_lib/graph.hpp
@@ -226,7 +226,7 @@ class Graph
     void update_node_name(Node *node, const std::string &new_name);
 
     void register_module_inputs(const std::vector<NodeId> &module_inputs, bool append = false);
-    void register_module_outputs(const std::vector<NodeId> &module_outputs, std::vector<bool> requires_grad, bool append = false);
+    void register_module_outputs(const std::vector<NodeId> &module_outputs, bool append = false);
     void register_module_targets(const std::vector<NodeId> &module_targets);
     void copy_module_inputs(Graph *old_graph, const std::unordered_map<Node *, Node *> &old_to_new);
     void copy_module_outputs(Graph *old_graph, const std::unordered_map<Node *, Node *> &old_to_new);
@@ -248,6 +248,7 @@ class Graph
     std::vector<Node *> ordered_module_inputs() const;
     std::vector<Node *> ordered_module_outputs() const;
     std::vector<Node *> ordered_partial_datacopy_outputs() const;
+    std::vector<Node *> ordered_intermediates() const;
     std::vector<Node *> get_constant_nodes(bool recurse = false) const;
     std::vector<Node *> get_parameter_nodes() const;
     std::vector<std::string> get_constant_names() const;
@@ -314,6 +315,7 @@ class Graph
     std::vector<NodeId> ordered_module_input_node_ids_;
     std::vector<NodeId> ordered_module_output_node_ids_;
     std::vector<NodeId> ordered_module_target_node_ids_;
+    std::vector<NodeId> ordered_module_intermediate_node_ids_;
 
     // ordered by insertion order
     std::vector<Node *> nodes_;
@@ -343,7 +345,7 @@ NodeClassType *Graph::add_node(std::unique_ptr<NodeClassType> node, unsigned int
     if (this->has_node_with_name(node->name()))
     {
         throw std::runtime_error(
-            "In graph " + std::to_string(this->id()) +
+            "In graph " + this->name() +
             ": trying to add a node with a name that already exists: " + node->name() + "\n");
     }
 

--- a/forge/csrc/graph_lib/node_types.hpp
+++ b/forge/csrc/graph_lib/node_types.hpp
@@ -260,7 +260,7 @@ class OutputNode : public QueueNode {
 protected:
     bool requires_grad_;
     bool is_loss_output_;
-    bool is_saved_intermediate_;
+    bool is_intermediate_;
     bool untilize_;
     RuntimeTensorTransform runtime_tensor_transform;
     // The golden info is needed if we fractured the output and need to reconstruct it for golden comparison
@@ -272,17 +272,17 @@ protected:
         QueueNode(name, QueueNodeType::Output, NodeType::kOutput),
         requires_grad_(false),
         is_loss_output_(false),
-        is_saved_intermediate_(false),
+        is_intermediate_(false),
         untilize_(true)
     {
     }
     bool requires_grad() const { return requires_grad_; }
     bool is_loss_output() const { return is_loss_output_; }
-    bool is_saved_intermediate() const { return is_saved_intermediate_; }
+    bool is_intermediate() const { return is_intermediate_; }
     bool untilize() const { return untilize_; }
     void set_requires_grad(bool requires_grad) { requires_grad_ = requires_grad; }
     void set_loss_output() { is_loss_output_ = true; }
-    void set_saved_intermediate(bool saved_intermediate) { is_saved_intermediate_ = saved_intermediate; }
+    void set_intermediate(bool intermediate) { is_intermediate_ = intermediate; }
     void set_untilize(bool should_untilize) { untilize_ = should_untilize; }
     virtual std::unique_ptr<Node> clone(std::string const& name = "") const override;
 

--- a/forge/csrc/graph_lib/python_bindings.cpp
+++ b/forge/csrc/graph_lib/python_bindings.cpp
@@ -86,6 +86,7 @@ void GraphModule(py::module &m_graph)
         .def("get_ordered_intermediate_names", &Graph::get_ordered_intermediate_names)
         .def("get_ordered_output_names", &Graph::get_ordered_output_names)
         .def("get_ordered_target_names", &Graph::get_ordered_target_names)
+        .def("get_ordered_intermediate_names", &Graph::get_ordered_intermediate_names)
         .def("get_ordered_input_gradient_names", &Graph::get_ordered_input_gradient_names)
         .def("get_ordered_output_gradient_names", &Graph::get_ordered_output_gradient_names)
         .def("get_ordered_input_requires_grad", &Graph::get_ordered_input_requires_grad)
@@ -110,7 +111,6 @@ void GraphModule(py::module &m_graph)
             "register_module_outputs",
             &Graph::register_module_outputs,
             py::arg("module_outputs"),
-            py::arg("requires_grad"),
             py::arg("append") = false)
         .def("register_module_targets", &Graph::register_module_targets)
         .def("get_ordered_input_shapes", &Graph::get_ordered_input_shapes)

--- a/forge/csrc/passes/mlir_compiler.cpp
+++ b/forge/csrc/passes/mlir_compiler.cpp
@@ -64,6 +64,8 @@ namespace tt::passes
         run_mlir_passes(mlir_module);
         tt::log_info(LogMLIRCompiler, "MLIR passes run successfully.");
 
+        mlir_module->dump();
+
         // Generate binary from the MLIR module.
         auto binary = mlir::tt::ttnn::ttnnToFlatbuffer(mlir_module.get());
         tt::log_info(LogMLIRCompiler, "Flatbuffer binary generated successfully.");

--- a/forge/csrc/passes/pre_placer_forge_passes.cpp
+++ b/forge/csrc/passes/pre_placer_forge_passes.cpp
@@ -371,7 +371,7 @@ void insert_queues_for_op_intermediates(graphlib::Graph *graph, const std::vecto
         graph->add_edge(node, intermediate_output);
         intermediate_output->set_shape(Shape::create(node->shape().as_vector()));
         intermediate_output->set_output_df(node->output_df());
-        intermediate_output->set_saved_intermediate(true);
+        intermediate_output->set_intermediate(true);
         intermediate_output->set_epoch_type(node->get_epoch_type());
     }
 }

--- a/forge/csrc/passes/remove_nops.cpp
+++ b/forge/csrc/passes/remove_nops.cpp
@@ -17,7 +17,6 @@ void remove_nops(graphlib::Graph *graph) {
             continue;
 
         if (op->op_name() == "nop") {
-            log_warning("Removing nop: {}", op->name());
             graphlib::bypass_node(graph, node, true);
         }
     }

--- a/forge/csrc/passes/split_graph.cpp
+++ b/forge/csrc/passes/split_graph.cpp
@@ -1,0 +1,355 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "split_graph.hpp"
+
+#include <memory>
+#include <utils/assert.hpp>
+#include <utils/logger.hpp>
+
+#include "forge_graph_module.hpp"
+#include "graph_lib/defines.hpp"
+#include "graph_lib/graph.hpp"
+#include "graph_lib/node.hpp"
+#include "graph_lib/node_types.hpp"
+#include "graph_lib/utils.hpp"
+#include "reportify/reportify.hpp"
+
+using Graph = tt::graphlib::Graph;
+
+namespace tt::passes
+{
+
+bool is_parameter_node(const tt::graphlib::Node *node)
+{
+    return node->node_type() == graphlib::NodeType::kInput && node->as<graphlib::InputNode>()->is_parameter();
+}
+
+bool is_loss_input_node(const tt::graphlib::Node *node)
+{
+    return node->node_type() == graphlib::NodeType::kInput && node->as<graphlib::InputNode>()->is_loss();
+}
+
+void clone_and_add(const graphlib::Node *node, Graph *new_graph)
+{
+    auto cloned_node = node->clone(node->name());
+    new_graph->add_node(std::move(cloned_node), 0 /*subgraph_id=*/);
+}
+
+// 1. Clone a node from the source graph
+// 2. Add it to the dest graph
+// 3. Replicate all operand edges from the source graph to the dest graph
+void clone_and_connect_operands(const graphlib::Graph *src_graph, const graphlib::Node *src_node, Graph *dst_graph)
+{
+    auto cloned_node = src_node->clone(src_node->name());
+    dst_graph->add_node(std::move(cloned_node), 0 /*subgraph_id=*/);
+
+    auto &src_node_name = src_node->name();
+
+    for (auto operand : src_graph->operands(src_node))
+    {
+        TT_ASSERT(
+            dst_graph->has_node_with_name(operand->name()),
+            "Expected operand {} to be present in the destination graph",
+            operand->name());
+        auto dst_operand = dst_graph->get_node_by_name(operand->name());
+        dst_graph->add_edge(dst_operand, dst_graph->get_node_by_name(src_node_name));
+    }
+}
+
+bool has_users_in_bwd(const Graph *graph, const graphlib::Node *node)
+{
+    auto user_edges = graph->user_data_edges(node);
+
+    return std::any_of(
+        user_edges.begin(),
+        user_edges.end(),
+        [graph](const graphlib::Edge &edge) { return graph->node_by_id(edge.consumer_node_id)->is_backward(); });
+}
+
+bool needs_intermediate_output(const Graph *graph, const graphlib::Node *node)
+{
+    if (!node->is_forward() || node->node_type() != graphlib::NodeType::kPyOp)
+    {
+        return false;
+    }
+
+    // Intermediate node is needed if an op in forward graph has a data user in the backward graph.
+    bool has_bwd_user = has_users_in_bwd(graph, node);
+
+    // Don't add duplicate intermediate output nodes.
+    auto user_edges = graph->user_data_edges(node);
+
+    bool has_output_node_already = std::any_of(
+        user_edges.begin(),
+        user_edges.end(),
+        [graph](const graphlib::Edge &edge)
+        { return graph->node_by_id(edge.consumer_node_id)->node_type() == graphlib::NodeType::kOutput; });
+
+    return has_bwd_user && !has_output_node_already;
+}
+
+// Create a forward graph by extracting all forward nodes from the original graph.
+// The forward graph also needs to have intermediate output nodes for ops that have data users in the backward graph.
+std::unique_ptr<Graph> extract_forward_graph(const Graph *graph, const std::vector<graphlib::Node *> &topo)
+{
+    auto fwd_graph = std::make_unique<Graph>(tt::graphlib::IRLevel::IR_TT_FORGE, "forward");
+    fwd_graph->set_training(graph->training());
+
+    // Create a forward graph by cloning all forward nodes from the original graph.
+    // Also, establish the same data edges between forward nodes as in the original graph.
+    for (auto node : topo)
+    {
+        if (!node->is_forward())
+        {
+            continue;
+        }
+
+        clone_and_connect_operands(graph, node, fwd_graph.get());
+    }
+
+    // Add all the module inputs to the forward graph (keeping the same order as in the original graph).
+    std::vector<graphlib::NodeId> fwd_module_inputs;
+    for (auto input : graph->ordered_module_inputs())
+    {
+        if (input->is_forward())
+        {
+            log_debug("Adding input node {} to inputs", input->name());
+            fwd_module_inputs.push_back(fwd_graph->get_node_by_name(input->name())->id());
+        }
+    }
+
+    fwd_graph->register_module_inputs(fwd_module_inputs);
+
+    // Since we are splitting the graph, we need to add intermediate output nodes for all ops which will have
+    // data users outside of this graph.
+    std::vector<graphlib::NodeId> fwd_intermediates;
+    for (auto node : graph->nodes())
+    {
+        if (needs_intermediate_output(graph, node))
+        {
+            auto intermediate_name = node->name() + "_intermediate";
+
+            log_debug("Adding intermediate output node {}", intermediate_name);
+            auto intermediate_output = graphlib::create_node<graphlib::OutputNode>(intermediate_name);
+            intermediate_output->set_intermediate(true);
+            intermediate_output->set_shape(node->shape());
+            intermediate_output->set_output_df(node->output_df());
+
+            auto intermediate_output_node = fwd_graph->add_node(std::move(intermediate_output), 0 /*subgraph_id=*/);
+            fwd_graph->add_edge(fwd_graph->get_node_by_name(node->name()), intermediate_output_node);
+
+            fwd_intermediates.push_back(intermediate_output_node->id());
+        }
+    }
+
+    for (auto output : graph->ordered_module_outputs())
+    {
+        log_debug("Adding node {} to fwd module outputs", output->name());
+        auto fwd_output = fwd_graph->get_node_by_name(output->name());
+        fwd_graph->register_module_outputs({fwd_output->id()}, true /* append */);
+
+        TT_ASSERT(
+            graph->data_operands(output).size() == 1, "Expected only one operand for output node {}", output->name());
+        auto output_producer = graph->data_operands(output)[0];
+
+        if (has_users_in_bwd(graph, output_producer))
+        {
+            log_debug("Marking output node {} as intermediate!", output->name());
+            fwd_output->as<graphlib::OutputNode>()->set_intermediate(true);
+        }
+    }
+
+    fwd_graph->register_module_outputs(fwd_intermediates, true /* append */);
+
+    return fwd_graph;
+}
+
+std::unique_ptr<Graph> extract_backward_graph(
+    const Graph *graph, const Graph *fwd_graph, const std::vector<graphlib::Node *> &topo)
+{
+    auto bwd_graph = std::make_unique<Graph>(tt::graphlib::IRLevel::IR_TT_FORGE, "backward");
+    bwd_graph->set_training(graph->training());
+
+    // Adding all the intermediate outputs from the forward graph as inputs to the backward graph.
+    auto fwd_intermediate_outputs = fwd_graph->ordered_intermediates();
+    std::vector<graphlib::NodeId> bwd_intermediate_inputs;
+
+    bwd_intermediate_inputs.reserve(fwd_intermediate_outputs.size());
+    for (auto intermediate_output : fwd_intermediate_outputs)
+    {
+        log_debug("Adding intermediate output {} as input to bwd graph", intermediate_output->name());
+        auto intermediate_output_node = graphlib::create_node<graphlib::InputNode>(
+            intermediate_output->name(), graphlib::InputNodeType::Activation, false);
+        intermediate_output_node->set_shape(intermediate_output->shape());
+        intermediate_output_node->set_output_df(intermediate_output->output_df());
+
+        auto added_node = bwd_graph->add_node(std::move(intermediate_output_node), 0 /*subgraph_id=*/);
+        bwd_intermediate_inputs.push_back(added_node->id());
+    }
+
+    // For all inputs for the forward graph that have users in the backward graph,
+    // clone them and add them to the backward graph.
+    for (auto input : graph->ordered_module_inputs())
+    {
+        if (input->is_forward())
+        {
+            bool has_bwd_user = has_users_in_bwd(graph, input);
+
+            if (has_bwd_user)
+            {
+                log_debug("Adding input node {} as input to bwd graph", input->name());
+                clone_and_add(input, bwd_graph.get());
+            }
+        }
+    }
+
+    for (auto node : topo)
+    {
+        if (!node->is_backward())
+        {
+            continue;
+        }
+
+        if (node->node_type() == graphlib::NodeType::kQueue)
+        {
+            auto queue_node = node->as<graphlib::QueueNode>();
+
+            // Previous compiler passes shouldn't have added any other type of queue nodes.
+            TT_ASSERT(queue_node->is_grad_accumulator(), "Expected only grad accumulator queue nodes in the graph");
+
+            // For grad accumulator queue nodes, we need to add an output node to the backward graph.
+            TT_ASSERT(
+                graph->operand_data_edges(queue_node).size() == 1,
+                "Expected only one operand edge for grad accumulator queue node");
+            auto operand = graph->data_operands(queue_node)[0];
+
+            auto output_node = graphlib::create_node<graphlib::OutputNode>(queue_node->name() + "_grad_accumulator");
+            output_node->set_shape(queue_node->shape());
+            output_node->set_output_df(queue_node->output_df());
+            auto grad_out = bwd_graph->add_node(std::move(output_node), 0 /*subgraph_id=*/);
+
+            // Since we are traversing the graph in topological order, the operand node should already be present in the
+            // backward graph.
+            TT_ASSERT(
+                bwd_graph->has_node_with_name(operand->name()),
+                "Expected operand {} to be present in the backward graph",
+                operand->name());
+
+            auto cloned_operand = bwd_graph->get_node_by_name(operand->name());
+            bwd_graph->add_edge(cloned_operand, grad_out, 0, 0, graphlib::EdgeType::kData);
+
+            continue;
+        }
+
+        clone_and_add(node, bwd_graph.get());
+
+        for (auto operand : graph->data_operands(node))
+        {
+            if (bwd_graph->has_node_with_name(operand->name()))
+            {
+                bwd_graph->add_edge(
+                    bwd_graph->get_node_by_name(operand->name()), bwd_graph->get_node_by_name(node->name()));
+                continue;
+            }
+
+            if (operand->is_forward())
+            {
+                auto fwd_operand = fwd_graph->get_node_by_name(operand->name());
+                auto users = fwd_graph->data_users(fwd_operand);
+
+                for (auto user : users)
+                {
+                    if (user->node_type() == graphlib::NodeType::kOutput)
+                    {
+                        // Find the intermediate output node in the fwd graph
+                        if (bwd_graph->has_node_with_name(user->name()))
+                        {
+                            bwd_graph->add_edge(
+                                bwd_graph->get_node_by_name(user->name()), bwd_graph->get_node_by_name(node->name()));
+                            continue;
+                        }
+
+                        auto intermediate_input_node = graphlib::create_node<graphlib::InputNode>(
+                            user->name(), graphlib::InputNodeType::Activation, false);
+                        intermediate_input_node->set_shape(user->shape());
+                        intermediate_input_node->set_output_df(user->output_df());
+
+                        bwd_graph->add_node(std::move(intermediate_input_node), 0 /*subgraph_id=*/);
+                        bwd_graph->add_edge(
+                            bwd_graph->get_node_by_name(user->name()), bwd_graph->get_node_by_name(node->name()));
+                    }
+                }
+            }
+        }
+    }
+
+    // We will construct backward inputs in the following order:
+    // 1. Inputs that are exclusive to the backward graph
+    // 2. Intermediate outputs from the forward graph
+    // 3. Inputs from the forward graph that have users in the backward graph
+    std::vector<graphlib::NodeId> bwd_module_inputs;
+    for (auto input : graph->ordered_module_inputs())
+    {
+        if (input->is_backward())
+        {
+            bwd_module_inputs.push_back(bwd_graph->get_node_by_name(input->name())->id());
+        }
+    }
+
+    for (auto input : fwd_graph->ordered_module_outputs())
+    {
+        if (bwd_graph->has_node_with_name(input->name()))
+        {
+            bwd_module_inputs.push_back(bwd_graph->get_node_by_name(input->name())->id());
+        }
+    }
+
+    for (auto input : graph->ordered_module_inputs())
+    {
+        if (input->is_forward())
+        {
+            if (bwd_graph->has_node_with_name(input->name()))
+            {
+                bwd_module_inputs.push_back(bwd_graph->get_node_by_name(input->name())->id());
+            }
+        }
+    }
+
+    bwd_graph->register_module_inputs(bwd_module_inputs);
+
+    std::vector<graphlib::NodeId> bwd_module_outputs;
+    for (auto output : bwd_graph->nodes_by_type(graphlib::NodeType::kOutput))
+    {
+        bwd_module_outputs.push_back(output->id());
+    }
+
+    bwd_graph->register_module_outputs(bwd_module_outputs);
+    return bwd_graph;
+}
+
+// Splits the graph into multiple graphs which will be lowered to MLIR as different functions.
+ForgeGraphModule split_graph(graphlib::Graph *graph)
+{
+    auto topo = graphlib::topological_sort(*graph);
+
+    auto fwd_graph = extract_forward_graph(graph, topo);
+    reportify::dump_graph(graph->name(), "extracted_fwd", fwd_graph.get());
+
+    ForgeGraphModule module(graph->name(), fwd_graph.release());
+
+    if (!graph->training())
+    {
+        // We're not in training mode, so we don't need to split the graph further.
+        return module;
+    }
+
+    auto bwd_graph = extract_backward_graph(graph, module.get_graph(GraphType::Forward), topo);
+    reportify::dump_graph(graph->name(), "extracted_bwd", bwd_graph.get());
+
+    module.set_graph(GraphType::Backward, bwd_graph.release());
+    return module;
+}
+
+}  // namespace tt::passes

--- a/forge/csrc/passes/split_graph.hpp
+++ b/forge/csrc/passes/split_graph.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include "forge_graph_module.hpp"
+
+namespace tt::graphlib
+{
+    class Graph;
+}
+
+namespace tt::passes 
+{
+    // Split the graph into multiple graphs which will lower to different MLIR programs,
+    // i.e. forward, backward, etc.
+    ForgeGraphModule split_graph(tt::graphlib::Graph* graph);
+
+} // namespace tt:passes
+

--- a/forge/csrc/reportify/reportify.cpp
+++ b/forge/csrc/reportify/reportify.cpp
@@ -183,7 +183,7 @@ json node_to_json(const graphlib::Node* node, const graphlib::Graph* graph)
         ret_json["is_cross_epoch_type"] = node->as<graphlib::QueueNode>()->is_epoch_to_epoch() and
                                           node->as<graphlib::EpochToEpochQueueNode>()->is_cross_epoch_type();
         ret_json["memory_access"] = node->as<graphlib::QueueNode>()->memory_access_type_string();
-        ret_json["is_saved_intermediate"] = node->as<graphlib::OutputNode>()->is_saved_intermediate();
+        ret_json["is_intermediate"] = node->as<graphlib::OutputNode>()->is_intermediate();
     }
     else if (node->node_type() == graphlib::NodeType::kPyOp)
     {

--- a/forge/forge/config.py
+++ b/forge/forge/config.py
@@ -26,9 +26,10 @@ class CompileDepth(Enum):
     AUTOGRAD = 6
     POST_AUTOGRAD_PASS = 7
     PRE_LOWERING_PASS = 8
-    RUN_MLIR_COMPILER = 9
-    FINISH_COMPILE = 10
-    FULL = 11
+    SPLIT_GRAPH = 9
+    RUN_MLIR_COMPILER = 10
+    FINISH_COMPILE = 11
+    FULL = 12
 
     @classmethod
     def has_value(cls, value):

--- a/forge/forge/fx/capture.py
+++ b/forge/forge/fx/capture.py
@@ -274,7 +274,6 @@ class CaptureFX:
     
         module_inputs = []
         output_nids = []
-        output_requires_grad = []
         output_tensors = []
 
         device_graph = copy.deepcopy(aten_module.graph)
@@ -347,14 +346,13 @@ class CaptureFX:
                     o_nids, o_tensors, o_requires_grad = self.add_outputs(node, graph_idx)
                     output_nids.extend(o_nids)
                     output_tensors.extend(o_tensors)
-                    output_requires_grad.extend(o_requires_grad)
                 else:
                     assert False, f"Unsupported op {node.op}"
         
             self.output_nodes_per_subgraph[graph_idx].append(output_nids)
 
         self.get_forge_graph().register_module_inputs(module_inputs, append=True)
-        self.get_forge_graph().register_module_outputs(output_nids, output_requires_grad, append=True)
+        self.get_forge_graph().register_module_outputs(output_nids, append=True)
         return True, graph_inputs, self.id_to_intermed, output_tensors, schedule
     
 def generate_device_inputs_from_sample_inputs(inputs: List[torch.Tensor], schedule: Schedule) -> List[List[torch.Tensor]]:

--- a/forge/forge/fx/nodes.py
+++ b/forge/forge/fx/nodes.py
@@ -673,7 +673,7 @@ def append_to_graph(graph, module, aten_module, activations, subgraph_idx, input
             assert False, f"Unsupported op {node.op}"
 
     graph.register_module_inputs(module_inputs, append=True)
-    graph.register_module_outputs(output_nids, output_requires_grad, append=True)
+    graph.register_module_outputs(output_nids, append=True)
 
     output_nodes_per_subgraph[subgraph_idx] = output_nids
     return graph, id_to_intermed, output_tensors

--- a/forge/forge/tvm.py
+++ b/forge/forge/tvm.py
@@ -845,7 +845,7 @@ def compile_tvm_for_forge(forge_graph, torchmod, inputs, compiler_cfg, graph_nam
 
     # TODO: figure out how to get requires_grad for output nodes?
     forge_graph.register_module_inputs(ordered_input_bids)
-    forge_graph.register_module_outputs(ordered_output_bids, [True] * len(ordered_output_bids))
+    forge_graph.register_module_outputs(ordered_output_bids)
 
     forge_inputs = []
     for forge_input in input_nodes:

--- a/forge/test/mlir/mnist/test_inference.py
+++ b/forge/test/mlir/mnist/test_inference.py
@@ -17,4 +17,4 @@ def test_mnist_inference():
     co_out = compiled_model(*inputs)
 
     co_out = [co.to("cpu") for co in co_out]
-    assert [compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)]
+    assert compare_with_golden_pcc(golden=fw_out, calculated=co_out[0], pcc=0.99)

--- a/forge/test/mlir/mnist/training/test_training.py
+++ b/forge/test/mlir/mnist/training/test_training.py
@@ -6,15 +6,21 @@ import torch
 from torch import nn
 
 import forge
-from .utils import *
+from ..utils import *
+from forge.op.eval.common import compare_with_golden
+
+from loguru import logger
 
 def test_mnist_training():
     torch.manual_seed(0)
 
     # Config
-    num_epochs = 9
-    batch_size = 64
-    learning_rate = 0.005
+    num_epochs = 3
+    batch_size = 1
+    learning_rate = 0.001
+
+    # Limit number of batches to run - quicker test
+    limit_num_batches = 1000
     
     # Load dataset
     test_loader, train_loader = load_dataset(batch_size)
@@ -24,46 +30,61 @@ def test_mnist_training():
     
     # Define model and instruct it to compile and run on TT device
     framework_model = MNISTLinear()
-    tt_model = forge.compile(framework_model)
-    tt_model.to("tt")
 
     # Create a torch loss and leave on CPU
-    loss = torch.nn.L1Loss()
+    loss_fn = torch.nn.CrossEntropyLoss()
 
     # Define optimizer and instruct it to compile and run on TT device
     framework_optimizer = torch.optim.SGD(framework_model.parameters(), lr=learning_rate)
-    tt_optimizer = forge.compile(framework_optimizer)
-    tt_optimizer.to("tt")
+    tt_model = forge.compile(framework_model, sample_inputs=[torch.rand(batch_size, 784)], loss=loss_fn, optimizer=framework_optimizer)
 
+    logger.info("Starting training loop... (logger will be disabled)")
+    logger.disable("")
     for epoch_idx in range(num_epochs):
+        # Reset gradients (every epoch) - since our batch size is currently 1,
+        # we accumulate gradients across multiple batches (limit_num_batches),
+        # and then run the optimizer.
+        framework_optimizer.zero_grad()
+
+        total_loss = 0
         for batch_idx, (data, target) in enumerate(train_loader):
-            # Put inputs on device
-            data = data.to("tt")
-            
+
             # Create target tensor and leave on CPU
             target = nn.functional.one_hot(target, num_classes=10).float()
 
-            # Reset gradients (every batch)
-            tt_optimizer.zero_grad()
-            
             # Forward pass (prediction) on device
-            pred = tt_model(data)
-            
-            # Pull output back to CPU
-            pred = pred.to("cpu")
+            pred = tt_model(data)[0]
+            golden_pred = framework_model(data)
+            compare_with_golden(golden_pred, pred)
 
             # Compute loss on CPU
-            loss = tt_loss(pred, target)
+            loss = loss_fn(pred, target)
+            total_loss += loss.item()
+
+            golden_loss = loss_fn(golden_pred, target)
+            compare_with_golden(golden_loss, loss)
             
-            # RUn backward pass on device
+            # Run backward pass on device
             loss.backward()
             
-            # Adjust weights (on device)
-            tt_optimizer.step()
+            tt_model.backward(pred.grad)
 
-            # Log gradients
-            for name, param in tt_model.named_parameters():
-                writer.add_histogram(f"{name}.grad", param.grad, batch_idx)
+            if batch_idx >= limit_num_batches:
+                break
 
-            # Log loss
-            writer.add_scalar("Loss", loss.item(), batch_idx)
+        print(f"epoch: {epoch_idx} loss: {total_loss}")
+
+        # Adjust weights (on CPU)
+        framework_optimizer.step()
+
+    test_loss = 0
+    for batch_idx, (data, target) in enumerate(test_loader):
+        pred = tt_model(data)[0]
+        target = nn.functional.one_hot(target, num_classes=10).float()
+
+        test_loss += loss_fn(pred, target)
+
+        if batch_idx == 1000:
+            break
+
+    print(f"Test (total) loss: {test_loss}")

--- a/forge/test/mlir/mnist/utils.py
+++ b/forge/test/mlir/mnist/utils.py
@@ -28,7 +28,6 @@ class MNISTLinear(nn.Module):
         return nn.functional.softmax(x)
 
 
-
 def load_tb_writer():
     """
     Load TensorBoard writer for logging
@@ -60,6 +59,6 @@ def load_dataset(batch_size):
     )
 
     train_loader = DataLoader(train_dataset, batch_size=batch_size, shuffle=True)
-    test_loader = DataLoader(test_dataset, batch_size=1000, shuffle=False)
+    test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False)
 
     return test_loader, train_loader

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,7 @@ testpaths =
 
     # MNIST Linear
     forge/test/mlir/mnist/test_inference.py
+    forge/test/mlir/mnist/training/test_training.py
     forge/test/mlir/test_training.py
 
     # Llama


### PR DESCRIPTION
A pass is added, which takes the forge graph and creates a `ForgeGraphModule`, by splitting the forward and backward parts of the graph.

Since we are currently executing forward and backward pass as separate programs (functions) within a binary, splitting the graphs seems to be the natural approach.

Forward graph is created by cloning the forward nodes of the original graph, and adding output nodes for all the intermediate results the backward pass will need.

The backward graph is constructed from backward nodes of the original graph and utilizing the intermediate results from the forward graph. For each gradient an output node is created.

The `CompiledModel` is updated to have the state from both graphs.  Additionally, `CompiledGraphState` is cleaned up a little - removing the unused stuff.

In `lower_to_mlir()` removed the previous hacks - now we simply emit mlir function for each graph in `ForgeGraphModule` and no special hacks are needed for getting inputs/params/outputs of each graph.

This change enables MNIST Linear training to work.

Closes #100 #163