### PR TITLE
Update Llama block test cases and add cosine and sine op in lowering_handler_map in lower_to_mlir.cpp

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -574,6 +574,8 @@ class MLIRGenerator
         lowering_handler_map["greater"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::GreaterThanOp>;
         lowering_handler_map["not_equal"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::NotEqualOp>;
         lowering_handler_map["cast"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::TypecastOp>;
+        lowering_handler_map["cosine"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::CosOp>;
+        lowering_handler_map["sine"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::SinOp>;
     }
 };
 }  // namespace

--- a/forge/test/mlir/llama/tests/test_llama_decode.py
+++ b/forge/test/mlir/llama/tests/test_llama_decode.py
@@ -135,7 +135,9 @@ def test_llama_prefill_on_cpu_decode_on_tt_no_cache(run_on_tt_device):
 
         # Compile the model on TT
         compiled_model = forge.compile(framework_model, sample_inputs=[input_ids, attention_mask])
-        pytest.xfail("Found Unsupported operations while lowering from TTForge to TTIR in forward graph.")
+        pytest.xfail(
+            "Found Unsupported operations while lowering from TTForge to TTIR in forward graph: {Clip Op: input_shape:(1, 1, 58, 58), min=0.0, max=1.0}"
+        )
 
     # Run decode stage on TT device and generate tokens by appending predicted token into sequence of input tokens
     # untill the a specified maximum number of new tokens is reached or an end-of-sequence token is encountered.
@@ -247,7 +249,9 @@ def test_llama_prefill_on_cpu_decode_on_tt_cache(run_on_tt_device):
         compiled_model = forge.compile(
             framework_model, sample_inputs=[model_inputs[0], attention_mask, position_ids, model_inputs[1]]
         )
-        pytest.xfail("Found Unsupported operations while lowering from TTForge to TTIR in forward graph.")
+        pytest.xfail(
+            "Found Unsupported operations while lowering from TTForge to TTIR in forward graph: {Clip Op: input_shape:(1, 1, 1, 59), min=0.0, max=1.0}"
+        )
 
     # Run decode stage on TT device and generate tokens by passing the last predicted token and the past key values.
     # untill the a specified maximum number of new tokens is reached or an end-of-sequence token is encountered.

--- a/forge/test/mlir/llama/tests/test_llama_embedding.py
+++ b/forge/test/mlir/llama/tests/test_llama_embedding.py
@@ -10,10 +10,13 @@ from forge.op.eval.common import compare_with_golden_pcc
 
 
 @pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.xfail()
+@pytest.mark.xfail(reason="RuntimeError: ttnn.embedding op fails while validating the input_tensor layout")
 def test_llama_embedding(model_path):
     if model_path == "meta-llama/Llama-3.2-1B":
         pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+
+    # RuntimeError: ttnn.embedding op fails while validating the input_tensor layout(i,e it is in ROW_MAJOR LAYOUT)
+    # tt-mlir issue: https://github.com/tenstorrent/tt-mlir/issues/679
 
     # Load Llama model and tokenizer
     framework_model, _ = load_model(model_path)

--- a/forge/test/mlir/llama/tests/test_llama_lm_head.py
+++ b/forge/test/mlir/llama/tests/test_llama_lm_head.py
@@ -10,7 +10,6 @@ from forge.op.eval.common import compare_with_golden_pcc
 
 
 @pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.xfail()
 def test_llama_lm_head(model_path):
     if model_path == "meta-llama/Llama-3.2-1B":
         pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")

--- a/forge/test/mlir/llama/tests/test_llama_mlp.py
+++ b/forge/test/mlir/llama/tests/test_llama_mlp.py
@@ -10,7 +10,6 @@ from forge.op.eval.common import compare_with_golden_pcc
 
 
 @pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.xfail()
 def test_llama_mlp(model_path):
     if model_path == "meta-llama/Llama-3.2-1B":
         pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")

--- a/forge/test/mlir/llama/tests/test_llama_prefil.py
+++ b/forge/test/mlir/llama/tests/test_llama_prefil.py
@@ -49,7 +49,7 @@ def decode_on_cpu(model, tokenizer, input_ids, hidden_states, max_new_tokens):
 
 
 @pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.xfail()
+@pytest.mark.xfail(reason="RuntimeError: ttnn.embedding op fails while validating the input_tensor layout")
 def test_llama_prefil_on_device_decode_on_cpu(model_path):
     """
     This function tests the inference of the Llama models split into two parts:
@@ -69,6 +69,9 @@ def test_llama_prefil_on_device_decode_on_cpu(model_path):
     # This is the part of the model needed for prefill; model without the last Linear layer (lm_head)
     model_decoder = model.get_decoder()
     compiled_decoder = forge.compile(model_decoder, sample_inputs=input_ids)
+
+    # RuntimeError: ttnn.embedding op fails while validating the input_tensor layout(i,e it is in ROW_MAJOR LAYOUT)
+    # tt-mlir issue: https://github.com/tenstorrent/tt-mlir/issues/679
 
     # Prefill Phase - Process the initial prompt on device
     transformer_outputs = compiled_decoder(input_ids)

--- a/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
+++ b/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
@@ -11,8 +11,13 @@ from forge.op.eval.common import compare_with_golden_pcc
 
 
 @pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.xfail()
+@pytest.mark.xfail("RuntimeError: ttnn.concat doesn't support tile padding along concatenated dim")
 def test_llama_rotary_emb(model_path):
+
+    # RuntimeError: ttnn.concat fails when the concat dimension of the input tensors are not TILE aligned.
+    # tt-mlir issue: https://github.com/tenstorrent/tt-mlir/issues/795
+    # tt-metal issue: https://github.com/tenstorrent/tt-metal/issues/13667
+
     class Llama_Rotary_Embedding(torch.nn.Module):
         def __init__(self, model):
             super().__init__()

--- a/forge/test/mlir/llama/tests/test_llama_self_attn.py
+++ b/forge/test/mlir/llama/tests/test_llama_self_attn.py
@@ -10,10 +10,14 @@ from forge.op.eval.common import compare_with_golden_pcc
 
 
 @pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.xfail()
+@pytest.mark.xfail("RuntimeError:  ttnn.concat doesn't support tile padding along concatenated dim")
 def test_llama_self_attn(model_path):
     if model_path == "meta-llama/Llama-3.2-1B":
         pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+
+    # RuntimeError: ttnn.concat fails when the concat dimension of the input tensors are not TILE aligned.
+    # tt-mlir issue: https://github.com/tenstorrent/tt-mlir/issues/795
+    # tt-metal issue: https://github.com/tenstorrent/tt-metal/issues/13667
 
     # Define wrapper function
     class SelfAttention(torch.nn.Module):

--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -59,9 +59,10 @@ def test_cast(operand_and_cast_dtype):
     "shape",
     [
         (1, 7, 256),
+        (1, 58, 100),
+        (1, 1, 100),
     ],
 )
-@pytest.mark.xfail(reason="Found Unsupported operations while lowering from TTForge to TTIR in forward graph")
 def test_sin(shape):
     class sin(nn.Module):
         def __init__(self):
@@ -87,9 +88,10 @@ def test_sin(shape):
     "shape",
     [
         (1, 7, 256),
+        (1, 58, 100),
+        (1, 1, 100),
     ],
 )
-@pytest.mark.xfail(reason="Found Unsupported operations while lowering from TTForge to TTIR in forward graph")
 def test_cosine(shape):
     class cosine(nn.Module):
         def __init__(self):
@@ -211,6 +213,8 @@ def test_gelu(shape):
     "shape, min_val, max_val",
     [
         ((1, 1, 256, 256), 0, 1),
+        ((1, 1, 58, 58), 0.0, 1.0),
+        ((1, 1, 1, 59), 0.0, 1.0),
     ],
 )
 @pytest.mark.xfail(reason="Found Unsupported operations while lowering from TTForge to TTIR in forward graph")


### PR DESCRIPTION
- Tested the Llama model test cases present in `forge/test/mlir/llama/tests` path in latest tt-forge-fe main and removed the xfail markers for the passing test and added some reason for the failure with issue link
- Add sine and cosine op  in lowering_handler_map in lower_to_mlir.cpp