### PR TITLE
Enable pytest xfail strict mode - Fail test on xpassed

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,6 +4,9 @@
 # Ignore specific tests
 addopts = -svv
 
+# Fail on xpadded
+xfail_strict=true
+
 # Add pytest markers
 markers =
     push: marks tests as push


### PR DESCRIPTION
Fix #731

This is the display of the xpassed test now:
<img width="1003" alt="image" src="https://github.com/user-attachments/assets/8ec21dd5-4982-4567-a6f5-a540d6adaee1">
