### PR TITLE
Skip bypassing the node when binary ops involved in between

### DIFF
--- a/forge/csrc/passes/erase_inverse_ops.cpp
+++ b/forge/csrc/passes/erase_inverse_ops.cpp
@@ -80,6 +80,23 @@ static std::vector<graphlib::Node *> find_path_to_inverse_op(
     if (not found_inverse)
         path.clear();
 
+    // Skip bypassing the node when binary ops involved in between
+    // Ex: transpose -> multiply -> add -> transpose
+    bool is_valid_path = true;
+    int path_len = path.size();
+    if (path_len > 2)
+    {
+        for (int idx = 1; idx < path_len - 1; idx++)
+        {
+            auto &node = path.at(idx);
+            graphlib::OpNode *op_node = dynamic_cast<graphlib::OpNode *>(node);
+            if (is_eltwise_unary(op_node) or is_eltwise_binary(op_node))
+                is_valid_path = false;
+        }
+    }
+    if (!is_valid_path)
+        path.clear();
+
     return path;
 }
 


### PR DESCRIPTION
This fix is to avoid bypassing the nodes when there is a shape match between two nodes but binary ops involved in between.

Before removing Transpose Op:
![image (4)](https://github.com/user-attachments/assets/055fd9a9-2293-412c-a26f-7a2a8de13cbf)

After removing transpose Op:
![image (5)](https://github.com/user-attachments/assets/05a48481-c2e2-4f3b-9888-e875e067d220)
