### PR TITLE
Fix a bug where copy of data json also was uploaded to sftp

### DIFF
--- a/.github/workflows/produce_data.yml
+++ b/.github/workflows/produce_data.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           python3 infra/src/generate_data.py --run_id ${{ steps.get-run-id-and-attempt.outputs.run-id }}
           # Workaround: Copy file to avoid GH upload filename limitations
-          cp pipeline_${{ steps.get-run-id-and-attempt.outputs.run-id }}*.json pipeline_${{ steps.get-run-id-and-attempt.outputs.run-id }}.json
+          cp pipeline_${{ steps.get-run-id-and-attempt.outputs.run-id }}*.json pipelinecopy_${{ steps.get-run-id-and-attempt.outputs.run-id }}.json
 
       - name: Upload cicd data
         uses: ./.github/actions/upload-data-via-sftp
@@ -107,6 +107,6 @@ jobs:
           path: |
             if-no-files-found: warn
             path: |
-              pipeline_${{ steps.get-run-id-and-attempt.outputs.run-id }}.json
+              pipelinecopy_${{ steps.get-run-id-and-attempt.outputs.run-id }}.json
               generated/cicd/${{ steps.get-run-id-and-attempt.outputs.run-id }}/workflow.json
               generated/cicd/${{ steps.get-run-id-and-attempt.outputs.run-id }}/workflow_jobs.json


### PR DESCRIPTION
The Gihub artifacts name convention doesn't allow us to upload files with a colon in the name, so we create a renamed copy. This copy was also uploaded to SFTP by mistake, as we uploaded all pipeline_*.json files. Renaming file copy to pipelinecopy_ to avoid this duplicate upload.