### PR TITLE
Fix stack op sanity failure

### DIFF
--- a/forge/csrc/passes/commute_utils.cpp
+++ b/forge/csrc/passes/commute_utils.cpp
@@ -45,9 +45,12 @@ std::tuple<bool, int> can_commute_reshape_through_dim(
     {
         if (input_shape_vec[i] == output_shape_vec[dim])
         {
+            log_trace("output_shape_vec.size() = {}", output_shape_vec.size());
+            log_trace("i value = {}", i);
             // check whether volume above and below matching dim is the same
             if ((volume_above(input_shape_vec, i) == volume_above(output_shape_vec, dim)) and
-                (volume_below(input_shape_vec, i) == volume_below(output_shape_vec, dim)))
+                (volume_below(input_shape_vec, i) == volume_below(output_shape_vec, dim)) and
+                (i < output_shape_vec.size()))
             {
                 can_commute = true;
                 new_dim = i;

--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -1322,3 +1322,46 @@ def test_avg_pool2d():
     co_out = [co.to("cpu") for co in co_out]
     fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
     assert all([compare_with_golden(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        ([(1, 256, 24, 24), (1, 256, 24, 24)], -4),
+        ([(5, 64, 128, 128), (5, 64, 128, 128)], -3),
+        ([(1, 30, 30, 16), (1, 30, 30, 16)], -2),
+        ([(1, 30, 30, 16), (1, 30, 30, 16)], 3),
+        ([(5, 64, 128, 128), (5, 64, 128, 128)], -1),
+        ([(1, 256, 24, 24), (1, 256, 24, 24)], 4),
+        ([(1, 256, 24, 24), (1, 256, 24, 24)], 2),
+        ([(5, 64, 128, 128), (5, 64, 128, 128)], 1),
+        ([(1, 30, 30, 16), (1, 30, 30, 16)], 0),
+    ],
+)
+def test_stack(params):
+    class Stack(nn.Module):
+        def __init__(self, dim):
+            super().__init__()
+            self.dim = dim
+
+        def forward(self, *tensors):
+            return torch.stack(tensors, dim=self.dim)
+
+    input_shapes, dim = params
+    if dim == -3 or dim == 1:
+        pytest.xfail("Tensor rank is not 4")
+    else:
+        pytest.xfail(
+            "Unable to reshape a tensor in TILE_LAYOUT to non-tile height and width! Please convert the tensor to ROW_MAJOR_LAYOUT first"
+        )
+    inputs = [torch.rand(shape) for shape in input_shapes]
+
+    framework_model = Stack(dim)
+    fw_out = framework_model(*inputs)
+
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name="stack_sanity")
+    co_out = compiled_model(*inputs)
+
+    co_out = [co.to("cpu") for co in co_out]
+    fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+    assert all([compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])


### PR DESCRIPTION
Fix for #506 
1. Axis has been changed in eltwise_nary.py to address #506  for codegen model
2. Stack op test case was failing with error `Trying to access element outside of dimensions: 4` for test cases with dim =-2 and dim =3 in optmised graph pass. It was failing because new_dim was not calculated correctly in can_commute_reshape_through_dim in commute_utils.cpp, hence it was going out of bounds, so a condition was added to skip the out of bounds test case.
Full log: [stack_sanity.log](https://github.com/user-attachments/files/17616011/stack_sanity.log)

