### PR TITLE
Map ops from FFE emit of TTIR to MLIR if it is supported

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -567,6 +567,12 @@ class MLIRGenerator
         lowering_handler_map["concatenate"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ConcatOp>;
         lowering_handler_map["sigmoid"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::SigmoidOp>;
         lowering_handler_map["max_pool2d"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MaxPool2dOp>;
+        lowering_handler_map["abs"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::AbsOp>;
+        lowering_handler_map["exp"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ExpOp>;
+        lowering_handler_map["maximum"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MaximumOp>;
+        lowering_handler_map["less"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::LessEqualOp>;
+        lowering_handler_map["greater"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::GreaterThanOp>;
+        lowering_handler_map["not_equal"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::NotEqualOp>;
     }
 };
 }  // namespace

--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -13,6 +13,205 @@ import forge
 from forge.op.eval.common import compare_with_golden_pcc, compare_with_golden
 from forge.tensor import to_forge_tensors, to_pt_tensors
 
+shapes = [(1, 1, 256, 256), (1, 1, 1, 128), (1, 1, 1, 384), (1, 1, 32, 32), (1, 1, 6, 6), (1, 1, 29, 29)]
+
+
+@pytest.mark.parametrize("shape", shapes)
+def test_abs(shape):
+    class abs(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            return torch.abs(x)
+
+    inputs = [torch.rand(shape)]
+
+    framework_model = abs()
+    fw_out = framework_model(*inputs)
+
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    co_out = compiled_model(*inputs)
+
+    co_out = [co.to("cpu") for co in co_out]
+    fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+    assert all([compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])
+
+
+shapes = [
+    (1, 128, 28, 28),
+    (1, 64, 28, 28),
+    (1, 256, 28, 28),
+    (1, 128, 14, 14),
+    (1, 128, 56, 56),
+    (1, 32, 64, 64),
+    (1, 512, 7, 7),
+]
+
+
+@pytest.mark.parametrize("shape", shapes)
+def test_exp(shape):
+    class exp(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            return torch.exp(x)
+
+    inputs = [torch.rand(shape)]
+
+    framework_model = exp()
+    fw_out = framework_model(*inputs)
+
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    co_out = compiled_model(*inputs)
+
+    co_out = [co.to("cpu") for co in co_out]
+    fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+    assert all([compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])
+
+
+shapes = [
+    ((1, 12, 256, 256), (1,)),
+    ((1, 16, 256, 256), (1,)),
+    ((1, 32, 256, 256), (1,)),
+    ((1, 12, 32, 32), (1,)),
+    ((1, 16, 32, 32), (1,)),
+    ((1, 32, 32, 32), (1,)),
+]
+
+
+@pytest.mark.parametrize("shape_x, shape_y", shapes)
+def test_maximum(shape_x, shape_y):
+    class maximum(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x, y):
+            return torch.maximum(x, y)
+
+    x = torch.rand(shape_x)
+    y = torch.rand(shape_y)
+
+    framework_model = maximum()
+    inputs = [x, y]
+
+    fw_out = framework_model(*inputs)
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    co_out = compiled_model(*inputs)
+
+    co_out = [co.to("cpu") for co in co_out]
+    fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+    assert all([compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])
+
+
+shapes = [
+    ((1, 128, 28, 28), (1, 128, 28, 28)),
+    ((1, 64, 28, 28), (1, 64, 28, 28)),
+    ((1, 256, 28, 28), (1, 256, 28, 28)),
+    ((1, 128, 14, 14), (1, 128, 14, 14)),
+    ((1, 128, 56, 56), (1, 128, 56, 56)),
+    ((1, 32, 64, 64), (1, 32, 64, 64)),
+    ((1, 512, 7, 7), (1, 512, 7, 7)),
+    ((1, 32, 32, 32), (1, 32, 32, 32)),
+]
+
+
+@pytest.mark.parametrize("shape_x, shape_y", shapes)
+def test_less(shape_x, shape_y):
+    class less(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x, y):
+            return torch.less(x, y)
+
+    x = torch.rand(shape_x)
+    y = torch.rand(shape_y)
+
+    framework_model = less()
+    inputs = [x, y]
+
+    fw_out = framework_model(*inputs)
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    co_out = compiled_model(*inputs)
+
+    co_out = [co.to("cpu") for co in co_out]
+    fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+    assert all([compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])
+
+
+shapes = [
+    ((1, 128, 28, 28), (1, 128, 28, 28)),
+    ((1, 64, 28, 28), (1, 64, 28, 28)),
+    ((1, 256, 28, 28), (1, 256, 28, 28)),
+    ((1, 128, 14, 14), (1, 128, 14, 14)),
+    ((1, 128, 56, 56), (1, 128, 56, 56)),
+    ((1, 32, 64, 64), (1, 32, 64, 64)),
+    ((1, 512, 7, 7), (1, 512, 7, 7)),
+    ((1, 32, 32, 32), (1, 32, 32, 32)),
+]
+
+
+@pytest.mark.parametrize("shape_x, shape_y", shapes)
+def test_greater_op(shape_x, shape_y):
+    class greater(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x, y):
+            return torch.greater(x, y)
+
+    x = torch.rand(shape_x)
+    y = torch.rand(shape_y)
+
+    framework_model = greater()
+    inputs = [x, y]
+
+    fw_out = framework_model(*inputs)
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    co_out = compiled_model(*inputs)
+
+    co_out = [co.to("cpu") for co in co_out]
+    fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+    assert all([compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])
+
+
+shapes = [
+    ((1, 128, 28, 28), (1, 128, 28, 28)),
+    ((1, 64, 28, 28), (1, 64, 28, 28)),
+    ((1, 256, 28, 28), (1, 256, 28, 28)),
+    ((1, 128, 14, 14), (1, 128, 14, 14)),
+    ((1, 128, 56, 56), (1, 128, 56, 56)),
+    ((1, 32, 64, 64), (1, 32, 64, 64)),
+    ((1, 512, 7, 7), (1, 512, 7, 7)),
+    ((1, 32, 32, 32), (1, 32, 32, 32)),
+]
+
+
+@pytest.mark.parametrize("shape_x, shape_y", shapes)
+def test_not_equal(shape_x, shape_y):
+    class not_equal(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x, y):
+            return torch.ne(x, y)
+
+    x = torch.rand(shape_x)
+    y = torch.rand(shape_y)
+
+    framework_model = not_equal()
+    inputs = [x, y]
+
+    fw_out = framework_model(*inputs)
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    co_out = compiled_model(*inputs)
+
+    co_out = [co.to("cpu") for co in co_out]
+    fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+    assert all([compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])
+
 
 @pytest.mark.parametrize(
     "batch_size, num_channels, height, width",


### PR DESCRIPTION
Mapping done for below ops

- abs
- exp
- maximum
- less
- greater( both inputs should have same number of dimensions .if not it will face [#1081](https://github.com/tenstorrent/tt-mlir/issues/1081) or [#1080](https://github.com/tenstorrent/tt-mlir/issues/1080) 
- not_equal ( both inputs should have same number of dimensions. if not it will face [#1080](https://github.com/tenstorrent/tt-mlir/issues/1080) 


Ops and its required unique test cases 

| op        | model      | shapes                                 |
|-----------|------------|----------------------------------------|
| abs       | bart       | {1, 1, 256, 256}                       |
| abs       | distilbert | {1, 1, 1, 128}                         |
| abs       | distilbert | {1, 1, 1, 384}                         |
| abs       | gptneo     | {1, 1, 32, 32}                         |
| abs       | qwen       | {1, 1, 6, 6}                           |
| abs       | qwen       | {1, 1, 29, 29}                         |
| greater   | bart       | [{1, 1, 256, 256}, {1}, ]              |
| greater   | distilbert | [{1, 12, 384, 384}, {1}, ]             |
| greater   | distilbert | [{1, 1, 384, 384}, {1}, ]              |
| greater   | distilbert | [{1, 12, 128, 128}, {1}, ]             |
| greater   | distilbert | [{1, 1, 128, 128}, {1}, ]              |
| greater   | opt        | [{1, 1, 32, 32}, {1}, ]                |
| greater   | openpose   | [{1, 128, 28, 28}, {1, 128, 28, 28}, ] |
| exp       | openpose   | [{1, 128, 28, 28}, ]                   |
| maximum   | opt        | [{1, 12, 256, 256}, {1}, ]             |
| maximum   | opt        | [{1, 16, 256, 256}, {1}, ]             |
| maximum   | opt        | [{1, 32, 256, 256}, {1}, ]             |
| maximum   | opt        | [{1, 12, 32, 32}, {1}, ]               |
| maximum   | opt        | [{1, 16, 32, 32}, {1}, ]               |
| maximum   | opt        | [{1, 32, 32, 32}, {1}, ]               |
| not equal | roberta    |  [{1, 128}, {1}, ]                     |
| less      | openpose   | [{1, 128, 28, 28}, {1, 128, 28, 28}, ] |
