### PR TITLE
Fix matmul shapes mismatch

### DIFF
--- a/forge/csrc/passes/fuse_redundant_tm_sequence.hpp
+++ b/forge/csrc/passes/fuse_redundant_tm_sequence.hpp
@@ -18,11 +18,9 @@ struct OpTypeItem
     OpTypeItem(OpType const& op_type, bool check_attrs) :
         op_name(op_type.op),
         attrs(
-            op_type.op == "transpose" ? std::vector<OpType::Attr>(
-                                            {op_type.get_attr_as<int>("dim0"),
-                                             op_type.get_attr_as<int>("dim1"),
-                                             op_type.get_attr_as<int>("z_dim_slice")})
-                                      : op_type.attr),
+            op_type.op == "transpose"
+                ? std::vector<OpType::Attr>({op_type.get_attr_as<int>("dim0"), op_type.get_attr_as<int>("dim1")})
+                : op_type.attr),
         check_attrs(check_attrs)
     {
     }
@@ -34,14 +32,10 @@ struct OpTypeItem
 
     OpType as_op_type() const
     {
-        return op_name == "transpose" ? graphlib::OpType(
-                                            op_name,
-                                            {},
-                                            {},
-                                            {{"dim0", std::get<int>(attrs[0])},
-                                             {"dim1", std::get<int>(attrs[1])},
-                                             {"z_dim_slice", std::get<int>(attrs[1])}})
-                                      : graphlib::OpType(op_name, attrs);
+        return op_name == "transpose"
+                   ? graphlib::OpType(
+                         op_name, {}, {}, {{"dim0", std::get<int>(attrs[0])}, {"dim1", std::get<int>(attrs[1])}})
+                   : graphlib::OpType(op_name, attrs);
     }
 };
 
@@ -51,31 +45,31 @@ using TMPatternPairs = std::vector<std::pair<TMPattern, TMPattern>>;
 // PreDefine TM sequence pattern
 static TMPattern pattern_0 = {
     OpTypeItem("vslice", {}, false),
-    OpTypeItem("transpose", {-3, -1, -1}, true),
-    OpTypeItem("transpose", {-2, -1, -1}, true),
+    OpTypeItem("transpose", {-3, -1}, true),
+    OpTypeItem("transpose", {-2, -1}, true),
     OpTypeItem("reshape", {}, false),
 };
 
 static TMPattern replace_0 = {
-    OpTypeItem("transpose", {-2, -1, -1}, true),
+    OpTypeItem("transpose", {-2, -1}, true),
 };
 
 static TMPattern pattern_1 = {
     OpTypeItem("reshape", {}, false),
-    OpTypeItem("transpose", {-3, -1, -1}, true),
-    OpTypeItem("transpose", {-2, -1, -1}, true),
+    OpTypeItem("transpose", {-3, -1}, true),
+    OpTypeItem("transpose", {-2, -1}, true),
     OpTypeItem("reshape", {}, false),
 };
 
 static TMPattern replace_1 = {
-    OpTypeItem("transpose", {-2, -1, -1}, true),
+    OpTypeItem("transpose", {-2, -1}, true),
 };
 
 static TMPattern pattern_2 = {
-    OpTypeItem("transpose", {-2, -1, -1}, true),
+    OpTypeItem("transpose", {-2, -1}, true),
     OpTypeItem("reshape", {}, false),
-    OpTypeItem("transpose", {-3, -2, -1}, true),
-    OpTypeItem("transpose", {-2, -1, -1}, true),
+    OpTypeItem("transpose", {-3, -2}, true),
+    OpTypeItem("transpose", {-2, -1}, true),
     OpTypeItem("reshape", {}, false),
 };
 
@@ -144,10 +138,10 @@ static TMPattern replace_2_15 = {
 };
 
 static TMPattern pattern_3 = {
-    OpTypeItem("transpose", {-2, -1, -1}, true),
+    OpTypeItem("transpose", {-2, -1}, true),
     OpTypeItem("reshape", {}, false),
-    OpTypeItem("transpose", {-4, -2, -1}, true),
-    OpTypeItem("transpose", {-3, -1, -1}, true),
+    OpTypeItem("transpose", {-4, -2}, true),
+    OpTypeItem("transpose", {-3, -1}, true),
     OpTypeItem("reshape", {}, false),
 };
 
@@ -192,10 +186,10 @@ static TMPattern replace_3_9 = {
 };
 
 static TMPattern pattern_4 = {
-    OpTypeItem("transpose", {-2, -1, -1}, true),
+    OpTypeItem("transpose", {-2, -1}, true),
     OpTypeItem("reshape", {}, false),
-    OpTypeItem("transpose", {-3, -2, -1}, true),
-    OpTypeItem("transpose", {-2, -1, -1}, true),
+    OpTypeItem("transpose", {-3, -2}, true),
+    OpTypeItem("transpose", {-2, -1}, true),
 };
 
 static TMPatternPairs pattern_map = {

--- a/forge/csrc/test/passes/test_erase_inverse_ops.cpp
+++ b/forge/csrc/test/passes/test_erase_inverse_ops.cpp
@@ -25,26 +25,17 @@ struct EraseInverseOps : testing::Test
         auto in0_b = create_input(*graph, "in0_b", graphlib::Shape::create({1, 1, 256, shape[3]}));
         auto matmul0 = add_node<graphlib::PyOpNode>(*graph, "matmul0", "matmul", {}, {in0_a, in0_b});
         auto transpose0 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose0",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", 0}, {"dim1", 1}, {"z_dim_slice", 1}}),
-            {matmul0});
+            *graph, "transpose0", graphlib::OpType("transpose", {}, {}, {{"dim0", 0}, {"dim1", 1}}), {matmul0});
 
         auto in1_a = create_input(*graph, "in1_a", graphlib::Shape::create({1, 1, shape[2], 128}));
         auto in1_b = create_input(*graph, "in1_b", graphlib::Shape::create({1, 1, 128, shape[3]}));
         auto matmul1 = add_node<graphlib::PyOpNode>(*graph, "matmul1", "matmul", {}, {in1_a, in1_b});
         auto transpose1 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose1",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", 0}, {"dim1", 1}, {"z_dim_slice", 1}}),
-            {matmul1});
+            *graph, "transpose1", graphlib::OpType("transpose", {}, {}, {{"dim0", 0}, {"dim1", 1}}), {matmul1});
 
         auto add = add_node<graphlib::PyOpNode>(*graph, "add", "add", {}, {transpose0, transpose1});
         auto post_transpose = add_node<graphlib::PyOpNode>(
-            *graph,
-            "post_transpose",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", 0}, {"dim1", 1}, {"z_dim_slice", 1}}),
-            {add});
+            *graph, "post_transpose", graphlib::OpType("transpose", {}, {}, {{"dim0", 0}, {"dim1", 1}}), {add});
 
         create_output(*graph, "out0", post_transpose);
     }
@@ -115,10 +106,7 @@ TEST_F(EraseInverseOps, erase_inverse_ops_transpose_fork_join)
     auto post_transpose = graph->get_node_by_name("post_transpose");
     auto unary = add_node<graphlib::PyOpNode>(*graph, "unary", "exp", {}, {post_transpose});
     auto unary_transpose = add_node<graphlib::PyOpNode>(
-        *graph,
-        "unary_transpose",
-        graphlib::OpType("transpose", {}, {}, {{"dim0", 0}, {"dim1", 1}, {"z_dim_slice", 1}}),
-        {unary});
+        *graph, "unary_transpose", graphlib::OpType("transpose", {}, {}, {{"dim0", 0}, {"dim1", 1}}), {unary});
     auto join = add_node<graphlib::PyOpNode>(*graph, "join", "add", {}, {unary_transpose, buffer2});
 
     graph->remove_node(graph->get_node_by_name("out0"));

--- a/forge/csrc/test/passes/test_erase_unnecessary_4d_tm_sequence.cpp
+++ b/forge/csrc/test/passes/test_erase_unnecessary_4d_tm_sequence.cpp
@@ -24,10 +24,7 @@ struct EraseUnnecessary4DSeq : testing::Test
         auto reshape_0 =
             add_node<graphlib::PyOpNode>(*graph, "reshape_0", "reshape", {NumOperands, 58, 64, 64}, {input_0});
         auto transpose_0 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose_0",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -4}, {"dim1", -3}, {"z_dim_slice", -1}}),
-            {reshape_0});
+            *graph, "transpose_0", graphlib::OpType("transpose", {}, {}, {{"dim0", -4}, {"dim1", -3}}), {reshape_0});
         auto reshape_1 =
             add_node<graphlib::PyOpNode>(*graph, "reshape_1", "reshape", {1, NumOperands * 58, 64, 64}, {transpose_0});
 

--- a/forge/csrc/test/passes/test_link_past_cache_ios.cpp
+++ b/forge/csrc/test/passes/test_link_past_cache_ios.cpp
@@ -34,20 +34,14 @@ struct WhisperPastCacheBase : testing::Test
 
         // define other nodes
         auto transpose_1 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose_1",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}, {"z_dim_slice", -1}}),
-            {weight});
+            *graph, "transpose_1", graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto matmul_1 = add_node<graphlib::PyOpNode>(*graph, "matmul_1", "matmul", {}, {in_1, transpose_1});
         auto hslice_1 = add_node<graphlib::PyOpNode>(*graph, "hslice_1", "hslice", {12}, {matmul_1});
         auto concat_1 = add_node<graphlib::PyOpNode>(*graph, "concat_1", "concatenate", {-2}, {pkv_input_1, hslice_1});
         auto output_1 = create_output(*graph, "output_1", concat_1);
 
         auto transpose_2 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose_2",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}, {"z_dim_slice", -1}}),
-            {weight});
+            *graph, "transpose_2", graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto matmul_2 = add_node<graphlib::PyOpNode>(*graph, "matmul_2", "matmul", {}, {in_2, transpose_2});
         auto hslice_2 = add_node<graphlib::PyOpNode>(*graph, "hslice_2", "hslice", {12}, {matmul_2});
         auto concat_2 = add_node<graphlib::PyOpNode>(*graph, "concat_2", "concatenate", {-2}, {pkv_input_2, hslice_2});
@@ -131,7 +125,7 @@ struct WhisperPastCacheSubGraph : testing::Test
         auto transpose_1 = add_node<graphlib::PyOpNode>(
             *graph,
             "transpose_1",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}, {"z_dim_slice", -1}}),
+            graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}}),
             {weight},
             {},
             0);
@@ -221,10 +215,7 @@ struct T5PastCacheRotate : testing::Test
 
         // path 1
         auto transpose_1 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose_1",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}, {"z_dim_slice", -1}}),
-            {weight});
+            *graph, "transpose_1", graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto matmul_1 = add_node<graphlib::PyOpNode>(*graph, "matmul_1", "matmul", {}, {in_1, transpose_1});
         auto hslice_1 = add_node<graphlib::PyOpNode>(*graph, "hslice_1", "hslice", {8}, {matmul_1});
         auto concat_1 = add_node<graphlib::PyOpNode>(*graph, "concat_1", "concatenate", {-2}, {pkv_input_1, hslice_1});
@@ -232,10 +223,7 @@ struct T5PastCacheRotate : testing::Test
 
         // path 2
         auto transpose_2 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose_2",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}, {"z_dim_slice", -1}}),
-            {weight});
+            *graph, "transpose_2", graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto matmul_2 = add_node<graphlib::PyOpNode>(*graph, "matmul_2", "matmul", {}, {in_2, transpose_2});
         auto hslice_2 = add_node<graphlib::PyOpNode>(*graph, "hslice_2", "hslice", {8}, {matmul_2});
         auto concat_2 = add_node<graphlib::PyOpNode>(*graph, "concat_2", "concatenate", {-2}, {pkv_input_2, hslice_2});
@@ -352,10 +340,7 @@ struct Falcon40bPastCache : testing::Test
 
         // path 1
         auto transpose_1 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose_1",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}, {"z_dim_slice", -1}}),
-            {weight});
+            *graph, "transpose_1", graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto matmul_1 = add_node<graphlib::PyOpNode>(*graph, "matmul_1", "matmul", {}, {in_1_1, transpose_1});
         auto hslice_1 = add_node<graphlib::PyOpNode>(*graph, "hslice_1", "hslice", {1}, {matmul_1});
         auto multiply_1 = add_node<graphlib::PyOpNode>(*graph, "multiply_1", "multiply", {}, {hslice_1, cos_0});
@@ -365,19 +350,13 @@ struct Falcon40bPastCache : testing::Test
 
         // path 2
         auto transpose_2 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose_2",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}, {"z_dim_slice", -1}}),
-            {weight});
+            *graph, "transpose_2", graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto matmul_2 = add_node<graphlib::PyOpNode>(*graph, "matmul_2", "matmul", {}, {in_2_1, transpose_2});
         auto reshape_2 = add_node<graphlib::PyOpNode>(*graph, "reshape_2", "reshape", {1, 1, 32, 64}, {matmul_2});
         auto multiply_2 = add_node<graphlib::PyOpNode>(*graph, "multiply_2", "multiply", {}, {reshape_2, cos_1});
         auto add_2 = add_node<graphlib::PyOpNode>(*graph, "add_2", "add", {}, {multiply_2, in_2_2});
         auto transpose_3 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose_3",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -3}, {"dim1", -2}, {"z_dim_slice", 32}}),
-            {add_2});
+            *graph, "transpose_3", graphlib::OpType("transpose", {}, {}, {{"dim0", -3}, {"dim1", -2}}), {add_2});
         auto multiply_3 = add_node<graphlib::PyOpNode>(*graph, "multiply_3", "multiply", {}, {transpose_3, in_2_3});
         auto multiply_4 = add_node<graphlib::PyOpNode>(*graph, "multiply_4", "multiply", {}, {pkv_input, in_2_4});
         auto add_3 = add_node<graphlib::PyOpNode>(*graph, "add_3", "add", {}, {multiply_3, multiply_4});
@@ -465,10 +444,7 @@ struct Fuyu8bPastCache : testing::Test
         auto matmul_1 = add_node<graphlib::PyOpNode>(*graph, "matmul_1", "matmul", {}, {in_1, weight});
         auto reshape_1 = add_node<graphlib::PyOpNode>(*graph, "reshape_1", "reshape", {1, 32, 64, 64}, {matmul_1});
         auto transpose_1 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose_1",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -3}, {"dim1", -2}, {"z_dim_slice", 64}}),
-            {reshape_1});
+            *graph, "transpose_1", graphlib::OpType("transpose", {}, {}, {{"dim0", -3}, {"dim1", -2}}), {reshape_1});
         auto concat_1 = add_node<graphlib::PyOpNode>(*graph, "concat_1", "concatenate", {-2}, {pkv_input, transpose_1});
         auto output_1 = create_output(*graph, "output_1", concat_1);
 
@@ -476,10 +452,7 @@ struct Fuyu8bPastCache : testing::Test
         auto matmul_2 = add_node<graphlib::PyOpNode>(*graph, "matmul_2", "matmul", {}, {in_2, weight});
         auto reshape_2 = add_node<graphlib::PyOpNode>(*graph, "reshape_2", "reshape", {1, 416, 64, 64}, {matmul_2});
         auto transpose_2 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose_2",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -3}, {"dim1", -2}, {"z_dim_slice", 64}}),
-            {reshape_2});
+            *graph, "transpose_2", graphlib::OpType("transpose", {}, {}, {{"dim0", -3}, {"dim1", -2}}), {reshape_2});
         auto index_2_1 = add_node<graphlib::PyOpNode>(*graph, "index_2_1", "index", {-1, 0, 32, 64}, {transpose_2});
         auto index_2_2 = add_node<graphlib::PyOpNode>(*graph, "index_2_2", "index", {-1, 32, 64, 64}, {transpose_2});
         auto add_2 = add_node<graphlib::PyOpNode>(*graph, "add_2", "add", {}, {in_add, index_2_2});

--- a/forge/csrc/test/passes/test_move_index_to_mm_weights.cpp
+++ b/forge/csrc/test/passes/test_move_index_to_mm_weights.cpp
@@ -31,7 +31,7 @@ struct Gpt2Split : testing::Test
         auto transpose_1_1 = add_node<graphlib::PyOpNode>(
             *graph,
             "transpose_1_1",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -3}, {"dim1", -2}, {"z_dim_slice", -1}}),
+            graphlib::OpType("transpose", {}, {}, {{"dim0", -3}, {"dim1", -2}}),
             {reshape_1_1});
         create_output(*graph, "output_1_1", transpose_1_1);
 
@@ -40,7 +40,7 @@ struct Gpt2Split : testing::Test
         auto transpose_1_2 = add_node<graphlib::PyOpNode>(
             *graph,
             "transpose_1_2",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -3}, {"dim1", -2}, {"z_dim_slice", -1}}),
+            graphlib::OpType("transpose", {}, {}, {{"dim0", -3}, {"dim1", -2}}),
             {reshape_1_2});
         create_output(*graph, "output_1_2", transpose_1_2);
 
@@ -49,7 +49,7 @@ struct Gpt2Split : testing::Test
         auto transpose_1_3 = add_node<graphlib::PyOpNode>(
             *graph,
             "transpose_1_3",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -3}, {"dim1", -2}, {"z_dim_slice", -1}}),
+            graphlib::OpType("transpose", {}, {}, {{"dim0", -3}, {"dim1", -2}}),
             {reshape_1_3});
         create_output(*graph, "output_1_3", transpose_1_3);
     }
@@ -112,10 +112,7 @@ struct Fuyu8bSplit : testing::Test
 
         // path 1
         auto transpose_1 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose_1",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}, {"z_dim_slice", -1}}),
-            {weight});
+            *graph, "transpose_1", graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto reshape_1_0 = add_node<graphlib::PyOpNode>(*graph, "reshape_1_0", "reshape", {32, 4096}, {in_1});
         auto matmul_1 = add_node<graphlib::PyOpNode>(*graph, "matmul_1", "matmul", {}, {reshape_1_0, transpose_1});
         auto reshape_1_1 = add_node<graphlib::PyOpNode>(*graph, "reshape_1_1", "reshape", {1, 32, 12288}, {matmul_1});
@@ -133,10 +130,7 @@ struct Fuyu8bSplit : testing::Test
 
         // path 2
         auto transpose_2 = add_node<graphlib::PyOpNode>(
-            *graph,
-            "transpose_2",
-            graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}, {"z_dim_slice", -1}}),
-            {weight});
+            *graph, "transpose_2", graphlib::OpType("transpose", {}, {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto reshape_2_0 = add_node<graphlib::PyOpNode>(*graph, "reshape_2_0", "reshape", {416, 4096}, {in_2});
         auto matmul_2 = add_node<graphlib::PyOpNode>(*graph, "matmul_2", "matmul", {}, {reshape_2_0, transpose_2});
         auto reshape_2_1 = add_node<graphlib::PyOpNode>(*graph, "reshape_2_1", "reshape", {1, 32, 12288}, {matmul_2});

--- a/forge/forge/fx/nodes.py
+++ b/forge/forge/fx/nodes.py
@@ -190,7 +190,7 @@ def process_transpose(node, forge_op_name):
     if dim0 > dim1:
         dim0, dim1 = dim1, dim0
 
-    named_attrs = {"dim0": dim0, "dim1": dim1, "z_dim_slice": -1}
+    named_attrs = {"dim0": dim0, "dim1": dim1}
 
     return ForgeNode(
         OpType(forge_op_name, named_attrs=named_attrs),

--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -763,9 +763,9 @@ def lower(type, attr, lc, ops, outputs):
         assert attr[1] >= 0 and attr[1] <= 3, f"Invalid transpose dim after lowering: {attr[0]}"
 
         if attr[0] == 2 and attr[1] == 3:
-            lc.tm("transpose", ops[0], attr, named_attrs={"dim0": attr[0], "dim1": attr[1], "z_dim_slice": attr[2]})
+            lc.tm("transpose", ops[0], attr, named_attrs={"dim0": attr[0], "dim1": attr[1]})
         else:
-            lc.op("transpose", ops, attr, {"dim0": attr[0], "dim1": attr[1], "z_dim_slice": attr[2]})
+            lc.op("transpose", ops, attr, {"dim0": attr[0], "dim1": attr[1]})
 
     elif type == "broadcast":
         if attr[0] < 0:
@@ -1021,14 +1021,14 @@ def backward(type, attr, ac, operand, inputs, output, grad):
             ret = ac.op("reduce_sum", (grad,), (attr[0],), {"keep_dim": True})
         else:
             ret = ac.op(
-                TransposeTM.create(attr[0], -2, z_dim_slice=grad.shape[-2]),
+                TransposeTM.create(attr[0], -2),
                 [
                     grad,
                 ],
             )
             ret = ac.op("reduce_sum", (ret,), (-2,), {"keep_dim": True})
             ret = ac.op(
-                TransposeTM.create(attr[0], -2, z_dim_slice=ret.shape[-2]),
+                TransposeTM.create(attr[0], -2),
                 [
                     ret,
                 ],

--- a/forge/forge/op/eval/forge/transpose.py
+++ b/forge/forge/op/eval/forge/transpose.py
@@ -42,7 +42,7 @@ class TransposeTM(PyTM):
 
         if self.dim0 == -2 and self.dim1 == -1:
             lc.tm(
-                ForgeTransposeTM.create(self.dim0, self.dim1, z_dim_slice=self.z_dim_slice),
+                ForgeTransposeTM.create(self.dim0, self.dim1),
                 tensors[0],
             )
         else:
@@ -58,7 +58,7 @@ class TransposeTM(PyTM):
                 self.dim1 -= inputs[0].shape.len()
             dc.fuse(
                 dc.op(
-                    TransposeTM.create(self.dim0, self.dim1, z_dim_slice=self.z_dim_slice),
+                    TransposeTM.create(self.dim0, self.dim1),
                     inputs,
                 )
             )

--- a/forge/forge/op/eval/lforge/transpose.py
+++ b/forge/forge/op/eval/lforge/transpose.py
@@ -7,11 +7,10 @@ from ..interface import ForgeTM
 
 class TransposeTM(ForgeTM):
     @classmethod
-    def create(cls, dim0, dim1, z_dim_slice=-1):
+    def create(cls, dim0, dim1):
         self = cls("transpose")
         self.dim0 = dim0
         self.dim1 = dim1
-        self.z_dim_slice = z_dim_slice
         return self
 
     def eval(self, tensors):

--- a/forge/forge/op/tm.py
+++ b/forge/forge/op/tm.py
@@ -115,9 +115,7 @@ def VStack(name: str, operandA: Tensor, slices: int = -1) -> Tensor:
     return op("vstack", name, operandA, attrs=(slices,)).get_tensor()
 
 
-def Transpose(
-    name: str, operandA: Tensor, dim0: int, dim1: int, z_dim_slice: int = -1, out_dtype: torch.dtype = torch.float32
-) -> Tensor:
+def Transpose(name: str, operandA: Tensor, dim0: int, dim1: int, out_dtype: torch.dtype = torch.float32) -> Tensor:
 
     """
     Tranpose X and Y (i.e. rows and columns) dimensions.
@@ -150,7 +148,7 @@ def Transpose(
     if dim0 > dim1:
         dim0, dim1 = dim1, dim0
 
-    return op("transpose", name, operandA, attrs=(dim0, dim1, z_dim_slice), dim0=dim0, dim1=dim1).get_tensor(
+    return op("transpose", name, operandA, attrs=(dim0, dim1), dim0=dim0, dim1=dim1).get_tensor(
         out_df=pytorch_dtype_to_forge_dataformat(out_dtype)
     )
 

--- a/forge/forge/tvm.py
+++ b/forge/forge/tvm.py
@@ -296,11 +296,10 @@ def populate_transpose_attrs(graph, nid, attrs):
     else:
         attrs.append(-1)
 
-    dim0, dim1, z_dim_slice = attrs
+    dim0, dim1 = attrs
     return {
         "dim0": dim0,
         "dim1": dim1,
-        "z_dim_slice": z_dim_slice,
     }
 
 

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1264,12 +1264,6 @@ def populate_transpose_args(graph, nid, compiler_cfg):
     args.append(("dim0", f"{transpose_axes[0]}"))
     args.append(("dim1", f"{transpose_axes[1]}"))
 
-    # If transpose unpadded Z dim, record the original shape
-    if (transpose_axes[0] == -3 and transpose_axes[1] != -4) or (transpose_axes[0] == -4 and transpose_axes[1] != -3):
-        args.append(("z_dim_slice", f"{transpose_shape[transpose_axes[0]]}"))
-    elif (transpose_axes[1] == -3 and transpose_axes[0] != -4) or (transpose_axes[1] == -4 and transpose_axes[0] != -3):
-        args.append(("z_dim_slice", f"{transpose_shape[transpose_axes[1]]}"))
-
     args.append(("out_dtype", "torch." + node["attrs"]["dtype"][0][0]))
 
     return args

--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -105,12 +105,17 @@ def test_reshape(source_and_target_shape):
         ((8, 1, 16, 32, 32), -4),
         ((8, 16, 1, 32, 32), -3),
         ([1, 12, 3200], 0),
+        ([1, 1, 2048, 1], [-3, -4]),
+        ([1, 64, 1, 1], [-1, -4]),
+        ([1, 1, 1, 128], [-2, -4]),
+        ([1, 1, 32, 1], [-1, -3]),
+        ([1, 1, 1, 64], [-4, -3]),
     ],
 )
 def test_squeeze(input_shape_and_dim):
     input_shape, dim = input_shape_and_dim
 
-    if input_shape == [1, 12, 3200]:
+    if input_shape == [1, 12, 3200] or isinstance(dim, list) and len(dim) > 1 and all(d < 0 for d in dim):
         pytest.xfail("TTNN: Tensor layout issues with non tile dim aligned shapes")
 
     class Squeeze(nn.Module):

--- a/forge/test/operators/tm/fuse/test_fuse_tm_sequence.py
+++ b/forge/test/operators/tm/fuse/test_fuse_tm_sequence.py
@@ -44,7 +44,7 @@ class PtFuseTMMultiUser(ForgeModule):
             epsilon=1e-05,
         )
         reshape_341 = forge.op.Reshape("", layernorm_340, shape=(1, 128, 128, 32))
-        transpose_342 = forge.op.Transpose("", reshape_341, dim0=-3, dim1=-1, z_dim_slice=32, out_dtype=torch.float32)
+        transpose_342 = forge.op.Transpose("", reshape_341, dim0=-3, dim1=-1, out_dtype=torch.float32)
         transpose_343 = forge.op.Transpose("", transpose_342, dim0=-2, dim1=-1, out_dtype=torch.float32)
         conv2d_344 = forge.op.Conv2d(
             "",


### PR DESCRIPTION
DecomposeMultiDimSqueeze callback is added since LowerSqueezeToReshape callback is commented in forge and since squeeze is not being converted to reshape, there is mismatch in final shape. 
With LowerSqueezeToReshape
```
2024-10-22 16:25:05.076 | INFO     | forge.op.eval.forge.pooling:eval:288 - Result from avgpool2d = torch.Size([1, 2048, 1, 1])
2024-10-22 16:25:05.080 | INFO     | forge.op.eval.forge:get_f_forge_shape:210 - op_type = reshape
2024-10-22 16:25:05.080 | INFO     | forge.op.eval.forge.tm:eval:55 - result from reshape = torch.Size([1, 2048, 1, 1])
2024-10-22 16:25:05.081 | INFO     | forge.op.eval.forge:get_f_forge_shape:210 - op_type = reshape
2024-10-22 16:25:05.081 | INFO     | forge.op.eval.forge.tm:eval:55 - result from reshape = torch.Size([1, 2048])
```
Without LowerSqueezeToReshape
```
2024-10-22 16:25:42.328 | INFO     | forge.op.eval.forge.pooling:eval:288 - Result from avgpool2d = torch.Size([1, 2048, 1, 1])
2024-10-22 16:25:42.331 | INFO     | forge.op.eval.forge:get_f_forge_shape:210 - op_type = reshape
2024-10-22 16:25:42.331 | INFO     | forge.op.eval.forge.tm:eval:55 - result from reshape = torch.Size([1, 2048, 1, 1])
2024-10-22 16:25:42.331 | INFO     | forge.op.eval.forge:get_f_forge_shape:210 - op_type = squeeze
2024-10-22 16:25:42.331 | INFO     | forge.op.eval.forge.tm:eval:372 - result from squeeze = torch.Size([1, 2048, 1])
```
