### PR TITLE
Decompose AvgPool3d Op to Conv3d for Support

### DIFF
--- a/forge/forge/op/__init__.py
+++ b/forge/forge/op/__init__.py
@@ -4,8 +4,8 @@
 
 from .matmul import Matmul, SparseMatmul
 
-from .convolution import Conv2d, Conv2dTranspose, Conv3d
-from .pooling import MaxPool1d, MaxPool2d, MaxPool3d, AvgPool1d, AvgPool2d
+from .convolution import Conv2d, Conv2dTranspose, Conv3d, Conv3d
+from .pooling import MaxPool1d, MaxPool2d, MaxPool3d, AvgPool1d, AvgPool2d, AvgPool3d
 from .eltwise_binary import (
     Add,
     Divide,

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -19,7 +19,7 @@ from .tilizer import Tilizer
 from .clip import Clip
 from .cumulativesum import CumulativeSum
 from .argmax import Argmax
-from .convolution import Conv2d
+from .convolution import Conv2d, Conv3d
 from .convolution import Conv2dTranspose
 from .pooling import MaxPool2d
 from .cast import Cast
@@ -110,12 +110,13 @@ op_to_module_map = {
     "grouped_reduce_avg": "reduce",
     "conv2d": Conv2d,
     "conv2d_transpose": Conv2dTranspose,
-    "conv3d": "convolution",
+    "conv3d": Conv3d,
     "max_pool1d": "pooling",
     "max_pool2d": MaxPool2d,
     "max_pool3d": "pooling",
     "avg_pool1d": "pooling",
     "avg_pool2d": "pooling",
+    "avg_pool3d": "pooling",
     "constant": "constant",
     "resize2d": "resize",
     "resize3d": "resize",

--- a/forge/forge/op/eval/forge/convolution.py
+++ b/forge/forge/op/eval/forge/convolution.py
@@ -372,3 +372,194 @@ class Conv2dTranspose(PyOp):
 
     def is_eltwise_nary(self) -> bool:
         return False
+
+
+class Conv3d(PyOp):
+    @classmethod
+    def create(
+        cls,
+        stride_depth,
+        stride_height,
+        stride_width,
+        dilation_depth,
+        dilation_height,
+        dilation_width,
+        groups,
+        padding_front,
+        padding_back,
+        padding_left,
+        padding_right,
+        padding_top,
+        padding_bottom,
+        channel_last,
+    ):
+        self = cls("conv3d")
+        self.stride_depth = stride_depth
+        self.stride_height = stride_height
+        self.stride_width = stride_width
+        self.dilation_depth = dilation_depth
+        self.dilation_height = dilation_height
+        self.dilation_width = dilation_width
+        self.groups = groups
+        self.padding_front = padding_front
+        self.padding_back = padding_back
+        self.padding_left = padding_left
+        self.padding_right = padding_right
+        self.padding_top = padding_top
+        self.padding_bottom = padding_bottom
+        self.channel_last = int(channel_last)
+        return self
+
+    def eval(self, tensors):
+        assert len(tensors) <= 3, "Conv ops should have up to three inputs (input, weight, bias)"
+        assert len(tensors) >= 2, "Conv ops should have at least two inputs (input, weight)"
+        t_ops = to_torch_operands(*tensors)
+
+        activations = t_ops[0]
+        weights = t_ops[1]
+        bias = t_ops[2] if len(t_ops) == 3 else None
+
+        stride = [self.stride_depth, self.stride_height, self.stride_width]
+        dilation = [self.dilation_depth, self.dilation_height, self.dilation_width]
+        groups = self.groups
+        padding = [
+            self.padding_front,
+            self.padding_back,
+            self.padding_top,
+            self.padding_bottom,
+            self.padding_left,
+            self.padding_right,
+        ]
+
+        if self.channel_last:
+            activations = activations.permute((0, 4, 1, 2, 3))
+
+        padded_activations = torch.nn.functional.pad(
+            activations,
+            padding,
+        )
+
+        result = torch.nn.functional.conv3d(
+            padded_activations,
+            weights,
+            bias=bias,
+            stride=stride,
+            padding=0,
+            dilation=dilation,
+            groups=groups,
+        )
+
+        if self.channel_last:
+            result = result.permute((0, 2, 3, 4, 1))
+
+        result = result.to(activations.dtype)
+        return result
+
+    def shape(self, tensor_shapes):
+
+        act, weight = tensor_shapes[:2]
+        batch_size = act[0]
+        cout = weight[0]
+
+        d_in = act[-4] if self.channel_last else act[-3]
+        h_in = act[-3] if self.channel_last else act[-2]
+        w_in = act[-2] if self.channel_last else act[-1]
+
+        d_numerator = d_in + (self.padding_front + self.padding_back) - self.dilation_depth * (weight[-3] - 1) - 1
+        d_out = math.floor(1 + (d_numerator / self.stride_depth))
+
+        h_numerator = h_in + (self.padding_top + self.padding_bottom) - self.dilation_height * (weight[-2] - 1) - 1
+        h_out = math.floor(1 + (h_numerator / self.stride_height))
+
+        w_numerator = w_in + (self.padding_left + self.padding_right) - self.dilation_width * (weight[-1] - 1) - 1
+        w_out = math.floor(1 + (w_numerator / self.stride_width))
+
+        out_shape = (
+            [batch_size, d_out, h_out, w_out, cout] if self.channel_last else [batch_size, cout, d_out, h_out, w_out]
+        )
+
+        return out_shape, []
+
+    def decompose(self, dc, inputs):
+        # conv3d op is not yet supported in TTNN, based on refrence from conv2d following transformations are done
+        # TTNN can only perform a channel-last convolution with its conv3d op.
+        # The TTNN conv3d requires the input to be in the shape: (N, D, H, W, C) or (1, 1, N*D*H*W, C).
+        # It requires the weight to be in the shape: (C_out, C_in, kernel_depth, kernel_height, kernel_width).
+        # It requires the bias to be in the shape: (1, 1, 1, 1, C_out).
+        #
+        # If the forge conv3d op is channel-first, we must permute the input (N, C, D, H, W) tensor to (N, D, H, W, C)
+        # and then transpose it back to (N, C_out, D_out, H_out, W_out) afterward.
+        #     - This is done with three transposes
+        #     - (N, C, D, H, W) --> transpose(-4, -3): (N, D, C, H, W) --> transpose(-3, -2): (N, D, H, C, W)
+        #     --> transpose(-2, -1): (N, D, H, W, C)
+        # Afterward:
+        #     - (N, D_out, H_out, W_out, C_out) --> transpose(-3, -2): (N, D_out, H_out, C_out, W_out)
+        #     --> transpose(-4, -3): (N, C_out, D_out, H_out, W_out)
+
+        activations = inputs[0]
+        weight = inputs[1]
+        bias = inputs[2] if len(inputs) == 3 else None
+
+        is_channel_last = self.channel_last
+
+        if bias is not None and len(bias.shape) < len(activations.shape):
+            while len(bias.shape) < len(activations.shape):
+                bias = dc.op("unsqueeze", [bias], (0, len(bias.shape)))
+        is_bias_unchanged = bias is None or bias == inputs[2]
+
+        if not is_channel_last:
+            activations = dc.op(TransposeTM.create(dim0=-4, dim1=-3), [activations])
+            activations = dc.op(TransposeTM.create(dim0=-3, dim1=-2), [activations])
+            activations = dc.op(TransposeTM.create(dim0=-2, dim1=-1), [activations])
+
+        # Only want to re-create the Conv3d op if something has changed. Otherwise it the compiler will infinitely
+        # decompose the same Conv3d over and over.
+        if not is_bias_unchanged or not is_channel_last:
+
+            new_inputs = [activations, weight] if bias is None else [activations, weight, bias]
+            result = dc.op(
+                Conv3d.create(
+                    self.stride_depth,
+                    self.stride_height,
+                    self.stride_width,
+                    self.dilation_depth,
+                    self.dilation_height,
+                    self.dilation_width,
+                    self.groups,
+                    self.padding_front,
+                    self.padding_back,
+                    self.padding_left,
+                    self.padding_right,
+                    self.padding_top,
+                    self.padding_bottom,
+                    True,
+                ),
+                new_inputs,
+            )
+
+            if not is_channel_last:
+                result = dc.op(TransposeTM.create(dim0=-1, dim1=-2), [result])
+                result = dc.op(TransposeTM.create(dim0=-2, dim1=-3), [result])
+                result = dc.op(TransposeTM.create(dim0=-3, dim1=-4), [result])
+            dc.fuse(result)
+
+    def backward(self, ac, operand, inputs, output, grad):
+        raise NotImplementedError("Backward operation is not yet supported for this op")
+
+    def lower(self, lc, tensors, outputs):
+        pass
+
+    def is_tm(self) -> bool:
+        return False
+
+    def is_eltwise(self) -> bool:
+        return False
+
+    def is_eltwise_binary(self) -> bool:
+        return False
+
+    def is_eltwise_unary(self) -> bool:
+        return False
+
+    def is_eltwise_nary(self) -> bool:
+        return False

--- a/forge/forge/op/pooling.py
+++ b/forge/forge/op/pooling.py
@@ -278,3 +278,62 @@ def AvgPool2d(
         activations,
         attrs=attrs,  # 1 is placeholder for dilation
     ).get_tensor()
+
+
+def AvgPool3d(
+    name: str,
+    activations: Tensor,
+    kernel_size: Union[int, Tuple[int, int, int]],
+    stride: int = 1,
+    padding: Union[int, str] = "same",
+    ceil_mode: bool = False,
+    count_include_pad: bool = True,
+    divisor_override: float = None,
+    channel_last: bool = False,
+) -> Tensor:
+    """
+    Avgpool3d transformation on input activations
+
+    Parameters
+    ----------
+    name: str
+        Op name, unique to the module, or leave blank to autoset
+
+    activations: Tensor
+        Input activations of shape (N, Cin, iD, iH, iW)
+
+    kernel_size:
+        Size of pooling region
+    """
+    assert divisor_override is None, "Unsupported"
+    assert isinstance(kernel_size, (int, tuple, list)), "Unsupported"
+
+    if isinstance(stride, int):
+        stride = [stride] * 3
+
+    if isinstance(kernel_size, int):
+        kernel_size = [kernel_size] * 3
+    elif isinstance(kernel_size, Tuple):
+        kernel_size = list(kernel_size)
+    if padding == "same":
+
+        padding = [
+            kernel_size[2] // 2,
+            kernel_size[2] // 2,
+            kernel_size[1] // 2,
+            kernel_size[1] // 2,
+            kernel_size[0] // 2,
+            kernel_size[0] // 2,
+        ]
+    if isinstance(padding, int):
+        padding = [padding] * 6  # [left, right, top, bottom, front, back]
+
+    dilation = 1  # Only as place holder to standardize interface with MaxPool3d
+    attrs = kernel_size + stride + [dilation, ceil_mode] + padding + [count_include_pad] + [channel_last]
+
+    return op(
+        "avg_pool3d",
+        name,
+        activations,
+        attrs=attrs,  # 1 is placeholder for dilation
+    ).get_tensor()

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -736,6 +736,57 @@ def populate_argmax_args(graph, nid, compiler_cfg):
     return args
 
 
+def populate_avgpool3d_args(graph, nid, compiler_cfg):
+    node = graph["nodes"][nid]
+    args = []
+
+    kernel_size = [int(pool_size) for pool_size in node["attrs"]["pool_size"][0]]
+    args.append(
+        (
+            "kernel_size",
+            f"{kernel_size}",
+        )
+    )
+
+    strides = [int(stride) for stride in node["attrs"]["strides"][0]]
+    args.append(
+        (
+            "stride",
+            f"{strides}",
+        )
+    )
+
+    padding = [int(padding) for padding in node["attrs"]["padding"][0]]
+    # TVM has padding [depth_first, top, left, depth_last, bottom, right]
+    # Convert to [left right top bottom depth_first depth_last]
+    reordered_padding = [padding[2], padding[5], padding[1], padding[4], padding[0], padding[3]]
+
+    args.append(
+        (
+            "padding",
+            f"{reordered_padding}",
+        )
+    )
+
+    ceil_mode = int(node["attrs"]["ceil_mode"][0][0])  # 1 for True
+    ceil_mode = "True" if ceil_mode == 1 else "False"
+    args.append(
+        (
+            "ceil_mode",
+            f"{ceil_mode}",
+        )
+    )
+
+    count_include_pad = int(node["attrs"]["count_include_pad"][0][0])
+    count_include_pad = "True" if count_include_pad == 1 else "False"
+    args.append(("count_include_pad", count_include_pad))
+
+    channel_last = int(node["attrs"]["layout"][0][0] == "NDHWC")
+    args.append(("channel_last", f"{channel_last}"))
+
+    return args
+
+
 def populate_avgpool2d_args(graph, nid, compiler_cfg):
     node = graph["nodes"][nid]
     args = []
@@ -1644,6 +1695,7 @@ tvm_to_forge_op_map = {
     "multiply": "multiply",
     "nn.avg_pool1d": "avg_pool1d",
     "nn.avg_pool2d": "avg_pool2d",
+    "nn.avg_pool3d": "avg_pool3d",
     "nn.batch_matmul": "matmul",
     "nn.conv2d_transpose": "conv2d_transpose",
     "nn.conv2d": "conv2d",
@@ -1704,6 +1756,7 @@ forge_op_to_function_name = {
     "argmax": "forge.op.Argmax",
     "avg_pool1d": "forge.op.AvgPool1d",
     "avg_pool2d": "forge.op.AvgPool2d",
+    "avg_pool3d": "forge.op.AvgPool3d",
     "binary_stack": "forge.op.BinaryStack",
     "broadcast": "forge.op.Broadcast",
     "cast": "forge.op.Cast",  # Datatype cast
@@ -1781,6 +1834,7 @@ forge_ops_needing_arguments = {
     "argmax": populate_argmax_args,
     "avg_pool1d": populate_avgpool1d_args,
     "avg_pool2d": populate_avgpool2d_args,
+    "avg_pool3d": populate_avgpool3d_args,
     "binary_stack": populate_binary_stack_args,
     "broadcast": populate_broadcast_args,
     "cast": populate_cast_args,


### PR DESCRIPTION
## Summary:

- This PR fixes [#713](https://github.com/tenstorrent/tt-forge-fe/issues/713)

- The core idea behind this transformation is to use Conv3d as a replacement for AvgPool3d by setting the convolution kernel's weights to a constant value. Specifically, the weight for each element in the kernel is set to:

```
weight_value = 1.0 / (kD * kH * kW)
weight = torch.ones(1, 1, kD, kH, kW) * weight_value
```

- This approach effectively turns the convolution into an average pooling operation, as the weights are identical, and their sum over the receptive field will produce the average. (Note : conv3d is not yet supported in MLIR and TTNN)

- eval,shape,decompose fucntions and sanity tests are added for conv3d, avgpool3d



## Logs

- [avgpool3d_test_case_results.log](https://github.com/user-attachments/files/17772062/nov15_avgpool3d_all_cases_f1.log)
- [conv3d_test_case_results.log](https://github.com/user-attachments/files/17772063/nov15_conv3d_all_cases_f1.log)
