### PR TITLE
Fix: Update dim in named attrs of concat op

### DIFF
--- a/forge/csrc/passes/commute_utils.cpp
+++ b/forge/csrc/passes/commute_utils.cpp
@@ -539,7 +539,11 @@ bool commute_through_concat(
         concat_golden_transform.attr[concat_dim >= 0 ? concat_dim : concat_dim + concat_golden_transform.attr.size()] =
             concat_output_len;
     op->add_golden_transform(concat_golden_transform);
-    op->overwrite_op_attrs(attr);
+    std::vector<graphlib::OpType::Attr> concat_attr;
+    concat_attr.push_back(new_dim);
+    graphlib::OpType::Attrs named_attrs;
+    named_attrs["dim"] = new_dim;
+    op->change_op_type(graphlib::OpType("concatenate", concat_attr, {}, named_attrs));
 
     *commute_shape = concat_shape;
     *golden_transform = concat_golden_transform;

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_dla.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_dla.py
@@ -41,10 +41,6 @@ variants = list(variants_func.keys())
 def test_dla_pytorch(variant, test_device):
     # Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
-    if variant in ("dla102", "dla102x", "dla102x2", "dla169"):
-        compiler_cfg.compile_depth = forge.CompileDepth.FINISH_COMPILE
-    else:
-        compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
     func = variants_func[variant]
 
     # Load data sample


### PR DESCRIPTION
Fixes #651 

- variants in DLA were failing due to error: 'ttir.concat' op All input tensors must have the same dimensions, except for dimension 1

Before fix - [dla1.log](https://github.com/user-attachments/files/17720113/dla1.log)

After fix - [dla.log](https://github.com/user-attachments/files/17720133/dla.log)