### PR TITLE
fix shape mismatch issue in maxpool2d when ceil model is true

### DIFF
--- a/forge/forge/op/eval/forge/pooling.py
+++ b/forge/forge/op/eval/forge/pooling.py
@@ -95,12 +95,18 @@ class MaxPool2d(PyOp):
         h_numerator = (
             h_in + (self.padding_top + self.padding_bottom) - self.dilation_height * (self.kernel_height - 1) - 1
         )
-        h_out = math.floor(1 + (h_numerator / self.stride_height))
+        if self.ceil_mode:
+            h_out = math.ceil(1 + (h_numerator / self.stride_height))
+        else:
+            h_out = math.floor(1 + (h_numerator / self.stride_height))
 
         w_numerator = (
             w_in + (self.padding_left + self.padding_right) - self.dilation_width * (self.kernel_width - 1) - 1
         )
-        w_out = math.floor(1 + (w_numerator / self.stride_width))
+        if self.ceil_mode:
+            w_out = math.ceil(1 + (w_numerator / self.stride_width))
+        else:
+            w_out = math.floor(1 + (w_numerator / self.stride_width))
 
         out_shape = [batch_size, h_out, w_out, channels] if self.channel_last else [batch_size, channels, h_out, w_out]
 

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_googlenet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_googlenet.py
@@ -15,7 +15,7 @@ import os
 def test_googlenet_pytorch(test_device):
     # Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # Create Forge module from PyTorch model
     # Two ways to load the same model

--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_vovnet.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_vovnet.py
@@ -45,7 +45,7 @@ def get_image():
 def generate_model_vovnet_imgcls_osmr_pytorch(test_device, variant):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # STEP 2: Create Forge module from PyTorch model
     model = download_model(ptcv_get_model, variant, pretrained=True)
@@ -94,7 +94,7 @@ def preprocess_steps(model_type):
 def generate_model_vovnet39_imgcls_stigma_pytorch(test_device, variant):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # STEP 2: Create Forge module from PyTorch model
     model, image_tensor = download_model(preprocess_steps, vovnet39)
@@ -118,7 +118,7 @@ from src_vovnet_stigma import vovnet57
 def generate_model_vovnet57_imgcls_stigma_pytorch(test_device, variant):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # STEP 2: Create Forge module from PyTorch model
     model, image_tensor = download_model(preprocess_steps, vovnet57)
@@ -159,7 +159,7 @@ def generate_model_vovnet_imgcls_timm_pytorch(test_device, variant):
     model, image_tensor = download_model(preprocess_timm_model, variant)
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.CONSTEVAL_GRAPH
 
     return model, [image_tensor], {}
 


### PR DESCRIPTION
## Summary

- This PR fixes [#628](https://github.com/tenstorrent/tt-forge-fe/issues/628) 
- The shape mismatch issue arises due to the way the shape method is computing the output height (h_out) and width (w_out) in maxpool2d.Earlier it used torch.floor even when ceil mode = true which causes rounding down the result instead of rounding up which leads to shape mismatch.
- Now based on ceil mode (false/true) , operation (torch.floor/torch.ceil) will be determined .
- Compile depth of the corresonding blocked model are updated.
- Tracks these [TVM changes](https://github.com/tenstorrent/tt-tvm/compare/be49f296bf30220584469cc4715ef9c97ee19b17...b332bb7031c17a81d2629683f6b7f0cec8deabf9#diff-afd1b9179c4d052038fb665278188afce38f9a0b290efcfb20ef9d0598c8f39e) and sanity tests for maxpool2d (with ceil_mode=True) and power=0.75 are added 

- Note : model and input data type are changed to bfloat16 in maxpool2d sanity to avoid  `ttnn.max_pool2d currently only supports an input type of bfloat16. Recieved 'f32'.` issue.

# Logs

- [googlenet_after_fix.log](https://github.com/user-attachments/files/17776887/nov15_z_googlenet_after_fix.log)

- [googlenet_before_fix.log](https://github.com/user-attachments/files/17776893/nov15_z_googlenet_before_fix.log)

- [maxpool2d_before_fix.log](https://github.com/user-attachments/files/17811369/nov19_maxpool2d_c4.log)

- [maxpool2d_after_fix.log](https://github.com/user-attachments/files/17813137/nov19_maxpool2d_8.log)

- [vovnet_after_fix.log](https://github.com/user-attachments/files/17776897/nov15_z_vovnet_after_fix.log)

- [vovnet_after_fix.log.zip](https://github.com/user-attachments/files/17777450/nov15_z_vovnet_after_fix.log.zip)

