### PR TITLE
Fix: Unhandled attribute type for std::tuple<int, int, int>

### DIFF
--- a/forge/csrc/lower_to_forge/common.hpp
+++ b/forge/csrc/lower_to_forge/common.hpp
@@ -56,7 +56,6 @@ using ForgeOpAttr = ::std::variant<
     bool,
     int,
     float,
-    std::tuple<int, int, int>,
     std::vector<int>,
     std::vector<std::tuple<int, int, int>>,
     std::vector<std::tuple<int, int, int, int>>,


### PR DESCRIPTION
Fix https://github.com/tenstorrent/tt-forge-fe/issues/505

The `std::tuple<int, int, int>` type handled and mapped to `llvm::SmallVector<mlir::Attribute, 3>` type

### Logs
Below five models blocked in this issue and now its fixed

1. Blazepose
- [test_blazepose_detector_pytorch_without_fix.log](https://github.com/user-attachments/files/17734013/test_blazepose_detector_pytorch_without_fix.log)
- [test_blazepose_detector_pytorch_with_fix.log](https://github.com/user-attachments/files/17734011/test_blazepose_detector_pytorch_with_fix.log) -  https://github.com/tenstorrent/tt-forge-fe/issues/682
2. Llama3
- [test_llama3_sequence_classification_instruct_without_fix.log](https://github.com/user-attachments/files/17734015/test_llama3_sequence_classification_instruct_without_fix.log)
- [test_llama3_sequence_classification_instruct_with_fix.log](https://github.com/user-attachments/files/17734014/test_llama3_sequence_classification_instruct_with_fix.log) - https://github.com/tenstorrent/tt-forge-fe/issues/683
- [test_llama3_sequence_classification_without_fix.log](https://github.com/user-attachments/files/17734017/test_llama3_sequence_classification_without_fix.log)
- [test_llama3_sequence_classification_with_fix.log](https://github.com/user-attachments/files/17734016/test_llama3_sequence_classification_with_fix.log) - https://github.com/tenstorrent/tt-forge-fe/issues/683
3. Mistral
- [test_mistral_without_fix.log](https://github.com/user-attachments/files/17734020/test_mistral_without_fix.log)
- [test_mistral_with_fix.log](https://github.com/user-attachments/files/17734019/test_mistral_with_fix.log) - https://github.com/tenstorrent/tt-forge-fe/issues/683
4. Mobilenet V1 SSD
- [test_mobilenet_v1_ssd_pytorch_1x1_without_fix.log](https://github.com/user-attachments/files/17734022/test_mobilenet_v1_ssd_pytorch_1x1_without_fix.log)
- [test_mobilenet_v1_ssd_pytorch_1x1_with_fix.log](https://github.com/user-attachments/files/17734021/test_mobilenet_v1_ssd_pytorch_1x1_with_fix.log) - https://github.com/tenstorrent/tt-forge-fe/issues/618
5. SSD 300 resnet 50
- [test_ssd300_resnet50_without_fix.log](https://github.com/user-attachments/files/17734025/test_ssd300_resnet50_without_fix.log)
- [test_ssd300_resnet50_with_fix.log](https://github.com/user-attachments/files/17734023/test_ssd300_resnet50_with_fix.log) - https://github.com/tenstorrent/tt-forge-fe/issues/618



