### PR TITLE
Fix: swin model failures

### DIFF
--- a/forge/csrc/forge_passes.cpp
+++ b/forge/csrc/forge_passes.cpp
@@ -25,7 +25,7 @@
 #include "passes/generate_initial_flops_estimate.hpp"
 #include "passes/hoist_transforms_to_inputs.hpp"
 #include "passes/insert_inverse_on_io.hpp"
-#include "passes/limit_to_4d_reshape.hpp"
+#include "passes/limit_to_5d_reshape.hpp"
 #include "passes/link_past_cache_ios.hpp"
 #include "passes/lower_concat_to_runtime_transform.hpp"
 #include "passes/lowering_context.hpp"
@@ -84,7 +84,7 @@ run_post_initial_graph_passes(
     passes::print_graph(graph, "INITIAL");
     passes::generate_initial_flops_estimate(graph);
     passes::decompose_nd_reshape_split(graph);
-    passes::limit_to_4d_reshape(graph);
+    passes::limit_to_5d_reshape(graph);
     passes::erase_unnecessary_4d_tm_sequence(graph);
     passes::fuse_pad_conv2d(graph);
     passes::explicate_unsqueeze(graph);

--- a/forge/csrc/passes/limit_to_5d_reshape.hpp
+++ b/forge/csrc/passes/limit_to_5d_reshape.hpp
@@ -10,6 +10,6 @@ class Graph;
 
 namespace tt::passes
 {
-void limit_to_4d_reshape(graphlib::Graph *graph);
+void limit_to_5d_reshape(graphlib::Graph *graph);
 void decompose_nd_reshape_split(graphlib::Graph *graph);
 }  // namespace tt::passes

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_swin.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_swin.py
@@ -20,7 +20,7 @@ def test_swin_v1_tiny_4_224_hf_pytorch(test_device):
     # pytest.skip() # Working on it
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # STEP 2: Create Forge module from PyTorch model
     feature_extractor = ViTImageProcessor.from_pretrained("microsoft/swin-tiny-patch4-window7-224")


### PR DESCRIPTION
Fix https://github.com/tenstorrent/tt-forge-fe/issues/646

Fixed below issues from Swin model:
1. `Don't support reshape with more than 4 non-singleton dimensions`. When I checked `ReshapeOp::verify()` function in  `third_party/tt-mlir/lib/Dialect/TTIR/IR/TTIROps.cpp` , It says reshape was supported till 5D. Hence updated the limits to 5D at `post initial graph passes`
2. As a followup issue, hit with `AssertionError: Broadcast on dimensions beyond 3rd is not supported [[1, 1, 3, 1, 3], [49, 64, 3, 3, 32]]` from `matmul` op (decomposed from index op). Since matmul op works in H & W dimensions, reshaped matmul inputs to 4D (having batch size as 1), and followed by matmul op and the reshaped Bach to original dimensions.
3. Finally now this model is now blocked in
```
Found Unsupported operations while lowering from TTForge to TTIR in forward graph
Unsupported Ops at: RUN_MLIR_COMPILER stage
gelu
		 Input_shape: [{1, 3136, 384}, ]
					 Attributes: gelu(none,)
		 Input_shape: [{1, 784, 768}, ]
					 Attributes: gelu(none,)
		 Input_shape: [{1, 196, 1536}, ]
					 Attributes: gelu(none,)
		 Input_shape: [{1, 49, 3072}, ]
					 Attributes: gelu(none,)
```

### Logs

[test_swin_v1_tiny_4_224_hf_pytorch_4.log](https://github.com/user-attachments/files/17719483/test_swin_v1_tiny_4_224_hf_pytorch_4.log)
[test_broadcast_pytorch_3.log](https://github.com/user-attachments/files/17719537/test_broadcast_pytorch_3.log)
[test_reshape_pytorch_2.log](https://github.com/user-attachments/files/17719538/test_reshape_pytorch_2.log)
