### PR TITLE
Add eval, decompose, lower for ConvTranspose2d Op

### DIFF
--- a/forge/forge/op/convolution.py
+++ b/forge/forge/op/convolution.py
@@ -135,6 +135,16 @@ def Conv2dTranspose(
         name,
         *inputs,
         attrs=attrs,
+        stride_height=stride[0],
+        stride_width=stride[1],
+        dilation_height=dilation,
+        dilation_width=dilation,
+        groups=groups,
+        padding_left=padding[0],
+        padding_right=padding[1],
+        padding_top=padding[2],
+        padding_bottom=padding[3],
+        channel_last=channel_last,
     ).get_tensor()
 
 

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -20,6 +20,7 @@ from .clip import Clip
 from .cumulativesum import CumulativeSum
 from .argmax import Argmax
 from .convolution import Conv2d
+from .convolution import Conv2dTranspose
 from .pooling import MaxPool2d
 
 op_to_module_map = {
@@ -106,7 +107,7 @@ op_to_module_map = {
     "reduce_max": "reduce",
     "grouped_reduce_avg": "reduce",
     "conv2d": Conv2d,
-    "conv2d_transpose": "convolution",
+    "conv2d_transpose": Conv2dTranspose,
     "conv3d": "convolution",
     "max_pool1d": "pooling",
     "max_pool2d": MaxPool2d,

--- a/forge/forge/op/eval/forge/convolution.py
+++ b/forge/forge/op/eval/forge/convolution.py
@@ -192,3 +192,190 @@ class Conv2d(PyOp):
 
     def is_eltwise_nary(self) -> bool:
         return False
+
+
+class Conv2dTranspose(PyOp):
+    @classmethod
+    def create(
+        cls,
+        stride_height,
+        stride_width,
+        dilation_height,
+        dilation_width,
+        groups,
+        padding_left,
+        padding_right,
+        padding_top,
+        padding_bottom,
+        channel_last,
+    ):
+        self = cls("conv2d_transpose")
+        self.stride_height = stride_height
+        self.stride_width = stride_width
+        self.dilation_height = dilation_height
+        self.dilation_width = dilation_width
+        self.groups = groups
+        self.padding_left = padding_left
+        self.padding_right = padding_right
+        self.padding_top = padding_top
+        self.padding_bottom = padding_bottom
+        self.channel_last = int(channel_last)
+        return self
+
+    def eval(self, tensors):
+        assert len(tensors) <= 3, "ConvTranspose ops should have up to three inputs (input, weight, bias)"
+        assert len(tensors) >= 2, "ConvTranspose ops should have at least two inputs (input, weight)"
+        t_ops = to_torch_operands(*tensors)
+
+        activations = t_ops[0]
+        weights = t_ops[1]
+        bias = t_ops[2] if len(t_ops) == 3 else None
+
+        stride = [self.stride_height, self.stride_width]
+        dilation = [self.dilation_height, self.dilation_width]
+        groups = self.groups
+        padding = [
+            self.padding_left,
+            self.padding_right,
+            self.padding_top,
+            self.padding_bottom,
+        ]
+
+        channel_last = self.channel_last
+        if channel_last:
+            activations = activations.permute((0, 3, 1, 2))
+
+        padded_activations = torch.nn.functional.pad(
+            activations,
+            padding,
+        )
+        if t_ops[1].dtype == torch.int8:
+            target_dtype = torch.int32
+            padded_activations, weights = padded_activations.float(), weights.float()
+            if bias is not None:
+                bias = bias.float()
+        else:
+            target_dtype = torch.float32
+
+        result = torch.nn.functional.conv_transpose2d(
+            padded_activations,
+            weights,
+            bias=bias,
+            stride=stride,
+            padding=0,
+            dilation=dilation,
+            groups=groups,
+        )
+
+        if channel_last:
+            result = result.permute((0, 2, 3, 1))
+
+        result = result.to(target_dtype)
+        return result
+
+    def shape(self, tensor_shapes):
+        act, weight = tensor_shapes[:2]
+        batch_size = act[0]
+        cout = weight[1]
+
+        h_in = act[-3] if self.channel_last else act[-2]
+        w_in = act[-2] if self.channel_last else act[-1]
+
+        output_padding_height = 0
+        output_padding_width = 0
+
+        h_out = (
+            ((h_in - 1) * self.stride_height)
+            - (2 * (self.padding_top + self.padding_bottom))
+            + (self.dilation_height * (weight[-2] - 1))
+            + output_padding_height
+            + 1
+        )
+        w_out = (
+            ((w_in - 1) * self.stride_width)
+            - (2 * (self.padding_left + self.padding_right))
+            + (self.dilation_width * (weight[-1] - 1))
+            + output_padding_width
+            + 1
+        )
+
+        out_shape = [batch_size, h_out, w_out, cout] if self.channel_last else [batch_size, cout, h_out, w_out]
+
+        return out_shape, []
+
+    def decompose(self, dc, inputs):
+        # TTNN can only perform a channel last convolution with its conv_transpose2d op.
+        # The TTNN conv_transpose2d requires the input to be in the shape: (N, H, W, C) or (1, 1, N*H*W, C).
+        # It requires the weight to be in the shape: (C_out, C_in, kernel_height, kernel_width).
+        # It requires the bias to be in the shape: (1, 1, 1, C_out).
+        #
+        # If the forge conv_transpose2d op is channel-first, we must permute the input (N, C, H, W) tensor to (N, H, W, C)
+        # and then transpose it back to (N, C_out, H_out, W_out) afterward.
+        #     - This is done with two transposes
+        #     - (N, C, H, W) --> transpose(-3, -2): (N, H, C, W) --> transpose(-2, -1): (N, H, W, C)
+        # Afterward:
+        #     - (N, H_out, W_out, C_out) --> transpose(-2, -1): (N, H_out, C_out, W_out) --> transpose(-3, -2): (N, C_out, H_out, W_out)
+        activations = inputs[0]
+        weight = inputs[1]
+        bias = inputs[2] if len(inputs) == 3 else None
+
+        is_channel_last = self.channel_last
+
+        if bias is not None and len(bias.shape) < len(activations.shape):
+            while len(bias.shape) < len(activations.shape):
+                bias = dc.op("unsqueeze", [bias], (0, len(bias.shape)))
+
+        is_bias_unchanged = bias is None or bias == inputs[2]
+
+        if not is_channel_last:
+            activations = dc.op(TransposeTM.create(dim0=-3, dim1=-2), [activations])
+            activations = dc.op(TransposeTM.create(dim0=-2, dim1=-1), [activations])
+
+        # Only want to re-create the Conv2dTranspose op if something has changed. Otherwise it the compiler will infinitely
+        # decompose the same Conv2dTranspose over and over.
+        if not is_bias_unchanged or not is_channel_last:
+            new_inputs = [activations, weight] if bias is None else [activations, weight, bias]
+            result = dc.op(
+                Conv2dTranspose.create(
+                    self.stride_height,
+                    self.stride_width,
+                    self.dilation_height,
+                    self.dilation_width,
+                    self.groups,
+                    self.padding_left,
+                    self.padding_right,
+                    self.padding_top,
+                    self.padding_bottom,
+                    True,  # If the original Conv2dTranspose was channel-last, that will not change.
+                    # If it was channel-first, it the input will have been permuted by this point.
+                    # So, the Conv2dTranspose op being created here is certainly channel-last.
+                ),
+                new_inputs,
+            )
+
+            if not is_channel_last:
+                result = dc.op(TransposeTM.create(dim0=-2, dim1=-1), [result])
+                result = dc.op(TransposeTM.create(dim0=-3, dim1=-2), [result])
+
+            dc.fuse(result)
+
+    def backward(self, ac, operand, inputs, output, grad):
+        pass
+
+    def lower(self, lc, tensors, outputs):
+        pass
+
+    def is_tm(self) -> bool:
+        return False
+
+    def is_eltwise(self) -> bool:
+        return False
+
+    def is_eltwise_binary(self) -> bool:
+        return False
+
+    def is_eltwise_unary(self) -> bool:
+        return False
+
+    def is_eltwise_nary(self) -> bool:
+        return False

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_yolo_v6.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_yolo_v6.py
@@ -87,7 +87,7 @@ def test_yolo_v6_pytorch(variant, test_device):
 
     # STEP 1 : Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # STEP 2 :prepare model
     url = f"https://github.com/meituan/YOLOv6/releases/download/0.3.0/{variant}.pt"


### PR DESCRIPTION
Implement eval, decompose, lower and other required methods for ConvTranspose2d Op.

- This op is required for the yolov6 Model bringup.