### PR TITLE
[build] option to build tt-mlir runtime debug

### DIFF
--- a/docs/src/build.md
+++ b/docs/src/build.md
@@ -71,6 +71,16 @@ cmake -G Ninja -B build
 cmake --build build
 ```
 
+You can pass additional options to the `cmake` command to customize the build. For example, to build everything in debug mode, you can run:
+```sh
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+```
+
+> List of commonly used options:
+> - `-DCMAKE_BUILD_TYPE=Debug|Release`  - Build type (Debug, Release)
+> - `-DTTMLIR_RUNTIME_DEBUG=ON|OFF`     - Build runtime debug tools (more logging, debug environment flags)
+
 ### Incremental build
 If you have made changes to the C++ sources (of the `tt-forge-fe` compiler, `tt-mlir` or `tt-metal`), you might want to do an incremental build to save time. This can be done by running the following command:
 ```sh

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -10,6 +10,7 @@ add_custom_target(build_tt_mlir ALL
     TTMLIR_TOOLCHAIN_DIR=${TTMLIR_TOOLCHAIN_DIR} # Export TTMLIR_TOOLCHAIN_DIR to use
     TTMLIR_VENV_DIR=${TTMLIR_VENV_DIR} # Export TTMLIR_VENV_DIR to use
     TTMLIR_ENABLE_RUNTIME=ON # Always build runtime
+    TTMLIR_RUNTIME_DEBUG=${TTMLIR_RUNTIME_DEBUG} # Whether to build runtime debug tools (logging, debug environment flags, etc.) - Default is OFF
     bash ${CMAKE_CURRENT_SOURCE_DIR}/build_mlir.sh
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tt-mlir
     BYPRODUCTS ${METAL_LIB_DIR}/_ttnn.so # Workaround how Ninja handles dependencies

--- a/third_party/build_mlir.sh
+++ b/third_party/build_mlir.sh
@@ -8,8 +8,9 @@ source env/activate
 build_type=${BUILD_TYPE:-Release}
 c_compiler=${C_COMPILER:-clang}
 cxx_compiler=${CXX_COMPILER:-clang++}
+tt_runtime_debug=${TTMLIR_RUNTIME_DEBUG:-OFF}
 
 source env/activate
-cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=$build_type -DCMAKE_C_COMPILER=$c_compiler -DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DTTMLIR_ENABLE_RUNTIME=ON
+cmake -G Ninja -B build -DCMAKE_BUILD_TYPE=$build_type -DCMAKE_C_COMPILER=$c_compiler -DCMAKE_CXX_COMPILER=$cxx_compiler -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DTTMLIR_ENABLE_RUNTIME=ON -DTT_RUNTIME_DEBUG=$tt_runtime_debug
 
 cmake --build build


### PR DESCRIPTION
Using `-DTTMLIR_RUNTIME_DEBUG=ON` you can choose to build `tt-mlir` runtime debug tools.

If you need additional logging in `Release` build, this can be handy. Since it enables all debug/trace level logs.

If you are already in `Debug` build you can use the environment var `TTMLIR_RUNTIME_LOGGER_LEVEL` to enable debug/trace level logs.