### PR TITLE
Fix for passing unnecessary inputs to the backward pass of the 

### DIFF
--- a/forge/forge/compiled_graph_state.py
+++ b/forge/forge/compiled_graph_state.py
@@ -281,11 +281,17 @@ class CompiledModel:
         for grad in self.loss_grad:
             assert grad is not None, "Gradients not provided for backward pass."
 
+        inputs = [
+            self.inputs[i]
+            for i, name in enumerate(self.fwd_compiled_graph_state.ordered_input_names)
+            if name in self.bwd_compiled_graph_state.ordered_input_names
+        ]
+
         logger.info(f"Running backward pass on model {self.bwd_compiled_graph_state.graph.get_name()} on device...")
         grads = run_binary(
             self.compiled_binary,
             int(ProgramId.BACKWARD),
-            [*self.loss_grad, *self.intermediates, *self.inputs, *consts_and_params],
+            [*self.loss_grad, *self.intermediates, *inputs, *consts_and_params],
         )
 
         for name, param in self.framework_module.module.named_parameters():

--- a/forge/forge/compiled_graph_state.py
+++ b/forge/forge/compiled_graph_state.py
@@ -281,6 +281,10 @@ class CompiledModel:
         for grad in self.loss_grad:
             assert grad is not None, "Gradients not provided for backward pass."
 
+        # Inputs from forward pass are needed in backward pass only if
+        # they are used in the backward pass computation
+        # They will be used if there is backward operation that explicitly requires them
+        # as in other cases, intermediate tensors can be used if they exists
         inputs = [
             self.inputs[i]
             for i, name in enumerate(self.fwd_compiled_graph_state.ordered_input_names)

--- a/forge/test/mlir/mnist/training/test_training.py
+++ b/forge/test/mlir/mnist/training/test_training.py
@@ -105,9 +105,9 @@ def test_forge_vs_torch_gradients(freeze_layer):
     in_features = 28 * 28
     out_features = 10
 
-    torch_model = MNISTLinear()
+    torch_model = MNISTLinear(dtype=dtype, bias=True)
 
-    forge_model = MNISTLinear()
+    forge_model = MNISTLinear(dtype=dtype, bias=True)
 
     copy_params(torch_model, forge_model)
 
@@ -169,9 +169,6 @@ def test_forge_vs_torch():
 
     copy_params(torch_model, forge_model)
 
-    forge_model.linear_relu_stack[0].weight.requires_grad = False
-    forge_model.linear_relu_stack[0].bias.requires_grad = False
-
     torch_writer = load_tb_writer("torch")
     forge_writer = load_tb_writer("forge")
 
@@ -179,7 +176,6 @@ def test_forge_vs_torch():
     torch_optimizer = torch.optim.SGD(torch_model.parameters(), lr=learning_rate)
     forge_optimizer = torch.optim.SGD(forge_model.parameters(), lr=learning_rate)
 
-    forge_model.train()
     tt_model = forge.compile(
         forge_model, sample_inputs=[torch.ones(batch_size, 784, dtype=dtype)], loss=loss_fn, optimizer=forge_optimizer
     )

--- a/forge/test/mlir/mnist/training/test_training.py
+++ b/forge/test/mlir/mnist/training/test_training.py
@@ -93,7 +93,8 @@ def test_mnist_training():
     print(f"Test (total) loss: {test_loss}")
 
 
-def test_forge_vs_torch_gradients():
+@pytest.mark.parametrize("freeze_layer", [None, 0, 2, 4])
+def test_forge_vs_torch_gradients(freeze_layer):
     logger.disable("")
     torch.manual_seed(0)
     batch_size = 64
@@ -104,11 +105,17 @@ def test_forge_vs_torch_gradients():
     in_features = 28 * 28
     out_features = 10
 
-    torch_model = MNISTLinear(dtype=dtype, bias=True)
+    torch_model = MNISTLinear()
 
-    forge_model = MNISTLinear(dtype=dtype, bias=True)
+    forge_model = MNISTLinear()
 
     copy_params(torch_model, forge_model)
+
+    if freeze_layer is not None:
+        forge_model.linear_relu_stack[freeze_layer].weight.requires_grad = False
+        forge_model.linear_relu_stack[freeze_layer].bias.requires_grad = False
+        torch_model.linear_relu_stack[freeze_layer].weight.requires_grad = False
+        torch_model.linear_relu_stack[freeze_layer].bias.requires_grad = False
 
     loss_fn = nn.CrossEntropyLoss()
 
@@ -132,6 +139,10 @@ def test_forge_vs_torch_gradients():
     forge_loss.backward()
     tt_model.backward()
     forge_grads = get_param_grads(forge_model.named_parameters)
+
+    if freeze_layer is not None:
+        assert forge_model.linear_relu_stack[freeze_layer].weight.grad is None
+        assert forge_model.linear_relu_stack[freeze_layer].bias.grad is None
 
     # Compare gradients for each parameter
     for name in reversed(list(torch_grads.keys())):

--- a/forge/test/mlir/mnist/training/test_training.py
+++ b/forge/test/mlir/mnist/training/test_training.py
@@ -158,6 +158,9 @@ def test_forge_vs_torch():
 
     copy_params(torch_model, forge_model)
 
+    forge_model.linear_relu_stack[0].weight.requires_grad = False
+    forge_model.linear_relu_stack[0].bias.requires_grad = False
+
     torch_writer = load_tb_writer("torch")
     forge_writer = load_tb_writer("forge")
 
@@ -165,6 +168,7 @@ def test_forge_vs_torch():
     torch_optimizer = torch.optim.SGD(torch_model.parameters(), lr=learning_rate)
     forge_optimizer = torch.optim.SGD(forge_model.parameters(), lr=learning_rate)
 
+    forge_model.train()
     tt_model = forge.compile(
         forge_model, sample_inputs=[torch.ones(batch_size, 784, dtype=dtype)], loss=loss_fn, optimizer=forge_optimizer
     )

--- a/forge/test/mlir/mnist/utils.py
+++ b/forge/test/mlir/mnist/utils.py
@@ -107,7 +107,7 @@ def load_dataset(batch_size, dtype=torch.float32):
 
 
 def get_param_grads(named_params):
-    return {name: param.grad.detach().clone() for name, param in named_params()}
+    return {name: param.grad.detach().clone() for name, param in named_params() if param.grad is not None}
 
 
 def copy_params(src, dst):


### PR DESCRIPTION
Filtered inputs from the forward pass that are passed to backward pass by name.

For test: test_forge_vs_torch_gradients added option to freeze layer
if the layer is freezed gradient should be None.

Modified `forge/test/mlir/mnist/utils.py::get_param_grads` to skip parameters that dont have grad.