### PR TITLE
Update submodules for docker build

### DIFF
--- a/.github/get-docker-tag.sh
+++ b/.github/get-docker-tag.sh
@@ -13,10 +13,10 @@ else
 fi
 
 # The hash is based on the environment files
-ENV_HASH=$(find env -type f -name "*.txt" -exec cat {} + | sha256sum | cut -d ' ' -f 1)
+ENV_HASH=$(find env -type f -name "*.txt" | sort | xargs cat | sha256sum | cut -d ' ' -f 1)
 
 # The hash is based on the Dockerfile(s)
-DOCKERFILE_HASH=$(find .github -type f -name "Dockerfile.*" -exec cat {} + | sha256sum | cut -d ' ' -f 1)
+DOCKERFILE_HASH=$(find .github -type f -name "Dockerfile.*" | sort | xargs cat | sha256sum | cut -d ' ' -f 1)
 
 # Combine the hashes and calculate the final hash
 DOCKER_TAG=$( (echo $MLIR_DOCKER_TAG; echo $ENV_HASH; echo $DOCKERFILE_HASH) | sha256sum | cut -d ' ' -f 1)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,8 +15,17 @@ jobs:
         shell: bash
         run: sudo chown ubuntu:ubuntu -R $(pwd)
 
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+            submodules: recursive
+            fetch-depth: 0 # Fetch all history and tags
+
+      # Clean everything from submodules (needed to avoid issues
+      # with cmake generated files leftover from previous builds)
+      - name: Cleanup submodules
+        run: |
+          git submodule foreach --recursive git clean -ffdx
+          git submodule foreach --recursive git reset --hard
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3


### PR DESCRIPTION
The image build job wasn't updating submodules so it was always building images with the same tt-mlir version.

Also, the find command can return files in a different order depending on when they were created, so we could get different hash for docker tag on different machines even thought the files content are same.

- Update submodules for the docker build
- Fix bug in .github/get-docker-tag.sh