### PR TITLE
Tests for transpose op

### DIFF
--- a/forge/test/operators/pytorch/tm/__init__.py
+++ b/forge/test/operators/pytorch/tm/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0

--- a/forge/test/operators/pytorch/tm/test_transpose.py
+++ b/forge/test/operators/pytorch/tm/test_transpose.py
@@ -1,0 +1,312 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for testing of transpose operators
+#
+# In this test we test pytorch transpose operator
+
+# GENERAL OP SUPPORT TEST PLAN:
+# 1. Operand type - any supported type
+# 2. Operand source(s):
+# (+)  2.1 From another op
+#       - Operator -> input
+# (+)  2.2 From DRAM queue
+#       - Operator is first node in network
+#       - Input_queue flag = false
+# (+)  2.3 Const Inputs (const eval pass)
+#       - Operator where all inputs are constants.
+# (+)  2.4 From host
+#       - Input tensor as input of network
+#       - Operator is first node in network
+#       - Input_queue flag = true
+# 3 Operand shapes type(s):
+# (+)  3.1 Full tensor (i.e. full expected shape)
+#       - 3-4 by default P1 (high prioriy)
+#       - 2, 5, ++ include P2 (lower prioriy)
+# (+)  3.2 Tensor reduce on one or more dims to 1
+#       - Vector
+#       - Only one dim is not equal to 1
+# (+)  3.3 Scalar P2
+#       - Create tensor of dimension equal to 0 (tensor from scalar) or just to use scalar as simple value
+# 4. Operand / output size of dimensions (few examples of each, 10 values total)
+# (+)  4.1 Divisible by 32
+# (+)  4.2 Prime numbers
+# (+)  4.3 Very large (thousands, 10s of thousands)
+#       - 100x100, 100x1000
+#       - maybe nightly only
+# (+)  4.4 Extreme ratios between height/width
+#      4.5 ...probably many more interesting combinations here
+# 5. Data format - all supported formats
+# (/)  5.1 Output DF
+# (/)  5.2 Intermediate DF
+# (/)  5.3 Accumulation DF
+# (+)  5.4 Operand DFs
+#       - Fix HiFi4 for math fidelity value
+# (+) 6. Math fidelity - LoFi, HiFi2a, Hifi2b, Hifi3, Hifi4
+#       - Fix fp16b (default) for data format value
+# (/) 7. Special attributes - if applicable.. like approx_mode for Exp, for example
+# (/) 8. Special cases - if applicable
+# 9. Variable number of operands - if applicable
+# (/) Few representative values
+# (/) Reuse inputs for selected operators
+
+
+import pytest
+
+from typing import List, Dict, Type, Optional, Any
+from loguru import logger
+
+import torch
+import forge
+import forge.op
+
+
+from test.operators.utils import InputSourceFlags, VerifyUtils
+from test.operators.utils import ShapeUtils
+from test.operators.utils import InputSource
+from test.operators.utils import TestVector
+from test.operators.utils import TestPlan
+from test.operators.utils import FailingReasons
+from test.operators.utils.compat import TestDevice
+from test.operators.utils import TestCollection
+from test.operators.utils import TestCollectionCommon
+
+
+class ModelFromAnotherOp(torch.nn.Module):
+
+    model_name = "model_op_src_from_another_op"
+
+    def __init__(self, operator, opname, shape, kwargs):
+        super(ModelFromAnotherOp, self).__init__()
+        self.testname = "Transpose_pytorch_operator_" + opname + "_test_op_src_from_another_op"
+        self.operator = operator
+        self.opname = opname
+        self.shape = shape
+        self.kwargs = kwargs
+
+    def forward(self, x: torch.Tensor):
+        # we use Add operator to create one operand which is input for the transpose operator
+        add = torch.add(x, x)
+        output = self.operator(add, **self.kwargs)
+        return output
+
+
+class ModelDirect(torch.nn.Module):
+
+    model_name = "model_op_src_from_host"
+
+    def __init__(self, operator, opname, shape, kwargs):
+        super(ModelDirect, self).__init__()
+        self.testname = "Transpose_pytorch_operator_" + opname + "_test_op_src_from_host"
+        self.operator = operator
+        self.opname = opname
+        self.shape = shape
+        self.kwargs = kwargs
+
+    def forward(self, x: torch.Tensor):
+        output = self.operator(x, **self.kwargs)
+        return output
+
+
+class ModelConstEvalPass(torch.nn.Module):
+
+    model_name = "model_op_src_const_eval_pass"
+
+    def __init__(self, operator, opname, shape, kwargs):
+        super(ModelConstEvalPass, self).__init__()
+        self.testname = "Transpose_pytorch_operator_" + opname + "_test_op_src_const_eval_pass"
+        self.operator = operator
+        self.opname = opname
+        self.shape = shape
+        self.kwargs = kwargs
+
+        self.c1 = torch.rand(*self.shape) - 0.5
+
+    def forward(self, x: torch.Tensor):
+        v1 = self.operator(self.c1, **self.kwargs)
+        v2 = self.operator(x, **self.kwargs)
+        # add consume inputs
+        add = torch.add(v1, v2)
+        return add
+
+
+class TestVerification:
+
+    MODEL_TYPES = {
+        InputSource.FROM_ANOTHER_OP: ModelFromAnotherOp,
+        InputSource.FROM_HOST: ModelDirect,
+        InputSource.FROM_DRAM_QUEUE: ModelDirect,
+        InputSource.CONST_EVAL_PASS: ModelConstEvalPass,
+    }
+
+    @classmethod
+    def verify(
+        cls,
+        test_device: TestDevice,
+        test_vector: TestVector,
+        number_of_operands: int = 1,
+        input_params: List[Dict] = [],
+        warm_reset: bool = False,
+    ):
+        """Common verification function for all tests"""
+
+        input_source_flag: InputSourceFlags = None
+        if test_vector.input_source in (InputSource.FROM_DRAM_QUEUE,):
+            input_source_flag = InputSourceFlags.FROM_DRAM
+
+        operator = getattr(torch, test_vector.operator)
+
+        kwargs = test_vector.kwargs if test_vector.kwargs else {}
+
+        model_type = cls.MODEL_TYPES[test_vector.input_source]
+        pytorch_model = model_type(
+            operator=operator,
+            opname=test_vector.operator,
+            shape=test_vector.input_shape,
+            kwargs=kwargs,
+        )
+
+        input_shapes = tuple([test_vector.input_shape for _ in range(number_of_operands)])
+
+        logger.trace(f"***input_shapes: {input_shapes}")
+
+        VerifyUtils.verify(
+            model=pytorch_model,
+            test_device=test_device,
+            input_shapes=input_shapes,
+            input_params=input_params,
+            input_source_flag=input_source_flag,
+            dev_data_format=test_vector.dev_data_format,
+            math_fidelity=test_vector.math_fidelity,
+            pcc=test_vector.pcc,
+            warm_reset=warm_reset,
+        )
+
+
+class TestParamsData:
+
+    __test__ = False  # Avoid collecting TestParamsData as a pytest test
+
+    test_plan: TestPlan = None
+
+    @classmethod
+    def generate_kwargs(cls, test_vector: TestVector):
+        size = len(test_vector.input_shape)
+        kwarg_list = []
+        for dim0 in list(range(0, size, 1)):
+            for dim1 in list(range(dim0 + 1, size, 1)):
+                kwargs = {}
+                kwargs["dim0"] = dim0
+                kwargs["dim1"] = dim1
+                kwarg_list.append(kwargs)
+        return kwarg_list
+
+
+class TestCollectionData:
+
+    __test__ = False  # Avoid collecting TestCollectionData as a pytest test
+
+    all = TestCollection(
+        operators=[
+            "transpose",  # 00
+        ],
+        input_sources=TestCollectionCommon.all.input_sources,
+        input_shapes=TestCollectionCommon.all.input_shapes,
+        dev_data_formats=TestCollectionCommon.all.dev_data_formats,
+        math_fidelities=TestCollectionCommon.all.math_fidelities,
+    )
+
+    single = TestCollection(
+        input_sources=TestCollectionCommon.single.input_sources,
+        input_shapes=TestCollectionCommon.single.input_shapes,
+        dev_data_formats=TestCollectionCommon.single.dev_data_formats,
+        math_fidelities=TestCollectionCommon.single.math_fidelities,
+    )
+
+
+TestParamsData.test_plan = TestPlan(
+    verify=lambda test_device, test_vector: TestVerification.verify(
+        test_device,
+        test_vector,
+    ),
+    collections=[
+        # Test plan:
+        # 2. Operand source(s):
+        # 3. Operand shapes type(s):
+        # 4. Operand / output size of dimensions
+        TestCollection(
+            operators=TestCollectionData.all.operators,
+            input_sources=TestCollectionData.all.input_sources,
+            input_shapes=TestCollectionData.all.input_shapes,
+            kwargs=lambda test_vector: TestParamsData.generate_kwargs(test_vector),
+        ),
+        # Test plan:
+        # 5. Data format
+        TestCollection(
+            operators=TestCollectionData.all.operators,
+            input_sources=TestCollectionData.single.input_sources,
+            input_shapes=TestCollectionData.single.input_shapes,
+            kwargs=lambda test_vector: TestParamsData.generate_kwargs(test_vector),
+            dev_data_formats=[
+                item
+                for item in TestCollectionData.all.dev_data_formats
+                if item not in TestCollectionData.single.dev_data_formats
+            ],
+            math_fidelities=TestCollectionData.single.math_fidelities,
+        ),
+        # Test plan:
+        # 6. Math fidelity
+        TestCollection(
+            operators=TestCollectionData.all.operators,
+            input_sources=TestCollectionData.single.input_sources,
+            input_shapes=TestCollectionData.single.input_shapes,
+            kwargs=lambda test_vector: TestParamsData.generate_kwargs(test_vector),
+            dev_data_formats=TestCollectionData.single.dev_data_formats,
+            math_fidelities=TestCollectionData.all.math_fidelities,
+        ),
+    ],
+    failing_rules=[
+        # Skip all tests with input shapes with 2 dimensions
+        TestCollection(
+            criteria=lambda test_vector: len(test_vector.input_shape) == 2,
+            skip_reason=FailingReasons.NOT_IMPLEMENTED,
+        ),
+        # E       RuntimeError: TT_FATAL @ /home/kmilanovic/src/ttforge/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp:32: input_tensor.get_dtype() == DataType::FLOAT32 || input_tensor.get_dtype() == DataType::BFLOAT16
+        # E       info:
+        # E       Cannot pad tilized tensor with specified format
+        TestCollection(
+            kwargs=[
+                # {"dim0": 0, "dim1": 1}, # those are passing
+                {"dim0": 0, "dim1": 2},
+                {"dim0": 0, "dim1": 3},
+                {"dim0": 1, "dim1": 2},
+                {"dim0": 1, "dim1": 3},
+                # {"dim0": 2, "dim1": 3}, # those are failing with different error
+            ],
+            dev_data_formats=TestCollectionCommon.int.dev_data_formats,
+            math_fidelities=TestCollectionData.single.math_fidelities,
+            failing_reason=FailingReasons.INFERENCE_FAILED,
+        ),
+        # E       AssertionError: PCC check failed
+        TestCollection(
+            kwargs=[
+                # {"dim0": 0, "dim1": 1}, # those are passing
+                # {"dim0": 0, "dim1": 2}, # those are failing with different error
+                # {"dim0": 0, "dim1": 3}, # those are failing with different error
+                # {"dim0": 1, "dim1": 2}, # those are failing with different error
+                # {"dim0": 1, "dim1": 3}, # those are failing with different error
+                {"dim0": 2, "dim1": 3},
+            ],
+            dev_data_formats=TestCollectionCommon.int.dev_data_formats,
+            math_fidelities=TestCollectionData.single.math_fidelities,
+            failing_reason=FailingReasons.DATA_MISMATCH,
+        ),
+    ],
+)
+
+
+def get_test_plans() -> List[TestPlan]:
+    return [
+        TestParamsData.test_plan,
+    ]

--- a/forge/test/operators/utils/failing_reasons.py
+++ b/forge/test/operators/utils/failing_reasons.py
@@ -152,6 +152,12 @@ class FailingReasonsValidation:
             lambda ex: isinstance(ex, RuntimeError)
             and "tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp"
             in f"{ex}",
+            lambda ex: isinstance(ex, RuntimeError)
+            and "tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp"
+            in f"{ex}",
+            lambda ex: isinstance(ex, RuntimeError)
+            and "tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_op.cpp:106: input_tensor.get_dtype() == DataType::BFLOAT16 || input_tensor.get_dtype() == DataType::FLOAT32"
+            in f"{ex}",
         ],
     }
 


### PR DESCRIPTION
Test torch transpose operator

Supported operand source models for Forge:

from dram
from host
from another op
const eval pass
mf and df tests

Closes [#253](https://github.com/tenstorrent/tt-forge-fe/issues/253)