### PR TITLE
Tag image as latest when running on main branch

### DIFF
--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -34,17 +34,17 @@ build_and_push() {
             --build-arg FROM_TAG=$DOCKER_TAG \
             ${from_image:+--build-arg FROM_IMAGE=$from_image} \
             -t $image_name:$DOCKER_TAG \
-            -t $image_name:latest \
             -f $dockerfile .
 
         echo "Pushing image $image_name:$DOCKER_TAG"
-        docker push $image_name:$DOCKER_TAG
+        docker push $image_name:$DOCKER_TAG        
+    fi
 
-        # If we are on main branch also push the latest tag
-        if [ "$on_main" = "true" ]; then
-            echo "Pushing image $image_name:latest"
-            docker push $image_name:latest
-        fi
+    # If we are on main branch update manifest and add latest tag
+    if [ "$on_main" = "true" ]; then
+        echo "Adding latest tag to image $image_name:$DOCKER_TAG"
+        docker manifest create $image_name:latest --amend $image_name:$DOCKER_TAG
+        docker manifest push $image_name:latest
     fi
 }
 


### PR DESCRIPTION
The script for building docker images does not properly tag the latest images.
When running on main, images are already built by PR run, and CI on main just checks if they exist and never tags main.

Fix by setting the main tag using docker manifest on every run on main script will tag current version of Docker image as latest.