### PR TITLE
Add support for Llama 3B decode with and without cache tests and cast op

### DIFF
--- a/forge/csrc/forge_passes.cpp
+++ b/forge/csrc/forge_passes.cpp
@@ -217,9 +217,6 @@ graphlib::Graph *run_pre_lowering_passes(graphlib::Graph *graph, const std::opti
     // Note this is not lowering, these are still forge tms
     convert_broadcast_ops_to_tms(graph);
 
-    // Bypass embedding input nops
-    bypass_embedding_input_nops(graph);
-
     //
     // Data formats
     //

--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -573,6 +573,7 @@ class MLIRGenerator
         lowering_handler_map["less"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::LessEqualOp>;
         lowering_handler_map["greater"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::GreaterThanOp>;
         lowering_handler_map["not_equal"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::NotEqualOp>;
+        lowering_handler_map["cast"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::TypecastOp>;
     }
 };
 }  // namespace

--- a/forge/csrc/passes/pre_lowering_passes.cpp
+++ b/forge/csrc/passes/pre_lowering_passes.cpp
@@ -184,27 +184,6 @@ void replace_with_broadcasted_const(
     graph->remove_node(constant);
 }
 
-void bypass_embedding_input_nops(Graph *graph)
-{
-    for (Node *node : graph->nodes())
-    {
-        if ((node->node_type() != NodeType::kPyOp) || (node->as<graphlib::PyOpNode>()->op_type().op != "embedding"))
-            continue;
-
-        graphlib::PyOpNode *embedding = node->as<graphlib::PyOpNode>();
-
-        Node *input_ids = graph->data_operands(embedding)[0];
-        if (input_ids->node_type() == NodeType::kInput)
-            continue;
-
-        if (input_ids->node_type() == NodeType::kPyOp)
-        {
-            TT_ASSERT(input_ids->as<graphlib::PyOpNode>()->op_type().op == "nop");
-            graphlib::bypass_node(graph, input_ids, true);
-        }
-    }
-}
-
 bool safe_to_hoist_past(const Graph *graph, const Node *operand)
 {
     if (graph->user_data_edges(operand).size() > 1)

--- a/forge/csrc/passes/pre_lowering_passes.hpp
+++ b/forge/csrc/passes/pre_lowering_passes.hpp
@@ -17,8 +17,6 @@ using Node = graphlib::Node;
 
 void convert_broadcast_ops_to_tms(Graph *graph);
 
-void bypass_embedding_input_nops(Graph *graph);
-
 bool safe_to_hoist_past(const Graph *graph, const Node *operand);
 
 void fuse_bias(Graph *graph);

--- a/forge/forge/op/__init__.py
+++ b/forge/forge/op/__init__.py
@@ -46,6 +46,7 @@ from .eltwise_unary import (
     Dropout,
     Pow,
     Tilize,
+    Cast,
 )
 from .reduce import ReduceSum, ReduceAvg, ReduceMax, GroupedReduceAvg
 from .tm import (

--- a/forge/forge/op/eltwise_unary.py
+++ b/forge/forge/op/eltwise_unary.py
@@ -2,7 +2,10 @@
 
 # SPDX-License-Identifier: Apache-2.0
 from typing import Union, Tuple
-from ..tensor import Tensor
+import torch
+
+from forge._C import DataFormat
+from ..tensor import Tensor, pytorch_dtype_to_forge_dataformat
 from .common import ForgeOp as op
 
 
@@ -25,6 +28,30 @@ def Abs(name: str, operandA: Tensor) -> Tensor:
     """
 
     return op("abs", name, operandA).get_tensor()
+
+
+def Cast(name: str, operandA: Tensor, dtype: Union[torch.dtype, DataFormat]) -> Tensor:
+    """
+    Cast
+
+    Parameters
+    ----------
+    name: str
+        Op name, unique to the module, or leave blank to autoset
+
+    operandA: Tensor
+        First operand
+
+    dtype: Union[torch.dtype, DataFormat]
+        Specify Torch datatype / Forge DataFormat to convert operandA
+
+    Returns
+    -------
+    Tensor
+        Forge tensor
+    """
+    dtype = pytorch_dtype_to_forge_dataformat(dtype)
+    return op("cast", name, operandA, dtype=dtype.to_json()).get_tensor(out_df=dtype)
 
 
 def Exp(name: str, operandA: Tensor) -> Tensor:

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -22,9 +22,11 @@ from .argmax import Argmax
 from .convolution import Conv2d
 from .convolution import Conv2dTranspose
 from .pooling import MaxPool2d
+from .cast import Cast
 
 op_to_module_map = {
     "add": "eltwise_binary",
+    "cast": Cast,
     "divide": "eltwise_binary",
     "subtract": "eltwise_binary",
     "multiply": "eltwise_binary",

--- a/forge/forge/op/eval/forge/cast.py
+++ b/forge/forge/op/eval/forge/cast.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Union
+import torch
+
+from ..interface import PyEltwiseUnaryOp
+from ....tensor import forge_dataformat_to_pytorch_dtype, pytorch_dtype_to_forge_dataformat
+from forge._C import DataFormat
+
+
+class Cast(PyEltwiseUnaryOp):
+    @classmethod
+    def create(cls, dtype: Union[torch.dtype, DataFormat]):
+        self = cls("cast")
+        self.dtype = pytorch_dtype_to_forge_dataformat(dtype).to_json()
+        return self
+
+    def eval(self, tensors):
+        assert len(tensors) == 1, "Cast should have one input"
+        dtype = forge_dataformat_to_pytorch_dtype(DataFormat.from_json(self.dtype))
+        ret = tensors[0].to(dtype)
+        return ret
+
+    def shape(self, tensor_shapes):
+        assert len(tensor_shapes) == 1, "Cast should have one input"
+        shape = tensor_shapes[0]
+        return shape, []

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1234,6 +1234,14 @@ def populate_layernorm_args(graph, nid, compiler_cfg):
     return args
 
 
+def populate_cast_args(graph, nid, compiler_cfg):
+    node = graph["nodes"][nid]
+    args = []
+    dtype = node["attrs"]["dtype"][0][0]
+    args.append(("dtype", "torch." + f"{dtype}"))
+    return args
+
+
 def populate_transpose_args(graph, nid, compiler_cfg):
     node = graph["nodes"][nid]
     axes = [int(axis) for axis in node["attrs"]["axes"][0]]
@@ -1690,7 +1698,7 @@ forge_op_to_function_name = {
     "avg_pool2d": "forge.op.AvgPool2d",
     "binary_stack": "forge.op.BinaryStack",
     "broadcast": "forge.op.Broadcast",
-    "cast": "forge.op.Identity",  # Datatype cast
+    "cast": "forge.op.Cast",  # Datatype cast
     "clip": "forge.op.Clip",
     "concatenate": "forge.op.Concatenate",
     "conv2d_transpose": "forge.op.Conv2dTranspose",
@@ -1767,6 +1775,7 @@ forge_ops_needing_arguments = {
     "avg_pool2d": populate_avgpool2d_args,
     "binary_stack": populate_binary_stack_args,
     "broadcast": populate_broadcast_args,
+    "cast": populate_cast_args,
     "clip": populate_clip_transpose_args,
     "concatenate": populate_concatenate_args,
     "conv2d_transpose": populate_conv2d_transpose_args,

--- a/forge/forge/verify/config.py
+++ b/forge/forge/verify/config.py
@@ -107,7 +107,7 @@ class VerifyConfig:
     verify_tvm_compile: bool = False  # Should tvm run forward and verify the results
     verify_pipeline_result_vs_framework: bool = False  # Compare Framework output on CPU vs module pipline outputs
     verify_forge_codegen_vs_framework: bool = (
-        False  # Compare Framework output on CPU vs forge codegen from TVM json graphs
+        True  # Compare Framework output on CPU vs forge codegen from TVM json graphs
     )
 
     verify_all: bool = (

--- a/forge/test/mlir/llama/tests/test_llama_decode.py
+++ b/forge/test/mlir/llama/tests/test_llama_decode.py
@@ -1,0 +1,324 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+import torch
+from transformers import LlamaConfig, LlamaForCausalLM, LlamaTokenizer
+from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
+
+import forge
+from forge.op.eval.common import compare_with_golden
+from test.mlir.llama.utils.utils import load_model
+
+
+class LlamaModelWrapper(torch.nn.Module):
+    """
+    In LlamaModelWrapper class, forward function takes input_ids (i.e list of input token or
+    or last predicted single token), attention_mask and return logits
+    Args:
+        1) use_cache = False
+            input_id (`torch.Tensor`) - shape of (batch_size, seq_length)
+            attention_mask (`torch.Tensor`) -  shape of (batch_size, seq_length)
+        2) use_cache = True
+            input_id (`torch.Tensor`) - shape of (batch_size, 1)
+            attention_mask (`torch.Tensor`) -  shape of (batch_size, key_value_seq_len + 1)
+            position_ids (`torch.Tensor`) -  shape of (batch_size, 1)
+            past_key_values (`List[List[torch.Tensor, torch.Tensor]]`)
+                        key/values shape: (batch_size, num_of_key_values_heads, key_value_seq_len, head_dim)
+
+    Returns:
+        1) use_cache = False
+            logits (`torch.Tensor`) - shape (batch_size, seq_length, vocab_size)
+        2) use_cache = True
+            logits (`torch.Tensor`) - shape (batch_size, 1, vocab_size)
+            past_key_values (`List[List[torch.Tensor, torch.Tensor]]`)
+                        key/values shape: (batch_size, num_of_key_values_heads, key_value_seq_len + 1, head_dim)
+    """
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self.embed_tokens = model.model.embed_tokens
+
+    def forward(self, input_ids, attention_mask, position_ids=None, past_key_values=None):
+
+        inputs_embeds = self.embed_tokens(input_ids)
+
+        # The causal_mask calculated inside _update_causal_mask method in LlamaModel module
+        # is not properly traced by torch.jit.trace while converting pytorch to relay ops in TVM PyTorch Frontend Conversion
+        # which leads to pcc drops, because the causal mask helps to avoid attention calculation on padding token in LlamaAttention module
+        # To overcome this jit trace issue, causal mask is calculated by using _prepare_4d_causal_attention_mask function.
+        past_key_values_length = past_key_values[0][0].shape[-2] if past_key_values is not None else 0
+        causal_attention_mask = _prepare_4d_causal_attention_mask(
+            attention_mask, input_ids.shape, inputs_embeds, past_key_values_length
+        )
+        model_outputs = self.model(
+            attention_mask=causal_attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+        )
+
+        if model_outputs.past_key_values is not None:
+            return model_outputs.logits, model_outputs.past_key_values
+
+        return model_outputs.logits
+
+
+def calculate_attention_mask_and_postion_ids(
+    padded_past_key_values_seq_length, non_padding_past_key_values_seq_length, input_seq_length
+):
+
+    # Calculate attention mask
+    attention_mask = torch.zeros(padded_past_key_values_seq_length + input_seq_length)
+    attention_mask[:non_padding_past_key_values_seq_length] = 1
+    attention_mask[-1] = 1
+    attention_mask = attention_mask.unsqueeze(0)
+
+    # Calculate position ids
+    position_ids = torch.arange(
+        non_padding_past_key_values_seq_length,
+        input_seq_length + non_padding_past_key_values_seq_length,
+        dtype=torch.long,
+    )
+    position_ids = position_ids.unsqueeze(0)
+
+    return attention_mask, position_ids
+
+
+@pytest.mark.parametrize("run_on_tt_device", [False, True])
+def test_llama_prefill_on_cpu_decode_on_tt_no_cache(run_on_tt_device):
+
+    if run_on_tt_device:
+        compiler_cfg = forge.config._get_global_compiler_config()
+        compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
+
+    # Load Llama 3B model and tokenizer
+    model_path = "openlm-research/open_llama_3b"
+    model, tokenizer = load_model(model_path, return_dict=True, use_cache=False, use_fast=False)
+    framework_model = LlamaModelWrapper(model)
+    framework_model.eval()
+    tokenizer.pad_token_id = model.config.pad_token_id
+
+    # Prepare input sentence
+    max_sequence_length = 58
+    prompt = "Q: What is the largest animal?\nA:"
+    inputs = tokenizer(
+        prompt,
+        return_tensors="pt",
+        max_length=max_sequence_length,
+        pad_to_max_length=True,
+        truncation=True,
+    )
+    input_ids = inputs.input_ids
+    attention_mask = inputs.attention_mask
+
+    non_padding_seq_len = int(torch.sum(attention_mask))
+    padding_seq_len = attention_mask.shape[1] - non_padding_seq_len
+
+    # Run Prefill on CPU with no cache to get the initial logits
+    logits = framework_model(input_ids=input_ids, attention_mask=attention_mask)
+
+    # Take the last non padding token index in logits for the next token
+    next_token_logits = logits[:, non_padding_seq_len - 1, :]
+    next_token = torch.argmax(next_token_logits, dim=-1)
+
+    # Update the input_ids with predicted token from prefill in the first padding token index
+    input_ids[:, non_padding_seq_len] = next_token
+    attention_mask[:, non_padding_seq_len] = 1
+
+    non_padding_seq_len = int(torch.sum(attention_mask))
+    padding_seq_len = attention_mask.shape[1] - non_padding_seq_len
+
+    if run_on_tt_device:
+
+        # Compile the model on TT
+        compiled_model = forge.compile(framework_model, sample_inputs=[input_ids, attention_mask])
+        pytest.xfail("Found Unsupported operations while lowering from TTForge to TTIR in forward graph.")
+
+    # Run decode stage on TT device and generate tokens by appending predicted token into sequence of input tokens
+    # untill the a specified maximum number of new tokens is reached or an end-of-sequence token is encountered.
+    max_new_tokens = padding_seq_len
+    for idx in range(max_new_tokens):
+
+        # CPU Inference
+        framework_output = framework_model(input_ids=input_ids, attention_mask=attention_mask)
+
+        if run_on_tt_device:
+
+            model_inputs = [input_ids, attention_mask]
+
+            # Run on TT device
+            tt_output = compiled_model(*model_inputs)
+            tt_output = [tt_out.to("cpu") for tt_out in tt_output]
+
+            framework_output = [framework_output] if isinstance(framework_output, torch.Tensor) else framework_output
+
+            # Validate TT result with Framework
+            assert all(
+                [
+                    compare_with_golden(golden=fw_out, calculated=tt_out, pcc=0.99)
+                    for fw_out, tt_out in zip(framework_output, tt_output)
+                ]
+            )
+
+            logits = tt_output[0]
+
+        else:
+
+            logits = framework_output
+
+        next_token_index = non_padding_seq_len + idx
+        next_token_logits = logits[:, next_token_index - 1, :]
+        next_token = torch.argmax(next_token_logits, dim=-1)
+
+        if next_token == tokenizer.eos_token_id:
+            break
+
+        input_ids[:, next_token_index] = next_token
+        attention_mask[:, next_token_index] = 1
+
+    # Generated text
+    generated_text = tokenizer.decode(input_ids[0], skip_special_tokens=True)
+    print("generated_text=", generated_text)
+
+
+@pytest.mark.parametrize("run_on_tt_device", [False, True])
+def test_llama_prefill_on_cpu_decode_on_tt_cache(run_on_tt_device):
+
+    if run_on_tt_device:
+        compiler_cfg = forge.config._get_global_compiler_config()
+        compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
+
+    # Load Llama 3B model and tokenizer
+    model_path = "openlm-research/open_llama_3b"
+    model, tokenizer = load_model(model_path, return_dict=True, use_cache=True, use_fast=False)
+    framework_model = LlamaModelWrapper(model)
+    framework_model.eval()
+    tokenizer.pad_token_id = model.config.pad_token_id
+
+    # Prepare input sentence
+    prompt = "Q: What is the largest animal?\nA:"
+    inputs = tokenizer(prompt, return_tensors="pt")
+
+    # Run Prefill on CPU with cache to get the initial logits and past key-values
+    prefill_output = framework_model(input_ids=inputs.input_ids, attention_mask=inputs.attention_mask)
+    next_token_logits = prefill_output[0][:, -1, :]
+    next_token = torch.argmax(next_token_logits, dim=-1)
+
+    generated_tokens = inputs.input_ids
+    generated_tokens = torch.cat([generated_tokens, next_token.unsqueeze(0)], dim=-1)
+
+    past_key_values_list = [[k, v] for k, v in prefill_output[1]]
+
+    model_inputs = [next_token.unsqueeze(0), past_key_values_list]
+
+    # Zero Pad past key values in key_value_seq_len(i.e -2) dimension
+    # Before padding past key values tensor shape -> (batch_size, num_of_key_values_heads, key_value_seq_len, head_dim)
+    # After Padding Past key value tensor shape -> (batch_size, num_of_key_values_heads, key_value_seq_len + max_new_tokens, head_dim)
+    max_new_tokens = 46
+    non_padding_seq_length = past_key_values_list[0][0].shape[-2]
+    for idx, (k, v) in enumerate(model_inputs[1]):
+        model_inputs[1][idx][0] = torch.cat(
+            [
+                k,
+                torch.zeros(k.shape[-4], k.shape[-3], max_new_tokens, k.shape[-1]).to(k.dtype),
+            ],
+            dim=-2,
+        )
+        model_inputs[1][idx][1] = torch.cat(
+            [
+                v,
+                torch.zeros(v.shape[-4], v.shape[-3], max_new_tokens, v.shape[-1]).to(k.dtype),
+            ],
+            dim=-2,
+        )
+
+    if run_on_tt_device:
+        # Calculate attention mask and postion_ids
+        padded_past_key_values_seq_length = model_inputs[1][0][0].shape[-2]
+        input_seq_length = model_inputs[0].shape[-1]
+        attention_mask, position_ids = calculate_attention_mask_and_postion_ids(
+            padded_past_key_values_seq_length, non_padding_seq_length, input_seq_length
+        )
+
+        # Compile the model
+        compiled_model = forge.compile(
+            framework_model, sample_inputs=[model_inputs[0], attention_mask, position_ids, model_inputs[1]]
+        )
+        pytest.xfail("Found Unsupported operations while lowering from TTForge to TTIR in forward graph.")
+
+    # Run decode stage on TT device and generate tokens by passing the last predicted token and the past key values.
+    # untill the a specified maximum number of new tokens is reached or an end-of-sequence token is encountered.
+    for max_new_tokens_idx in range(max_new_tokens):
+
+        non_padding_past_key_values_seq_length = non_padding_seq_length + max_new_tokens_idx
+        padded_past_key_values_seq_length = model_inputs[1][0][0].shape[-2]
+        input_seq_length = model_inputs[0].shape[-1]
+        attention_mask, position_ids = calculate_attention_mask_and_postion_ids(
+            padded_past_key_values_seq_length, non_padding_past_key_values_seq_length, input_seq_length
+        )
+
+        # CPU Inference
+        model_outputs = framework_model(model_inputs[0], attention_mask, position_ids, model_inputs[1])
+
+        # TT will return the logits and past key values as list of tensor, so flattening
+        # framework output past key values from List(List(Key1, Values1), ... , List(Key26, Values26)) to
+        # List(Key1, Values1, ... , Key26, Values26) for comparing the Framework and TT output in similar fashion.
+        framework_output = [model_outputs[0]]
+        for k, v in model_outputs[1]:
+            framework_output.append(k)
+            framework_output.append(v)
+
+        if run_on_tt_device:
+            # Run on TT device
+            tt_inputs = [model_inputs[0], attention_mask, position_ids, model_inputs[1]]
+            tt_output = compiled_model(*tt_inputs)
+            tt_output = [tt_out.to("cpu") for tt_out in tt_output]
+
+            # Validate TT result with Framework
+            assert all(
+                [
+                    compare_with_golden(golden=fw_out, calculated=tt_out, pcc=0.99)
+                    for fw_out, tt_out in zip(framework_output, tt_output)
+                ]
+            )
+
+            logits = tt_output[0]
+            past_key_values = tt_output[1:]
+
+        else:
+            logits = framework_output[0]
+            past_key_values = framework_output[1:]
+
+        next_token_logits = logits[:, -1, :]
+        next_token = torch.argmax(next_token_logits, dim=-1)
+
+        if next_token == tokenizer.eos_token_id:
+            break
+
+        model_inputs = [next_token.unsqueeze(0)]
+
+        # Formate the past key values from List(Key1, Values1, ... , Key26, Values26) to
+        # List(List(Key1, Values1), ... , List(Key26, Values26))
+        model_inputs.append([past_key_values[idx : idx + 2] for idx in range(0, len(past_key_values), 2)])
+
+        # Generated new token, key and values states are appended to the past key values tensor on key_values_sequence_length dim (i.e -2).
+        # For predicting next token, move the generated new token, key and values states from the last past key values tensor index
+        # to the first past key values tensor padding index on key_values_sequence_length dim (i.e -2).
+        for idx in range(len(model_inputs[1])):
+            model_inputs[1][idx][0][:, :, non_padding_past_key_values_seq_length, :] = model_inputs[1][idx][0][
+                :, :, -1, :
+            ]
+            model_inputs[1][idx][0] = model_inputs[1][idx][0][:, :, :-1, :]
+            model_inputs[1][idx][1][:, :, non_padding_past_key_values_seq_length, :] = model_inputs[1][idx][1][
+                :, :, -1, :
+            ]
+            model_inputs[1][idx][1] = model_inputs[1][idx][1][:, :, :-1, :]
+
+        generated_tokens = torch.cat([generated_tokens, next_token.unsqueeze(0)], dim=-1)
+
+    # Generated text
+    generated_text = tokenizer.decode(generated_tokens[0], skip_special_tokens=True)
+    print("generated_text=", generated_text)

--- a/forge/test/mlir/llama/utils/utils.py
+++ b/forge/test/mlir/llama/utils/utils.py
@@ -22,6 +22,7 @@ def load_model(model_path="openlm-research/open_llama_3b", **kwargs):
     framework_model.eval()
 
     # Using AutoTokenizer for default tokenizers for both openllama and llama 3.2
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    use_fast = kwargs.get("use_fast", True)
+    tokenizer = AutoTokenizer.from_pretrained(model_path, use_fast=use_fast)
 
     return framework_model, tokenizer


### PR DESCRIPTION
1. Add support for Llama 3B decode with and without cache:
      Fixes #422, #128  
      - No Cache (i.e test_llama_prefill_on_cpu_decode_on_tt_no_cache):
          - **Prefill stage:**
              - It will be executed on CPU. The input_ids and attention_mask are padded to max sequence length and then passed to the llama 3b model in prefill stage and return logits.
          - **Decode stage:**
              - It will be executed on TT devices. In this decode stage, the input_ids first padding token id(i.e 0) is replaced with predicted next token from the prefill/previous decode stage and attention_mask first padding mask(i.e 0) is replaced with non padding token mask (i.e 1) and the passed to the llama 3b model in decode stage for predicting the next token untill the a specified maximum number of new tokens is reached or an end-of-sequence token is encountered
      -  Cache (i.e test_llama_prefill_on_cpu_decode_on_tt_cache):
         - **Prefill stage:**
             - It will be executed on CPU. The input_ids and attention_mask are passed to the llama 3b model in prefill stage and return logits and past key values. Before passing to the decode stage, the past key values from prefill are zero padded on key_values_seq_length dim (i.e -2).
          - **Decode stage:**
              - It will be executed on TT devices. In this decode stage, the predicted next token from the prefill/previous decode stage, padded past key values, attention_mask(i.e will of shape (batch_size, key_value_seq_length +1), attention mask contains 0 or 1 as values. 0 means masked, 1 means not masked. The mask value 1 is applied upto the non padded past key value index and last index in past key values. The mask value 0 is applied to the padding past key values index) and postion_ids (i.e will be of shape (batch_size, 1), it contains the first non padding past key values index) are passed to the llama 3b model in decode stage for predicting the next token untill the a specified maximum number of new tokens is reached or an end-of-sequence token is encountered. 
 2. Add support for the cast op(i.e TTIR TypeCastOp) in Forge: - #336 
     - Currently tested the cast op conversion between float32 and int32.
 3. Remove the bypass_embedding_input_nops pass in run_pre_lowering_passes compilation stage:
     - Earlier the tvm relay cast op is mapped to Forge Identity Op(i.e Nop) in tvm_to_python.py file, though we are currently supporting cast op in Forge, there will be no introduction of nop op as input_id operand for the embedding op, so removing the pass.
 4. Enabling the verify_forge_codegen_vs_framework flag to compare Framework output and generated forge module output, because in the generated forge module some of the inputs passed to the forward function are mapped as unused input which leads to pcc drop once we compile and run the models.
                     