### PR TITLE
Pass for extracting the unique op configuration and script for cross correlating the model variants and Ops.

### DIFF
--- a/docs/src/tools.md
+++ b/docs/src/tools.md
@@ -39,3 +39,68 @@ cargo install mdbook
 ```
 
 >**NOTE:** If you don't want to install `mdbook` via cargo (Rust package manager), or this doesn't work for you, consult the [official mdbook installation guide](https://rust-lang.github.io/mdBook/cli/index.html).
+
+## Gather Unique Ops Configuration
+
+The model's unique ops configuration can be gathered, and the results can either be printed to the console or saved as a CSV file.
+
+1. **FORGE_EXTRACT_UNIQUE_OP_CONFIG_AT**
+   - By setting this flag to one of the following options, the model's unique ops configuration can be extracted at a specific compilation stage or across all stages:
+
+     - **`FORGE_EXTRACT_UNIQUE_OP_CONFIG_AT = ALL`**
+       Extracts all the unique ops configurations present in the graph at every compilation stage.
+
+     - **`FORGE_EXTRACT_UNIQUE_OP_CONFIG_AT = {INITIAL_GRAPH / PRE_OPTIMIZE_GRAPH / POST_OPTIMIZE_GRAPH / POST_AUTOGRAD_GRAPH / PRE_LOWERING_GRAPH}`**
+       Extracts the unique ops configuration only at the specified compilation stage.
+
+2. **FORGE_PRINT_UNIQUE_OP_CONFIG**
+   - By setting this flag to `1`, all unique configurations will be printed to the console.
+
+3. **FORGE_EXPORT_UNIQUE_OP_CONFIG_TO_CSV**
+   - By setting this flag to `1`, all unique configurations will be exported to a CSV file. The file can be saved to the default path (i.e., the current directory), or it can be saved to a specific path by setting the `FORGE_EXPORT_UNIQUE_OP_CONFIG_DIR_PATH` environment variable.
+
+> **Note:**
+> The delimiter used in the CSV file will be a hyphen (`-`) to avoid potential parsing issues. Commas (`,`) may appear in the op shapes and attributes, which could lead to misinterpretation of the data.
+
+## Cross Correlate Models and Ops
+
+The models and ops can be cross-correlated by running the `scripts/export_models_ops_correlation.py` python script.
+
+The script will perform the following tasks:
+
+1. Run all models until the compile depth specified by the user.
+2. Export unique op requirements to a file (each model variants has its own directory, in that directory each compile depth has its own file).
+3. Parse those unique op requirements and create a xlsx file that can be loaded into a google sheet.
+   1. The xlsx file will contain list of models on X axis (i.e. columns) and list of ops on Y axis (i.e. rows/indices).
+   2. Elements in between will contain a checkmark if the desired op from the Y axis (i.e., rows/indices) exists in the model on X axis (i.e., columns).
+   3. Models will be sorted alphabetically.
+   4. Ops will be sorted by the number of occurrences in the models.
+
+### Usage
+
+To run the script, use the following command:
+
+```sh
+python scripts/export_models_ops_correlation.py
+```
+
+### Required Options:
+
+|                              **Option**                                   |                                                **Description**                                                   |
+| :-----------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------: |
+| `-c`, `--compile_depth (GENERATE_INITIAL_GRAPH, PRE_LOWERING_PASS, etc.)` | Choose the compilation depth for extracting ops configuration for the models present in `pytest_directory_path`. |
+| `-i`, `--pytest_directory_path`                                           | Specify the directory path containing models to test.                                                            |
+
+### Optional Options:
+
+|                              **Option**                                   |                                                **Description**                                                   |
+| :-----------------------------------------------------------------------: | :--------------------------------------------------------------------------------------------------------------: |
+| `-f`, `--output_file_name`                                                | Specify the output file name for the xlsx/csv file.                                                              |
+| `-o`, `--output_directory_path`                                           | Specify the output directory path for saving the xlsx/csv file.                                                  |
+| `-s`, `--do_save_xlsx`                                                    | Specify whether to save the output in xlsx format.                                                               |
+
+### Example:
+
+```sh
+python scripts/export_models_ops_correlation.py --compile_depth GENERATE_INITIAL_GRAPH --pytest_directory_path forge/test/model_demos/high_prio/nlp/pytorch
+```

--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -49,3 +49,4 @@ ultralytics==8.0.145
 keras>=2.13.1
 pytorch_forecasting==1.0.0
 patool
+openpyxl==3.1.5

--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -23,6 +23,7 @@ namespace py = pybind11;
 #include "lower_to_forge/common.hpp"
 #include "passes/amp.hpp"
 #include "passes/consteval.hpp"
+#include "passes/extract_unique_op_configuration.hpp"
 #include "passes/fracture.hpp"
 #include "passes/link_past_cache_ios.hpp"
 #include "passes/mlir_compiler.hpp"
@@ -211,6 +212,13 @@ PYBIND11_MODULE(_C, m)
     m.def("run_mlir_compiler", &passes::run_mlir_compiler);
     m.def("split_graph", &passes::split_graph);
 
+    m.def(
+        "extract_unique_op_configuration",
+        [](tt::graphlib::Graph *graph, std::string stage, const std::optional<std::vector<std::string>> &supported_ops)
+        { tt::passes::extract_unique_op_configuration(graph, stage, supported_ops); },
+        py::arg("graph"),
+        py::arg("stage"),
+        py::arg("supported_ops") = std::nullopt);
     m.def(
         "dump_graph",
         [](const tt::graphlib::Graph *graph, std::string test_name, std::string graph_name)

--- a/forge/csrc/passes/extract_unique_op_configuration.cpp
+++ b/forge/csrc/passes/extract_unique_op_configuration.cpp
@@ -1,0 +1,236 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "passes/extract_unique_op_configuration.hpp"
+
+#include <filesystem>
+#include <fstream>
+
+#include "graph_lib/utils.hpp"
+#include "utils/logger.hpp"
+
+namespace tt::passes
+{
+
+bool equivalent_shapes(OpShapesType vec1, OpShapesType vec2)
+{
+    if (vec1.size() != vec2.size())
+        return false;
+    for (size_t i = 0; i < vec1.size(); i++)
+    {
+        if (vec1[i] != vec2[i])
+            return false;
+    }
+    return true;
+}
+
+UniqueOpShapesAttrsType extract_unique_op_configuration(
+    graphlib::Graph *graph, const std::optional<std::vector<std::string>> &supported_ops)
+{
+    UniqueOpShapesAttrsType unique_op_shapes_attrs;
+    OpShapesType operand_shapes;
+    std::vector<std::string> supported_opnames;
+
+    if (supported_ops.has_value())
+        supported_opnames = supported_ops.value();
+
+    for (graphlib::Node *current_node : graphlib::topological_sort(*graph))
+    {
+        auto current_op = dynamic_cast<graphlib::OpNode *>(current_node);
+        if (not current_op)
+        {
+            continue;
+        }
+
+        graphlib::OpType current_node_optype = current_op->op_type();
+
+        // If the list of op names (i.e supported_ops) is passed, it will only extract the
+        // list of unique ops configuration that are not present in the supported_opnames,
+        // otherwise it will extract all the unique op configurations in the graph
+        if (!supported_opnames.empty())
+        {
+            if (std::find(supported_opnames.begin(), supported_opnames.end(), current_node_optype.op) !=
+                supported_opnames.end())
+                continue;
+        }
+
+        // Get the current node operand shapes
+        operand_shapes.clear();
+        for (auto operand : graph->data_operands(current_op))
+        {
+            operand_shapes.push_back(operand->shape());
+        }
+
+        // If the op is present in the unique_op_shapes_attrs map, then list of operand shapes
+        // of the matched op is compared with the current node operand shapes otherwise the
+        // current node operand_shapes and attributes(i.e OpTypes) are added to the unique_op_shapes_attrs map.
+        if (unique_op_shapes_attrs.find(current_node_optype.op) != unique_op_shapes_attrs.end())
+        {
+            auto unique_shapes_attrs_list = unique_op_shapes_attrs.at(current_node_optype.op);
+            bool operand_shapes_matched = false;
+            for (size_t idx = 0; idx < unique_shapes_attrs_list.size(); idx++)
+            {
+                auto unique_shapes_attrs = unique_shapes_attrs_list.at(idx);
+                auto unique_shapes = unique_shapes_attrs.first;
+                auto unique_attrs = unique_shapes_attrs.second;
+
+                // If the current node and matched op operand shapes are equivalent,
+                // then take the list of OpType from the unique_shapes_attrs_list map with matched op name and
+                // matched operand shapes and then compare with  current node optype, if the current
+                // node optype is not present, then add current node optype in unique_op_shapes_attrs map with matched
+                // op name and matched operand shapes.
+                if (equivalent_shapes(unique_shapes, operand_shapes))
+                {
+                    operand_shapes_matched = true;
+                    if (std::find(unique_attrs.begin(), unique_attrs.end(), current_node_optype) == unique_attrs.end())
+                    {
+                        unique_attrs.push_back(current_node_optype);
+                        unique_op_shapes_attrs[current_node_optype.op].at(idx) = {unique_shapes, unique_attrs};
+                        break;
+                    }
+                }
+            }
+            if (!operand_shapes_matched)
+            {
+                unique_op_shapes_attrs[current_node_optype.op].push_back({operand_shapes, {current_node_optype}});
+            }
+        }
+        else
+        {
+            unique_op_shapes_attrs[current_node_optype.op] = {{operand_shapes, {current_node_optype}}};
+        }
+    }
+
+    return unique_op_shapes_attrs;
+}
+
+void print_unique_op_configuration(const UniqueOpShapesAttrsType &unique_op_shapes_attrs, std::string op_config_info)
+{
+    std::cout << op_config_info << std::endl;
+    for (auto unique_op_shapes_attrs_iter = unique_op_shapes_attrs.begin();
+         unique_op_shapes_attrs_iter != unique_op_shapes_attrs.end();
+         ++unique_op_shapes_attrs_iter)
+    {
+        auto op_name = unique_op_shapes_attrs_iter->first;
+        auto shapes_attrs_list = unique_op_shapes_attrs_iter->second;
+        std::cout << op_name << std::endl;
+        for (auto shapes_attrs_iter = shapes_attrs_list.begin(); shapes_attrs_iter != shapes_attrs_list.end();
+             ++shapes_attrs_iter)
+        {
+            auto op_shapes = shapes_attrs_iter->first;
+            auto op_attrs = shapes_attrs_iter->second;
+            std::cout << "\t\t Input_shape: [";
+            for (size_t i = 0; i < op_shapes.size(); i++)
+            {
+                std::cout << op_shapes[i] << ", ";
+            }
+            std::cout << "]" << std::endl;
+            if (!op_attrs.empty())
+            {
+                for (size_t i = 0; i < op_attrs.size(); i++)
+                {
+                    if (op_attrs[i].attr.size() > 0 or op_attrs[i].named_attrs.size() > 0)
+                    {
+                        std::cout << "\t\t\t\t\t Attributes: " << op_attrs[i].as_string() << std::endl;
+                    }
+                }
+            }
+        }
+    }
+}
+
+void export_unique_op_configuration_to_csv_file(
+    const UniqueOpShapesAttrsType &unique_op_shapes_attrs, std::string graph_name, std::string stage)
+{
+    std::string export_unique_op_config_default_path = std::filesystem::current_path().string();
+    std::string export_unique_op_config_path =
+        env_as<std::string>("FORGE_EXPORT_UNIQUE_OP_CONFIG_DIR_PATH", export_unique_op_config_default_path);
+    export_unique_op_config_path = export_unique_op_config_path + "/OpConfigs/" + graph_name + "/";
+    if (not std::filesystem::exists(std::filesystem::path(export_unique_op_config_path)))
+    {
+        TT_ASSERT(
+            std::filesystem::create_directories(std::filesystem::path(export_unique_op_config_path)),
+            "Export Directory creation failed!");
+    }
+    std::string export_unique_op_config_file = export_unique_op_config_path + stage + ".csv";
+    std::string headers = "OpName-Operands Shape-Attributes";
+    std::string delimiter = "-";
+
+    log_info(
+        "Exporting unique ops configuration in {} compilation stage to {} file", stage, export_unique_op_config_file);
+
+    std::fstream fs;
+    fs.open(export_unique_op_config_file, std::fstream::out | std::fstream::trunc);
+    fs << headers << "\n";
+
+    for (auto unique_op_shapes_attrs_iter = unique_op_shapes_attrs.begin();
+         unique_op_shapes_attrs_iter != unique_op_shapes_attrs.end();
+         ++unique_op_shapes_attrs_iter)
+    {
+        auto op_name = unique_op_shapes_attrs_iter->first;
+        auto shapes_attrs_list = unique_op_shapes_attrs_iter->second;
+        for (auto shapes_attrs_iter = shapes_attrs_list.begin(); shapes_attrs_iter != shapes_attrs_list.end();
+             ++shapes_attrs_iter)
+        {
+            auto op_shapes = shapes_attrs_iter->first;
+            auto op_attrs = shapes_attrs_iter->second;
+            if (!op_attrs.empty())
+            {
+                for (size_t i = 0; i < op_attrs.size(); i++)
+                {
+                    fs << op_name << delimiter << "[";
+                    for (size_t j = 0; j < op_shapes.size(); j++)
+                    {
+                        fs << op_shapes[j] << ", ";
+                    }
+                    fs << "]" << delimiter;
+                    if (op_attrs[i].attr.size() > 0 or op_attrs[i].named_attrs.size() > 0)
+                    {
+                        fs << op_attrs[i].as_string();
+                    }
+                    fs << "\n";
+                }
+            }
+            else
+            {
+                fs << op_name << delimiter << "[";
+                for (size_t i = 0; i < op_shapes.size(); i++)
+                {
+                    fs << op_shapes[i] << ", ";
+                }
+                fs << "]" << delimiter;
+                fs << "\n";
+            }
+        }
+    }
+
+    fs.close();
+}
+
+void extract_unique_op_configuration(
+    graphlib::Graph *graph, std::string stage, const std::optional<std::vector<std::string>> &supported_ops)
+{
+    auto stage_to_extract = env_as_optional<std::string>("FORGE_EXTRACT_UNIQUE_OP_CONFIG_AT");
+    bool print_unique_op_config = env_as<bool>("FORGE_PRINT_UNIQUE_OP_CONFIG", false);
+    bool export_unique_op_config_to_csv = env_as<bool>("FORGE_EXPORT_UNIQUE_OP_CONFIG_TO_CSV", false);
+
+    if (not stage_to_extract or ((stage_to_extract != stage) and (stage_to_extract != "ALL")))
+        return;
+
+    UniqueOpShapesAttrsType unique_op_shapes_attrs = extract_unique_op_configuration(graph, supported_ops);
+
+    if (unique_op_shapes_attrs.empty())
+        return;
+
+    if (print_unique_op_config)
+    {
+        std::string op_config_info = std::string("Op Configuration at: ") + stage;
+        print_unique_op_configuration(unique_op_shapes_attrs, op_config_info);
+    }
+    if (export_unique_op_config_to_csv)
+    {
+        export_unique_op_configuration_to_csv_file(unique_op_shapes_attrs, graph->name(), stage);
+    }
+}
+
+}  // namespace tt::passes

--- a/forge/csrc/passes/extract_unique_op_configuration.hpp
+++ b/forge/csrc/passes/extract_unique_op_configuration.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "graph_lib/node_types.hpp"
+
+namespace tt::graphlib
+{
+class Graph;
+}
+
+namespace tt::passes
+{
+
+using OpShapesType = std::vector<graphlib::Shape>;
+using OpAttrsType = std::vector<graphlib::OpType>;
+using UniqueOpShapesAttrsType = std::map<std::string, std::vector<std::pair<OpShapesType, OpAttrsType>>>;
+
+UniqueOpShapesAttrsType extract_unique_op_configuration(
+    graphlib::Graph* graph, const std::optional<std::vector<std::string>>& supported_ops = std::nullopt);
+
+void print_unique_op_configuration(const UniqueOpShapesAttrsType& unique_op_shapes_attrs, std::string op_config_info);
+
+void export_unique_op_configuration_to_csv_file(
+    const UniqueOpShapesAttrsType& unique_op_shapes_attrs, std::string graph_name, std::string stage);
+
+void extract_unique_op_configuration(
+    graphlib::Graph* graph,
+    std::string stage,
+    const std::optional<std::vector<std::string>>& supported_ops = std::nullopt);
+}  // namespace tt::passes

--- a/forge/forge/config.py
+++ b/forge/forge/config.py
@@ -287,16 +287,19 @@ class CompilerConfig:
 
         if "FORGE_COMPILE_DEPTH" in os.environ:
             self.compile_depth = {
-                "full": CompileDepth.FULL,
                 "init_compile": CompileDepth.INIT_COMPILE,
                 "generate_initial_graph": CompileDepth.GENERATE_INITIAL_GRAPH,
                 "post_initial_graph_pass": CompileDepth.POST_INITIAL_GRAPH_PASS,
-                "pre_lowering_pass": CompileDepth.PRE_LOWERING_PASS,
-                "forge_graph_pre_placer": CompileDepth.FORGE_GRAPH_PRE_PLACER,
-                "balancer_pass": CompileDepth.BALANCER_PASS,
-                "generate_netlist": CompileDepth.GENERATE_NETLIST,
+                "consteval_graph": CompileDepth.CONSTEVAL_GRAPH,
                 "post_pattern_matcher": CompileDepth.POST_PATTERN_MATCHER,
-                "backend_golden_verify": CompileDepth.BACKEND_GOLDEN_VERIFY,
+                "optimized_graph": CompileDepth.OPTIMIZED_GRAPH,
+                "autograd": CompileDepth.AUTOGRAD,
+                "post_autograd_pass": CompileDepth.POST_AUTOGRAD_PASS,
+                "pre_lowering_pass": CompileDepth.PRE_LOWERING_PASS,
+                "split_graph": CompileDepth.SPLIT_GRAPH,
+                "run_mlir_compiler": CompileDepth.RUN_MLIR_COMPILER,
+                "finish_compile": CompileDepth.FINISH_COMPILE,
+                "full": CompileDepth.FULL,
             }[os.environ["FORGE_COMPILE_DEPTH"].lower()]
 
         if "FORGE_ENABLE_INPUT_QUEUES_ON_HOST" in os.environ:

--- a/scripts/export_models_ops_correlation.py
+++ b/scripts/export_models_ops_correlation.py
@@ -1,0 +1,298 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+import sys
+import os
+import subprocess
+import argparse
+from loguru import logger
+import pandas as pd
+from openpyxl import Workbook
+from openpyxl.styles import Alignment, Border, PatternFill, Side
+
+test_to_skip = []
+
+
+def collect_all_pytests(root_dir_path):
+
+    logger.info(f"Collecting all pytests in {root_dir_path}")
+
+    try:
+        res = subprocess.check_output(["pytest", root_dir_path, "--setup-plan"], stderr=subprocess.STDOUT).decode(
+            "utf-8"
+        )
+    except subprocess.CalledProcessError as e:
+        output = e.output.decode("utf-8")
+        logger.error(f"[Error!] output = {output}")
+        return []
+
+    test_list = []
+    lines = res.split("\n")
+    for line in lines:
+        if "warnings summary" in line or "slowest durations" in line:
+            break
+
+        if line and line.startswith("        " + root_dir_path) and "::" in line and "training" not in line:
+            line = line.strip()
+            line = line.split(" (fixtures used:")[0] if " (fixtures used:" in line else line
+            if "Grayskull" not in line and "Wormhole_B0" not in line:
+                test_list.append(line)
+
+    return test_list
+
+
+def run_and_export_models_unique_ops_configuration(compilation_depth, pytest_directory_path):
+
+    # Collect all the pytests in the directory path by the user
+    test_list = collect_all_pytests(pytest_directory_path)
+    assert test_list != [], "No tests found!"
+
+    # Run all the pytests upto compilation_depth provided by the user, which will dump all the ops configuration as CSV File
+    # in current working directory or path which is set using the FORGE_EXPORT_UNIQUE_OP_CONFIG_DIR_PATH flag.
+    for test in test_list:
+
+        if test in test_to_skip:
+            continue
+
+        logger.info(f"Running the test: {test} upto {compilation_depth.lower()} compilation depth...")
+
+        try:
+            result = subprocess.run(
+                [
+                    "pytest",
+                    test,
+                    "-vss",
+                ],
+                capture_output=True,
+                text=True,
+                check=True,
+                env=dict(
+                    os.environ,
+                    FORGE_COMPILE_DEPTH=compilation_depth,
+                    FORGE_EXTRACT_UNIQUE_OP_CONFIG_AT=compilation_depth.upper(),
+                    FORGE_EXPORT_UNIQUE_OP_CONFIG_TO_CSV="1",
+                    FORGE_DISABLE_REPORTIFY_DUMP="1",
+                    FORGE_EXPORT_UNIQUE_OP_CONFIG_DIR_PATH=os.getenv(
+                        "FORGE_EXPORT_UNIQUE_OP_CONFIG_DIR_PATH", os.getcwd()
+                    ),
+                ),
+            )
+            if result.returncode != 0:
+                logger.error(f"Error while running the pytest:\n stdout: {result.stdout}\n stderr: {result.stderr}")
+            else:
+                logger.info(f"Successfully ran the test")
+
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Error while running the pytest:\n {e.output}")
+
+
+def create_sheet_from_exported_models_unique_op_configuration(
+    compilation_depth, output_directory_path, output_file_name, do_save_xlsx
+):
+
+    logger.info("Creating a sheet for model variants and unique op configuration...")
+
+    # Get the exported models unique op config directory path
+    exported_unique_op_config_dir_path = os.getenv("FORGE_EXPORT_UNIQUE_OP_CONFIG_DIR_PATH", os.getcwd())
+    if "OpConfigs" not in exported_unique_op_config_dir_path:
+        exported_unique_op_config_dir_path = os.path.join(exported_unique_op_config_dir_path, "OpConfigs")
+
+    # Create python dictionary which contains key as model names and values as list of ops names
+    max_model_name_len = 0
+    models_ops_dict = dict()
+    models_list = os.listdir(exported_unique_op_config_dir_path)
+
+    for model_name in models_list:
+
+        # Calculate model name length for setting the column size
+        if len(str(model_name)) > max_model_name_len:
+            max_model_name_len = len(str(model_name))
+
+        model_path = os.path.join(exported_unique_op_config_dir_path, model_name)
+
+        dumped_op_configuration_files = os.listdir(model_path)
+        for dumped_op_configuration_file in dumped_op_configuration_files:
+
+            if dumped_op_configuration_file[:-4].lower() == compilation_depth.lower():
+
+                dumped_op_configuration_file_path = os.path.join(model_path, dumped_op_configuration_file)
+                op_config_df = pd.read_csv(
+                    dumped_op_configuration_file_path,
+                    sep="-",
+                    header=0,
+                    usecols=["OpName", "Operands Shape", "Attributes"],
+                )
+
+                if model_name not in models_ops_dict.keys():
+                    models_ops_dict[model_name] = op_config_df.OpName.tolist()
+                else:
+                    models_ops_dict[model_name].extend(op_config_df.OpName.tolist())
+
+    all_models_ops_list = []
+    for model, ops in models_ops_dict.items():
+        all_models_ops_list.append(pd.DataFrame({"Models": model, "Ops": ops}))
+
+    # Combine all into a single dataframe on index axis(i.e 0)
+    combined_models_ops_df = pd.concat(all_models_ops_list)
+
+    # Count occurrences of each operation across all models
+    op_count = combined_models_ops_df["Ops"].value_counts().rename("OpCount")
+
+    # Pivot to get Ops as rows and Models as columns
+    pivot_df = pd.pivot_table(
+        combined_models_ops_df,
+        index="Ops",
+        columns="Models",
+        aggfunc="size",
+        fill_value=0,
+    )
+
+    # Replace the counts with 'Y' for operations present, and 'N' for absent
+    pivot_df = pivot_df.applymap(lambda x: "Y" if x > 0 else "N")
+
+    # Add the operation counts as a new column
+    pivot_df["OpCount"] = op_count
+
+    # Sort rows by number of models supporting each operation
+    pivot_df["model_ops_count"] = pivot_df.apply(lambda row: (row == "Y").sum(), axis=1)
+    pivot_df = pivot_df.sort_values(by="model_ops_count", ascending=False).drop("model_ops_count", axis=1)
+
+    # Sort columns by model names in alphabetical order
+    column_names = list(pivot_df.columns)
+    column_names.remove("OpCount")
+    column_names.sort()
+    column_names.append("OpCount")
+    pivot_df = pivot_df[column_names]
+
+    # Check if the output directory exists otherwise create the directory
+    if not os.path.exists(output_directory_path):
+        os.makedirs(output_directory_path)
+
+    if not do_save_xlsx:
+        pivot_df.to_csv(os.path.join(output_directory_path, output_file_name + ".csv"))
+        logger.info(
+            f"Saved cross correlation details between model variants vs unique op configs to {os.path.join(output_directory_path,output_file_name+'.csv')}"
+        )
+        return
+
+    # Create a new Excel writer object
+    writer = pd.ExcelWriter(
+        os.path.join(output_directory_path, output_file_name + ".xlsx"),
+        engine="openpyxl",
+    )
+
+    # Write the dataframe to the Excel file
+    pivot_df.to_excel(writer, sheet_name=output_file_name)
+
+    # Access the workbook and sheet
+    workbook = writer.book
+    ws = workbook.active
+    sheet = writer.sheets[output_file_name]
+
+    # Define your styles for fill the cell with particular color, center align the text in cell
+    pastel_gray_fill = PatternFill(start_color="CED2BA", end_color="CED2BA", fill_type="solid")
+    red_fill = PatternFill(start_color="D30000", end_color="D30000", fill_type="solid")
+    blue_fill = PatternFill(start_color="6495ED", end_color="6495ED", fill_type="solid")
+    slightly_desaturated_violet_fill = PatternFill(start_color="8D6FD1", end_color="8D6FD1", fill_type="solid")
+    center_aligned = Alignment(horizontal="center", vertical="center")
+    side = Side(style="thin", color="000000")
+    thin_border = Border(left=side, right=side, top=side, bottom=side)
+
+    # Fill first column(i.e Ops) with blue color
+    for row in range(1, sheet.max_row + 1):
+        sheet.cell(row=row, column=1).fill = blue_fill
+        sheet.cell(row=row, column=1).border = thin_border
+        sheet.cell(row=row, column=1).alignment = center_aligned
+
+    # Fill first row(i.e Models) with blue color
+    for col in range(1, sheet.max_column + 1):
+        sheet.cell(row=1, column=col).fill = blue_fill
+        sheet.cell(row=1, column=col).border = thin_border
+        sheet.cell(row=1, column=col).alignment = center_aligned
+
+    # Fill last column(i.e OpCount) with red color
+    for rol in range(2, sheet.max_row + 1):
+        sheet.cell(row=rol, column=sheet.max_column).fill = slightly_desaturated_violet_fill
+
+    # Set column width for cells
+    column_offset = 2
+    for col in ws.columns:
+        column = col[0].column_letter
+        ws.column_dimensions[column].width = max_model_name_len + column_offset
+
+    # Loop over the cells in the sheet and apply color based on value
+    for row in sheet.iter_rows(min_row=2, max_row=sheet.max_row, min_col=2, max_col=sheet.max_column):
+        for cell in row:
+            cell.border = thin_border
+            cell.alignment = center_aligned
+            if cell.value == "Y":
+                cell.fill = pastel_gray_fill
+            elif cell.value == "N":
+                cell.fill = red_fill
+
+    # Save the Excel file with formatting
+    writer.save()
+    writer.close()
+
+    logger.info(
+        f"Saved cross correlation details between model variants vs unique op configs to {os.path.join(output_directory_path,output_file_name+'.xlsx')}"
+    )
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(
+        description="Gather cross correlation details between model variants vs unique op configs"
+    )
+    parser.add_argument(
+        "-c",
+        "--compile_depth",
+        choices=[
+            "GENERATE_INITIAL_GRAPH",
+            "POST_INITIAL_GRAPH_PASS",
+            "OPTIMIZED_GRAPH",
+            "AUTOGRAD",
+            "POST_AUTOGRAD_PASS",
+            "PRE_LOWERING_PASS",
+        ],
+        required=True,
+        help="Choose the compilation depth for extracting ops configuration for the models present in pytest_directory_path.",
+    )
+    parser.add_argument(
+        "-i",
+        "--pytest_directory_path",
+        required=True,
+        help="Specify the directory path containing models to test.",
+    )
+    parser.add_argument(
+        "-f",
+        "--output_file_name",
+        default="Models_Ops_cross_correlation_data",
+        required=False,
+        help="Specify the output file name for the xlsx/csv file.",
+    )
+    parser.add_argument(
+        "-o",
+        "--output_directory_path",
+        default=os.getcwd(),
+        required=False,
+        help="Specify the output directory path for saving the xlsx/csv file.",
+    )
+    parser.add_argument(
+        "-s",
+        "--do_save_xlsx",
+        default=True,
+        required=False,
+        help="Specify whether to save the output in xlsx format.",
+    )
+    args = parser.parse_args()
+
+    compilation_depth = args.compile_depth
+    pytest_directory_path = args.pytest_directory_path
+    output_file_name = args.output_file_name
+    output_directory_path = args.output_directory_path
+    do_save_xlsx = args.do_save_xlsx
+
+    run_and_export_models_unique_ops_configuration(compilation_depth, pytest_directory_path)
+    create_sheet_from_exported_models_unique_op_configuration(
+        compilation_depth, output_directory_path, output_file_name, do_save_xlsx
+    )


### PR DESCRIPTION
The MR will add a pass for extracting the list of unique op configurations that are present in graph in every compilation stages and python script for cross correlating the model variants and Ops in specific compilation depth provided by user.

### 1) Extracting Unique Op Configuration Passes:

Fixes https://github.com/tenstorrent/tt-forge-fe/issues/141

**Flags:**

1)  **FORGE_EXTRACT_UNIQUE_OP_CONFIG_AT** -> By setting the flag to one of the below options, the pass will extract all the unique op configurations either specified compilation stage or all the compilation stages(Upto PRE_LOWERING_GRAPH)
a) **FORGE_EXTRACT_UNIQUE_OP_CONFIG_AT = ALL** -> It will extract all the unique op configuration that are present in graph in every compilation stages.
b) **FORGE_PRINT_UNIQUE_OP_CONFIG_AT={INITIAL_GRAPH/ PRE_OPTIMIZE_GRAPH/ POST_OPTIMIZE_GRAPH/ POST_AUTOGRAD_GRAPH/ PRE_LOWERING_GRAPH}** -> It will only extract all the unique op configuration in specified compilation stage.

2) **FORGE_PRINT_UNIQUE_OP_CONFIG** -> It will directly print all the unique configuration in the console

3) **FORGE_EXPORT_UNIQUE_OP_CONFIG_TO_CSV** -> It will dump all the unique configuration in the csv file in the default path(Current Directory) or it can be also dumped in specific path by setting path to the **FORGE_EXPORT_UNIQUE_OP_CONFIG_DIR_PATH** env flag.


Below is the sample graph from the Initial compilation stages.

```
Graph at: INITIAL
#! INPUTS !#
input_1{1, 32, 32, 32}
#! GRAPH !#
conv2d_0{1, 32, 32, 32} = (input_1, conv1.weight, conv1.bias, ) : {OP: conv2d(1,1,1,1,1,1,1,1,0,0,0,0,0,)}
conv2d_1{1, 32, 15, 15} = (conv2d_0, conv2.weight, conv2.bias, ) : {OP: conv2d(2,2,1,1,0,0,0,0,0,0,0,0,0,)}
conv2d_2{1, 32, 7, 7} = (conv2d_1, conv2.weight, conv2.bias, ) : {OP: conv2d(2,2,1,1,0,0,0,0,0,0,0,0,0,)}
conv2d_3{1, 32, 3, 3} = (conv2d_2, conv2.weight, conv2.bias, ) : {OP: conv2d(2,2,1,1,0,0,0,0,0,0,0,0,0,)}
resize2d_4{1, 32, 32, 32} = (input_1, ) : {OP: resize2d(32,32,0,0,0,)}
resize2d_5{1, 32, 64, 64} = (input_1, ) : {OP: resize2d(64,64,1,0,0,)}
resize2d_6{1, 32, 128, 128} = (resize2d_5, ) : {OP: resize2d(128,128,0,0,0,)}
resize2d_7{1, 32, 128, 128} = (resize2d_6, ) : {OP: resize2d(128,128,0,0,0,)}
#! OUTPUTS !#
OPConfig.output_conv2d_3{1, 32, 3, 3}
OPConfig.output_resize2d_4{1, 32, 32, 32}
OPConfig.output_resize2d_5{1, 32, 64, 64}
OPConfig.output_resize2d_6{1, 32, 128, 128}
OPConfig.output_resize2d_7{1, 32, 128, 128}
Graph end
```


Below is the list of unique op configurations in the graph from the Initial compilation stages.

```
Op Configuration at: INITIAL_GRAPH
resize2d
		 Input_shape: [{1, 32, 128, 128}, ]
					 Attributes: resize2d(128,128,0,0,0,)
		 Input_shape: [{1, 32, 64, 64}, ]
					 Attributes: resize2d(128,128,0,0,0,)
		 Input_shape: [{1, 32, 32, 32}, ]
					 Attributes: resize2d(32,32,0,0,0,)
					 Attributes: resize2d(64,64,1,0,0,)
conv2d
		 Input_shape: [{1, 32, 7, 7}, {32, 32, 3, 3}, {32}]
					 Attributes: conv2d(2,2,1,1,0,0,0,0,0,0,0,0,0,)
		 Input_shape: [{1, 32, 15, 15}, {32, 32, 3, 3}, {32}]
					 Attributes: conv2d(2,2,1,1,0,0,0,0,0,0,0,0,0,)
		 Input_shape: [{1, 32, 32, 32}, {32, 32, 3, 3}, {32}]
					 Attributes: conv2d(1,1,1,1,1,1,1,1,0,0,0,0,0,)
					 Attributes: conv2d(2,2,1,1,0,0,0,0,0,0,0,0,0,)

```


### 2) Script for cross correlating models and ops:

Fixes https://github.com/tenstorrent/tt-forge-fe/issues/496

Created a script for cross correlating models and ops and dumps the output as xlsx/csv file.

Script Output xlsx file: [Models_Ops_cross_correlation_data.xlsx](https://github.com/user-attachments/files/17459694/Models_Ops_cross_correlation_data.xlsx)

Script Output Log: [Script_Output.log](https://github.com/user-attachments/files/17459702/Script_Output.log)


The script will do the following jobs.
1. Run all models until specified compile depth
2. Export unique op requirements to the file (each model as it's own file)
3. Parse those op requirements and create output file that can be loaded up into google sheet. This output file should contain the listed models on on one axis and then list of ops on another axis. Elements in between should contain checkmark if desired op from X axis, exists in model on Y axis. Models should be sorted alphabetically and ops should be sorted by number of occurrence in the models

To run the script user must provided compilation depth and the folder contains pytest folder path.
Example:
`python scripts/export_models_ops_details.py -c PRE_LOWERING_PASS -i pybuda/test/model_demos/high_prio/cnn/pytorch`