### PR TITLE
[pre-commit] add more hooks for formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,24 @@
 repos:
-   - repo: https://github.com/espressif/check-copyright/
+  - repo: https://github.com/espressif/check-copyright/
     rev: v1.0.3
     hooks:
       - id: check-copyright
-        args: ['--config', '.github/check-spdx.yaml']
+        args: ['--config', '.github/check-spdx.yml']
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        language_version: python3
+        args: [--line-length=120]
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v18.1.7
+    hooks:
+    - id: clang-format
+      types_or: [c++, c]
+      args: [-style=file, -i]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-added-large-files

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -6,6 +6,7 @@
 # Project setup
 - [Building](./build.md)
 - [Testing](./test.md)
+- [Tools](./tools.md)
 
 # User Guide
 - [Getting Started](./getting-started.md)

--- a/docs/src/build.md
+++ b/docs/src/build.md
@@ -35,9 +35,9 @@ python3 --version
 ```
 
 ## Build environment
-This is one off step to build the toolchain and create virtual environment for tt-forge. Generally you need to run this step only once, unless you want to update the toolchain (LLVM). 
+This is one off step to build the toolchain and create virtual environment for tt-forge. Generally you need to run this step only once, unless you want to update the toolchain (LLVM).
 
-First, it's required to create toolchain directories. Proposed example creates directories in default paths. You can change the paths if you want to use different locations (see build environment section below). 
+First, it's required to create toolchain directories. Proposed example creates directories in default paths. You can change the paths if you want to use different locations (see build environment section below).
 ```sh
 # FFE related toolchain (dafault path)
 sudo mkdir -p /opt/ttforge-toolchain
@@ -70,6 +70,22 @@ source env/activate
 cmake -G Ninja -B build
 cmake --build build
 ```
+
+## Build docs
+
+To build documentation `mdbook` is required, see the installation guide [here](./tools.md#mdbook).
+
+After installing `mdbook`, run the following commands to build and serve the documentation:
+
+```sh
+source env/activate
+cmake --build build -- docs
+
+# Serve the documentation
+mdbook serve build/docs
+```
+
+> **NOTE:** `mdbook serve` will by default create a local server at `http://localhost:3000`.
 
 ## Build Cleanup
 

--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -1,0 +1,41 @@
+# Tools
+
+This section will cover setup of various tools that can help you with development of tt-forge-fe.
+
+## Pre-commit
+
+We have defined various pre-commit hooks that check the code for formatting, licensing issues, etc.
+
+To install pre-commit, run the following command:
+
+```sh
+source env/activate
+pip install pre-commit
+```
+
+After installing pre-commit, you can install the hooks by running:
+
+```sh
+pre-commit install
+```
+
+Now, each time you run `git commit` the pre-commit hooks (checks) will be executed.
+
+If you have already committed before installing the pre-commit hooks, you can run on all files to "catch up":
+
+```sh
+pre-commit run --all-files
+```
+
+For more information visit [pre-commit](https://pre-commit.com/)
+
+## mdbook
+
+We use `mdbook` to generate the documentation. To install `mdbook` on Ubuntu, run the following commands:
+
+```sh
+sudo apt install cargo
+cargo install mdbook
+```
+
+>**NOTE:** If you don't want to install `mdbook` via cargo (Rust package manager), or this doesn't work for you, consult the [official mdbook installation guide](https://rust-lang.github.io/mdBook/cli/index.html).


### PR DESCRIPTION
Updated the pre-commit config with more checks:
- black - formatter for python files
- clang-format - formatter for c++ files
- generic hooks for detecting trailing whitespace, empty lines on the end of file, etc.

Documentation is also updated, providing instructions on how to setup pre-commit hooks as well as how to build and serve the docs.

NOTE: This change will be followed by the changes for formatting all of the files (since majority of them are not properly formatted) and enabling pre-commit checks to be ran as part of CI.

Closes #393