### PR TITLE
[bugfix]: Setting forge tensor dataformat to int32 instead of int8 when torch tensor is int64

### DIFF
--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -588,8 +588,8 @@ def pytorch_dtype_to_forge_dataformat(dtype: torch.dtype, fp32_fallback: Optiona
         return DataFormat.Int32
 
     if dtype == torch.int64:
-        logger.warning("Parameter is int64. Setting to int8 for now.")
-        return DataFormat.Int8
+        logger.warning("Parameter is int64. Setting to int32, since int64 is not supported .")
+        return DataFormat.Int32
     
 
     raise RuntimeError("Unsupported torch dtype " + str(dtype))


### PR DESCRIPTION
Solves #356. In `pytorch_dtype_to_forge_dataformat` pytorch dataformats are casted to forge dataformat. Since forge doesn't support int64 it has to be casted to some lower precision data format. Closest data format we support is int32 so we cast it to that, along with the warning.