### PR TITLE
Add new PyTorch unary operators to test

### DIFF
--- a/forge/test/operators/pytorch/eltwise_unary/test_commands.sh
+++ b/forge/test/operators/pytorch/eltwise_unary/test_commands.sh
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Commands for running unary operators tests
+
+# Run all unary operators tests:
+OPERATORS=\
+"relu",\
+"sqrt",\
+"reciprocal",\
+"sigmoid",\
+"abs",\
+"cos",\
+"exp",\
+"neg",\
+"rsqrt",\
+"sin",\
+"square" \
+pytest -svv forge/test/operators/pytorch/test_all.py::test_query -rap

--- a/forge/test/operators/pytorch/eltwise_unary/test_unary.py
+++ b/forge/test/operators/pytorch/eltwise_unary/test_unary.py
@@ -165,7 +165,21 @@ class TestCollectionData:
     __test__ = False
 
     implemented = TestCollection(
-        operators=["relu", "sqrt", "reciprocal", "sigmoid"],
+        operators=[
+            "relu",
+            "sqrt",
+            "reciprocal",
+            "sigmoid",
+            "abs",
+            # "absolute",     # alias for abs
+            "cos",
+            "exp",
+            "neg",
+            # "negative",     # alias for neg
+            "rsqrt",
+            "sin",
+            "square",
+        ],
     )
 
 
@@ -233,6 +247,63 @@ TestParamsData.test_plan = TestPlan(
             ],
             math_fidelities=[MathFidelity.HiFi4],
             failing_reason=FailingReasons.DATA_MISMATCH,
+        ),
+        TestCollection(
+            operators=["abs", "cos", "neg", "sin"],
+            input_sources=[InputSource.FROM_HOST],
+            input_shapes=[(1, 2, 3, 4)],
+            dev_data_formats=[
+                DataFormat.Int8,
+                DataFormat.Int32,
+            ],
+            math_fidelities=[MathFidelity.HiFi4],
+            failing_reason=FailingReasons.DATA_MISMATCH,
+        ),
+        TestCollection(
+            operators=["rsqrt"],
+            input_sources=[InputSource.FROM_HOST],
+            input_shapes=[(1, 2, 3, 4)],
+            dev_data_formats=[
+                DataFormat.Bfp2,
+                DataFormat.Bfp2_b,
+                DataFormat.Bfp4,
+                DataFormat.Bfp4_b,
+                DataFormat.Bfp8,
+                DataFormat.Bfp8_b,
+                DataFormat.Float16,
+                DataFormat.Float32,
+                DataFormat.Lf8,
+            ],
+            math_fidelities=[MathFidelity.HiFi4],
+            failing_reason=FailingReasons.DATA_MISMATCH,
+        ),
+        TestCollection(
+            operators=["rsqrt"],
+            input_sources=[InputSource.FROM_HOST],
+            input_shapes=[(1, 2, 3, 4)],
+            dev_data_formats=[DataFormat.Float16_b],
+            math_fidelities=[
+                MathFidelity.LoFi,
+                MathFidelity.HiFi2,
+                MathFidelity.HiFi3,
+                MathFidelity.HiFi4,
+            ],
+            failing_reason=FailingReasons.DATA_MISMATCH,
+        ),
+        TestCollection(
+            operators=["square"],
+            input_sources=[InputSource.FROM_HOST],
+            input_shapes=[(1, 2, 3, 4)],
+            dev_data_formats=[
+                DataFormat.RawUInt8,
+                DataFormat.RawUInt16,
+                DataFormat.RawUInt32,
+                DataFormat.Int8,
+                DataFormat.UInt16,
+                DataFormat.Int32,
+            ],
+            math_fidelities=[MathFidelity.HiFi4],
+            failing_reason=FailingReasons.ATTRIBUTE_ERROR,
         ),
     ],
 )

--- a/forge/test/operators/utils/failing_reasons.py
+++ b/forge/test/operators/utils/failing_reasons.py
@@ -58,6 +58,8 @@ class FailingReasons:
 
     UNSUPPORTED_INPUT_SOURCE = "Unsupported input source"
 
+    ATTRIBUTE_ERROR = "Attribute error"
+
 
 class FailingReasonsValidation:
     @classmethod
@@ -107,6 +109,9 @@ class FailingReasonsValidation:
             lambda ex: isinstance(ex, RuntimeError) and " not implemented for " in f"{ex}",
             lambda ex: isinstance(ex, AssertionError)
             and f"{ex}" == "Encountered unsupported op types. Check error logs for more details",
+        ],
+        FailingReasons.ATTRIBUTE_ERROR: [
+            lambda ex: isinstance(ex, AttributeError),
         ],
     }
 


### PR DESCRIPTION
Add new unary operators: abs, cos, exp, neg, rsqrt, sin, and square.