### PR TITLE
Automatically create uplift PR for tt-mlir

### DIFF
--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -1,42 +1,36 @@
 # This workflow automates creation of uplift pull requests.
 # Uplift PR is created daily to uplift the submodule to the latest version.
 
-name: Nighty Uplift PR
+name: Nighty Uplift
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 8 * * *'  # Runs at 08:00 UTC every day
+  workflow_dispatch:  # Manual trigger
+  push:
 
 jobs:    
   uplift-pr:    
-    runs-on: ubuntu-latest    
+    runs-on: ubuntu-latest
+
+    env:
+      SUBMODULE_PATH: third_party/tt-mlir
+      SUBMODULE_VERSION: origin/main
+
     steps:
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0 # Fetch all history and tags
+          ref: main
 
       - name: Set env variable
         run: |
           echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
-      - name: Create uplift PR
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          UPLIFT_BRANCH: uplift-${{ env.TODAY }}
-          SUBMODULE_PATH: third_party/tt-mlir
-          SUBMODULE_VERSION: origin/main
-        run: |
-            git config --global user.email ci@tenstorrent.com
-            git config --global user.name "Tenstorrent CI"
-            
-            if git branch -a | grep -q "remotes/origin/uplift-"; then
-              echo "### Branch already exists on remote ###"
-              exit 0
-            fi
 
-            git checkout main
-            git checkout -b $UPLIFT_BRANCH
+      - name: Create uplift PR
+        run: |
             cd $SUBMODULE_PATH
             git fetch origin
             git checkout $SUBMODULE_VERSION
@@ -44,19 +38,33 @@ jobs:
             git log -1
             cd ../..
 
-            if [ -z "$(git status --porcelain)" ]; then
-              echo "### No changes in $SUBMODULE_PATH ###"
-              exit 0
-            fi
-            echo "### Commit change and create PR ###"
-            git add $SUBMODULE_PATH
-            git commit -m "Uplift $SUBMODULE_PATH to $SUBMODULE_VERSION $TODAY"
-            git push origin $UPLIFT_BRANCH --force
-
-            gh pr create \
-            --title "Uplift $SUBMODULE_PATH to $SUBMODULE_VERSION $TODAY" \
-            --body "This PR uplifts the $SUBMODULE_PATH submodule to the $SUBMODULE_VERSION." \
-            --base main \
-            --head $UPLIFT_BRANCH \
-            --label uplift \
-            --reviewer ${{ vars.INTEGRATION_OWNER }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        id: create-pr
+        with:
+          branch: uplift
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          base: main
+          commit-message: "Uplift $SUBMODULE_PATH to $SUBMODULE_VERSION $TODAY"
+          title: "Uplift $SUBMODULE_PATH to $SUBMODULE_VERSION $TODAY"
+          body: "This PR uplifts the $SUBMODULE_PATH submodule to the $SUBMODULE_VERSION."          
+          labels: uplift
+          reviewers: ${{ vars.INTEGRATION_OWNER }}
+          delete-branch: true
+          token: ${{ secrets.GH_TOKEN }}
+          
+      - name: Approve Pull Request
+        if: ${{ steps.create-pr.outputs.pull-request-number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Pull Request Number - ${{ steps.create-pr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.create-pr.outputs.pull-request-url }}"        
+          gh pr review ${{ steps.create-pr.outputs.pull-request-number }} --approve      
+          
+      - name: Enable Pull Request Automerge
+        if: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: gh pr merge --merge --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -46,9 +46,9 @@ jobs:
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           base: main
-          commit-message: "Uplift $SUBMODULE_PATH to $SUBMODULE_VERSION $TODAY"
-          title: "Uplift $SUBMODULE_PATH to $SUBMODULE_VERSION $TODAY"
-          body: "This PR uplifts the $SUBMODULE_PATH submodule to the $SUBMODULE_VERSION."          
+          commit-message: "Uplift ${{ env.SUBMODULE_PATH }} to ${{ env.SUBMODULE_VERSION }} ${{ env.TODAY }}"
+          title: "Uplift ${{ env.SUBMODULE_PATH }} to ${{ env.SUBMODULE_VERSION }} ${{ env.TODAY }}"
+          body: "This PR uplifts the ${{ env.SUBMODULE_PATH }} submodule to the ${{ env.SUBMODULE_VERSION }}"          
           labels: uplift
           delete-branch: true
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Approve Pull Request
         if: ${{ steps.create-pr.outputs.pull-request-number }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           echo "Pull Request Number - ${{ steps.create-pr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.create-pr.outputs.pull-request-url }}"        

--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -7,7 +7,6 @@ on:
   schedule:
     - cron: '0 8 * * *'  # Runs at 08:00 UTC every day
   workflow_dispatch:  # Manual trigger
-  push:
 
 jobs:    
   uplift-pr:    
@@ -29,7 +28,7 @@ jobs:
         run: |
           echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
 
-      - name: Create uplift PR
+      - name: Update submodule
         run: |
             cd $SUBMODULE_PATH
             git fetch origin

--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -50,7 +50,6 @@ jobs:
           title: "Uplift $SUBMODULE_PATH to $SUBMODULE_VERSION $TODAY"
           body: "This PR uplifts the $SUBMODULE_PATH submodule to the $SUBMODULE_VERSION."          
           labels: uplift
-          reviewers: ${{ vars.INTEGRATION_OWNER }}
           delete-branch: true
           token: ${{ secrets.GH_TOKEN }}
           


### PR DESCRIPTION
Creates uplift PR every day to update tt-mlir submodule to the latest version.

- runs standard PR check
- auto approves PR
- enables auto-merge 

Uplift PR is created using action peter-evans/create-pull-request, more details on the exact behavior can be found [here](https://github.com/peter-evans/create-pull-request) :

> The default behaviour of the action is to create a pull request that will be continually updated with new changes until it is merged or closed. Changes are committed and pushed to a fixed-name branch, the name of which can be configured with the branch input. Any subsequent changes will be committed to the same branch and reflected in the open pull request.
> 
> How the action behaves:
> 
> If there are changes (i.e. a diff exists with the checked-out base branch), the changes will be pushed to a new branch and a pull request created.
> If there are no changes (i.e. no diff exists with the checked-out base branch), no pull request will be created and the action exits silently.
> If a pull request already exists it will be updated if necessary. Local changes in the Actions workspace, or changes on the base branch, can cause an update. If no update is required the action exits silently.
> If a pull request exists and new changes on the base branch make the pull request unnecessary (i.e. there is no longer a diff between the pull request branch and the base), the pull request is automatically closed. Additionally, if delete-branch is set to true the branch will be deleted.

We have similar action [here](https://github.com/tenstorrent/pytorch2.0_ttnn/blob/main/.github/workflows/update-ttnn-wheel.yaml)