### PR TITLE
[Lib] Optimum lib upgrade from 1.19.2 to 1.20.0

### DIFF
--- a/env/linux_requirements.txt
+++ b/env/linux_requirements.txt
@@ -4,7 +4,7 @@
 bitarray==2.5.1
 clang-format==14.0.3
 diffusers==0.27.2
-optimum==1.19.2
+optimum==1.20.0
 hydra-core
 IPython==8.8.0
 nvidia-ml-py3==7.352.0

--- a/env/mac_requirements.txt
+++ b/env/mac_requirements.txt
@@ -4,7 +4,7 @@
 bitarray==2.5.1
 clang-format==14.0.3
 diffusers==0.27.2
-optimum==1.19.2
+optimum==1.20.0
 hydra-core
 IPython==8.8.0
 nvidia-ml-py3==7.352.0


### PR DESCRIPTION
- Old Optimum version depends on transformers<4.41.0 and >=4.26.0.

- As Transformers library updated to 4.41.0 [here](https://github.com/tenstorrent/tt-forge-fe/commit/a116983ff49b502722cdd58038ead8fc37a373fa) , optimum version should be upgraded to solve below issue during build.

```
INFO: pip is looking at multiple versions of optimum to determine which version is compatible with other requirements. This could take a while.
ERROR: Cannot install -r /proj_sw/user_dev/kkannan/FORGE_OCT20/tt-forge-fe/env/linux_requirements.txt (line 7) and transformers==4.41.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested transformers==4.41.0
    optimum 1.19.2 depends on transformers<4.41.0 and >=4.26.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
gmake[2]: *** [CMakeFiles/python-venv.dir/build.make:70: CMakeFiles/python-venv] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:85: CMakeFiles/python-venv.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2
```

- Log - [oct20_build_1.log](https://github.com/user-attachments/files/17449894/oct20_build_1.log)
