### PR TITLE
Dumping ttir and ttnn into json files

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -105,8 +105,8 @@ class MLIRGenerator
         log_info(LogMLIRCompiler, "MLIR module generated successfully.");
         graphModule_.dump();
 
-        // save what's dumped to a file named "{name}.mlir"
-        reportify::dump_mlir("ttir", &graphModule_);
+        // save what's dumped to a file named "{file_name}.mlir"
+        reportify::dump_mlir("ttir", graphModule_.getNameAttr().getValue().str(), graphModule_.getOperation());
 
 #ifdef DEBUG
         // Create a string to store the output

--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -108,7 +108,6 @@ class MLIRGenerator
         // save what's dumped to a file named "{name}.mlir"
         reportify::dump_mlir("ttir", &graphModule_);
 
-
 #ifdef DEBUG
         // Create a string to store the output
         std::string moduleStr;

--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -40,6 +40,9 @@
 #include "ttmlir/Dialect/TT/IR/TTOpsTypes.h"
 #include "ttmlir/Dialect/TTIR/IR/TTIROps.h"
 
+// Reportify headers
+#include "reportify/reportify.hpp"
+
 namespace
 {
 using namespace tt;
@@ -101,6 +104,10 @@ class MLIRGenerator
 
         log_info(LogMLIRCompiler, "MLIR module generated successfully.");
         graphModule_.dump();
+
+        // save what's dumped to a file named "{name}.mlir"
+        reportify::dump_mlir("ttir", &graphModule_);
+
 
 #ifdef DEBUG
         // Create a string to store the output

--- a/forge/csrc/passes/mlir_compiler.cpp
+++ b/forge/csrc/passes/mlir_compiler.cpp
@@ -78,7 +78,7 @@ runtime::Binary run_mlir_compiler(tt::ForgeGraphModule& module)
 
     // save what's dumped to a file named "{name}.mlir"
     auto mlir_modulee = mlir_module.get();
-    reportify::dump_mlir("ttnn", &mlir_modulee);    
+    reportify::dump_mlir("ttnn", &mlir_modulee);
 
     // Generate binary from the MLIR module.
     auto binary = mlir::tt::ttnn::ttnnToFlatbuffer(mlir_module.get());

--- a/forge/csrc/passes/mlir_compiler.cpp
+++ b/forge/csrc/passes/mlir_compiler.cpp
@@ -34,6 +34,9 @@
 #include "ttmlir/Dialect/TTNN/IR/TTNN.h"
 #include "ttmlir/Target/TTNN/TTNNToFlatbuffer.h"
 
+// Reportify headers
+#include "reportify/reportify.hpp"
+
 namespace tt::passes
 {
 /// Public API for lowering to MLIR, running MLIR passes and generate runtime binary.
@@ -72,6 +75,10 @@ runtime::Binary run_mlir_compiler(tt::ForgeGraphModule& module)
     tt::log_info(LogMLIRCompiler, "MLIR passes run successfully.");
 
     mlir_module->dump();
+
+    // save what's dumped to a file named "{name}.mlir"
+    auto mlir_modulee = mlir_module.get();
+    reportify::dump_mlir("ttnn", &mlir_modulee);    
 
     // Generate binary from the MLIR module.
     auto binary = mlir::tt::ttnn::ttnnToFlatbuffer(mlir_module.get());

--- a/forge/csrc/passes/mlir_compiler.cpp
+++ b/forge/csrc/passes/mlir_compiler.cpp
@@ -77,7 +77,7 @@ runtime::Binary run_mlir_compiler(tt::ForgeGraphModule& module)
     mlir_module->dump();
 
     // save what's dumped to a file named "{name}.mlir"
-    reportify::dump_mlir("ttnn",  mlir_module->getName()->str(), mlir_module.get());
+    reportify::dump_mlir("ttnn", mlir_module->getName()->str(), mlir_module.get());
 
     // Generate binary from the MLIR module.
     auto binary = mlir::tt::ttnn::ttnnToFlatbuffer(mlir_module.get());

--- a/forge/csrc/passes/mlir_compiler.cpp
+++ b/forge/csrc/passes/mlir_compiler.cpp
@@ -77,8 +77,7 @@ runtime::Binary run_mlir_compiler(tt::ForgeGraphModule& module)
     mlir_module->dump();
 
     // save what's dumped to a file named "{name}.mlir"
-    auto mlir_modulee = mlir_module.get();
-    reportify::dump_mlir("ttnn", &mlir_modulee);
+    reportify::dump_mlir("ttnn",  mlir_module->getName()->str(), mlir_module.get());
 
     // Generate binary from the MLIR module.
     auto binary = mlir::tt::ttnn::ttnnToFlatbuffer(mlir_module.get());

--- a/forge/csrc/reportify/paths.cpp
+++ b/forge/csrc/reportify/paths.cpp
@@ -53,6 +53,13 @@ std::string get_pass_reports_relative_directory()
     return retstring;
 }
 
+std::string get_mlir_reports_relative_directory()
+{
+    std::string retstring("mlir_reports");
+
+    return retstring;
+}
+
 std::string get_router_report_relative_directory()
 {
     std::string retstring("/router_reports/EpochType/");

--- a/forge/csrc/reportify/paths.hpp
+++ b/forge/csrc/reportify/paths.hpp
@@ -13,6 +13,7 @@ std::string build_report_path(std::string const& base_path, std::string const& t
 bool initalize_reportify_directory(const std::string& reportify_dir, const std::string& test_name);
 std::string get_default_reportify_path(const std::string& test_name);
 std::string get_pass_reports_relative_directory();
+std::string get_mlir_reports_relative_directory();
 std::string get_router_report_relative_directory();
 std::string get_memory_report_relative_directory();
 std::string get_epoch_type_report_relative_directory();

--- a/forge/csrc/reportify/reportify.cpp
+++ b/forge/csrc/reportify/reportify.cpp
@@ -437,7 +437,8 @@ JsonNamePairs create_jsons_for_graph(
     return this_json_name_pairs;
 }
 
-JsonNamePairs create_jsons_for_mlir(const std::string& file_name, const std::string& module_name, mlir::Operation* operation)
+JsonNamePairs create_jsons_for_mlir(
+    const std::string& file_name, const std::string& module_name, mlir::Operation* operation)
 {
     JsonNamePairs this_json_name_pairs;
 
@@ -464,12 +465,13 @@ void dump_graph(
  *
  * This function generates a JSON representation of the given MLIR operation and writes it to a file.
  * The file path is following: `$REPORTIFY_PATH$/$OPERATION_NAME$/mlir_reports/$FILE_NAME$.mlir`.
- * If the environment variable "FORGE_DISABLE_REPORTIFY_DUMP" is set to true, the function returns without performing any action.
+ * If the environment variable "FORGE_DISABLE_REPORTIFY_DUMP" is set to true, the function returns without performing
+ * any action.
  *
  * @param name The name of the file to be saved (currently in use are 'ttir' and 'ttnn').
  * @param operation A pointer to the MLIR operation to be dumped.
  */
-void dump_mlir(const std::string& file_name,  const std::string& module_name, mlir::Operation* operation)
+void dump_mlir(const std::string& file_name, const std::string& module_name, mlir::Operation* operation)
 {
     if (env_as<bool>("FORGE_DISABLE_REPORTIFY_DUMP"))
         return;

--- a/forge/csrc/reportify/reportify.cpp
+++ b/forge/csrc/reportify/reportify.cpp
@@ -459,11 +459,9 @@ void dump_graph(
     dump_graph(default_dir, test_name, graph_prefix, graph, report_path);
 }
 
-void dump_mlir(
-    const std::string& name,
-    mlir::ModuleOp* module)
+void dump_mlir(const std::string& name, mlir::ModuleOp* module)
 {
-       if (env_as<bool>("FORGE_DISABLE_REPORTIFY_DUMP"))
+    if (env_as<bool>("FORGE_DISABLE_REPORTIFY_DUMP"))
         return;
 
     std::string path = get_default_reportify_path("");

--- a/forge/csrc/reportify/reportify.hpp
+++ b/forge/csrc/reportify/reportify.hpp
@@ -59,9 +59,7 @@ void dump_epoch_id_graphs(
     const graphlib::Graph* graph,
     const std::string& directory_path = get_default_reportify_path(""));
 
-void dump_mlir(
-    const std::string& name,
-    mlir::ModuleOp* module);
+void dump_mlir(const std::string& name, mlir::ModuleOp* module);
 
 }  // namespace reportify
 

--- a/forge/csrc/reportify/reportify.hpp
+++ b/forge/csrc/reportify/reportify.hpp
@@ -8,6 +8,10 @@
 #include "nlohmann/json_fwd.hpp"
 #include "reportify/paths.hpp"
 
+namespace mlir
+{
+class ModuleOp;
+}  // namespace mlir
 namespace tt
 {
 
@@ -33,6 +37,8 @@ json create_json_for_graph(
     const graphlib::Graph* graph,
     std::function<bool(graphlib::Node*)> node_filter = [](graphlib::Node*) { return true; });
 
+json create_json_for_mlir(mlir::ModuleOp* module);
+
 void dump_graph(
     const std::string& test_name,
     const std::string& graph_prefix,
@@ -52,6 +58,11 @@ void dump_epoch_id_graphs(
     const std::string& graph_prefix,
     const graphlib::Graph* graph,
     const std::string& directory_path = get_default_reportify_path(""));
+
+void dump_mlir(
+    const std::string& name,
+    mlir::ModuleOp* module);
+
 }  // namespace reportify
 
 }  // namespace tt

--- a/forge/csrc/reportify/reportify.hpp
+++ b/forge/csrc/reportify/reportify.hpp
@@ -10,7 +10,7 @@
 
 namespace mlir
 {
-class ModuleOp;
+class Operation;
 }  // namespace mlir
 namespace tt
 {
@@ -37,7 +37,7 @@ json create_json_for_graph(
     const graphlib::Graph* graph,
     std::function<bool(graphlib::Node*)> node_filter = [](graphlib::Node*) { return true; });
 
-json create_json_for_mlir(mlir::ModuleOp* module);
+json create_json_for_mlir(const std::string& module_name, mlir::Operation* operation);
 
 void dump_graph(
     const std::string& test_name,
@@ -59,7 +59,7 @@ void dump_epoch_id_graphs(
     const graphlib::Graph* graph,
     const std::string& directory_path = get_default_reportify_path(""));
 
-void dump_mlir(const std::string& name, mlir::ModuleOp* module);
+void dump_mlir(const std::string& file_name, const std::string& module_name, mlir::Operation* operation);
 
 }  // namespace reportify
 


### PR DESCRIPTION
This PR addresses issue #149 by adding functionality to `reportify` for formatting and storing **MLIR input** (`ttir`) and **MLIR output** (`ttnn`) in a JSON file. With this update, running any module will save MLIR information within the path `testify/ll-sw/%MODULE_NAME%/mlir_reports` as `ttir.mlir` and `ttnn.mlir`.

Fix #149
