### PR TITLE
Use different token for auto approval

### DIFF
--- a/.github/workflows/nightly-uplift.yml
+++ b/.github/workflows/nightly-uplift.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Approve Pull Request
         if: ${{ steps.create-pr.outputs.pull-request-number }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_APPROVE_TOKEN }}
         run: |
           echo "Pull Request Number - ${{ steps.create-pr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.create-pr.outputs.pull-request-url }}"        


### PR DESCRIPTION
We should use different token for approval step.
"failed to create review: GraphQL: Can not approve your own pull request (addPullRequestReview)" Switching to use GH_APPROVE_TOKEN