### PR TITLE
Fix for monodle failure

### DIFF
--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -697,7 +697,14 @@ def populate_conv2d_transpose_args(graph, nid, compiler_cfg):
         )
     )
 
-    in_channel = next((n["attrs"]["shape"][0][0][0] for n in graph["nodes"] if n["name"] == "model.weight"), None)
+    in_channel = None
+    for input_ in node["inputs"]:
+        input_nid = input_[0]
+        input_node = graph["nodes"][input_nid]
+        if input_node["op"] == "parameter" and input_node["name"].endswith("weight"):
+            in_channel = input_node["attrs"]["shape"][0][0][0]
+            break
+
     groups = int(node["attrs"]["groups"][0][0])
     assert groups == 1 or (in_channel is not None and groups == in_channel), "Only supports group of 1 or in_channel"
     args.append(

--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -1374,16 +1374,25 @@ def test_reduce_max(input_shape, dim):
 
 @pytest.mark.xfail(reason="Found Unsupported operations while lowering from TTForge to TTIR in forward graph")
 @pytest.mark.parametrize(
-    "in_channels, out_channels, kernel_size, stride, padding, groups, bias, dilation, padding_mode",
+    "in_channels, out_channels, kernel_size, stride, padding, groups, bias, dilation, padding_mode, input_shape",
     [
-        (16, 33, (3, 3), 2, 0, 1, True, 1, "zeros"),
-        (16, 33, (3, 3), 2, 0, 1, False, 1, "zeros"),
-        (16, 33, (3, 5), 2, 0, 1, True, 1, "zeros"),
+        (16, 33, (3, 3), 2, 0, 1, True, 1, "zeros", (16, 50, 100)),
+        (16, 32, (3, 5), 2, 1, 1, True, 1, "zeros", (16, 50, 100)),
+        (16, 16, (3, 3), 1, 1, 16, True, 1, "zeros", (16, 50, 100)),
+        (16, 33, (3, 3), 2, 0, 1, True, 1, "zeros", (20, 16, 50, 100)),
+        (16, 33, (3, 3), 2, 0, 1, False, 1, "zeros", (20, 16, 50, 100)),
+        (16, 33, (3, 5), 2, 0, 1, True, 1, "zeros", (20, 16, 50, 100)),
+        (16, 16, (5, 5), 1, 2, 1, True, 1, "zeros", (20, 16, 50, 100)),
+        (16, 32, (3, 5), 2, 1, 1, True, 1, "zeros", (20, 16, 50, 100)),
+        (16, 32, (3, 3), 4, 1, 1, False, 1, "zeros", (20, 16, 50, 100)),
+        (16, 16, (3, 3), 2, 2, 1, True, 1, "zeros", (20, 16, 50, 100)),
+        (16, 16, (3, 3), 1, 1, 16, True, 1, "zeros", (20, 16, 50, 100)),
     ],
 )
-@pytest.mark.push
-def test_convtranspose2d(in_channels, out_channels, kernel_size, stride, padding, groups, bias, dilation, padding_mode):
-    inputs = [torch.randn(20, 16, 50, 100)]
+def test_convtranspose2d(
+    in_channels, out_channels, kernel_size, stride, padding, groups, bias, dilation, padding_mode, input_shape
+):
+    inputs = [torch.randn(*input_shape)]
 
     framework_model = torch.nn.ConvTranspose2d(
         in_channels=in_channels,

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_monodle.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_monodle.py
@@ -14,7 +14,7 @@ import os
 def test_monodle_pytorch(test_device):
     # PyBuda configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     model_name = "monodle_pytorch"
 


### PR DESCRIPTION
Fix #513 
1. Moved [pybuda](https://yyz-gitlab.local.tenstorrent.com/tenstorrent/pybuda/-/merge_requests/2120/diffs#diff-content-47e775d7f3c6ed631c9df43e14513190b5a6f858) fix for monodle model to forge [](url)
2. padded activations was removed from convtranspose2d eval as it was causing improper output shape calculation.