### PR TITLE
[Ops] Add support for reduce_max(ttnn.max)

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -523,6 +523,7 @@ class MLIRGenerator
             lowering_handler_map["multiply"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MultiplyOp>;
             lowering_handler_map["reciprocal"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ReciprocalOp>;
             lowering_handler_map["reduce_avg"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MeanOp>;
+            lowering_handler_map["reduce_max"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MaxOp>;
             lowering_handler_map["reduce_sum"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::SumOp>;
             lowering_handler_map["relu"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ReluOp>;
             lowering_handler_map["reshape"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ReshapeOp>;

--- a/forge/forge/op/eval/forge/reduce.py
+++ b/forge/forge/op/eval/forge/reduce.py
@@ -23,17 +23,7 @@ def eval(type, attr, ops):
         "reduce_max": lambda i: torch.max(t_ops[0], dim=attr[0], keepdim=True)[0],
     }
 
-    if len(attr) == 2 and type == "reduce_max" and attr[0] == -3:
-        z = attr[1]
-        assert t_ops[0].shape[-3] % z == 0
-        ret = t_ops[0].squeeze(0)
-        squeeze_failed = False
-        if len(ret.shape) == len(t_ops[0].shape):
-            squeeze_failed = True
-        ret = t_ops[0].squeeze(0).split(z)
-        ret = [torch.max(s, dim=0)[0] for s in ret]
-        result = torch.stack(ret).unsqueeze(0) if not squeeze_failed else torch.stack(ret)
-    elif type == "grouped_reduce_avg":
+    if type == "grouped_reduce_avg":
         keep_dims = attr[2]
         groups = attr[1]
         dim = attr[0]

--- a/forge/forge/op/reduce.py
+++ b/forge/forge/op/reduce.py
@@ -109,9 +109,10 @@ def ReduceMax(
         name: str,
         operandA: Tensor,
         dim: int,
-        stride: int = -1) -> Tensor:
+        stride: int = -1,
+        keep_dim: bool = True) -> Tensor:
     """
-    Reduce by averaging along the given dimension
+    Reduce by taking maximum along the given dimension
 
     Parameters
     ----------
@@ -135,4 +136,4 @@ def ReduceMax(
     # if dim < 0:
     #     dim += 4
 
-    return op("reduce_max", name, operandA, attrs=(dim,stride)).get_tensor()
+    return op("reduce_max", name, operandA, attrs=(dim,stride), dim_arg=[dim], keep_dim=keep_dim).get_tensor()

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -907,13 +907,16 @@ def populate_reduce_args(graph, nid, compiler_cfg):
     dim = int(node["attrs"]["axis"][0][0])
     assert len(node['attrs']['axis'][0]) == 1, "Forge only supports reduce with a single axis"
 
+    keep_dim = int(node["attrs"]["keepdims"][0][0])    
+    assert keep_dim, f"Forge {node['op']} only support keep_dim = True" 
+
     input_nid = node["inputs"][0][0]
     input_shape = graph["nodes"][input_nid]["attrs"]["shape"][0][0]
     
     if dim >= 0:
         dim -= len(input_shape)
 
-    args = [("dim", f"{dim}"),]
+    args = [("dim", f"{dim}"),("keep_dim", f"{bool(keep_dim)}")]
     return args
 
 def populate_select_args(graph, nid, compiler_cfg):


### PR DESCRIPTION
Add support for reduce_max op in Forge

Raised issue in ttnn.max op:
- Unsupported dim - [https://github.com/tenstorrent/tt-metal/issues/13186](https://github.com/tenstorrent/tt-metal/issues/13186)
- Shape mismatch along the H and W dimension - [https://github.com/tenstorrent/tt-metal/issues/13189](https://github.com/tenstorrent/tt-metal/issues/13189)
- Tensor rank is not 4 - [https://github.com/tenstorrent/tt-metal/issues/13190](https://github.com/tenstorrent/tt-metal/issues/13190)

Fixes #139 