### PR TITLE
Update RMS normalization and reduce_mean tests

### DIFF
--- a/forge/test/mlir/llama/tests/test_llama_rms_norm.py
+++ b/forge/test/mlir/llama/tests/test_llama_rms_norm.py
@@ -9,7 +9,6 @@ from test.mlir.llama.utils.utils import load_model
 from forge.op.eval.common import compare_with_golden_pcc
 
 
-@pytest.mark.xfail()
 def test_llama_lm_head():
     # Load Llama 3B model and tokenizer
     framework_model = load_model()


### PR DESCRIPTION
1.  #125 - Test passed(i.e [forge/test/mlir/llama/tests/test_llama_rotary_emb.py](https://github.com/tenstorrent/tt-forge-fe/blob/3817b9b2e559cb97497e035c7cf62e69bac455b3/forge/test/mlir/llama/tests/test_llama_rotary_emb.py))

2. #114
        There are two test cases in the [forge/test/mlir/test_ops.py](https://github.com/tenstorrent/tt-forge-fe/blob/main/forge/test/mlir/test_ops.py)
        [test_reduce_mean](https://github.com/tenstorrent/tt-forge-fe/blob/3817b9b2e559cb97497e035c7cf62e69bac455b3/forge/test/mlir/test_ops.py#L361)
In this test cases, **TTNN: Issues with ttnn implicit reshape is resolved**
The below test cases alone is failing with pcc issue (PCC: 0.7203957195745748)
`pytest forge/test/mlir/test_ops.py::test_reduce_mean[-1-input_shape2] -vss `
[test_mean](https://github.com/tenstorrent/tt-forge-fe/blob/3817b9b2e559cb97497e035c7cf62e69bac455b3/forge/test/mlir/test_ops.py#L416)
In this test cases, the **FFE: Unsupported squeeze operation** issue is resolved, now all the test cases here are failing with `Unable to reshape a tensor in TILE_LAYOUT to non-tile height and width! Please convert the tensor to ROW_MAJOR_LAYOUT first` issue.