### PR TITLE
Pass unique module name to compiler for all models

### DIFF
--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_alexnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_alexnet.py
@@ -41,7 +41,7 @@ def test_alexnet_torchhub(test_device):
         img_tensor = torch.rand(1, 3, 224, 224)
 
     inputs = [img_tensor]
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name="pt_alexnet_torchhub")
 
 
 def test_alexnet_osmr(test_device):
@@ -73,4 +73,4 @@ def test_alexnet_osmr(test_device):
         img_tensor = torch.rand(1, 3, 224, 224)
 
     inputs = [img_tensor]
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name="pt_alexnet_osmr")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_autoencoder.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_autoencoder.py
@@ -109,7 +109,7 @@ def test_conv_ae_pytorch(test_device):
     sample = dataset["train"][0]["image"]
     sample_tensor = transform(sample).unsqueeze(0)
 
-    compiled_model = forge.compile(model, sample_inputs=[sample_tensor])
+    compiled_model = forge.compile(model, sample_inputs=[sample_tensor], module_name="pt_conv_ae")
 
 
 def test_linear_ae_pytorch(test_device):
@@ -139,7 +139,7 @@ def test_linear_ae_pytorch(test_device):
     fw_out = model(sample_tensor)
 
     # Inference
-    compiled_model = forge.compile(model, sample_inputs=[sample_tensor])
+    compiled_model = forge.compile(model, sample_inputs=[sample_tensor], module_name="pt_linear_ae")
     co_out = compiled_model(sample_tensor)
 
     co_out = [co.to("cpu") for co in co_out]

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_blazepose.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_blazepose.py
@@ -36,7 +36,7 @@ def test_blazepose_detector_pytorch(test_device):
     _, img2, scale, pad = resize_pad(orig_image)
     img2 = torch.from_numpy(img2).permute((2, 0, 1)).unsqueeze(0)
     img2 = img2.float() / 255.0
-    compiled_model = forge.compile(pose_detector, sample_inputs=[img2])
+    compiled_model = forge.compile(pose_detector, sample_inputs=[img2], module_name="pt_blazepose_detector")
 
 
 @pytest.mark.skip(reason="dependent on CCM repo")
@@ -48,50 +48,14 @@ def test_blazepose_regressor_pytorch(test_device):
     pose_regressor = BlazePoseLandmark()
     pose_regressor.load_weights("mediapipepytorch/blazepose_landmark.pth")
     img2 = [torch.rand(1, 3, 256, 256)]
-    compiled_model = forge.compile(pose_regressor, sample_inputs=[img2])
+    compiled_model = forge.compile(pose_regressor, sample_inputs=[img2], module_name="pt_blazepose_regressor")
 
 
 @pytest.mark.skip(reason="dependent on CCM repo")
-def test_blazepose_detector_pytorch_1x1(test_device):
+def test_blaze_palm_pytorch(test_device):
 
     # Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
-
-    # Load BlazePose Detector
-    pose_detector = BlazePose()
-    pose_detector.load_weights("mediapipepytorch/blazepose.pth")
-    pose_detector.load_anchors("mediapipepytorch/anchors_pose.npy")
-
-    # Load data sample
-    orig_image = cv2.imread("forge/test/model_demos/utils/cnn/pytorch/images/girl.png")
-
-    # Preprocess for BlazePose Detector
-    _, img2, scale, pad = resize_pad(orig_image)
-    img2 = torch.from_numpy(img2).permute((2, 0, 1)).unsqueeze(0)
-    img2 = img2.float() / 255.0
-    compiled_model = forge.compile(pose_detector, sample_inputs=[img2])
-
-
-@pytest.mark.skip(reason="dependent on CCM repo")
-def test_blazepose_regressor_pytorch_1x1(test_device):
-
-    # Set Forge configuration parameters
-    compiler_cfg = forge.config._get_global_compiler_config()
-
-    # Load BlazePose Landmark Regressor
-    pose_regressor = BlazePoseLandmark()
-    pose_regressor.load_weights("mediapipepytorch/blazepose_landmark.pth")
-
-    img2 = [torch.rand(1, 3, 256, 256)]
-    compiled_model = forge.compile(pose_regressor, sample_inputs=[img2])
-
-
-@pytest.mark.skip(reason="dependent on CCM repo")
-def test_blaze_palm_pytorch_1x1(test_device):
-
-    # Set Forge configuration parameters
-    compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.cpu_fallback_ops = set(["concatenate"])
 
     # Load BlazePalm Detector
     palm_detector = BlazePalm()
@@ -106,11 +70,11 @@ def test_blaze_palm_pytorch_1x1(test_device):
     img1, img2, scale, pad = resize_pad(orig_image)
     img2 = torch.from_numpy(img2).permute((2, 0, 1)).unsqueeze(0)
     img2 = img2.float() / 255.0
-    compiled_model = forge.compile(palm_detector, sample_inputs=[img2])
+    compiled_model = forge.compile(palm_detector, sample_inputs=[img2], module_name="pt_palm_detector")
 
 
 @pytest.mark.skip(reason="dependent on CCM repo")
-def test_blaze_hand_pytorch_1x1(test_device):
+def test_blaze_hand_pytorch(test_device):
 
     # Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
@@ -120,4 +84,4 @@ def test_blaze_hand_pytorch_1x1(test_device):
     hand_regressor.load_weights("mediapipepytorch/blazehand_landmark.pth")
 
     sample_tensor = [torch.rand(1, 3, 256, 256)]
-    compiled_model = forge.compile(hand_regressor, sample_inputs=[sample_tensor])
+    compiled_model = forge.compile(hand_regressor, sample_inputs=[sample_tensor], module_name="pt_hand_regressor")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_bts.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_bts.py
@@ -63,4 +63,4 @@ def test_bts_pytorch(test_device, variant):
 
     inputs = [image]
 
-    compiled_model = forge.compile(bts_model_wrapper, sample_inputs=inputs)
+    compiled_model = forge.compile(bts_model_wrapper, sample_inputs=inputs, module_name="pt_" + str(variant))

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_clip.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_clip.py
@@ -124,4 +124,4 @@ def test_clip_pytorch(test_device):
     text_model = CLIPTextWrapper(model)
     inputs = [inputs[0], inputs[2]]
 
-    compiled_model = forge.compile(text_model, sample_inputs=inputs)
+    compiled_model = forge.compile(text_model, sample_inputs=inputs, module_name="pt_clip_text_model")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_ddrnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_ddrnet.py
@@ -61,7 +61,7 @@ def test_ddrnet_pytorch(variant, test_device):
     )
     input_tensor = preprocess(input_image)
     input_batch = input_tensor.unsqueeze(0)
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name=f"pt_{variant}")
 
 
 variants = ["ddrnet23s_cityscapes", "ddrnet23_cityscapes"]
@@ -110,4 +110,4 @@ def test_ddrnet_semantic_segmentation_pytorch(variant, test_device):
     input_image = Image.open(image_path)
     input_tensor = transforms.ToTensor()(input_image)
     input_batch = input_tensor.unsqueeze(0)
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name=f"pt_{variant}")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_deit.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_deit.py
@@ -19,4 +19,6 @@ def test_vit_base_classify_224_hf_pytorch(variant, test_device):
     model, inputs, _ = generate_model_deit_imgcls_hf_pytorch(
         variant,
     )
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_"))
+    )

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_densenet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_densenet.py
@@ -101,7 +101,8 @@ def test_densenet_121_pytorch(variant, test_device):
     # STEP 3: Run inference on Tenstorrent device
     model(img_tensor)
     inputs = [img_tensor]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    variant_name = variant.replace("-", "_")
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name=f"pt_{variant_name}")
 
 
 def test_densenet_161_pytorch(test_device):
@@ -112,13 +113,12 @@ def test_densenet_161_pytorch(test_device):
 
     # STEP 2: Create Forge module from PyTorch model
     model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "densenet161", pretrained=True)
-    tt_model = forge.PyTorchModule("densnet161_pt", model)
 
     # STEP 3: Run inference on Tenstorrent device
     img_tensor = get_input_img()
     model(img_tensor)
     inputs = [img_tensor]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_densenet_161")
 
 
 def test_densenet_169_pytorch(test_device):
@@ -134,7 +134,7 @@ def test_densenet_169_pytorch(test_device):
     img_tensor = get_input_img()
     model(img_tensor)
     inputs = [img_tensor]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_densenet_169")
 
 
 def test_densenet_201_pytorch(test_device):
@@ -150,4 +150,4 @@ def test_densenet_201_pytorch(test_device):
     img_tensor = get_input_img()
     model(img_tensor)
     inputs = [img_tensor]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_densenet_201")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_dla.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_dla.py
@@ -60,4 +60,4 @@ def test_dla_pytorch(variant, test_device):
 
     pytorch_model = func(pretrained="imagenet")
     pytorch_model.eval()
-    compiled_model = forge.compile(pytorch_model, sample_inputs=[img_tensor])
+    compiled_model = forge.compile(pytorch_model, sample_inputs=[img_tensor], module_name=f"pt_{variant}")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_efficientnet_lite.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_efficientnet_lite.py
@@ -46,7 +46,7 @@ def test_efficientnet_lite_0_pytorch():
     # Image preprocessing
     wh = efflite.efficientnet_lite_params[model_name][2]
     img_tensor = get_image_tensor(wh)
-    compiled_model = forge.compile(model, sample_inputs=img_tensor)
+    compiled_model = forge.compile(model, sample_inputs=img_tensor, module_name="pt_efficientnet_lite_0")
 
 
 @pytest.mark.skip(reason="dependent on CCM repo")
@@ -66,7 +66,7 @@ def test_efficientnet_lite_1_pytorch(test_device):
     wh = efflite.efficientnet_lite_params[model_name][2]
     img_tensor = get_image_tensor(wh)
 
-    compiled_model = forge.compile(model, sample_inputs=img_tensor)
+    compiled_model = forge.compile(model, sample_inputs=img_tensor, module_name="pt_efficientnet_lite_1")
 
 
 @pytest.mark.skip(reason="dependent on CCM repo")
@@ -85,7 +85,7 @@ def test_efficientnet_lite_2_pytorch(test_device):
     # Image preprocessing
     wh = efflite.efficientnet_lite_params[model_name][2]
     img_tensor = get_image_tensor(wh)
-    compiled_model = forge.compile(model, sample_inputs=img_tensor)
+    compiled_model = forge.compile(model, sample_inputs=img_tensor, module_name="pt_efficientnet_lite_2")
 
 
 @pytest.mark.skip(reason="dependent on CCM repo")
@@ -104,7 +104,7 @@ def test_efficientnet_lite_3_pytorch(test_device):
     # Image preprocessing
     wh = efflite.efficientnet_lite_params[model_name][2]
     img_tensor = get_image_tensor(wh)
-    compiled_model = forge.compile(model, sample_inputs=img_tensor)
+    compiled_model = forge.compile(model, sample_inputs=img_tensor, module_name="pt_efficientnet_lite_3")
 
 
 @pytest.mark.skip(reason="dependent on CCM repo")
@@ -123,4 +123,4 @@ def test_efficientnet_lite_4_pytorch(test_device):
     # Image preprocessing
     wh = efflite.efficientnet_lite_params[model_name][2]
     img_tensor = get_image_tensor(wh)
-    compiled_model = forge.compile(model, sample_inputs=img_tensor)
+    compiled_model = forge.compile(model, sample_inputs=img_tensor, module_name="pt_efficientnet_lite_3")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_fchardnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_fchardnet.py
@@ -38,4 +38,4 @@ def test_fchardnet(test_device):
     model = fuse_bn_recursively(model)
     model.eval()
 
-    compiled_model = forge.compile(model, sample_inputs=[input_image])
+    compiled_model = forge.compile(model, sample_inputs=[input_image], module_name="fchardnet")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_fpn.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_fpn.py
@@ -3,15 +3,20 @@
 # SPDX-License-Identifier: Apache-2.0
 import torch
 import torch.nn as nn
+import os
 import forge
 from torchvision.ops import FeaturePyramidNetwork
 from collections import OrderedDict
+from torchvision.models.detection import fasterrcnn_resnet50_fpn_v2, FasterRCNN_ResNet50_FPN_V2_Weights
 
 
 class FPNWrapper(nn.Module):
-    def __init__(self, in_channels_list, out_channels, extra_blocks=None, norm_layer=None):
+    def __init__(self):
         super().__init__()
-        self.fpn = FeaturePyramidNetwork(in_channels_list, out_channels, extra_blocks, norm_layer)
+
+        weights = FasterRCNN_ResNet50_FPN_V2_Weights.DEFAULT
+        model = fasterrcnn_resnet50_fpn_v2(weights=weights, box_score_thresh=0.9)
+        self.fpn = model.backbone.fpn
 
     def forward(self, feat0, feat1, feat2):
         x = OrderedDict()
@@ -26,11 +31,11 @@ def test_fpn_pytorch(test_device):
     compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
 
     # Load FPN model
-    model = FPNWrapper([10, 20, 30], 5)
+    model = FPNWrapper()
 
-    feat0 = torch.rand(1, 10, 64, 64)
-    feat1 = torch.rand(1, 20, 16, 16)
-    feat2 = torch.rand(1, 30, 8, 8)
+    feat0 = torch.rand(1, 256, 64, 64)
+    feat1 = torch.rand(1, 512, 16, 16)
+    feat2 = torch.rand(1, 2048, 8, 8)
 
     inputs = [feat0, feat1, feat2]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_fpn")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_ghostnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_ghostnet.py
@@ -11,4 +11,4 @@ variants = ["ghostnet_100"]
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_ghostnet_timm(variant, test_device):
     model, inputs = generate_model_ghostnet_imgcls_timm(variant)
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name=f"pt_{variant}")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_googlenet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_googlenet.py
@@ -40,4 +40,4 @@ def test_googlenet_pytorch(test_device):
         )
         input_batch = torch.rand(1, 3, 224, 224)
     input_batch_list = [input_batch]
-    compiled_model = forge.compile(model, sample_inputs=input_batch_list)
+    compiled_model = forge.compile(model, sample_inputs=input_batch_list, module_name="pt_googlenet")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_hardnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_hardnet.py
@@ -55,4 +55,4 @@ def test_hardnet_pytorch(test_device, variant):
     )
     input_tensor = preprocess(input_image)
     input_batch = input_tensor.unsqueeze(0)
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name=f"pt_{variant}")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_hrnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_hrnet.py
@@ -22,7 +22,7 @@ torch.multiprocessing.set_sharing_strategy("file_system")
 #############
 
 
-def generate_model_hrnet_imgcls_osmr_pytorch(test_device, variant):
+def generate_model_hrnet_imgcls_osmr_pytorch(variant):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
     compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
@@ -86,7 +86,7 @@ def test_hrnet_osmr_pytorch(test_device, variant):
     model, inputs, _ = generate_model_hrnet_imgcls_osmr_pytorch(
         variant,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name=f"pt_hrnet_osmr_{variant}")
 
 
 def generate_model_hrnet_imgcls_timm_pytorch(variant):
@@ -150,4 +150,4 @@ def test_hrnet_timm_pytorch(test_device, variant):
     model, inputs, _ = generate_model_hrnet_imgcls_timm_pytorch(
         variant,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name=f"pt_hrnet_timm_{variant}")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_inception_v4.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_inception_v4.py
@@ -21,7 +21,7 @@ torch.multiprocessing.set_sharing_strategy("file_system")
 import forge
 
 
-def generate_model_inceptionV4_imgcls_osmr_pytorch(test_device, variant):
+def generate_model_inceptionV4_imgcls_osmr_pytorch(variant):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
     compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
@@ -78,10 +78,10 @@ def get_image():
 
 def test_inception_v4_osmr_pytorch(test_device):
     model, inputs = generate_model_inceptionV4_imgcls_osmr_pytorch("inceptionv4")
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_osmr_inception_v4")
 
 
-def generate_model_inceptionV4_imgcls_timm_pytorch(test_device, variant):
+def generate_model_inceptionV4_imgcls_timm_pytorch(variant):
     # Configurations
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
     compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
@@ -94,4 +94,4 @@ def generate_model_inceptionV4_imgcls_timm_pytorch(test_device, variant):
 def test_inception_v4_timm_pytorch(test_device):
     model, inputs = generate_model_inceptionV4_imgcls_timm_pytorch("inception_v4")
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_timm_inception_v4")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_mlp_mixer.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_mlp_mixer.py
@@ -56,4 +56,4 @@ def test_mlp_mixer_timm_pytorch(variant, test_device):
         image = torch.rand(1, 3, 256, 256)
     pixel_values = transform(image).unsqueeze(0)
     inputs = [pixel_values]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_" + variant)

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_mobilenet_v1.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_mobilenet_v1.py
@@ -154,7 +154,7 @@ def test_mobilenetv1_basic(test_device):
         None,
     )
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_mobilenet_v1_basic")
 
 
 import requests
@@ -187,7 +187,7 @@ def test_mobilenetv1_192(test_device):
         test_device,
         "google/mobilenet_v1_0.75_192",
     )
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_mobilenet_v1_192")
 
 
 def generate_model_mobilenetV1I224_imgcls_hf_pytorch(test_device, variant):
@@ -214,4 +214,4 @@ def test_mobilenetv1_224(test_device):
         test_device,
         "google/mobilenet_v1_1.0_224",
     )
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_mobilenet_v1_224")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_mobilenet_v1_ssd.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_mobilenet_v1_ssd.py
@@ -31,4 +31,4 @@ def test_mobilenet_v1_ssd_pytorch_1x1(test_device):
 
     input_shape = (1, 3, 300, 300)
     inputs = [torch.rand(input_shape)]
-    compiled_model = forge.compile(net, sample_inputs=inputs)
+    compiled_model = forge.compile(net, sample_inputs=inputs, module_name="pt_mobilenet_v1_ssd")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_mobilenet_v2.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_mobilenet_v2.py
@@ -39,7 +39,7 @@ def test_mobilenetv2_basic(test_device):
         test_device,
         "pytorch/vision:v0.10.0",
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="mobilenetv2_basic")
 
 
 def generate_model_mobilenetV2I96_imgcls_hf_pytorch(test_device, variant):
@@ -64,7 +64,7 @@ def test_mobilenetv2_96(test_device):
         test_device,
         "google/mobilenet_v2_0.35_96",
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="mobilenetv2_96")
 
 
 def generate_model_mobilenetV2I160_imgcls_hf_pytorch(test_device, variant):
@@ -89,7 +89,7 @@ def test_mobilenetv2_160(test_device):
         test_device,
         "google/mobilenet_v2_0.75_160",
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="mobilenetv2_160")
 
 
 def generate_model_mobilenetV2I244_imgcls_hf_pytorch(test_device, variant):
@@ -116,7 +116,7 @@ def test_mobilenetv2_224(test_device):
         test_device,
         "google/mobilenet_v2_1.0_224",
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="mobilenetv2_224")
 
 
 def generate_model_mobilenetV2_imgcls_timm_pytorch(test_device, variant):
@@ -152,7 +152,7 @@ def test_mobilenetv2_timm(test_device):
         test_device,
         "mobilenetv2_100",
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="mobilenetv2_timm")
 
 
 def generate_model_mobilenetV2_semseg_hf_pytorch(test_device, variant):
@@ -196,4 +196,4 @@ def test_mobilenetv2_deeplabv3(variant, test_device):
         test_device,
         variant,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="mobilenetv2_deeplabv3")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_mobilenet_v3.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_mobilenet_v3.py
@@ -43,7 +43,7 @@ def test_mobilenetv3_basic(variant, test_device):
         test_device,
         variant,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name=f"pt_{variant}")
 
 
 def generate_model_mobilenetV3_imgcls_timm_pytorch(test_device, variant):
@@ -88,20 +88,4 @@ def test_mobilenetv3_timm(variant, test_device):
         variant,
     )
 
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
-
-
-variants = ["mobilenetv3_large_100", "mobilenetv3_small_100"]
-
-
-@pytest.mark.parametrize("variant", variants, ids=variants)
-@pytest.mark.skip(reason="Not supported")
-def test_mobilenetv3_timm_1x1(variant, test_device):
-    pytest.skip()
-    os.environ["FORGE_OVERRIDE_DEVICE_YAML"] = "wormhole_b0_1x1.yaml"
-
-    model, inputs, _ = generate_model_mobilenetV3_imgcls_timm_pytorch(
-        test_device,
-        variant,
-    )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name=f"pt_{variant}")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_monodle.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_monodle.py
@@ -33,4 +33,4 @@ def test_monodle_pytorch(test_device):
 
     pytorch_model = CenterNet3D(backbone="dla34")
     pytorch_model.eval()
-    compiled_model = forge.compile(pytorch_model, sample_inputs=[img_tensor])
+    compiled_model = forge.compile(pytorch_model, sample_inputs=[img_tensor], module_name="pt_monodle")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_nbeats.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_nbeats.py
@@ -29,7 +29,7 @@ def test_nbeats_with_seasonality_basis(test_device):
         layer_size=2048,
     )
     pytorch_model.eval()
-    compiled_model = forge.compile(pytorch_model, sample_inputs=[x, x_mask])
+    compiled_model = forge.compile(pytorch_model, sample_inputs=[x, x_mask], module_name="nbeats_seasonality")
 
 
 def test_nbeats_with_generic_basis(test_device):
@@ -41,7 +41,7 @@ def test_nbeats_with_generic_basis(test_device):
     pytorch_model = NBeatsWithGenericBasis(input_size=72, output_size=24, stacks=30, layers=4, layer_size=512)
     pytorch_model.eval()
 
-    compiled_model = forge.compile(pytorch_model, sample_inputs=[x, x_mask])
+    compiled_model = forge.compile(pytorch_model, sample_inputs=[x, x_mask], module_name="nbeats_generic")
 
 
 def test_nbeats_with_trend_basis(test_device):
@@ -60,4 +60,4 @@ def test_nbeats_with_trend_basis(test_device):
     )
     pytorch_model.eval()
 
-    compiled_model = forge.compile(pytorch_model, sample_inputs=[x, x_mask])
+    compiled_model = forge.compile(pytorch_model, sample_inputs=[x, x_mask], module_name="nbeats_trend")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_openpose.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_openpose.py
@@ -313,22 +313,20 @@ def generate_model_openpose_posdet_custom_pytorch(test_device, variant):
 
 
 @pytest.mark.parametrize("variant", variants)
-@pytest.mark.skip(reason="Not needed for release")
+@pytest.mark.skip(reason="dependent on CCM repo")
 def test_openpose_basic(variant, test_device):
     model, inputs, _ = generate_model_openpose_posdet_custom_pytorch(
         test_device,
         variant,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name=f"pt_openpose_{variant}")
 
 
 def generate_model_openpose_posdet_osmr_pytorch(test_device, variant):
 
     # Configurations
     compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.balancer_policy = "CNN"
-    compiler_cfg.enable_auto_fusing = False
-    compiler_cfg.default_df_override = forge._C.DataFormat.Float16
+    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
 
     # Load model
     framework_model = download_model(ptcv_get_model, variant, pretrained=True)
@@ -356,4 +354,4 @@ def test_openpose_osmr(variant, test_device):
         test_device,
         variant,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name=f"pt_openpose_{variant}")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_perceiverio.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_perceiverio.py
@@ -66,4 +66,6 @@ def test_perceiverio_for_image_classification_pytorch(test_device, variant):
 
     model.eval()
     # Run inference on Tenstorrent device
-    compiled_model = forge.compile(model, sample_inputs=[pixel_values])
+    compiled_model = forge.compile(
+        model, sample_inputs=[pixel_values], module_name="pt_" + str(variant.split("/")[-1].replace("-", "_"))
+    )

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_pidnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_pidnet.py
@@ -47,4 +47,4 @@ def test_pidnet_pytorch(variant, test_device):
     model.load_state_dict(model_dict)
     model.eval()
 
-    compiled_model = forge.compile(model, sample_inputs=[input_image])
+    compiled_model = forge.compile(model, sample_inputs=[input_image], module_name=f"pt_{variant}")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_rcnn.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_rcnn.py
@@ -67,7 +67,7 @@ def test_rcnn_pytorch(test_device):
 
         rect_transform = transform(rect_img)
         inputs = rect_transform.unsqueeze(0)
-        compiled_model = forge.compile(model, sample_inputs=[inputs])
+        compiled_model = forge.compile(model, sample_inputs=[inputs], module_name="pt_rcnn")
 
         break  # As generated proposals will be around 2000, halt inference after getting result from single proposal.
 

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_resnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_resnet.py
@@ -14,7 +14,7 @@ from timm.data.transforms_factory import create_transform
 from loguru import logger
 
 
-def generate_model_resnet_imgcls_hf_pytorch(test_device, variant):
+def generate_model_resnet_imgcls_hf_pytorch(variant):
     # Load ResNet feature extractor and model checkpoint from HuggingFace
     model_ckpt = variant
     feature_extractor = download_model(AutoFeatureExtractor.from_pretrained, model_ckpt)
@@ -37,13 +37,11 @@ def generate_model_resnet_imgcls_hf_pytorch(test_device, variant):
     # Data preprocessing
     inputs = feature_extractor(image, return_tensors="pt")
     pixel_values = inputs["pixel_values"]
-    # model = forge.PyTorchModule("pt_resnet50", model)
 
     return model, [pixel_values], {}
 
 
-@pytest.mark.parametrize("enable_default_dram_parameters", [True, False])
-def test_resnet(test_device, enable_default_dram_parameters):
+def test_resnet(test_device):
 
     model, inputs, _ = generate_model_resnet_imgcls_hf_pytorch(
         "microsoft/resnet-50",
@@ -51,10 +49,10 @@ def test_resnet(test_device, enable_default_dram_parameters):
 
     compiler_cfg = forge.config._get_global_compiler_config()
     compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="pt_resnet50")
 
 
-def generate_model_resnet_imgcls_timm_pytorch(test_device, variant):
+def generate_model_resnet_imgcls_timm_pytorch(variant):
     # Load ResNet50 feature extractor and model from TIMM
     model = download_model(timm.create_model, variant, pretrained=True)
     config = resolve_data_config({}, model=model)
@@ -84,4 +82,4 @@ def test_resnet_timm(test_device):
     model, inputs, _ = generate_model_resnet_imgcls_timm_pytorch(
         "resnet50",
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="pt_resnet50_timm")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_resnext.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_resnext.py
@@ -50,7 +50,7 @@ def test_resnext_50_torchhub_pytorch(test_device):
     # STEP 3: Run inference on Tenstorrent device
     # CPU version commented out
     # output = model(input_batch)
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name="pt_resnext50_torchhub")
 
 
 def test_resnext_101_torchhub_pytorch(test_device):
@@ -67,7 +67,7 @@ def test_resnext_101_torchhub_pytorch(test_device):
     # STEP 3: Run inference on Tenstorrent device
     # CPU version commented out
     # output = model(input_batch)
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name="pt_resnext101_torchhub")
 
 
 def test_resnext_101_32x8d_fb_wsl_pytorch(test_device):
@@ -86,7 +86,7 @@ def test_resnext_101_32x8d_fb_wsl_pytorch(test_device):
     # STEP 3: Run inference on Tenstorrent device
     # CPU version commented out
     # output = model(input_batch)
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name="pt_resnext101_fb_wsl")
 
 
 def test_resnext_14_osmr_pytorch(test_device):
@@ -104,7 +104,7 @@ def test_resnext_14_osmr_pytorch(test_device):
     # STEP 3: Run inference on Tenstorrent device
     # CPU version commented out
     # output = model(input_batch)
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name="pt_resnext14_osmr")
 
 
 def test_resnext_26_osmr_pytorch(test_device):
@@ -121,7 +121,7 @@ def test_resnext_26_osmr_pytorch(test_device):
     # STEP 3: Run inference on Tenstorrent device
     # CPU version commented out
     # output = model(input_batch)
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name="pt_resnext26_osmr")
 
 
 def test_resnext_50_osmr_pytorch(test_device):
@@ -133,12 +133,12 @@ def test_resnext_50_osmr_pytorch(test_device):
     model = download_model(ptcv_get_model, "resnext50_32x4d", pretrained=True)
     model.eval()
 
-    input_batch = get_image_tensor(test_device)
+    input_batch = get_image_tensor()
 
     # STEP 3: Run inference on Tenstorrent device
     # CPU version commented out
     # output = model(input_batch)
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name="pt_resnext50_osmr")
 
 
 def test_resnext_101_osmr_pytorch(test_device):
@@ -155,4 +155,4 @@ def test_resnext_101_osmr_pytorch(test_device):
     # STEP 3: Run inference on Tenstorrent device
     # CPU version commented out
     # output = model(input_batch)
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name="pt_resnext101_osmr")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_retinanet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_retinanet.py
@@ -73,7 +73,7 @@ def test_retinanet(variant, test_device):
     # Prepare input
     input_batch = img_preprocess()
     inputs = [input_batch]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name=f"pt_{variant}")
 
     # Delete the extracted folder and the zip file
     shutil.rmtree(extracted_path)

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_segformer_imgcls.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_segformer_imgcls.py
@@ -53,4 +53,6 @@ def test_segformer_image_classification_pytorch(test_device, variant):
     # Load the sample image
     pixel_values = get_sample_data(variant)
 
-    compiled_model = forge.compile(model, sample_inputs=[pixel_values])
+    compiled_model = forge.compile(
+        model, sample_inputs=[pixel_values], module_name="pt_" + str(variant.split("/")[-1].replace("-", "_"))
+    )

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_segformer_semseg.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_segformer_semseg.py
@@ -44,4 +44,6 @@ def test_segformer_semantic_segmentation_pytorch(test_device, variant):
 
     # Load the sample image
     pixel_values = get_sample_data(variant)
-    compiled_model = forge.compile(model, sample_inputs=[pixel_values])
+    compiled_model = forge.compile(
+        model, sample_inputs=[pixel_values], module_name="pt_" + str(variant.split("/")[-1].replace("-", "_"))
+    )

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_ssd300_resnet50.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_ssd300_resnet50.py
@@ -79,4 +79,4 @@ def test_pytorch_ssd300_resnet50(test_device):
     CHW = np.swapaxes(np.swapaxes(HWC, 0, 2), 1, 2)
     batch = np.expand_dims(CHW, axis=0)
     input_batch = torch.from_numpy(batch).float()
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name="pt_ssd300_resnet50")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_stable_diffusion.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_stable_diffusion.py
@@ -151,13 +151,13 @@ def denoising_loop(
             # noise_pred_0 = pipeline(latent_model_input.detach()[0:1],timestep_.detach()[0:1],prompt_embeds.detach()[0:1],)
 
             inputs = [latent_model_input.detach()[0:1], timestep_.detach()[0:1], prompt_embeds.detach()[0:1]]
-            compiled_model = forge.compile(pipeline, sample_inputs=inputs)
+            compiled_model = forge.compile(pipeline, sample_inputs=inputs, module_name=f"pt_stable_diffusion_1_{i}")
             noise_pred_0 = compiled_model(*inputs)
 
             # sanity
             # noise_pred_1 = pipeline(latent_model_input.detach()[1:2],timestep_.detach()[1:2],prompt_embeds.detach()[1:2],)
             inputs = [latent_model_input.detach()[1:2], timestep_.detach()[1:2], prompt_embeds.detach()[1:2]]
-            compiled_model = forge.compile(pipeline, sample_inputs=inputs)
+            compiled_model = forge.compile(pipeline, sample_inputs=inputs, module_name=f"pt_stable_diffusion_2_{i}")
             noise_pred_1 = compiled_model(*inputs)
 
             noise_pred = torch.cat([noise_pred_0[0].value().detach(), noise_pred_1[0].value().detach()], dim=0)

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_swin.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_swin.py
@@ -31,4 +31,4 @@ def test_swin_v1_tiny_4_224_hf_pytorch(test_device):
     print(img_tensor.shape)
 
     inputs = [img_tensor]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_swin_tiny_patch4_window7_224")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_tri_basic_2.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_tri_basic_2.py
@@ -40,4 +40,4 @@ def test_tri_basic_2_sematic_segmentation_pytorch(test_device):
 
     print("type(image_tensor)", type(image_tensor))
     inputs = image_tensor
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_tri_basic_2_semseg")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_unet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_unet.py
@@ -40,7 +40,7 @@ def test_unet_osmr_cityscape_pytorch(test_device):
         test_device,
         "unet_cityscapes",
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="pt_unet_cityscapes_osmr")
 
 
 def get_imagenet_sample():
@@ -70,7 +70,7 @@ def get_imagenet_sample():
     return img_tensor
 
 
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="Model script not found")
 def test_unet_holocron_pytorch(test_device):
     from holocron.models.segmentation.unet import unet_tvvgg11
 
@@ -81,7 +81,7 @@ def test_unet_holocron_pytorch(test_device):
     model = download_model(unet_tvvgg11, pretrained=True).eval()
 
     img_tensor = get_imagenet_sample()
-    compiled_model = forge.compile(model, sample_inputs=[img_tensor])
+    compiled_model = forge.compile(model, sample_inputs=[img_tensor], module_name="pt_unet_holocron")
 
 
 def generate_model_unet_imgseg_smp_pytorch(test_device, variant):
@@ -120,7 +120,7 @@ def test_unet_qubvel_pytorch(test_device):
         test_device,
         None,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="pt_unet_qubvel_pt")
 
 
 def generate_model_unet_imgseg_torchhub_pytorch(test_device, variant):
@@ -170,4 +170,4 @@ def test_unet_torchhub_pytorch(test_device):
         test_device,
         "unet",
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="pt_unet_torchhub")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_vgg.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_vgg.py
@@ -53,7 +53,7 @@ def test_vgg_osmr_pytorch(variant, test_device):
         )
         input_batch = torch.rand(1, 3, 224, 224)
 
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name=f"pt_{variant}_osmr")
 
 
 def test_vgg_19_hf_pytorch(test_device):
@@ -92,7 +92,7 @@ def test_vgg_19_hf_pytorch(test_device):
             "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
         )
         input_batch = torch.rand(1, 3, 224, 224)
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name="pt_vgg_19_hf")
 
 
 def preprocess_timm_model(model_name):
@@ -123,7 +123,7 @@ def test_vgg_bn19_timm_pytorch(test_device):
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
     compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
 
-    compiled_model = forge.compile(model, sample_inputs=[image_tensor])
+    compiled_model = forge.compile(model, sample_inputs=[image_tensor], module_name=f"pt_{model_name}_timm")
 
 
 def test_vgg_bn19_torchhub_pytorch(test_device):
@@ -155,4 +155,4 @@ def test_vgg_bn19_torchhub_pytorch(test_device):
         )
         input_batch = torch.rand(1, 3, 224, 224)
 
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name="pt_vgg_bn19_torchhub")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_vilt.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_vilt.py
@@ -136,7 +136,9 @@ def test_vilt_question_answering_hf_pytorch(variant, test_device):
         test_device,
         variant,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0], inputs[1]])
+    compiled_model = forge.compile(
+        model, sample_inputs=[inputs[0], inputs[1]], module_name="pt_ViLt_question_answering"
+    )
 
 
 def generate_model_vilt_maskedlm_hf_pytorch(test_device, variant):
@@ -177,4 +179,4 @@ def test_vilt_maskedlm_hf_pytorch(variant, test_device):
         test_device,
         variant,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0], inputs[1]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0], inputs[1]], module_name="pt_ViLt_maskedlm")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_vit.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_vit.py
@@ -46,57 +46,6 @@ def test_vit_classify_224_hf_pytorch(variant, test_device):
         variant,
     )
 
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
-
-
-variants = ["google/vit-base-patch16-224", "google/vit-large-patch16-224"]
-
-
-@pytest.mark.parametrize("variant", variants, ids=variants)
-@pytest.mark.skip(reason="Redundant, already tested with test_vit_classification_1x1_demo")
-def test_vit_classify_224_hf_pytorch_1x1(variant, test_device):
-    os.environ["FORGE_OVERRIDE_DEVICE_YAML"] = "wormhole_b0_1x1.yaml"
-    if "large" in variant:
-        os.environ["FORGE_EXTRA_L1_MARGIN"] = "20000"
-
-    model, inputs, _ = generate_model_vit_imgcls_hf_pytorch(
-        test_device,
-        variant,
+    compiled_model = forge.compile(
+        model, sample_inputs=[inputs[0]], module_name="pt_" + str(variant.split("/")[-1].replace("-", "_"))
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
-
-
-modes = ["verify", "demo"]
-variants = [
-    "google/vit-base-patch16-224",
-    "google/vit-large-patch16-224",
-]
-
-
-@pytest.mark.skip(reason="1x1 grid size not supported yet")
-@pytest.mark.parametrize("mode", modes, ids=modes)
-@pytest.mark.parametrize("variant", variants, ids=variants)
-def test_vit_classification_1x1_demo(test_device, mode, variant):
-
-    # Setup for 1x1 grid
-    os.environ["FORGE_OVERRIDE_DEVICE_YAML"] = "wormhole_b0_1x1.yaml"
-
-    # Configurations
-    compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.balancer_policy = "Ribbon"
-    os.environ["FORGE_RIBBON2"] = "1"
-    compiler_cfg.default_df_override = forge._C.DataFormat.Float16_b
-    compiler_cfg.enable_tvm_cpu_fallback = False
-
-    # Load image preprocessor and model
-    image_processor = download_model(AutoImageProcessor.from_pretrained, variant)
-    framework_model = download_model(ViTForImageClassification.from_pretrained, variant)
-    model_name = "_".join(variant.split("/")[-1].split("-")[:2]) + f"_{mode}"
-
-    # Load and preprocess image
-    dataset = load_dataset("huggingface/cats-image")
-    input_image = dataset["test"]["image"][0]
-    input_image = image_processor(input_image, return_tensors="pt").pixel_values
-
-    if mode == "verify":
-        compiled_model = forge.compile(framework_model, sample_inputs=[input_image])

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_vovnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_vovnet.py
@@ -63,7 +63,7 @@ def test_vovnet_osmr_pytorch(variant, test_device):
         test_device,
         variant,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name=f"pt_{variant}")
 
 
 # https://github.com/stigma0617/VoVNet.pytorch
@@ -108,7 +108,7 @@ def test_vovnet_v1_39_stigma_pytorch(test_device, enable_default_dram_parameters
     )
 
     compiler_cfg = forge.config._get_global_compiler_config()
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name=f"pt_vovnet_39_stigma")
 
 
 from src_vovnet_stigma import vovnet57
@@ -130,7 +130,7 @@ def test_vovnet_v1_57_stigma_pytorch(test_device):
         test_device,
         None,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name=f"vovnet_57_stigma_pt")
 
 
 def preprocess_timm_model(model_name):
@@ -171,4 +171,4 @@ def test_vovnet_timm_pytorch(variant, test_device):
         test_device,
         variant,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name=f"pt_{variant}")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_wideresnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_wideresnet.py
@@ -18,7 +18,7 @@ def test_wideresnet_pytorch(variant, test_device):
         variant,
     )
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name=f"pt_{variant}_hub")
 
 
 variants = ["wide_resnet50_2", "wide_resnet101_2"]
@@ -31,4 +31,4 @@ def test_wideresnet_timm(variant, test_device):
         variant,
     )
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name=f"pt_{variant}_timm")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_xception.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_xception.py
@@ -15,4 +15,4 @@ def test_xception_timm(variant, test_device):
         test_device,
         variant,
     )
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name=f"pt_{variant}_timm")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_yolo_v3.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_yolo_v3.py
@@ -40,7 +40,7 @@ def test_yolov3_tiny_holli_pytorch(test_device):
         test_device,
         None,
     )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="pt_yolov3_tiny_holli")
 
 
 def generate_model_yoloV3_imgcls_holli_pytorch(test_device, variant):
@@ -71,13 +71,4 @@ def test_yolov3_holli_pytorch(test_device):
         None,
     )
 
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
-
-
-@pytest.mark.skip(reason="1x1 grid size not supported yet")
-def test_yolov3_holli_pytorch_1x1(test_device):
-    model, inputs, other = generate_model_yoloV3_imgcls_holli_pytorch(
-        test_device,
-        None,
-    )
-    compiled_model = forge.compile(model, sample_inputs=[inputs[0]])
+    compiled_model = forge.compile(model, sample_inputs=[inputs[0]], module_name="pt_yolov3_holli")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_yolo_v5.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_yolo_v5.py
@@ -31,7 +31,8 @@ def test_yolov5_320x320(test_device, size):
         size=size,
     )
     ouputs = model(inputs[0])
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    name = "yolov5" + size
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_" + name + "_320x320")
 
 
 def generate_model_yoloV5I640_imgcls_torchhub_pytorch(test_device, variant, size):
@@ -59,7 +60,8 @@ def test_yolov5_640x640(test_device, size):
         size=size,
     )
     ouputs = model(inputs[0])
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    name = "yolov5" + size
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_" + name + "_640x640")
 
 
 def generate_model_yoloV5I480_imgcls_torchhub_pytorch(test_device, variant, size):
@@ -82,7 +84,8 @@ def test_yolov5_480x480(test_device, size):
         size=size,
     )
     ouputs = model(inputs[0])
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    name = "yolov5" + size
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_" + name + "_480x480")
 
 
 def test_yolov5_1280x1280(test_device):
@@ -96,4 +99,4 @@ def test_yolov5_1280x1280(test_device):
     input_tensor = torch.rand(input_shape)
     inputs = [input_tensor]
     ouputs = model(inputs[0])
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_yolov5s_1280x1280")

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_yolo_v6.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_yolo_v6.py
@@ -114,7 +114,7 @@ def test_yolo_v6_pytorch(variant, test_device):
     input_batch = img.unsqueeze(0)
 
     # STEP 4 : Inference
-    compiled_model = forge.compile(model, sample_inputs=[input_batch])
+    compiled_model = forge.compile(model, sample_inputs=[input_batch], module_name=f"pt_{variant}")
 
     # STEP 5 : remove downloaded weights
     os.remove(weights)

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_yolox.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_yolox.py
@@ -94,7 +94,7 @@ def test_yolox_pytorch(variant, test_device):
 
     inputs = [img_tensor]
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name=f"pt_{variant}")
 
     # remove downloaded weights,image
     os.remove(weight_name)

--- a/forge/test/model_demos/high_prio/cnn/tflite/test_efficientnet_lite.py
+++ b/forge/test/model_demos/high_prio/cnn/tflite/test_efficientnet_lite.py
@@ -31,7 +31,7 @@ def test_efficientnet_lite0(test_device):
     compiled_model = forge.compile(tflite_path, sample_inputs=sample_tensor)
 
 
-@pytest.mark.skip(reason="dependent on CCM repo")
+@pytest.mark.skip(reason="Not supported yet")
 def test_efficientnet_lite1(test_device):
     compiler_cfg = _get_global_compiler_config()
     tflite_path = "third_party/confidential_customer_models/model_2/tflite/efficientnet-lite1-fp32.tflite"
@@ -39,7 +39,7 @@ def test_efficientnet_lite1(test_device):
     compiled_model = forge.compile(tflite_path, sample_inputs=sample_tensor)
 
 
-@pytest.mark.skip(reason="dependent on CCM repo")
+@pytest.mark.skip(reason="Not supported yet")
 def test_efficientnet_lite2(test_device):
     compiler_cfg = _get_global_compiler_config()
     tflite_path = "third_party/confidential_customer_models/model_2/tflite/efficientnet-lite2-fp32.tflite"
@@ -47,7 +47,7 @@ def test_efficientnet_lite2(test_device):
     compiled_model = forge.compile(tflite_path, sample_inputs=sample_tensor)
 
 
-@pytest.mark.skip(reason="dependent on CCM repo")
+@pytest.mark.skip(reason="Not supported yet")
 def test_efficientnet_lite3(test_device):
     compiler_cfg = _get_global_compiler_config()
     tflite_path = "third_party/confidential_customer_models/model_2/tflite/efficientnet-lite3-fp32.tflite"
@@ -55,7 +55,7 @@ def test_efficientnet_lite3(test_device):
     compiled_model = forge.compile(tflite_path, sample_inputs=sample_tensor)
 
 
-@pytest.mark.skip(reason="dependent on CCM repo")
+@pytest.mark.skip(reason="Not supported yet")
 def test_efficientnet_lite4(test_device):
     compiler_cfg = _get_global_compiler_config()
     tflite_path = "third_party/confidential_customer_models/model_2/tflite/efficientnet-lite4-fp32.tflite"

--- a/forge/test/model_demos/high_prio/cnn/tflite/test_hand_landmarker.py
+++ b/forge/test/model_demos/high_prio/cnn/tflite/test_hand_landmarker.py
@@ -7,14 +7,14 @@ from forge.config import _get_global_compiler_config
 import forge
 
 
-@pytest.mark.skip(reason="dependent on CCM repo")
+@pytest.mark.skip(reason="Not supported yet")
 def test_hand_landmark_lite_1x1(test_device):
     tflite_path = "third_party/confidential_customer_models/model_2/tflite/hand_landmark_lite.tflite"
     sample_tensor = [torch.rand(1, 224, 224, 3)]
     compiled_model = forge.compile(tflite_path, sample_inputs=sample_tensor)
 
 
-@pytest.mark.skip(reason="dependent on CCM repo")
+@pytest.mark.skip(reason="Not supported yet")
 def test_palm_detection_lite_1x1(test_device):
     compiler_cfg = _get_global_compiler_config()
     tflite_path = "third_party/confidential_customer_models/model_2/tflite/palm_detection_lite.tflite"

--- a/forge/test/model_demos/high_prio/cnn/tflite/test_mobilenet_ssd.py
+++ b/forge/test/model_demos/high_prio/cnn/tflite/test_mobilenet_ssd.py
@@ -7,7 +7,7 @@ from forge.config import _get_global_compiler_config
 import forge
 
 
-@pytest.mark.skip(reason="dependent on CCM repo")
+@pytest.mark.skip(reason="Not supported yet")
 def test_mobilenet_ssd_1x1(test_device):
     compiler_cfg = _get_global_compiler_config()
     tflite_path = "third_party/confidential_customer_models/model_2/tflite/ssd_mobilenet_v2.tflite"

--- a/forge/test/model_demos/high_prio/cnn/tflite/test_pose_landmark.py
+++ b/forge/test/model_demos/high_prio/cnn/tflite/test_pose_landmark.py
@@ -7,7 +7,7 @@ from forge.config import _get_global_compiler_config
 import forge
 
 
-@pytest.mark.skip(reason="dependent on CCM repo")
+@pytest.mark.skip(reason="Not supported yet")
 def test_pose_landmark_lite_1x1(test_device):
     compiler_cfg = _get_global_compiler_config()
     tflite_path = "third_party/confidential_customer_models/model_2/tflite/pose_landmark_lite.tflite"
@@ -16,7 +16,7 @@ def test_pose_landmark_lite_1x1(test_device):
     compiled_model = forge.compile(tflite_path, sample_inputs=sample_tensor)
 
 
-@pytest.mark.skip(reason="dependent on CCM repo")
+@pytest.mark.skip(reason="Not supported yet")
 def test_pose_landmark_heavy_1x1(test_device):
     compiler_cfg = _get_global_compiler_config()
     tflite_path = "third_party/confidential_customer_models/model_2/tflite/pose_landmark_heavy.tflite"
@@ -25,8 +25,7 @@ def test_pose_landmark_heavy_1x1(test_device):
     compiled_model = forge.compile(tflite_path, sample_inputs=sample_tensor)
 
 
-@pytest.mark.skip(reason="dependent on CCM repo")
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="Not supported yet")
 def test_pose_landmark_lite(test_device):
     compiler_cfg = _get_global_compiler_config()
     tflite_path = "third_party/confidential_customer_models/model_2/tflite/pose_landmark_lite.tflite"
@@ -34,8 +33,7 @@ def test_pose_landmark_lite(test_device):
     compiled_model = forge.compile(tflite_path, sample_inputs=sample_tensor)
 
 
-@pytest.mark.skip(reason="dependent on CCM repo")
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="Not supported yet")
 def test_pose_landmark_heavy(test_device):
     compiler_cfg = _get_global_compiler_config()
     tflite_path = "third_party/confidential_customer_models/model_2/tflite/pose_landmark_heavy.tflite"

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_albert.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_albert.py
@@ -37,7 +37,8 @@ def test_albert_masked_lm_pytorch(size, variant, test_device):
     model(**input_tokens)
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    varaint_name = model_ckpt.replace("-", "_")
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name=f"pt_{varaint_name}_masked_lm")
 
 
 sizes = ["base", "large", "xlarge", "xxlarge"]
@@ -75,4 +76,5 @@ def test_albert_token_classification_pytorch(size, variant, test_device):
     model(**input_tokens)
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    varaint_name = model_ckpt.replace("-", "_")
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name=f"pt_{varaint_name}_token_cls")

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_bart.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_bart.py
@@ -50,4 +50,4 @@ def test_pt_bart_classifier(test_device):
     # Compile & feed data
     pt_mod = BartWrapper(model.model)
 
-    compiled_model = forge.compile(pt_mod, sample_inputs=inputs)
+    compiled_model = forge.compile(pt_mod, sample_inputs=inputs, module_name="pt_bart")

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_bert.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_bert.py
@@ -40,7 +40,7 @@ def generate_model_bert_maskedlm_hf_pytorch(variant):
 def test_bert_masked_lm_pytorch(test_device):
     model, inputs, _ = generate_model_bert_maskedlm_hf_pytorch("bert-base-uncased")
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_bert_masked_lm")
 
 
 def generate_model_bert_qa_hf_pytorch(variant):
@@ -80,7 +80,7 @@ def generate_model_bert_qa_hf_pytorch(variant):
 def test_bert_question_answering_pytorch(test_device):
     model, inputs, _ = generate_model_bert_qa_hf_pytorch("bert-large-cased-whole-word-masking-finetuned-squad")
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_bert_qa")
 
 
 def generate_model_bert_seqcls_hf_pytorch(variant):
@@ -112,7 +112,7 @@ def test_bert_sequence_classification_pytorch(test_device):
         "textattack/bert-base-uncased-SST-2",
     )
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_bert_sequence_classification")
 
 
 def generate_model_bert_tkcls_hf_pytorch(variant):
@@ -142,4 +142,4 @@ def generate_model_bert_tkcls_hf_pytorch(variant):
 def test_bert_token_classification_pytorch(test_device):
     model, inputs, _ = generate_model_bert_tkcls_hf_pytorch("dbmdz/bert-large-cased-finetuned-conll03-english")
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_bert_sequence_classification")

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_codegen.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_codegen.py
@@ -59,4 +59,6 @@ def test_codegen(test_device, variant):
     out = framework_model(input_ids, attn_mask)
 
     inputs = [input_ids, attn_mask]
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_"))
+    )

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_distilbert.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_distilbert.py
@@ -41,7 +41,7 @@ def test_distilbert_masked_lm_pytorch(variant, test_device):
     )
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_distilbert_masked_lm")
 
 
 def test_distilbert_question_answering_pytorch(test_device):
@@ -76,7 +76,7 @@ def test_distilbert_question_answering_pytorch(test_device):
     )
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_distilbert_question_answering")
 
 
 def test_distilbert_sequence_classification_pytorch(test_device):
@@ -102,7 +102,7 @@ def test_distilbert_sequence_classification_pytorch(test_device):
     )
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_distilbert_sequence_classification")
 
 
 def test_distilbert_token_classification_pytorch(test_device):
@@ -127,4 +127,4 @@ def test_distilbert_token_classification_pytorch(test_device):
     )
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_distilbert_token_classification")

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_dpr.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_dpr.py
@@ -41,7 +41,9 @@ def test_dpr_context_encoder_pytorch(variant, test_device):
     )
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"], input_tokens["token_type_ids"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_"))
+    )
 
 
 variants = ["facebook/dpr-question_encoder-single-nq-base", "facebook/dpr-question_encoder-multiset-base"]
@@ -71,7 +73,9 @@ def test_dpr_question_encoder_pytorch(variant, test_device):
     )
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"], input_tokens["token_type_ids"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_"))
+    )
 
 
 variants = ["facebook/dpr-reader-single-nq-base", "facebook/dpr-reader-multiset-base"]
@@ -100,4 +104,6 @@ def test_dpr_reader_pytorch(variant, test_device):
     )
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_"))
+    )

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_falcon.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_falcon.py
@@ -33,4 +33,4 @@ def test_falcon(test_device):
     output = model(input_tokens["input_ids"], input_tokens["attention_mask"])
 
     # Forge inference
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_falcon")

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_gpt2.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_gpt2.py
@@ -35,7 +35,7 @@ def test_gpt2_text_gen(test_device):
     ).to(torch.int64)
     attn_mask = torch.ones(1, 256)
     inputs = [input_ids, attn_mask]
-    compiled_model = forge.compile(Wrapper(model), sample_inputs=inputs)
+    compiled_model = forge.compile(Wrapper(model), sample_inputs=inputs, module_name="pt_gpt2_generation")
 
 
 class Wrapper(torch.nn.Module):

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_gptneo.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_gptneo.py
@@ -60,7 +60,11 @@ def test_gptneo_causal_lm(variant, test_device):
             return self.model(input_ids, None, attention_mask)
 
     inputs = [inputs["input_ids"], inputs["attention_mask"]]
-    compiled_model = forge.compile(Wrapper(model), sample_inputs=inputs)
+    compiled_model = forge.compile(
+        Wrapper(model),
+        sample_inputs=inputs,
+        module_name="pt_" + str(variant.split("/")[-1].replace("-", "_").replace(".", "_")) + "_causal_lm",
+    )
 
 
 variants = [
@@ -106,4 +110,8 @@ def test_gptneo_sequence_classification(variant, test_device):
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
 
-    compiled_model = forge.compile(Wrapper(model), sample_inputs=inputs)
+    compiled_model = forge.compile(
+        Wrapper(model),
+        sample_inputs=inputs,
+        module_name="pt_" + str(variant.split("/")[-1].replace("-", "_").replace(".", "_")) + "_seq_cls",
+    )

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_llama3.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_llama3.py
@@ -143,7 +143,11 @@ def test_llama3_causal_lm(variant, test_device):
 
     inputs = [input_ids, attn_mask]
 
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        framework_model,
+        sample_inputs=inputs,
+        module_name="pt_" + str(variant.split("/")[-1].replace("-", "_")) + "_causal_lm",
+    )
 
 
 @pytest.mark.parametrize("variant", variants, ids=variants)
@@ -168,4 +172,8 @@ def test_llama3_sequence_classification(variant, test_device):
 
     inputs = [input_ids]
 
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        framework_model,
+        sample_inputs=inputs,
+        module_name="pt_" + str(variant.split("/")[-1].replace("-", "_")) + "_seq_cls",
+    )

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_mistral.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_mistral.py
@@ -31,7 +31,7 @@ def test_mistral_decoder_layer(variant, test_device):
 
     sample_inputs = torch.randn(batch_size, seqlen, hidden_dim)
     inputs = [sample_inputs]
-    compiled_model = forge.compile(module, sample_inputs=inputs)
+    compiled_model = forge.compile(module, sample_inputs=inputs, module_name="pt_mistral_decoder")
 
 
 variants = ["mistralai/Mistral-7B-v0.1"]
@@ -46,6 +46,7 @@ def test_mistral(variant, test_device):
     configuration.use_cache = False
     configuration.return_dict = False
     compiler_cfg = forge.config._get_global_compiler_config()
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     module = AutoModelForCausalLM.from_pretrained(variant, device_map="auto", config=configuration)
     tokenizer = AutoTokenizer.from_pretrained(variant)
@@ -60,7 +61,7 @@ def test_mistral(variant, test_device):
     sample_inputs = tokenizer(prompt, return_tensors="pt")["input_ids"]
     inputs = [sample_inputs]
 
-    compiled_model = forge.compile(module, sample_inputs=inputs)
+    compiled_model = forge.compile(module, sample_inputs=inputs, module_name="pt_mistral")
 
 
 variants = ["mistralai/Mistral-7B-v0.1"]

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_opt.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_opt.py
@@ -37,7 +37,11 @@ def test_opt_causal_lm(variant, test_device):
     )
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model,
+        sample_inputs=inputs,
+        module_name="pt_" + str(variant.split("/")[-1].replace("-", "_").replace(".", "_")) + "_causal_lm",
+    )
 
 
 @pytest.mark.parametrize("variant", variants, ids=variants)
@@ -67,8 +71,11 @@ def test_opt_qa(variant, test_device):
     )
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
-    co_out = compiled_model(*inputs)
+    compiled_model = forge.compile(
+        model,
+        sample_inputs=inputs,
+        module_name="pt_" + str(variant.split("/")[-1].replace("-", "_").replace(".", "_")) + "_qa",
+    )
 
 
 @pytest.mark.parametrize("variant", variants, ids=variants)
@@ -98,4 +105,8 @@ def test_opt_sequence_classification(variant, test_device):
     )
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model,
+        sample_inputs=inputs,
+        module_name="pt_" + str(variant.split("/")[-1].replace("-", "_").replace(".", "_")) + "_seq_cls",
+    )

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_phi2.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_phi2.py
@@ -51,7 +51,9 @@ def test_phi2_clm(variant, test_device):
     attn_mask = inputs["attention_mask"].to(torch.float32)
 
     inputs = [input_ids, attn_mask]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_")) + "_causal_lm"
+    )
 
 
 @pytest.mark.parametrize("variant", variants)
@@ -81,7 +83,9 @@ def test_phi2_token_classification(variant, test_device):
 
     inputs = [inputs["input_ids"]]
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_")) + "_token_cls"
+    )
 
 
 @pytest.mark.parametrize("variant", variants)
@@ -111,4 +115,6 @@ def test_phi2_sequence_classification(variant, test_device):
     inputs = tokenizer(input_prompt, return_tensors="pt")
 
     inputs = [inputs["input_ids"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_")) + "_seq_cls"
+    )

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_phi3.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_phi3.py
@@ -53,7 +53,9 @@ def test_phi3_causal_lm(variant, test_device):
 
     inputs = [input_ids, attn_mask]
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_")) + "_causal_lm"
+    )
 
 
 @pytest.mark.parametrize("variant", variants)
@@ -84,7 +86,9 @@ def test_phi3_token_classification(variant, test_device):
 
     inputs = [inputs["input_ids"]]
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_")) + "_token_cls"
+    )
 
 
 @pytest.mark.parametrize("variant", variants)
@@ -114,4 +118,6 @@ def test_phi3_sequence_classification(variant, test_device):
     inputs = tokenizer(input_prompt, return_tensors="pt")
     inputs = [inputs["input_ids"]]
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_")) + "_seq_cls"
+    )

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_qwen.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_qwen.py
@@ -42,7 +42,7 @@ def test_qwen1_5_causal_lm(test_device):
     # Pass the tensors to the model
     op = model(input_ids, attention_mask)
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_qwen_causal_lm")
 
 
 def parse_chat_completion(text: str):
@@ -104,4 +104,4 @@ def test_qwen1_5_chat(test_device):
     # Pass the tensors to the model
     op = model(input_ids, attention_mask)
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_qwen_chat")

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_roberta.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_roberta.py
@@ -28,7 +28,7 @@ def test_roberta_masked_lm(test_device):
     attention_mask[input_tokens != 1] = 1
 
     inputs = [input_tokens, attention_mask]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_roberta_masked_lm")
 
 
 def test_roberta_sentiment_pytorch(test_device):
@@ -53,4 +53,4 @@ def test_roberta_sentiment_pytorch(test_device):
         return_tensors="pt",
     )
     inputs = [input_tokens]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_roberta_sentiment")

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_squeezebert.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_squeezebert.py
@@ -12,7 +12,7 @@ def test_squeezebert_sequence_classification_pytorch(test_device):
     model = download_model(AutoModelForSequenceClassification.from_pretrained, "squeezebert/squeezebert-mnli")
 
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
-    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
+    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
 
     # Example from multi-nli validation set
     text = """Hello, my dog is cute"""
@@ -27,4 +27,4 @@ def test_squeezebert_sequence_classification_pytorch(test_device):
     )
 
     inputs = [input_tokens]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_squeezebert")

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_t5.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_t5.py
@@ -112,7 +112,8 @@ def test_t5_generation(variant, test_device):
         encoder_outputs = torch.randn(1, 256, 1024)
 
     inputs = [decoder_input_ids, encoder_outputs]
-    compiled_model = forge.compile(Wrapper(model), sample_inputs=inputs)
+    variant_name = variant.replace("-", "_").replace("/", "_")
+    compiled_model = forge.compile(Wrapper(model), sample_inputs=inputs, module_name=f"pt_{variant_name}")
 
 
 class T5_encoder(torch.nn.Module):

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_whisper_0.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_whisper_0.py
@@ -106,7 +106,9 @@ def test_whisper(test_device, variant):
         variant,
     )
 
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_"))
+    )
 
 
 @pytest.mark.parametrize("variant", variants, ids=variants)

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_whisper_1.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_whisper_1.py
@@ -23,11 +23,7 @@ from typing import Optional
 from forge.forgeglobal import TILE_DIM
 import forge
 from test.utils import download_model
-from forge.verify import verify_module
-from forge.verify.config import TestKind
-from forge import PyTorchModule, VerifyConfig
 from forge.config import _get_global_compiler_config
-from forge._C.backend_api import BackendType, BackendDevice
 from forge.transformers.pipeline import pipeline as forge_pipeline
 from test.model_demos.models.whisper import Whisper_encoder, Whisper_decoder, generate_model_whisper_decoder_past_cache
 

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_xglm.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_xglm.py
@@ -36,4 +36,6 @@ def test_xglm_causal_lm(variant, test_device):
     )
 
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
-    compiled_model = forge.compile(model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_").replace(".", "_"))
+    )

--- a/forge/test/model_demos/models/whisper.py
+++ b/forge/test/model_demos/models/whisper.py
@@ -17,7 +17,6 @@ import forge
 from test.utils import download_model
 from forge.forgeglobal import TILE_DIM
 from forge.config import _get_global_compiler_config
-from forge._C.backend_api import BackendType, BackendDevice
 
 
 class Whisper_encoder(torch.nn.Module):


### PR DESCRIPTION
- This PR solves [#529](https://github.com/tenstorrent/tt-forge-fe/issues/529), [#516](https://github.com/tenstorrent/tt-forge-fe/issues/516)

**Summary**

- compiler.cgf flags cleanup

- Redundant 1x1 tests removed

- Download image from url to avoid local file dependency - Fuyu8b

- efficientNet torchvision variants failed due to RuntimeError: invalid hash value ([#516](https://github.com/tenstorrent/tt-forge-fe/issues/516)). fix referred from [here](https://github.com/pytorch/vision/issues/7744#issuecomment-1757321451)

- Add updated code of FPN(from Resnet50 backend)