### PR TITLE
Store and use all parameters from the model only during op test generation

### DIFF
--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -2041,7 +2041,7 @@ def generate_forge_module(
         else:
             forge_mod = TestClass(writer.module_name)
 
-            if isinstance(framework_mod, forge.module.PyTorchModule):
+            if isinstance(framework_mod, forge.module.PyTorchModule) and compiler_cfg.tvm_generate_op_tests:
                 forge_mod.process_framework_parameters()
             else:
                 forge_mod.process_framework_parameters(framework_mod.module)
@@ -2661,7 +2661,7 @@ def compile_tvm_to_python(
             param_file_name = os.path.join(writer.module_directory, writer.module_name + "_params.pt")
             torch.save(params_from_tvm, param_file_name)
 
-        if framework == "pytorch":
+        if framework == "pytorch" and compiler_cfg.tvm_generate_op_tests:
             # Store named parameters
             names_params_file_name = os.path.join(writer.module_directory, writer.module_name + "_names_params.pt")
             named_parameters = dict(framework_mod.module.state_dict().items())

--- a/forge/test/mlir/llama/test_llama_inference.py
+++ b/forge/test/mlir/llama/test_llama_inference.py
@@ -10,9 +10,9 @@ import forge
 from test.mlir.llama.utils.utils import load_model
 
 
-@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
 @pytest.mark.push
-@pytest.mark.skip(reason="Out of system memory during compile time. Skipping until resolved")
+@pytest.mark.xfail()
+@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
 def test_llama_inference(model_path):
     if model_path == "meta-llama/Llama-3.2-1B":
         pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")


### PR DESCRIPTION
- Currently, utilizing stored params doubles memory usage
- Use serialized params only for op test generation (current limitation, WIP on removing it)

Fix #650