### PR TITLE
[training] add unit tests for split graph pass

### DIFF
--- a/forge/csrc/autograd/autograd.hpp
+++ b/forge/csrc/autograd/autograd.hpp
@@ -19,7 +19,7 @@ namespace tt {
 
 namespace autograd2 {
 
-struct __attribute__ ((visibility ("hidden"))) autograd_config {
+struct autograd_config {
     bool recompute = false; // Add recompute
     py::object optimizer = py::none();
 };
@@ -30,7 +30,7 @@ using Node = graphlib::Node;
 using Graph = graphlib::Graph;
 using NodeContext = graphlib::NodeContext;
 
-class __attribute__ ((visibility ("hidden"))) autograd2_engine {
+class autograd2_engine {
 
 private:
     tt::graphlib::Graph *graph;

--- a/forge/csrc/forge_graph_module.hpp
+++ b/forge/csrc/forge_graph_module.hpp
@@ -16,7 +16,7 @@ namespace tt
 
 namespace graphlib
 {
-    class Graph;
+class Graph;
 }
 
 enum class GraphType : std::uint8_t
@@ -45,7 +45,7 @@ using StaticGraphArray = std::array<graphlib::Graph*, GRAPH_TYPE_COUNT>;
  */
 class ForgeGraphModule
 {
-public:
+   public:
     ForgeGraphModule(std::string name, graphlib::Graph* forward_graph) : name_(name), graphs_{nullptr}
     {
         TT_ASSERT(forward_graph != nullptr);
@@ -58,10 +58,7 @@ public:
         graphs_[to_underlying(type)] = graph;
     }
 
-    graphlib::Graph* get_graph(GraphType type) const
-    {
-        return graphs_[to_underlying(type)];
-    }
+    graphlib::Graph* get_graph(GraphType type) const { return graphs_[to_underlying(type)]; }
 
     /**
      * @brief Get all existing graphs in the module.
@@ -71,8 +68,10 @@ public:
     {
         std::vector<graphlib::Graph*> res;
         res.reserve(graphs_.size());
-        for (auto graph : graphs_) {
-            if (graph != nullptr) {
+        for (auto graph : graphs_)
+        {
+            if (graph != nullptr)
+            {
                 res.push_back(graph);
             }
         }
@@ -81,11 +80,11 @@ public:
 
     std::string name() const { return name_; }
 
-private:
+   private:
     std::string name_;
-    
+
     // Static array of graphs, indexed by GraphType.
     StaticGraphArray graphs_;
 };
 
-} // namespace tt
+}  // namespace tt

--- a/forge/csrc/graph_lib/node_types.hpp
+++ b/forge/csrc/graph_lib/node_types.hpp
@@ -171,6 +171,7 @@ public:
     InputNodeType input_type() const { return input_type_; }
     std::string input_type_string() const;
     bool requires_grad() const { return requires_grad_; }
+    void set_requires_grad(bool requires_grad) { requires_grad_ = requires_grad; }
     void clone_consteval_graph_from(Node* original);
     ConstEvalGraph *get_consteval_graph(Graph* graph = nullptr, bool create = false, bool promote_input = false);
     void clear_consteval_graph();

--- a/forge/csrc/test/common.hpp
+++ b/forge/csrc/test/common.hpp
@@ -6,7 +6,6 @@
 #include <type_traits>
 #include <unordered_map>
 
-#include "backend_api/device_config.hpp"
 #include "gtest/gtest.h"
 #include "test/graph_api.hpp"
 
@@ -79,7 +78,9 @@ class GraphTest : public ::testing::Test
 
     graphlib::InputNode* create_activation(graphlib::Shape const& shape)
     {
-        return create_input(shape, tt::graphlib::InputNodeType::Activation);
+        auto node = create_input(shape, tt::graphlib::InputNodeType::Activation);
+        graph->register_module_inputs({node->id()}, true /* append */);
+        return node;
     }
 
     template <typename... Dims>
@@ -88,9 +89,11 @@ class GraphTest : public ::testing::Test
         return create_activation(shape(dims...));
     }
 
-    graphlib::InputNode* create_parameter(graphlib::Shape const& shape)
+    graphlib::InputNode* create_parameter(graphlib::Shape const& shape, bool requires_grad = false)
     {
-        return create_input(shape, tt::graphlib::InputNodeType::Parameter);
+        auto node = create_input(shape, tt::graphlib::InputNodeType::Parameter);
+        node->set_requires_grad(requires_grad);
+        return node;
     }
 
     template <typename... Dims>

--- a/forge/csrc/test/passes/test_split_graph.cpp
+++ b/forge/csrc/test/passes/test_split_graph.cpp
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "autograd/autograd.hpp"
+#include "forge_graph_module.hpp"
+#include "passes/split_graph.hpp"
+#include "test/common.hpp"
+
+namespace tt::test
+{
+struct SplitGraphTest
+    : public ForgeGraphTest,
+      public testing::WithParamInterface<bool>
+{
+   protected:
+    virtual std::vector<OpType*> create_graph() override
+    {
+        int batch_size = 32;
+        int input_size = 784;
+        int output_size = 10;
+        int hidden = 256;
+
+        auto act = create_activation(shape(1, 1, batch_size, input_size));
+
+        constexpr bool requires_grad = true;
+
+        auto weight_l1 = create_parameter(shape(1, 1, hidden, input_size), requires_grad);
+        auto bias_l1 = create_parameter(shape(1, 1, 1, hidden), requires_grad);
+
+        auto weight_l2 = create_parameter(shape(1, 1, output_size, hidden), requires_grad);
+        auto bias_l2 = create_parameter(shape(1, 1, 1, output_size), requires_grad);
+
+        auto transposed_weight_l1 = create_op("transpose", {weight_l1}, {{"dim0", -2}, {"dim1", -1}});
+        auto l1 = create_op("matmul", {act, transposed_weight_l1});
+        matmul_op_name = l1->name();
+
+        auto add = create_op("add", {l1, bias_l1});
+
+        auto transposed_weight_l2 = create_op("transpose", {weight_l2}, {{"dim0", -2}, {"dim1", -1}});
+        auto l2 = create_op("matmul", {add, transposed_weight_l2});
+        matmul_op_name = l2->name();
+
+        auto add2 = create_op("add", {l2, bias_l2});
+
+        auto softmax = create_op("softmax", {add2}, {{"dimension", 1}, {"keep_dim", true}}, 1, true);
+
+        return {softmax};
+    }
+
+    std::string matmul_op_name;
+};
+
+using Graph = graphlib::Graph;
+
+// Tests that the invariants from the original graph (specifically forward subgraph)
+// are perserved in the extracted forward graph.
+TEST_P(SplitGraphTest, test_forward)
+{
+    Graph* graph = get_graph();
+    graph->set_training(true);
+    Graph* original_graph = graph->clone();
+
+    // TODO(#366): Recompute parameter in autograd config is not used.
+    // So the variant of the test which uses recompute = true is still not actually testing training with recompute.
+    bool recompute = GetParam();
+    autograd2::autograd_config config{.recompute = recompute, .optimizer = py::none()};
+
+    auto autograd_engine = tt::autograd2::autograd2_engine(graph, config);
+    graph = autograd_engine.run();
+
+    EXPECT_TRUE(graph->contains_bwd_nodes());
+
+    auto graph_module = passes::split_graph(graph);
+
+    auto fwd_graph = graph_module.get_graph(tt::GraphType::Forward);
+
+    // Verify that all nodes from the initial graph are present in the
+    // extracted forward graph.
+    for (auto node : original_graph->nodes())
+    {
+        EXPECT_TRUE(fwd_graph->has_node_with_name(node->name()));
+    }
+
+    // Verify ordered module inputs.
+    // We need to perserve the original order of module inputs, throughout the transformations and passes.
+    // The order of module inputs is determined by the user in the python code (torch, tf, etc.) and
+    // is set by us when creating initial graph.
+    for (auto input : original_graph->ordered_module_inputs())
+    {
+        EXPECT_TRUE(fwd_graph->has_node_with_name(input->name()));
+    }
+    EXPECT_EQ(original_graph->get_ordered_input_names(), fwd_graph->get_ordered_input_names());
+}
+
+// Tests that the invariants from the original graph (specifically backward subgraph)
+// are perserved in the extracted backward graph.
+TEST_P(SplitGraphTest, test_backward)
+{
+    Graph* graph = get_graph();
+    graph->set_training(true);
+
+    // TODO(#366): Recompute parameter in autograd config is not used.
+    // So the variant of the test which uses recompute = true is still not actually testing training with recompute.
+    bool recompute = GetParam();
+    autograd2::autograd_config config{.recompute = recompute, .optimizer = py::none()};
+
+    auto autograd_engine = tt::autograd2::autograd2_engine(graph, config);
+    graph = autograd_engine.run();
+
+    EXPECT_TRUE(graph->contains_bwd_nodes());
+
+    auto graph_module = passes::split_graph(graph);
+
+    auto fwd_graph = graph_module.get_graph(tt::GraphType::Forward);
+    auto bwd_graph = graph_module.get_graph(tt::GraphType::Backward);
+    EXPECT_TRUE(bwd_graph != nullptr);
+
+    // Verify that all intermediate outputs from the forward graph are inputs
+    // to the backward graph.
+    for (auto intermediate_output : fwd_graph->get_ordered_intermediate_names())
+    {
+        EXPECT_TRUE(fwd_graph->get_node_by_name(intermediate_output)->node_type() == graphlib::NodeType::kOutput);
+        EXPECT_TRUE(bwd_graph->has_node_with_name(intermediate_output));
+        EXPECT_TRUE(bwd_graph->get_node_by_name(intermediate_output)->node_type() == graphlib::NodeType::kInput);
+    }
+
+    // Verify that all nodes from the backward graph have the same number
+    // of operands as in the original graph (containing both forward and backward subgraphs).
+    auto is_bwd_op_node = [](graphlib::Node* node) { return node->is_backward() && node->node_type() == graphlib::NodeType::kPyOp; };
+    for (auto node : graph->nodes(is_bwd_op_node))
+    {
+        EXPECT_TRUE(bwd_graph->has_node_with_name(node->name()));
+        auto bwd_node = bwd_graph->get_node_by_name(node->name());
+        EXPECT_EQ(graph->data_operands(node).size(), bwd_graph->data_operands(bwd_node).size()) << "Node " << node->name() << " has different number of operands in the backward graph";
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SplitGraphTest,
+    SplitGraphTest,
+    ::testing::Values(true, false)
+);
+
+}  // namespace tt::test


### PR DESCRIPTION
Unit tests are added to test some of the invariants that need to hold when extracting the forward and backward pass as separate graphs.

Added variants for training with recompute, however that part still doesn't work (#366). However, the testing infra is in place, so once the issue is fixed this test should hopefully work.

Changes to the `forge_graph_module.hpp` are only whitespace (formatting).

Closes #363