### PR TITLE
Add xfail to resnet and llama mlp

### DIFF
--- a/forge/test/mlir/llama/tests/test_llama_mlp.py
+++ b/forge/test/mlir/llama/tests/test_llama_mlp.py
@@ -10,6 +10,7 @@ from forge.op.eval.common import compare_with_golden_pcc
 
 
 @pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
+@pytest.mark.xfail()
 @pytest.mark.push
 def test_llama_mlp(model_path):
     if model_path == "meta-llama/Llama-3.2-1B":

--- a/forge/test/mlir/resnet/test_resnet_inference.py
+++ b/forge/test/mlir/resnet/test_resnet_inference.py
@@ -11,6 +11,9 @@ from forge.op.eval.common import compare_with_golden
 
 
 @pytest.mark.push
+@pytest.mark.xfail(
+    reason=" Metal issue:  Can only tilize bfloat16 tensors. tracked on: https://github.com/tenstorrent/tt-metal/issues/14570"
+)
 def test_resnet_inference():
     # Compiler configurations
     compiler_cfg = forge.config._get_global_compiler_config()


### PR DESCRIPTION
In [PR](https://github.com/tenstorrent/tt-forge-fe/pull/672) I removed xfail from `test_llama_mlp` because it had worked on main at the time. I rebased and merged immediately. Unfortunately, somewhere in between test started failing. Thus, returning xfail until I investigate.
Also adding xfail for resnet inference with known [issue](https://github.com/tenstorrent/tt-metal/issues/14570) that is being addressed on metal 