### PR TITLE
Fix const eval input tensor stride and update tests

### DIFF
--- a/forge/test/mlir/llama/tests/test_llama_lm_head.py
+++ b/forge/test/mlir/llama/tests/test_llama_lm_head.py
@@ -10,7 +10,6 @@ from forge.op.eval.common import compare_with_golden_pcc
 
 
 @pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.xfail()
 @pytest.mark.push
 def test_llama_lm_head(model_path):
     if model_path == "meta-llama/Llama-3.2-1B":

--- a/forge/test/mlir/llama/tests/test_llama_mlp.py
+++ b/forge/test/mlir/llama/tests/test_llama_mlp.py
@@ -10,7 +10,6 @@ from forge.op.eval.common import compare_with_golden_pcc
 
 
 @pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.xfail()
 @pytest.mark.push
 def test_llama_mlp(model_path):
     if model_path == "meta-llama/Llama-3.2-1B":

--- a/forge/test/mlir/resnet/test_resnet_inference.py
+++ b/forge/test/mlir/resnet/test_resnet_inference.py
@@ -6,6 +6,7 @@ import torch
 from torchvision.models.resnet import resnet50
 
 import forge
+from forge.op.eval.common import compare_with_golden
 
 
 @pytest.mark.push
@@ -21,8 +22,12 @@ def test_resnet_inference():
     input_image = torch.rand(1, 3, 224, 224)
 
     # Sanity run
-    generation_output = framework_model(input_image)
-    print(generation_output)
+    fw_out = framework_model(input_image)
 
     # Compile the model
     compiled_model = forge.compile(framework_model, input_image)
+    co_out = compiled_model(input_image)
+
+    co_out = [co.to("cpu") for co in co_out]
+    fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+    assert all([compare_with_golden(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])


### PR DESCRIPTION
Closes #673. Closes #609.
- Fix const eval input tensor stride.
- Change resnet test: Run compiled ResNet model
- Remove xfail from Llama mlp and lm_head tests since they pass now.