### PR TITLE
Remove transpose cast to float32 and update test_transpose

### DIFF
--- a/forge/forge/op/tm.py
+++ b/forge/forge/op/tm.py
@@ -115,7 +115,7 @@ def VStack(name: str, operandA: Tensor, slices: int = -1) -> Tensor:
     return op("vstack", name, operandA, attrs=(slices,)).get_tensor()
 
 
-def Transpose(name: str, operandA: Tensor, dim0: int, dim1: int, out_dtype: torch.dtype = torch.float32) -> Tensor:
+def Transpose(name: str, operandA: Tensor, dim0: int, dim1: int) -> Tensor:
 
     """
     Tranpose X and Y (i.e. rows and columns) dimensions.
@@ -148,9 +148,7 @@ def Transpose(name: str, operandA: Tensor, dim0: int, dim1: int, out_dtype: torc
     if dim0 > dim1:
         dim0, dim1 = dim1, dim0
 
-    return op("transpose", name, operandA, attrs=(dim0, dim1), dim0=dim0, dim1=dim1).get_tensor(
-        out_df=pytorch_dtype_to_forge_dataformat(out_dtype)
-    )
+    return op("transpose", name, operandA, attrs=(dim0, dim1), dim0=dim0, dim1=dim1).get_tensor()
 
 
 def Reshape(name: str, operandA: Tensor, shape: Tuple[int, ...]) -> Tensor:

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1282,8 +1282,6 @@ def populate_transpose_args(graph, nid, compiler_cfg):
     args.append(("dim0", f"{transpose_axes[0]}"))
     args.append(("dim1", f"{transpose_axes[1]}"))
 
-    args.append(("out_dtype", "torch." + node["attrs"]["dtype"][0][0]))
-
     return args
 
 

--- a/forge/test/operators/tm/fuse/test_fuse_tm_sequence.py
+++ b/forge/test/operators/tm/fuse/test_fuse_tm_sequence.py
@@ -44,8 +44,8 @@ class PtFuseTMMultiUser(ForgeModule):
             epsilon=1e-05,
         )
         reshape_341 = forge.op.Reshape("", layernorm_340, shape=(1, 128, 128, 32))
-        transpose_342 = forge.op.Transpose("", reshape_341, dim0=-3, dim1=-1, out_dtype=torch.float32)
-        transpose_343 = forge.op.Transpose("", transpose_342, dim0=-2, dim1=-1, out_dtype=torch.float32)
+        transpose_342 = forge.op.Transpose("", reshape_341, dim0=-3, dim1=-1)
+        transpose_343 = forge.op.Transpose("", transpose_342, dim0=-2, dim1=-1)
         conv2d_344 = forge.op.Conv2d(
             "",
             transpose_343,
@@ -58,7 +58,7 @@ class PtFuseTMMultiUser(ForgeModule):
             channel_last=0,
         )
         reshape_783 = forge.op.Reshape("", transpose_343, shape=(1, 32, 16384))
-        transpose_784 = forge.op.Transpose("", reshape_783, dim0=-2, dim1=-1, out_dtype=torch.float32)
+        transpose_784 = forge.op.Transpose("", reshape_783, dim0=-2, dim1=-1)
         reshape_785 = forge.op.Reshape("", transpose_784, shape=(16384, 32))
         return conv2d_344, reshape_785
 


### PR DESCRIPTION
Closes #690.
Changes in this PR:

1. Remove transpose output cast to float32 and transpose op argument data_format. Transpose shouldn't have data_format attribute! It should give the same data_format on output as it gets on input.
2. Update test_transpose to vary between torch.float32 and torch.bfloat16 inputs. 
3. Caught tensor mismatch for transpose when using torch.bfloat16 inputs, and marked as xfail untill resolved on metal side.

Effort to test transpose on bfloat16 inputs emerges from the need to run Llama 3B on bfloat16 since embedding only has support for bfloat16.