### PR TITLE
Add support for mod(remainder) op

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -577,6 +577,7 @@ class MLIRGenerator
         lowering_handler_map["subtract"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::SubtractOp>;
         lowering_handler_map["transpose"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::TransposeOp>;
         lowering_handler_map["unsqueeze"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::UnsqueezeOp>;
+        lowering_handler_map["remainder"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::RemainderOp>;
     }
 };
 }  // namespace

--- a/forge/forge/op/__init__.py
+++ b/forge/forge/op/__init__.py
@@ -23,6 +23,7 @@ from .eltwise_binary import (
     Equal,
     NotEqual,
     LogicalAnd,
+    Remainder,
 )
 from .eltwise_unary import (
     Exp,

--- a/forge/forge/op/eltwise_binary.py
+++ b/forge/forge/op/eltwise_binary.py
@@ -441,3 +441,7 @@ def LogicalAnd(name: str, operandA: Tensor, operandB: Union[Tensor, Parameter]) 
     """
 
     return op("logical_and", name, operandA, operandA).get_tensor()
+
+
+def Remainder(name: str, operandA: Tensor, operandB: Union[Tensor, Parameter]) -> Tensor:
+    return _Eltwise(name, operandA, operandB, "remainder")

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -28,6 +28,7 @@ op_to_module_map = {
     "add": "eltwise_binary",
     "cast": Cast,
     "divide": "eltwise_binary",
+    "remainder": "eltwise_binary",
     "subtract": "eltwise_binary",
     "multiply": "eltwise_binary",
     "maximum": "eltwise_binary",

--- a/forge/forge/op/eval/forge/eltwise_binary.py
+++ b/forge/forge/op/eval/forge/eltwise_binary.py
@@ -50,6 +50,7 @@ def eval(type, attr, ops):
         "equal": lambda i: torch.eq(t_ops[0], t_ops[1]).to(t_ops[0].dtype),
         "not_equal": lambda i: torch.ne(t_ops[0], t_ops[1]).to(t_ops[0].dtype),
         "logical_and": lambda i: torch.logical_and(t_ops[0], t_ops[1]).to(t_ops[0].dtype),
+        "remainder": lambda i: torch.remainder(t_ops[0], t_ops[1]),
     }
     assert type in f, f"{type} not defined in eval map for eltwise binary ops."
 

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1615,6 +1615,7 @@ def populate_requantize_args(graph, nid, compiler_cfg):
 tvm_to_forge_op_map = {
     "abs": "abs",
     "add": "add",
+    "floor_mod": "remainder",
     "argmax": "argmax",
     "broadcast_to": "broadcast",
     "cast": "cast",
@@ -1700,6 +1701,7 @@ tvm_to_forge_op_map = {
 forge_op_to_function_name = {
     "abs": "forge.op.Abs",
     "add": "forge.op.Add",
+    "remainder": "forge.op.Remainder",
     "adv_index": "forge.op.AdvIndex",
     "argmax": "forge.op.Argmax",
     "avg_pool1d": "forge.op.AvgPool1d",

--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_opt.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_opt.py
@@ -85,7 +85,7 @@ def test_opt_qa(variant, test_device):
 def test_opt_sequence_classification(variant, test_device):
     # Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # Load tokenizer and model from HuggingFace
     # Variants: "facebook/opt-125m", "facebook/opt-350m", "facebook/opt-1.3b"


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-forge-fe/issues/517
Fixes https://github.com/tenstorrent/tt-forge-fe/issues/710

TTNN directly supports [remainder](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/api/ttnn.remainder.html#ttnn-remainder) op and supported in TT-mlir [ttir.remainder](https://docs.tenstorrent.com/tt-mlir/autogen/md/Dialect/TTIROp.html#ttirremainder-ttttirremainderop). Since TVM doesn't have remainder op, aten::remainder is mapped to tvm's [mod](https://tvm.apache.org/docs/reference/api/python/relax/op.html?highlight=mod#tvm.relax.op.mod) op and this is mapped to Remainder op in Forge
