### PR TITLE
Fix: new OpType interface for conv2d decomposing context

### DIFF
--- a/forge/forge/op/eval/forge/pooling.py
+++ b/forge/forge/op/eval/forge/pooling.py
@@ -11,6 +11,7 @@ from forge.utils import align_up_tile
 from .transpose import TransposeTM
 from .nop import Nop
 from .nop import Nop
+from .convolution import Conv2d
 from ..interface import PyOp
 
 from ..common import to_torch_operands
@@ -498,8 +499,32 @@ def decompose(type, attr, dc, inputs):
         weight_tensor = weight_value * torch.ones((cin, 1, kH, kW))
 
         weight = dc.tensor(weight_tensor)
-        result = dc.op(
-            "conv2d", [activations, weight], stride + [dilation, cin] + padding + [False, 0, 0, 0, channel_last]
+        result = dc.op_with_named_attrs(
+            Conv2d.create(
+                stride_height=stride[0],
+                stride_width=stride[1],
+                dilation_height=dilation,
+                dilation_width=dilation,
+                groups=cin,
+                padding_left=padding[0],
+                padding_right=padding[1],
+                padding_top=padding[2],
+                padding_bottom=padding[3],
+                channel_last=channel_last,
+            ),
+            [activations, weight],
+            {
+                "stride_height": stride[0],
+                "stride_width": stride[1],
+                "dilation_height": dilation,
+                "dilation_width": dilation,
+                "groups": cin,
+                "padding_left": padding[0],
+                "padding_right": padding[1],
+                "padding_top": padding[2],
+                "padding_bottom": padding[3],
+                "channel_last": channel_last,
+            },
         )
 
         #

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_alexnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_alexnet.py
@@ -17,7 +17,7 @@ import os
 def test_alexnet_torchhub(test_device):
     # Configurations
     compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.compile_depth = forge.CompileDepth.GENERATE_INITIAL_GRAPH
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # Load model
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "alexnet", pretrained=True)

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_ddrnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_ddrnet.py
@@ -75,7 +75,7 @@ def test_ddrnet_semantic_segmentation_pytorch(variant, test_device):
 
     # Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # prepare model
     if variant == "ddrnet23s_cityscapes":

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_densenet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_densenet.py
@@ -87,7 +87,10 @@ def test_densenet_121_pytorch(variant, test_device):
 
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
-    compiler_cfg.compile_depth = forge.CompileDepth.GENERATE_INITIAL_GRAPH
+    if variant == densenet121_hf_xray:
+        compiler_cfg.compile_depth = forge.CompileDepth.GENERATE_INITIAL_GRAPH
+    else:
+        compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # STEP 2: Create Forge module from PyTorch model
     if variant == "densenet121":
@@ -110,7 +113,7 @@ def test_densenet_161_pytorch(test_device):
 
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
-    compiler_cfg.compile_depth = forge.CompileDepth.GENERATE_INITIAL_GRAPH
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # STEP 2: Create Forge module from PyTorch model
     model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "densenet161", pretrained=True)
@@ -127,7 +130,7 @@ def test_densenet_169_pytorch(test_device):
 
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
-    compiler_cfg.compile_depth = forge.CompileDepth.GENERATE_INITIAL_GRAPH
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # STEP 2: Create Forge module from PyTorch model
     model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "densenet169", pretrained=True)
@@ -144,7 +147,7 @@ def test_densenet_201_pytorch(test_device):
 
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
-    compiler_cfg.compile_depth = forge.CompileDepth.GENERATE_INITIAL_GRAPH
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # STEP 2: Create Forge module from PyTorch model
     model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "densenet201", pretrained=True)

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_fchardnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_fchardnet.py
@@ -19,7 +19,7 @@ import os
 def test_fchardnet(test_device):
     # STEP 1: Set PyBuda configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.compile_depth = forge.CompileDepth.GENERATE_INITIAL_GRAPH
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # Load and pre-process image
     image_path = "tt-forge-fe/forge/test/model_demos/high_prio/cnn/pytorch/model2/pytorch/pidnet/image/road_scenes.png"

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_inception_v4.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_inception_v4.py
@@ -24,7 +24,7 @@ import forge
 def generate_model_inceptionV4_imgcls_osmr_pytorch(variant):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
-    compiler_cfg.compile_depth = forge.CompileDepth.GENERATE_INITIAL_GRAPH
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # Load model
     framework_model = download_model(ptcv_get_model, variant, pretrained=True)
@@ -85,7 +85,7 @@ def test_inception_v4_osmr_pytorch(test_device):
 def generate_model_inceptionV4_imgcls_timm_pytorch(variant):
     # Configurations
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
-    compiler_cfg.compile_depth = forge.CompileDepth.GENERATE_INITIAL_GRAPH
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # Load model & Preprocess image
     framework_model, img_tensor = download_model(preprocess_timm_model, variant)


### PR DESCRIPTION
Fix https://github.com/tenstorrent/tt-forge-fe/issues/612

Also updated CompileDepth for CNN model blocked with this issue


### Logs

[nov7_x_ddrnet_cityscapes.log](https://github.com/user-attachments/files/17660129/nov7_x_ddrnet_cityscapes.log)
[nov7_x_fc_hardnet.log](https://github.com/user-attachments/files/17660132/nov7_x_fc_hardnet.log)
[nov7_x_pidnet.log](https://github.com/user-attachments/files/17660133/nov7_x_pidnet.log)
[test_alexnet_torchhub.log](https://github.com/user-attachments/files/17660157/test_alexnet_torchhub.log)
[test_ddrnet_semantic_segmentation_pytorch.log](https://github.com/user-attachments/files/17660158/test_ddrnet_semantic_segmentation_pytorch.log)
[test_ddrnet_semseg.log](https://github.com/user-attachments/files/17660159/test_ddrnet_semseg.log)
[test_inception_v4.log](https://github.com/user-attachments/files/17660160/test_inception_v4.log)
[test_padding_with_decompose_avgpool2d.log](https://github.com/user-attachments/files/17660161/test_padding_with_decompose_avgpool2d.log)
[test_rcnn.log](https://github.com/user-attachments/files/17660162/test_rcnn.log)
[test_vgg_19_hf_pytorch.log](https://github.com/user-attachments/files/17660163/test_vgg_19_hf_pytorch.log)
[test_vgg_bn19_torchhub_pytorch.log](https://github.com/user-attachments/files/17660164/test_vgg_bn19_torchhub_pytorch.log)
