### PR TITLE
Updating checker to accept MIT / BSD3 and fixing some SPDX headers.

### DIFF
--- a/.github/check-spdx.yml
+++ b/.github/check-spdx.yml
@@ -2,6 +2,8 @@ DEFAULT:
   perform_check: yes  # Perform check for all files
   allowed_licenses:
     - Apache-2.0
+    - BSD-3-Clause
+    - MIT
   license_for_new_files: Apache-2.0  # license to be used when inserting a new copyright notice
   new_notice_c: |+  # notice for new C, CPP, H, HPP and LD files
     // SPDX-FileCopyrightText: (c) {years} Tenstorrent AI ULC

--- a/forge/forge/torch_optimizers.py
+++ b/forge/forge/torch_optimizers.py
@@ -4,7 +4,8 @@
 #
 # This file incorporates work covered by the following copyright and permission notice:
 # SPDX-FileCopyrightText: Copyright (c) 2016 Facebook, Inc
-# SPDX-License-Identifier: Caffe2
+# SPDX-License-Identifier: BSD-3-Clause
+# https://github.com/pytorch/pytorch/blob/main/LICENSE 
 
 from typing import Dict, List, Optional, Tuple, Iterable
 


### PR DESCRIPTION
Update the torch file to represent https://github.com/pytorch/pytorch/blob/main/LICENSE  which is covered by https://spdx.org/licenses/BSD-3-Clause.html 

Adding MIT as an accepted license to the checker as well. 