### PR TITLE
Draft: Add llama 3b decode tests with prefill on cpu

### DIFF
--- a/forge/test/mlir/llama/test_llama_inference.py
+++ b/forge/test/mlir/llama/test_llama_inference.py
@@ -7,7 +7,8 @@ import pytest
 from transformers import LlamaConfig, LlamaForCausalLM, LlamaTokenizer
 
 import forge
-from test.mlir.llama.utils.utils import load_model
+from forge.op.eval.common import compare_with_golden_pcc
+from test.mlir.llama.utils.utils import load_model_and_tokenizer
 
 
 @pytest.mark.xfail()
@@ -120,3 +121,239 @@ def test_llama_inference_cache_cpu():
     # Generated text
     generated_text = tokenizer.decode(generated_tokens[0], skip_special_tokens=True)
     print(generated_text)
+
+
+@pytest.mark.xfail()
+def test_llama_prefill_on_cpu_decode_on_tt_no_cache():
+
+    # Load Llama 3B model and tokenizer
+    model_path = "openlm-research/open_llama_3b"
+    framework_model, tokenizer = load_model_and_tokenizer(
+        model_path=model_path, use_cache=False
+    )
+    tokenizer.pad_token_id = framework_model.config.pad_token_id
+
+    # Prepare input sentence
+    max_sequence_length = 53
+    prompt = "Q: What is the largest animal?\nA:"
+    inputs = tokenizer(
+        prompt,
+        return_tensors="pt",
+        max_length=max_sequence_length,
+        pad_to_max_length=True,
+        truncation=True,
+    )
+    input_ids = inputs.input_ids
+    attention_mask = inputs.attention_mask
+
+    non_padding_seq_len = int(torch.sum(attention_mask))
+    padding_seq_len = attention_mask.shape[1] - non_padding_seq_len
+
+    # Run Prefill on CPU with no cache to get the initial logits
+    logits = framework_model(input_ids=input_ids, attention_mask=attention_mask)
+
+    # Take the last non padding token index in logits for the next token
+    next_token_logits = logits[0][:, non_padding_seq_len - 1, :]
+    next_token = torch.argmax(next_token_logits, dim=-1)
+
+    # Update the input_ids with predicted token from prefill in the first padding token index
+    input_ids[:, non_padding_seq_len] = next_token
+    attention_mask[:, non_padding_seq_len] = 1
+
+    non_padding_seq_len = int(torch.sum(attention_mask))
+    padding_seq_len = attention_mask.shape[1] - non_padding_seq_len
+
+    # Compile the model on TT
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=[input_ids, attention_mask]
+    )
+
+    # Run decode stage on TT device and generate tokens by appending predicted token into sequence of input tokens
+    # untill the a specified maximum number of new tokens is reached or an end-of-sequence token is encountered.
+    max_new_tokens = padding_seq_len
+    for idx in range(max_new_tokens):
+
+        model_inputs = [input_ids, attention_mask]
+
+        # CPU Inference
+        framework_output = framework_model(
+            input_ids=input_ids, attention_mask=attention_mask
+        )
+
+        # Run on TT device
+        tt_output = compiled_model(*model_inputs)
+        tt_output = [tt_out.to("cpu") for tt_out in tt_output]
+
+        # Validate TT result with Framework
+        assert all(
+            [
+                compare_with_golden_pcc(golden=fw_out, calculated=tt_out, pcc=0.99)
+                for fw_out, tt_out in zip(framework_output, tt_output)
+            ]
+        )
+
+        next_token_index = non_padding_seq_len + idx
+        next_token_logits = tt_output[0][:, next_token_index - 1, :]
+        next_token = torch.argmax(next_token_logits, dim=-1)
+
+        if next_token == tokenizer.eos_token_id:
+            break
+
+        input_ids[:, next_token_index] = next_token
+        attention_mask[:, next_token_index] = 1
+
+    # Generated text
+    generated_text = tokenizer.decode(input_ids[0], skip_special_tokens=True)
+    print("generated_text=", generated_text)
+
+
+# The test is just workaround for checking with/without padding.
+@pytest.mark.xfail()
+def test_llama_prefill_on_cpu_decode_on_tt_cache_padding():
+
+    # Load Llama 3B model and tokenizer
+    model_path = "openlm-research/open_llama_3b"
+    framework_model, tokenizer = load_model_and_tokenizer(
+        model_path=model_path, use_cache=True, return_dict=True
+    )
+
+    class LlamaModelWrapper(torch.nn.Module):
+        """
+        In LlamaModelWrapper class, forward function takes single input token (i.e last predicted token)
+        and past key values from the previous iteration and return logits and past key values
+        Args:
+            input_id (`torch.Tensor`) - shape of (batch_size, 1)
+            past_key_values (`List[List[torch.Tensor, torch.Tensor]]`) - key/values shape - (batch_size, num_of_key_values_heads, key_value_seq_len, head_dim)
+        Returns:
+            outputs - Logits of shape (batch_size, 1, vocab_size) and past_key_values (`List[List[torch.Tensor, torch.Tensor]]`)
+            past key/values tensor shape - (batch_size, num_of_key_values_heads, key_value_seq_len + 1, head_dim)
+        """
+
+        def __init__(self, model):
+            super().__init__()
+            self.model = model
+
+        def forward(self, input_id, past_key_values):
+            model_outputs = self.model(
+                input_ids=input_id, past_key_values=past_key_values
+            )
+            return model_outputs.logits, model_outputs.past_key_values
+
+    llama_model = LlamaModelWrapper(framework_model)
+
+    # Prepare input sentence
+    prompt = "Q: What is the largest animal?\nA:"
+    inputs = tokenizer(prompt, return_tensors="pt")
+
+    # Run Prefill on CPU with cache to get the initial logits and past key-values
+    prefill_output = framework_model(
+        input_ids=inputs.input_ids, attention_mask=inputs.attention_mask
+    )
+    next_token_logits = prefill_output.logits[:, -1, :]
+    next_token = torch.argmax(next_token_logits, dim=-1)
+
+    generated_tokens = inputs.input_ids
+    generated_tokens = torch.cat([generated_tokens, next_token.unsqueeze(0)], dim=-1)
+
+    past_key_values_list = [[k, v] for k, v in prefill_output.past_key_values]
+
+    model_inputs = [next_token.unsqueeze(0), past_key_values_list]
+
+    # Padding on past key values can be enabled by setting apply_padding_on_past_key_values to True.
+    apply_padding_on_past_key_values = True
+    max_new_tokens = 32
+    if apply_padding_on_past_key_values:
+        padding_seq_len = max_new_tokens
+        non_padding_seq_len = past_key_values_list[0][0].shape[-2]
+
+        # Zero Pad past key values in key_value_seq_len(i.e -2) dimension
+        # Before padding past key values tensor shape -> (batch_size, num_of_key_values_heads, key_value_seq_len, head_dim)
+        # After Padding Past key value tensor shape -> (batch_size, num_of_key_values_heads, key_value_seq_len + padding_seq_len, head_dim)
+        for idx, (k, v) in enumerate(model_inputs[1]):
+            model_inputs[1][idx][0] = torch.cat(
+                [
+                    k,
+                    torch.zeros(
+                        k.shape[-4], k.shape[-3], max_new_tokens, k.shape[-1]
+                    ).to(k.dtype),
+                ],
+                dim=-2,
+            )
+            model_inputs[1][idx][1] = torch.cat(
+                [
+                    v,
+                    torch.zeros(
+                        v.shape[-4], v.shape[-3], max_new_tokens, v.shape[-1]
+                    ).to(k.dtype),
+                ],
+                dim=-2,
+            )
+
+    # # Compile the model
+    # compiled_model = forge.compile(llama_model, sample_inputs=model_inputs)
+
+    # Run decode stage on TT device and generate tokens by passing the last predicted token and the past key values.
+    # untill the a specified maximum number of new tokens is reached or an end-of-sequence token is encountered.
+    for max_new_tokens_idx in range(max_new_tokens):
+
+        # CPU Inference
+        model_outputs = llama_model(model_inputs[0], model_inputs[1])
+
+        # TT will return the logits and past key values as list of tensor, so flattening
+        # framework output past key values from List(List(Key1, Values1), ... , List(Key26, Values26)) to
+        # List(Key1, Values1, ... , Key26, Values26) for comparing the Framework and TT output in similar fashion.
+        framework_output = [model_outputs[0]]
+        for k, v in model_outputs[1]:
+            framework_output.append(k)
+            framework_output.append(v)
+
+        # # Run on TT device
+        # tt_output = compiled_model(*model_inputs)
+        # tt_output = [tt_out.to("cpu") for tt_out in tt_output]
+
+        # # Validate TT result with Framework
+        # assert all([compare_with_golden_pcc(golden=fw_out, calculated=tt_out, pcc=0.99) for fw_out, tt_out in zip(framework_output, tt_output)])
+
+        logits = framework_output[0]
+        past_key_values = framework_output[1:]
+
+        next_token_logits = logits[:, -1, :]
+        next_token = torch.argmax(next_token_logits, dim=-1)
+        print("next_token=", next_token)
+
+        if next_token == tokenizer.eos_token_id:
+            break
+
+        model_inputs = [next_token.unsqueeze(0)]
+
+        # Formate the past key values from List(Key1, Values1, ... , Key26, Values26) to
+        # List(List(Key1, Values1), ... , List(Key26, Values26))
+        model_inputs.append(
+            [
+                past_key_values[idx : idx + 2]
+                for idx in range(0, len(past_key_values), 2)
+            ]
+        )
+
+        if apply_padding_on_past_key_values:
+
+            for idx in range(len(model_inputs[1])):
+                key_state = torch.clone(model_inputs[1][idx][0][:, :, -1, :])
+                value_state = torch.clone(model_inputs[1][idx][1][:, :, -1, :])
+                model_inputs[1][idx][0][
+                    :, :, non_padding_seq_len + max_new_tokens_idx, :
+                ] = model_inputs[1][idx][0][:, :, -1, :]
+                model_inputs[1][idx][0] = model_inputs[1][idx][0][:, :, :-1, :]
+                model_inputs[1][idx][1][
+                    :, :, non_padding_seq_len + max_new_tokens_idx, :
+                ] = model_inputs[1][idx][1][:, :, -1, :]
+                model_inputs[1][idx][1] = model_inputs[1][idx][1][:, :, :-1, :]
+
+        generated_tokens = torch.cat(
+            [generated_tokens, next_token.unsqueeze(0)], dim=-1
+        )
+
+    print("generated_tokens[0]=", generated_tokens[0])
+    # Generated text
+    generated_text = tokenizer.decode(generated_tokens[0], skip_special_tokens=True)
+    print("generated_text=", generated_text)

--- a/forge/test/mlir/llama/utils/utils.py
+++ b/forge/test/mlir/llama/utils/utils.py
@@ -7,16 +7,26 @@ from transformers import LlamaConfig, LlamaForCausalLM, LlamaTokenizer
 import forge
 
 
-def load_model(model_path="openlm-research/open_llama_3b", use_cache=False):
-    # Load Llama 3B model
+def load_model_and_tokenizer(**kwargs):
+    # Default config values
     config = LlamaConfig()
     config.hidden_size = 3200
     config.intermediate_size = 8640
     config.num_hidden_layers = 26
     config.pad_token_id = 0
-    config.return_dict = False
-    config.use_cache = use_cache
-    framework_model = LlamaForCausalLM.from_pretrained(model_path, device_map="auto", config=config)
-    framework_model.eval()
 
-    return framework_model
+    # Use defaults or values from kwargs
+    model_path = kwargs.get("model_path", "openlm-research/open_llama_3b")
+    config.return_dict = kwargs.get("return_dict", False)
+    config.use_cache = kwargs.get("use_cache", False)
+    config.output_attentions = kwargs.get("output_attentions", False)
+    config.output_hidden_states = kwargs.get("output_hidden_states", False)
+
+    # Load the model
+    framework_model = LlamaForCausalLM.from_pretrained(
+        model_path, device_map="auto", config=config
+    )
+    framework_model.eval()
+    tokenizer = LlamaTokenizer.from_pretrained(model_path)
+
+    return framework_model, tokenizer


### PR DESCRIPTION
This is the Draft PR for Llama 3b model to run decode on TT devices and Prefill to run on CPU
There are two test cases based upon the cache/no cache(i.e past key values)

- `test_llama_prefill_on_cpu_decode_on_tt_no_cache `- Prefill will be executed on CPU and return only logits. Decode stage will be executed on TT devices. In this decode stage, the last token predicted is appended to  the sequences of input token and passed to the model for predicting the next token untill the a specified maximum number of new tokens is reached or an end-of-sequence token is encountered
- `test_llama_prefill_on_cpu_decode_on_tt_cache_padding ` - Prefill will be executed on CPU and returns logits and past key values.
                                                           Decode stage will be executed on TT devices. In this decode stage, the predicted last token (i.e single token) and past key values are zero padded in the key_value_seq_dim (dim=-2) and then passed to the model for predicting the next token (i.e which outputs single token) untill the a specified maximum number of new tokens is reached or an end-of-sequence token is encountered