### PR TITLE
Revert OpenCV version change

### DIFF
--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -29,7 +29,7 @@ networkx==2.8.5
 numpy==1.23.1
 onnx>=1.15.0
 onnxruntime>=1.16.3
-opencv-python-headless==4.5.5.64
+opencv-python-headless==4.10.0.84
 # This is needed to avoid issue https://yyz-gitlab.local.tenstorrent.com/devops/devops/-/issues/95
 pandas==1.5.3
 prettytable==3.0.0


### PR DESCRIPTION
Fix: https://github.com/tenstorrent/tt-forge-fe/issues/703

Previously CI was blocked with `ImportError: ERROR: recursion is detected during loading of "cv2" binary extensions. Check OpenCV installation.` issue. As per the suggestion [here](https://github.com/opencv/opencv-python/issues/680), downgraded the `opencv-python-headless` version from `4.6.0.66` to `4.5.5.64` in this [PR](https://github.com/tenstorrent/tt-forge-fe/pull/666).

Now this was blocking the MNIST Model with this [issue](https://github.com/tenstorrent/tt-forge-fe/issues/703). Hence reverting this change to see whether it still affect the CI.