### PR TITLE
[build] fixup clean_all script

### DIFF
--- a/clean_all.sh
+++ b/clean_all.sh
@@ -2,9 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+# Cleans all build artifacts, except for the environment and toolchains.
+# If you want to clean the environment (should be rarely needed), remove the env/build directories.
+# E.g. rm -rf env/build third_party/tt-mlir/env/build
+
 rm -rf build
-rm -rf env/build
 rm -rf third_party/tt-mlir/build
-rm -rf third_party/tt-mlir/env/build
 rm -rf third_party/tt-mlir/third_party/tt-metal
 rm -rf third_party/tvm/build

--- a/docs/src/build.md
+++ b/docs/src/build.md
@@ -85,7 +85,7 @@ cmake --build build -- docs
 mdbook serve build/docs
 ```
 
-> **NOTE:** `mdbook serve` will by default create a local server at `http://localhost:3000`.
+> **Note:** `mdbook serve` will by default create a local server at `http://localhost:3000`.
 
 ## Build Cleanup
 
@@ -101,9 +101,16 @@ To ensure a clean build environment, follow these steps to remove existing build
      ```sh
      ./clean_all.sh
      ```
-   Note: This script executes a comprehensive cleanup, removing all build artifacts across the entire Forge project, ensuring a clean slate for subsequent builds.
+   > **Note:** This script executes a comprehensive cleanup, removing all build artifacts across the entire Forge project, ensuring a clean slate for subsequent builds.
 
-_Note: `clean_all.sh` script will not clean toolchain (LLVM) build artifacts and dependencies._
+   > **Note:** `clean_all.sh` script will not clean toolchain (LLVM) build artifacts and dependencies.
+
+3. **Clean everything (including environment):**
+    ```sh
+    ./clean_all.sh
+    rm -rf env/build third_party/tt-mlir/env/build
+    ```
+    > **Note:** This should rarely be needed, as it removes the entire build and toolchain (LLVM, Flatbuffers).
 
 ## Useful build environment variables
 1. `TTMLIR_TOOLCHAIN_DIR` - Specifies the directory where TTMLIR dependencies will be installed. Defaults to `/opt/ttmlir-toolchain` if not defined.


### PR DESCRIPTION
The way `tt-mlir` builds the environment and the toolchain has changed, so now if you delete the environment directories, everything will need to be rebuilt (including LLVM, Flatbuffers, etc.)

Since cleaning everything (including toolchains) is rarely needed, update the script to leave `env/build` dirs intact.

Also, tidying up the build docs...