### PR TITLE
Documentation for single operator E2E tests

### DIFF
--- a/docs/src/test.md
+++ b/docs/src/test.md
@@ -45,3 +45,105 @@ pytest -svv forge/test/mlir/test_ops.py::test_add
 ```
 
 > - The `-svv` flag is optional and used to display more information about the test run.
+
+## Single operator E2E tests
+
+Single operator E2E tests consists of pre configured collections of in-depth tests for each operator according to test plan.
+Tests include small models consisting of single operator with or without combination with few other operators.
+More details about test plan available on [Test template page](https://github.com/tenstorrent/tt-forge-fe/blob/main/forge/test/operators/test_plan_template.md)
+
+To start interacting with test sweeps framework load helper commands via
+
+```sh
+source forge/test/operators/pytorch/test_commands.sh
+```
+
+Available commands
+
+| Command               | Description                                                           |
+| --------------------- | --------------------------------------------------------------------- |
+| `print_help`          | Print commands and current query parameters.                          |
+| `print_query_docs`    | Print docs for all available query parameters.                        |
+| `print_params`        | Print current query parameters values.                                |
+| `collect_only_on`     | Enable only collecting tests by including --collect-only.             |
+| `collect_only_off`    | Remove collect only setup.                                            |
+| `test_plan`           | Run all tests from test plan.                                         |
+| `test_query`          | Run subset of test plan based on a query parameters.                  |
+| `test_unique`         | Run representative examples of all available tests.                   |
+| `test_single`         | Run single test based on TEST_ID parameter.                           |
+
+Full list of supported query parameters
+
+| Parameter             | Description                                                                                   | Supported by commands                 |
+| --------------------- | --------------------------------------------------------------------------------------------- | ------------------------------------- |
+| OPERATORS             | List of operators                                                                             | test_plan, test_query, test_unique    |
+| FILTERS               | List of lambda filters                                                                        | test_query                            |
+| INPUT_SOURCES         | List of input sources                                                                         | test_query                            |
+| INPUT_SHAPES          | List of input shapes                                                                          | test_query                            |
+| DEV_DATA_FORMATS      | List of dev data formats                                                                      | test_query                            |
+| MATH_FIDELITIES       | List of math fidelities                                                                       | test_query                            |
+| KWARGS                | List of kwargs dictionaries.                                                                  | test_query                            |
+| FAILING_REASONS       | List of failing reasons                                                                       | test_query                            |
+| SKIP_REASONS          | List of skip reasons                                                                          | test_query                            |
+| RANGE                 | Limit number of results                                                                       | test_query                            |
+| TEST_ID               | Id of a test containing test parameters                                                       | test_single                           |
+
+
+To check supported values and options for each query parameter please run command `print_query_docs`.
+
+
+Usage examples
+
+Run all tests
+
+```sh
+test_plan
+```
+
+Run all tests for few operators
+
+```sh
+export OPERATORS=add,div
+test_plan
+```
+
+Run subset of tests based on query criteria
+
+```sh
+export OPERATORS=div
+export FILTERS=HAS_DATA_FORMAT,QUICK
+export INPUT_SOURCES=FROM_HOST,FROM_DRAM_QUEUE
+export DEV_DATA_FORMATS=Float16_b,Int8
+export MATH_FIDELITIES=HiFi4,HiFi3
+export KWARGS="[{'rounding_mode': 'trunc'},{'rounding_mode': 'floor'}]"
+print_params
+test_query
+```
+
+Print representative tests ids of all operators with examples for kwargs values
+
+```sh
+collect_only_on
+test_unique
+collect_only_off
+```
+
+Print representative tests ids of few operators
+
+```sh
+export OPERATORS=add,div
+collect_only_on
+test_unique
+collect_only_off
+```
+
+Each test can be uniquely identified via a test id. Format of test id is `{operator}-{input_source}-{kwargs}-{input_shape}[-{number_of_operands)-]{dev_data_format}-{math_fidelity}`.
+
+Kwarg is a mandatory or optional attribute of an operator. See framework (PyTorch, Forge, ...) operator documentation for each operator or use `test_unique` to find examples.
+
+Run single test based on a test id. Test id may be from a test plan or constructed custom by specifying custom values for kwargs and input_shapes.
+
+```sh
+export TEST_ID='ge-FROM_HOST-None-(1, 2, 3, 4)-Float16_b-HiFi4'
+test_single
+```

--- a/forge/test/operators/pytorch/test_all.py
+++ b/forge/test/operators/pytorch/test_all.py
@@ -22,8 +22,10 @@
 import os
 import pytest
 import forge
+import textwrap
 
 from loguru import logger
+from tabulate import tabulate
 
 from test.operators.utils import DeviceUtils
 from test.operators.utils import InputSource
@@ -418,3 +420,96 @@ def test_not_implemented(test_vector: TestVector, test_device):
 )
 def test_data_mismatch(test_vector: TestVector, test_device):
     TestVerification.verify(test_vector, test_device)
+
+
+class InfoUtils:
+    @classmethod
+    def print_query_params(cls, max_width=80):
+        print("Query parameters:")
+        cls.print_query_values(max_width)
+        print("Query examples:")
+        cls.print_query_examples(max_width)
+
+    @classmethod
+    def print_query_values(cls, max_width=80):
+
+        operators = [key for key in test_suite.indices]
+        operators = sorted(operators)
+        operators = ", ".join(operators)
+
+        filters = [key for key, value in VectorLambdas.__dict__.items() if not key.startswith("__")]
+        filters = [filter for filter in filters if filter not in ["ALL_OPERATORS", "NONE", "FILTERED"]]
+        filters = ", ".join(filters)
+
+        input_sources = [f"{input_source.name}" for input_source in TestCollectionCommon.all.input_sources]
+        input_sources = ", ".join(input_sources)
+
+        input_shapes = [f"{input_shape}" for input_shape in TestCollectionCommon.all.input_shapes]
+        input_shapes = ", ".join(input_shapes)
+
+        dev_data_formats = [f"{dev_data_format.name}" for dev_data_format in TestCollectionCommon.all.dev_data_formats]
+        dev_data_formats = ", ".join(dev_data_formats)
+
+        math_fidelities = [f"{math_fidelity.name}" for math_fidelity in TestCollectionCommon.all.math_fidelities]
+        math_fidelities = ", ".join(math_fidelities)
+
+        failing_reasons = [
+            key for key, value in FailingReasons.__dict__.items() if not callable(value) and not key.startswith("__")
+        ]
+        failing_reasons = ", ".join(failing_reasons)
+
+        parameters = [
+            {"name": "OPERATORS", "description": f"List of operators. Supported values: {operators}"},
+            {"name": "FILTERS", "description": f"List of lambda filters. Supported values: {filters}"},
+            {"name": "INPUT_SOURCES", "description": f"List of input sources. Supported values: {input_sources}"},
+            {"name": "INPUT_SHAPES", "description": f"List of input shapes. Supported values: {input_shapes}"},
+            {
+                "name": "DEV_DATA_FORMATS",
+                "description": f"List of dev data formats. Supported values: {dev_data_formats}",
+            },
+            {"name": "MATH_FIDELITIES", "description": f"List of math fidelities. Supported values: {math_fidelities}"},
+            {
+                "name": "KWARGS",
+                "description": "List of kwargs dictionaries. Kwarg is a mandatory or optional attribute of an operator. See operator documentation for each operator or use `test_unique` to find examples.",
+            },
+            {"name": "FAILING_REASONS", "description": f"List of failing reasons. Supported values: {failing_reasons}"},
+            {"name": "SKIP_REASONS", "description": "Same as FAILING_REASONS"},
+            {"name": "RANGE", "description": "Limit number of results"},
+            {"name": "TEST_ID", "description": "Id of a test containing test parameters"},
+        ]
+
+        cls.print_formatted_parameters(parameters, max_width, headers=["Parameter", "Supported values"])
+
+    @classmethod
+    def print_query_examples(cls, max_width=80):
+
+        parameters = [
+            {"name": "OPERATORS", "description": "export OPERATORS=add"},
+            {"name": "OPERATORS", "description": "export OPERATORS=add,div"},
+            {"name": "FILTERS", "description": "export FILTERS=HAS_DATA_FORMAT,QUICK"},
+            {"name": "INPUT_SOURCES", "description": "export INPUT_SOURCES=FROM_HOST,FROM_DRAM_QUEUE"},
+            {"name": "INPUT_SHAPES", "description": 'export INPUT_SHAPES="[(3, 4), (45, 17)]"'},
+            {"name": "DEV_DATA_FORMATS", "description": "export DEV_DATA_FORMATS=Float16_b,Int8"},
+            {"name": "MATH_FIDELITIES", "description": "export MATH_FIDELITIES=HiFi4,HiFi3"},
+            {
+                "name": "KWARGS",
+                "description": "export KWARGS=\"[{'rounding_mode': 'trunc'},{'rounding_mode': 'floor'}]\"",
+            },
+            {"name": "FAILING_REASONS", "description": "export FAILING_REASONS=DATA_MISMATCH,UNSUPPORTED_DATA_FORMAT"},
+            {"name": "FAILING_REASONS", "description": "export FAILING_REASONS=NOT_IMPLEMENTED"},
+            {"name": "SKIP_REASONS", "description": "export SKIP_REASONS=FATAL_ERROR"},
+            {"name": "RANGE", "description": "export RANGE=5"},
+            {"name": "RANGE", "description": "export RANGE=10,20"},
+            {"name": "TEST_ID", "description": "export TEST_ID='ge-FROM_HOST-None-(1, 2, 3, 4)-Float16_b-HiFi4'"},
+        ]
+
+        cls.print_formatted_parameters(parameters, max_width, headers=["Parameter", "Examples"])
+
+    @classmethod
+    def print_formatted_parameters(cls, parameters, max_width=80, headers=["Parameter", "Description"]):
+        for param in parameters:
+            param["description"] = "\n".join(textwrap.wrap(param["description"], width=max_width))
+
+        table_data = [[param["name"], param["description"]] for param in parameters]
+
+        print(tabulate(table_data, headers, tablefmt="grid"))

--- a/forge/test/operators/pytorch/test_all.py
+++ b/forge/test/operators/pytorch/test_all.py
@@ -6,12 +6,6 @@
 
 
 # Examples
-# pytest -svv forge/test/operators/pytorch/test_all.py::test_unique --collect-only
-# TEST_ID='no_device-ge-FROM_HOST-None-(1, 2, 3, 4)-Float16_b-HiFi4' pytest -svv forge/test/operators/pytorch/test_all.py::test_single
-# OPERATORS=add,div FILTERS=HAS_DATA_FORMAT,QUICK DEV_DATA_FORMATS=Float16_b,Int8 MATH_FIDELITIES=HiFi4,HiFi3 RANGE=5 pytest -svv forge/test/operators/pytorch/test_all.py::test_query --collect-only
-# OPERATORS=add,div FAILING_REASONS=DATA_MISMATCH,UNSUPPORTED_DATA_FORMAT SKIP_REASONS=FATAL_ERROR RANGE=5 pytest -svv forge/test/operators/pytorch/test_all.py::test_query --collect-only
-# FAILING_REASONS=NOT_IMPLEMENTED INPUT_SOURCES=FROM_HOST pytest -svv forge/test/operators/pytorch/test_all.py::test_query --collect-only
-
 # pytest -svv forge/test/operators/pytorch/test_all.py::test_plan
 # pytest -svv forge/test/operators/pytorch/test_all.py::test_failed
 # pytest -svv forge/test/operators/pytorch/test_all.py::test_skipped
@@ -20,6 +14,9 @@
 # pytest -svv forge/test/operators/pytorch/test_all.py::test_data_mismatch
 # pytest -svv forge/test/operators/pytorch/test_all.py::test_unsupported_df
 # pytest -svv forge/test/operators/pytorch/test_all.py::test_custom
+# pytest -svv forge/test/operators/pytorch/test_all.py::test_query
+# pytest -svv forge/test/operators/pytorch/test_all.py::test_unique
+# pytest -svv forge/test/operators/pytorch/test_all.py::test_single
 
 
 import os
@@ -74,8 +71,10 @@ class TestParamsData:
         Query criterias are defined by the following environment variables:
         - OPERATORS: List of operators to filter
         - INPUT_SOURCES: List of input sources to filter
+        - INPUT_SHAPES: List of input shapes to filter
         - DEV_DATA_FORMATS: List of data formats to filter
         - MATH_FIDELITIES: List of math fidelities to filter
+        - KWARGS: List of kwargs dictionaries to filter
         """
         operators = os.getenv("OPERATORS", None)
         if operators:
@@ -88,7 +87,9 @@ class TestParamsData:
             input_sources = input_sources.split(",")
             input_sources = [getattr(InputSource, input_source) for input_source in input_sources]
 
-        # TODO INPUT_SHAPES
+        input_shapes = os.getenv("INPUT_SHAPES", None)
+        if input_shapes:
+            input_shapes = eval(input_shapes)
 
         dev_data_formats = os.getenv("DEV_DATA_FORMATS", None)
         if dev_data_formats:
@@ -100,13 +101,17 @@ class TestParamsData:
             math_fidelities = math_fidelities.split(",")
             math_fidelities = [getattr(forge.MathFidelity, math_fidelity) for math_fidelity in math_fidelities]
 
-        # TODO KWARGS
+        kwargs = os.getenv("KWARGS", None)
+        if kwargs:
+            kwargs = eval(kwargs)
 
         filtered_collection = TestCollection(
             operators=operators,
             input_sources=input_sources,
+            input_shapes=input_shapes,
             dev_data_formats=dev_data_formats,
             math_fidelities=math_fidelities,
+            kwargs=kwargs,
         )
 
         return filtered_collection

--- a/forge/test/operators/pytorch/test_commands.sh
+++ b/forge/test/operators/pytorch/test_commands.sh
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Usage:
+# source forge/test/operators/pytorch/test_commands.sh
+# print_help
+# collect_only_on
+# test_plan
+# test_query
+# test_unique
+
+
+function print_help {
+    echo "Help:"
+    echo "  print_help          - Print commands and current query parameters."
+    echo "  print_query_docs    - Print docs for all available query parameters."
+    echo "Query parameters:"
+    echo "  print_params        - Print current query parameters values."
+    echo "  reset_params        - Reset all query parameters and pytest options."
+    echo "  reset_query_params  - Reset all query parameters."
+    echo "Setup pytest options:"
+    echo "  run_xfail_on        - Enable running xfail tests by including --runxfail."
+    echo "  run_xfail_off       - Remove run xfail setup."
+    echo "  no_skips_on         - Enable running tests without skips by including --no-skips."
+    echo "  no_skips_off        - Remove no skips setup."
+    echo "  collect_only_on     - Enable only collecting tests by including --collect-only."
+    echo "  collect_only_off    - Remove collect only setup."
+    echo "  reset_pytest_opts   - Reset pytest options."
+    echo "Run commands:"
+    echo "  test_plan           - Run all tests from test plan. Support OPERATORS query parameter."
+    echo "  test_query          - Run subset of test plan based on a query parameters."
+    echo "  test_unique         - Run representative examples of all available tests."
+    echo "  test_single         - Run single test based on TEST_ID parameter."
+    print_params
+}
+
+function print_params {
+    echo "Query Params:"
+    echo "  OPERATORS=$OPERATORS"
+    echo "  FILTERS=$FILTERS"
+    echo "  INPUT_SOURCES=$INPUT_SOURCES"
+    echo "  INPUT_SHAPES=\"$INPUT_SHAPES\""
+    echo "  DEV_DATA_FORMATS=$DEV_DATA_FORMATS"
+    echo "  MATH_FIDELITIES=$MATH_FIDELITIES"
+    echo "  KWARGS=\"$KWARGS\""
+    echo "  FAILING_REASONS=$FAILING_REASONS"
+    echo "  SKIP_REASONS=$SKIP_REASONS"
+    echo "  RANGE=$RANGE"
+    echo "  TEST_ID=$TEST_ID"
+    echo "Pytest options:"
+    echo "  PYTEST_ADDOPTS = $PYTEST_ADDOPTS"
+}
+
+function reset_params {
+    reset_query_params
+    reset_pytest_opts
+}
+
+function print_query_docs {
+    max_width=$(tput cols)
+    max_width=$((max_width * 80 / 100))
+
+    pushd ${SCRIPT_DIR}/../../../
+    python3 -c "from test.operators.pytorch.test_all import InfoUtils; InfoUtils.print_query_params(max_width=${max_width})"
+    popd
+}
+
+
+function reset_query_params {
+    unset OPERATORS
+    unset FILTERS
+    unset INPUT_SOURCES
+    unset INPUT_SHAPES
+    unset DEV_DATA_FORMATS
+    unset MATH_FIDELITIES
+    unset KWARGS
+    unset FAILING_REASONS
+    unset SKIP_REASONS
+    unset RANGE
+    unset TEST_ID
+    print_params
+}
+
+
+function run_xfail_on {
+    _PYTEST_RUN_XFAIL=true
+    _set_pytest_opts
+    print_params
+}
+
+function run_xfail_off {
+    unset _PYTEST_RUN_XFAIL
+    _set_pytest_opts
+    print_params
+}
+
+function no_skips_on {
+    _PYTEST_NO_SKIPS=true
+    _set_pytest_opts
+    print_params
+}
+
+function no_skips_off {
+    unset _PYTEST_NO_SKIPS
+    _set_pytest_opts
+    print_params
+}
+
+function collect_only_on {
+    _PYTEST_COLLECT_ONLY=true
+    _set_pytest_opts
+    print_params
+}
+
+function collect_only_off {
+    unset _PYTEST_COLLECT_ONLY
+    _set_pytest_opts
+    print_params
+}
+
+function _set_pytest_opts {
+    local PYTEST_PARAMS=""
+    # PYTEST_PARAMS="${PYTEST_PARAMS} -svv"
+    PYTEST_PARAMS="${PYTEST_PARAMS} -rap"
+    if [ "${_PYTEST_NO_SKIPS}" = "true" ]; then
+        PYTEST_PARAMS="${PYTEST_PARAMS} --no-skips"
+    fi
+    if [ "${_PYTEST_RUN_XFAIL}" = "true" ]; then
+        PYTEST_PARAMS="${PYTEST_PARAMS} --runxfail"  # run xfail tests
+    fi
+    if [ "${_PYTEST_COLLECT_ONLY}" = "true" ]; then
+        PYTEST_PARAMS="${PYTEST_PARAMS} --collect-only"  # collect only
+    fi
+    export PYTEST_ADDOPTS="${PYTEST_PARAMS}"
+}
+
+function reset_pytest_opts {
+    unset _PYTEST_RUN_XFAIL
+    unset _PYTEST_NO_SKIPS
+    unset _PYTEST_COLLECT_ONLY
+    _set_pytest_opts
+    print_params
+}
+
+
+function _run_test_all {
+    function_name=$1
+    print_params
+    pytest ${SCRIPT_DIR}/test_all.py::${function_name}
+    print_params
+}
+
+function test_plan {
+    _run_test_all test_plan
+}
+
+function test_query {
+    _run_test_all test_query
+}
+
+function test_unique {
+    _run_test_all test_unique
+}
+
+function test_single {
+    _run_test_all test_single
+}
+
+
+SCRIPT_DIR=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
+# echo "SCRIPT_DIR = ${SCRIPT_DIR}"
+
+_set_pytest_opts
+
+print_help
+# print_query_docs


### PR DESCRIPTION
Changes:
- Filter test plan by INPUT_SHAPES and KWARGS
- Helper test commands for test suite
- Single operator E2E tests documentation