### PR TITLE
Update named attrs in commute_utils

### DIFF
--- a/forge/csrc/graph_lib/node_types.hpp
+++ b/forge/csrc/graph_lib/node_types.hpp
@@ -523,7 +523,29 @@ class OpNode : public TaggedNode
     IRLevel get_ir_level() const { return (node_type() == NodeType::kPyOp) ? IRLevel::IR_TT_FORGE : IRLevel::IR_FORGE; }
     const std::string &op_name() const { return op_type_.op; }
     const std::vector<OpType::Attr> &op_attrs() const { return op_type_.attr; }
-    void overwrite_op_attrs(std::vector<OpType::Attr> op_attrs) { op_type_.attr = op_attrs; }
+    OpType::Attrs &named_attrs() { return op_type_.named_attrs; }
+    /**
+     * @brief Updates the attributes and named attributes of the operation.
+     *
+     * Overwrites the current operation's attributes and named attributes
+     * with the provided ones. It constructs a new `OpType` object with the updated
+     * attributes while retaining the existing operation name.
+     */
+    void overwrite_op_named_attrs(
+        const std::vector<graphlib::OpType::Attr> &op_attrs, const graphlib::OpType::Attrs &named_attrs)
+    {
+        const std::string &name = op_name();
+        log_trace("op name = {}", name);
+        op_type_ = graphlib::OpType(name, op_attrs, {}, named_attrs);
+    }
+    /**
+     * @brief Overwrites the named attributes of the operation.
+     *
+     * Updates the current operation's named attributes with the
+     * provided `named_attrs` without altering the operation's other properties.
+     */
+    void overwrite_named_attrs(graphlib::OpType::Attrs &named_attrs) { op_type_.named_attrs = named_attrs; }
+
     const ForgeOpAttrs &forge_attrs() const { return op_type_.forge_attrs; }
     void overwrite_forge_attrs(ForgeOpAttrs forge_attrs) { op_type_.forge_attrs = forge_attrs; }
     void set_gradient_op(bool value = true) { gradient_op_ = value; }

--- a/forge/csrc/passes/commute_utils.cpp
+++ b/forge/csrc/passes/commute_utils.cpp
@@ -403,7 +403,7 @@ bool commute_through_select(
     if (concat_golden_transform.op == "reshape")
         concat_golden_transform.attr[select_dim] = concat_output_len;
     op->add_golden_transform(concat_golden_transform);
-    op->overwrite_op_attrs(attr);
+    update_select_attr(op, new_dim);
 
     *commute_shape = concat_shape;
     *golden_transform = concat_golden_transform;
@@ -769,7 +769,7 @@ bool commute_through_reduce(
         }
 
         op->add_golden_transform(reduce_golden_transform);
-        op->overwrite_op_attrs(op_attr);
+        update_reduce_attr(op, op_reduce_dim);
 
         *commute_shape = reduce_shape;
         *golden_transform = reduce_golden_transform;
@@ -801,7 +801,7 @@ bool commute_through_reduce(
 
         op->add_golden_transform(reduce_golden_transform);
 
-        op->overwrite_op_attrs(attr);
+        update_reduce_attr(op, reduce_dim);
 
         *commute_shape = reduce_shape;
         *golden_transform = reduce_golden_transform;
@@ -898,18 +898,200 @@ bool can_commute_past_op(
     return (is_elementwise(op) and op->op_name() != "interleave") or is_quantization_ops(op);
 }
 
-void update_reshape_attr(graphlib::OpNode *reshape, graphlib::Shape new_shape)
+/**
+ * @brief Updates the attributes of a "select" operation with new values for dimension, begin, length, and stride.
+ */
+void update_select_attr(
+    graphlib::OpNode *select_op,
+    int select_dim,
+    std::optional<int> begin,
+    std::optional<int> length,
+    std::optional<int> stride)
 {
-    if (reshape->op_name() != "reshape")
-        return;
-    std::vector<graphlib::OpType::Attr> attr;
-    for (size_t i = 0; i < new_shape.size(); i++)
+    TT_ASSERT(select_op->op_name() == "select", "update_select_attr called for a non-select operation");
+
+    graphlib::OpType::Attrs named_attrs = select_op->named_attrs();
+    std::vector<graphlib::OpType::Attr> attr = select_op->op_attrs();
+
+    assert(attr.size() == 4 && "Invalid attribute size for select operation: expected 4");
+
+    std::get<int>(attr[0]) = select_dim;
+    named_attrs["select_dim"] = select_dim;
+
+    if (begin.has_value())
     {
-        attr.push_back((int)new_shape[i]);
+        std::get<int>(attr[1]) = begin.value();
+        named_attrs["begin"] = begin.value();
     }
-    reshape->overwrite_op_attrs(attr);
+    else
+    {
+        named_attrs["begin"] = std::get<int>(attr[1]);
+    }
+
+    if (length.has_value())
+    {
+        std::get<int>(attr[2]) = length.value();
+        named_attrs["length"] = length.value();
+    }
+    else
+    {
+        named_attrs["length"] = std::get<int>(attr[2]);
+    }
+
+    if (stride.has_value())
+    {
+        std::get<int>(attr[3]) = stride.value();
+        named_attrs["stride"] = stride.value();
+    }
+    else
+    {
+        named_attrs["stride"] = std::get<int>(attr[3]);
+    }
+
+    select_op->overwrite_op_named_attrs(attr, named_attrs);
+    log_trace(
+        "Updated select operation {}: select_dim = {}, begin = {}, length = {}, stride = {}",
+        select_op->name(),
+        select_dim,
+        begin.value_or(std::get<int>(attr[1])),
+        length.value_or(std::get<int>(attr[2])),
+        stride.value_or(std::get<int>(attr[3])));
 }
 
+/**
+ * @brief Updates the attributes and named attributes of concat operation with new dimension.
+ */
+void update_concat_attr(graphlib::OpNode *concatenate, int dim)
+{
+    TT_ASSERT(concatenate->op_name() == "concatenate", "update_concat_attr called for a non-concatenate operation");
+
+    std::vector<graphlib::OpType::Attr> attr;
+    attr.push_back(dim);
+
+    graphlib::OpType::Attrs named_attrs = concatenate->named_attrs();
+    named_attrs["dim"] = dim;
+
+    concatenate->overwrite_op_named_attrs(attr, named_attrs);
+    log_trace("Concatenate operation updated with new dim: {}", dim);
+}
+/**
+ * @brief Updates the attributes and named attributes of vstack operation with new slice_size.
+ */
+void update_vstack_attr(graphlib::OpNode *vstack, int slice_size)
+{
+    TT_ASSERT(vstack->op_name() == "vstack", "update_vstack_attr called for a non-vstack operation");
+
+    std::vector<graphlib::OpType::Attr> attr;
+    attr.push_back(slice_size);
+
+    graphlib::OpType::Attrs named_attrs = vstack->named_attrs();
+    named_attrs["slice_size"] = slice_size;
+
+    vstack->overwrite_op_named_attrs(attr, named_attrs);
+    log_trace("Vstack operation updated with new slice_size: {}", slice_size);
+}
+/**
+ * @brief Updates the attributes and named attributes of grouped_reduce_avg operation with new reduction dimension.
+ */
+void update_grouped_reduce_avg_attr(graphlib::OpNode *reduce, int reduce_dim)
+{
+    TT_ASSERT(
+        reduce->op_name().find("grouped_reduce_avg") != std::string::npos,
+        "update_grouped_reduce_avg_attr called for non-grouped_reduce_avg op");
+
+    graphlib::OpType::Attrs named_attrs = reduce->named_attrs();
+    std::vector<graphlib::OpType::Attr> attr;
+
+    auto current_attrs = reduce->op_attrs();
+
+    attr.push_back(reduce_dim);
+    attr.push_back(current_attrs.size() > 1 ? current_attrs[1] : 1);  // Update groups attribute
+    attr.push_back(current_attrs.size() > 2 ? current_attrs[2] : 0);  // Update keep_dims attribute
+
+    named_attrs["reduce_dim"] = reduce_dim;
+    reduce->overwrite_op_named_attrs(attr, named_attrs);
+}
+/**
+ * @brief Updates the attributes and named attributes of reduce operation(reduce_sum, reduce_avg, reduce_max) with new
+ * reduction dimension.
+ */
+void update_reduce_attr(graphlib::OpNode *reduce, int reduce_dim)
+{
+    log_info("reduce->op_name() = {}", reduce->op_name());
+    TT_ASSERT(
+        reduce->op_name().find("reduce") != std::string::npos, "update_reduce_attr called for a non-reduce operation");
+
+    if (reduce->op_name() == "grouped_reduce_avg")
+    {
+        update_grouped_reduce_avg_attr(reduce, reduce_dim);
+        return;
+    }
+    std::vector<graphlib::OpType::Attr> attr;
+    attr.push_back(reduce_dim);
+
+    graphlib::OpType::Attrs named_attrs = reduce->named_attrs();
+    named_attrs["dim"] = reduce_dim;
+
+    reduce->overwrite_op_named_attrs(attr, named_attrs);
+    log_trace("Reduce operation updated with reduce_dim: {}", reduce_dim);
+}
+/**
+ * @brief Updates the attributes and named attributes of a matmul operation with new requantization zero point.
+ */
+void update_matmul_attr(graphlib::OpNode *matmul, int requant_zp)
+{
+    TT_ASSERT(matmul->op_name() == "matmul", "update_matmul_attr called for a non-matmul operation");
+
+    auto matmul_attrs = matmul->op_attrs();
+    matmul_attrs.push_back(requant_zp);
+    graphlib::OpType::Attrs named_attrs = matmul->named_attrs();
+    named_attrs["requant_zp"] = requant_zp;
+    matmul->overwrite_op_named_attrs(matmul_attrs, named_attrs);
+    log_trace("MatMul operation updated with new requant_zp: {}", requant_zp);
+}
+/**
+ * @brief Updates the padding attributes and named attributes of a convolution operation.
+ */
+void update_conv_attr(graphlib::OpNode *conv, const std::vector<int> &pad_attrs)
+{
+    TT_ASSERT(conv->op_name() == "conv2d", "update_conv_attr called for a non-conv operation");
+
+    std::vector<graphlib::OpType::Attr> conv_attrs = conv->op_attrs();
+
+    int pad_idx_offset = 4;
+    for (uint32_t i = 0; i < 4; i++)
+    {
+        if (i < pad_attrs.size())
+        {
+            conv_attrs[pad_idx_offset + i] = pad_attrs[i];
+        }
+    }
+    graphlib::OpType::Attrs named_attrs = conv->named_attrs();
+    named_attrs["padding"] = pad_attrs;
+    conv->overwrite_op_named_attrs(conv_attrs, named_attrs);
+    log_trace("Conv2d operation updated with new padding values: {}", pad_attrs);
+}
+/**
+ * @brief Updates the attributes and named attributes of a reshape operation with new shape.
+ */
+void update_reshape_attr(graphlib::OpNode *reshape, graphlib::Shape new_shape)
+{
+    if (reshape->op_name() == "transpose")
+        return;
+
+    TT_ASSERT(reshape->op_name() == "reshape", "update_reshape_attr called for a non-reshape operation");
+    graphlib::OpType::Attrs named_attrs;
+    std::vector<graphlib::OpType::Attr> attr;
+    std::vector<int> shape_vector;
+    for (auto dim : new_shape)
+    {
+        int dim_value = static_cast<int>(dim);
+        shape_vector.push_back(dim);
+        attr.push_back(dim_value);
+    }
+    named_attrs["shape"] = shape_vector;
+    reshape->overwrite_op_named_attrs(attr, named_attrs);
+}
 std::pair<bool, std::pair<std::vector<int>, std::vector<int>>> handle_shape_change_through_bcast(
     graphlib::Graph *graph,
     graphlib::OpNode *initial_op,
@@ -1160,7 +1342,7 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
                 std::get<int>(attr[bcast_dim]) = 1;
                 new_reshape_shape[bcast_dim] = 1;
                 op->set_shape(new_reshape_shape);
-                op->overwrite_op_attrs(attr);
+                update_reshape_attr(op, new_reshape_shape);
 
                 // Remove the broadcasts from operand
                 graph->get_edge_attributes(operand_edge)->clear_broadcast_dims();
@@ -1190,7 +1372,7 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
                 std::get<int>(attr[op->shape().size() - 1]) = 1;
                 new_reshape_shape[op->shape().size() - 1] = 1;
                 op->set_shape(new_reshape_shape);
-                op->overwrite_op_attrs(attr);
+                update_reshape_attr(op, new_reshape_shape);
 
                 // Remove the broadcasts from operand
                 graph->get_edge_attributes(operand_edge)->clear_broadcast_dims();
@@ -1216,7 +1398,7 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
                 std::get<int>(attr[op->shape().size() - 2]) = 1;
                 new_reshape_shape[op->shape().size() - 2] = 1;
                 op->set_shape(new_reshape_shape);
-                op->overwrite_op_attrs(attr);
+                update_reshape_attr(op, new_reshape_shape);
 
                 // Remove the broadcasts from operand
                 graph->get_edge_attributes(operand_edge)->clear_broadcast_dims();
@@ -1243,7 +1425,7 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
                 std::get<int>(attr[op->shape().size() + bcast_dim]) = 1;
                 new_reshape_shape[op->shape().size() + bcast_dim] = 1;
                 op->set_shape(new_reshape_shape);
-                op->overwrite_op_attrs(attr);
+                update_reshape_attr(op, new_reshape_shape);
 
                 // Remove the broadcasts from operand
                 graph->get_edge_attributes(operand_edge)->clear_broadcast_dims();

--- a/forge/csrc/passes/commute_utils.hpp
+++ b/forge/csrc/passes/commute_utils.hpp
@@ -143,6 +143,18 @@ bool can_commute_past_op(
     graphlib::Node *producer = nullptr);
 
 void update_reshape_attr(graphlib::OpNode *reshape, graphlib::Shape new_shape);
+void update_select_attr(
+    graphlib::OpNode *select_op,
+    int select_dim,
+    std::optional<int> begin = std::nullopt,
+    std::optional<int> length = std::nullopt,
+    std::optional<int> stride = std::nullopt);
+void update_concat_attr(graphlib::OpNode *op, int new_dim);
+void update_reduce_attr(graphlib::OpNode *reduce, int reduce_dim);
+void update_grouped_reduce_avg_attr(graphlib::OpNode *reduce, int reduce_dim);
+void update_matmul_attr(graphlib::OpNode *matmul, int requant_zp);
+void update_conv_attr(graphlib::OpNode *conv, const std::vector<int> &pad_attrs);
+void update_vstack_attr(graphlib::OpNode *vstack, int new_value);
 
 std::pair<bool, std::pair<std::vector<int>, std::vector<int>>> handle_shape_change_through_bcast(
     graphlib::Graph *graph,

--- a/forge/csrc/passes/fuse_pad_conv2d.cpp
+++ b/forge/csrc/passes/fuse_pad_conv2d.cpp
@@ -6,6 +6,7 @@
 
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/utils.hpp"
+#include "passes/commute_utils.hpp"
 #include "passes/consteval.hpp"
 #include "python_bindings_common.hpp"
 #include "utils/logger.hpp"
@@ -67,7 +68,13 @@ void fuse_pad_conv2d(graphlib::Graph *graph)
                 conv_attrs[pad_idx_offset + i] =
                     std::get<int>(pad_attrs[i]) + std::get<int>(conv_attrs[pad_idx_offset + i]);
             }
-            user_op->overwrite_op_attrs(conv_attrs);
+            std::vector<int> int_conv_attrs;
+            for (const auto &attr : conv_attrs)
+            {
+                int_conv_attrs.push_back(std::get<int>(attr));
+            }
+
+            update_conv_attr(user_op, int_conv_attrs);
         }
 
         // bypass the pad node

--- a/forge/csrc/passes/pre_lowering_passes.cpp
+++ b/forge/csrc/passes/pre_lowering_passes.cpp
@@ -4,6 +4,7 @@
 #include "passes/pre_lowering_passes.hpp"
 
 #include "graph_lib/utils.hpp"
+#include "passes/commute_utils.hpp"
 #include "python_bindings_common.hpp"
 #include "reportify/reportify.hpp"
 
@@ -456,7 +457,7 @@ void fuse_requantize(Graph *graph)
 
         // copy over zp attrs
         matmul_attrs.push_back(requant_attrs[0]);  // Add requant zp to the back of matmul attr
-        matmul->overwrite_op_attrs(matmul_attrs);
+        passes::update_matmul_attr(matmul, std::get<int>(requant_attrs[0]));
         auto matmul_forge_attr = matmul->op_type().forge_attrs;
         matmul_forge_attr["requant"] = "true";
         matmul->overwrite_forge_attrs(matmul_forge_attr);

--- a/forge/csrc/passes/replace_incommutable_patterns.cpp
+++ b/forge/csrc/passes/replace_incommutable_patterns.cpp
@@ -213,7 +213,7 @@ static bool attempt_replace_downward_pattern(
 
         std::vector<graphlib::OpType::Attr> grouped_reduce_attrs{reduce_dim, (int)clone_shape[reduce_dim - 1], true};
         op->change_op_type("grouped_reduce_avg");
-        op->overwrite_op_attrs(grouped_reduce_attrs);
+        update_grouped_reduce_avg_attr(op, reduce_dim);
         auto grouped_reduce_shape = commute_shape;
         op->set_shape(grouped_reduce_shape);
 

--- a/forge/csrc/passes/squeeze_to_reshape.cpp
+++ b/forge/csrc/passes/squeeze_to_reshape.cpp
@@ -7,6 +7,7 @@
 
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/utils.hpp"
+#include "passes/commute_utils.hpp"
 
 namespace tt::passes
 {
@@ -31,7 +32,8 @@ bool squeeze_to_reshape(graphlib::Graph *graph)
         }
 
         op->change_op_type("reshape");
-        op->overwrite_op_attrs(shape);
+        graphlib::Shape new_shape = graphlib::Shape::create(shape_vec);
+        update_reshape_attr(op, new_shape);
         changed_anything = true;
     }
     return changed_anything;

--- a/forge/csrc/test/passes/test_erase_inverse_ops.cpp
+++ b/forge/csrc/test/passes/test_erase_inverse_ops.cpp
@@ -278,3 +278,376 @@ TEST_F(CommuteBroadcastThroughTranspose, commute_broadcast_through_transpose)
     EXPECT_EQ(std::get<int>(tms[1].attr[0]), -3);
     EXPECT_EQ(std::get<int>(tms[1].attr[1]), 112);
 }
+
+struct UpdateReshapeNamedAttrsTest : testing::Test
+{
+    graphlib::Graph *graph;
+
+    UpdateReshapeNamedAttrsTest()
+    {
+        graph = new graphlib::Graph(graphlib::IRLevel::IR_TT_FORGE, "UpdateReshapeNamedAttrs");
+
+        graphlib::Shape initial_shape = graphlib::Shape::create({1, 512, 160});
+        tt::graphlib::InputNode *input_node = create_input(*graph, "input", initial_shape);
+
+        auto reshape_node = add_node<graphlib::PyOpNode>(*graph, "reshape", "reshape", {1, 1, 512 * 160}, {input_node});
+
+        create_output(*graph, "out", reshape_node);
+    }
+};
+
+TEST_F(UpdateReshapeNamedAttrsTest, update_named_attrs)
+{
+    graphlib::Node *reshape = graph->get_node_by_name("reshape");
+    ASSERT_NE(reshape, nullptr) << "Reshape node not found.";
+
+    graphlib::OpNode *op_node_reshape = dynamic_cast<graphlib::OpNode *>(reshape);
+    ASSERT_NE(op_node_reshape, nullptr) << "Node is not of type OpNode.";
+
+    graphlib::Shape new_shape = graphlib::Shape::create({1, 512, 160, 1});
+    op_node_reshape->set_shape(new_shape);
+    passes::update_reshape_attr(op_node_reshape, new_shape);
+
+    auto updated_attrs = op_node_reshape->op_type().named_attrs;
+    EXPECT_TRUE(updated_attrs.count("shape")) << "Shape attribute not found.";
+    auto shape_vector = std::get<std::vector<int>>(updated_attrs["shape"]);
+
+    std::vector<std::uint32_t> shape_vector_uint(shape_vector.begin(), shape_vector.end());
+    graphlib::Shape updated_shape = graphlib::Shape::create(shape_vector_uint);
+
+    // Compare updated_shape with new_shape
+    EXPECT_EQ(updated_shape, new_shape) << "Shape attribute does not match expected value.";
+
+    // Verify the node's shape
+    EXPECT_EQ(op_node_reshape->shape(), new_shape);
+}
+
+struct UpdateSelectNamedAttrsTest : testing::Test
+{
+    graphlib::Graph *graph;
+
+    UpdateSelectNamedAttrsTest()
+    {
+        int dim = 1;
+        int begin = 0;
+        int length = 5;
+        int stride = 1;
+        graph = new graphlib::Graph(graphlib::IRLevel::IR_TT_FORGE, "UpdateSelectNamedAttrs");
+
+        graphlib::Shape initial_shape = graphlib::Shape::create({1, 512, 160});
+        tt::graphlib::InputNode *input_node = create_input(*graph, "input", initial_shape);
+        auto select_node =
+            add_node<graphlib::PyOpNode>(*graph, "select", "select", {dim, begin, length, stride}, {input_node});
+
+        create_output(*graph, "out", select_node);
+    }
+};
+
+TEST_F(UpdateSelectNamedAttrsTest, update_named_attrs)
+{
+    graphlib::Node *select = graph->get_node_by_name("select");
+    ASSERT_NE(select, nullptr) << "Select node not found.";
+
+    graphlib::OpNode *op_node_select = dynamic_cast<graphlib::OpNode *>(select);
+    ASSERT_NE(op_node_select, nullptr) << "Node is not of type OpNode.";
+
+    int select_dim = 1;
+    graphlib::Shape commute_shape = graphlib::Shape::create({1, 3, 512, 160});
+
+    passes::update_select_attr(op_node_select, select_dim);
+
+    auto updated_attrs = op_node_select->named_attrs();
+
+    EXPECT_TRUE(updated_attrs.count("select_dim")) << "select_dim attribute not found.";
+    EXPECT_EQ(std::get<int>(updated_attrs["select_dim"]), select_dim) << "select_dim does not match expected value.";
+}
+
+struct UpdateConcatNamedAttrsTest : testing::Test
+{
+    graphlib::Graph *graph;
+    graphlib::OpNode *reshape_0;
+    graphlib::OpNode *reshape_1;
+    graphlib::OpNode *reshape_2;
+
+    UpdateConcatNamedAttrsTest()
+    {
+        graph = new graphlib::Graph(graphlib::IRLevel::IR_TT_FORGE, "UpdateConcatNamedAttrs");
+
+        graphlib::Shape shape_0 = graphlib::Shape::create({1, 512, 160});
+        graphlib::Shape shape_1 = graphlib::Shape::create({1, 512, 160});
+        graphlib::Shape shape_2 = graphlib::Shape::create({1, 512, 160});
+
+        tt::graphlib::InputNode *input_node_0 = create_input(*graph, "input_0", shape_0);
+        tt::graphlib::InputNode *input_node_1 = create_input(*graph, "input_1", shape_1);
+        tt::graphlib::InputNode *input_node_2 = create_input(*graph, "input_2", shape_2);
+
+        reshape_0 = add_node<graphlib::PyOpNode>(*graph, "reshape_0", "reshape", {1, 1, 512 * 160}, {input_node_0});
+        reshape_1 = add_node<graphlib::PyOpNode>(*graph, "reshape_1", "reshape", {1, 1, 512 * 160}, {input_node_1});
+        reshape_2 = add_node<graphlib::PyOpNode>(*graph, "reshape_2", "reshape", {1, 1, 512 * 160}, {input_node_2});
+
+        auto concat_node =
+            add_node<graphlib::PyOpNode>(*graph, "concat", "concatenate", {-2}, {reshape_0, reshape_1, reshape_2});
+
+        create_output(*graph, "out", concat_node);
+    }
+};
+
+TEST_F(UpdateConcatNamedAttrsTest, update_named_attrs)
+{
+    graphlib::Node *concat = graph->get_node_by_name("concat");
+    ASSERT_NE(concat, nullptr) << "Concatenate node not found.";
+    graphlib::OpNode *op_node_concat = dynamic_cast<graphlib::OpNode *>(concat);
+    ASSERT_NE(op_node_concat, nullptr) << "Node is not of type OpNode.";
+    int new_dim = 2;
+    passes::update_concat_attr(op_node_concat, new_dim);
+    auto updated_attrs = op_node_concat->named_attrs();
+    EXPECT_TRUE(updated_attrs.count("dim")) << "Dim attribute not found.";
+    auto dim_value = std::get<int>(updated_attrs["dim"]);
+    EXPECT_EQ(dim_value, new_dim) << "Dim attribute does not match expected value.";
+}
+
+struct UpdateVStackAttrsTest : testing::Test
+{
+    graphlib::Graph *graph;
+    graphlib::OpNode *vstack_node;
+
+    UpdateVStackAttrsTest()
+    {
+        graph = new graphlib::Graph(graphlib::IRLevel::IR_TT_FORGE, "UpdateVStackAttrs");
+
+        graphlib::Shape shape_0 = graphlib::Shape::create({32, 512, 160});
+
+        auto input_node_0 = create_input(*graph, "input_0", shape_0);
+
+        vstack_node = add_node<graphlib::PyOpNode>(*graph, "vstack", "vstack", {16}, {input_node_0});
+
+        create_output(*graph, "out", vstack_node);
+    }
+};
+
+TEST_F(UpdateVStackAttrsTest, update_vstack_attr)
+{
+    graphlib::Node *vstack = graph->get_node_by_name("vstack");
+    ASSERT_NE(vstack, nullptr) << "VStack node not found.";
+    graphlib::OpNode *op_node_vstack = dynamic_cast<graphlib::OpNode *>(vstack);
+    ASSERT_NE(op_node_vstack, nullptr) << "Node is not of type OpNode.";
+
+    int new_slice_size = 32;
+
+    passes::update_vstack_attr(op_node_vstack, new_slice_size);
+
+    auto updated_attrs = op_node_vstack->named_attrs();
+
+    EXPECT_TRUE(updated_attrs.count("slice_size")) << "Slice size attribute not found.";
+    auto slice_size_value = std::get<int>(updated_attrs["slice_size"]);
+    EXPECT_EQ(slice_size_value, new_slice_size) << "Slice size attribute does not match expected value.";
+}
+
+struct UpdateMatMulNamedAttrsTest : testing::Test
+{
+    graphlib::Graph *graph;
+    graphlib::OpNode *matmul;
+
+    UpdateMatMulNamedAttrsTest()
+    {
+        graph = new graphlib::Graph(graphlib::IRLevel::IR_TT_FORGE, "UpdateMatMulNamedAttrs");
+
+        graphlib::Shape shape_0 = graphlib::Shape::create({1, 512, 512});
+        graphlib::Shape shape_1 = graphlib::Shape::create({512, 512});
+
+        auto input_node_0 = create_input(*graph, "input_0", shape_0);
+        auto input_node_1 = create_input(*graph, "input_1", shape_1);
+
+        matmul = add_node<graphlib::PyOpNode>(*graph, "matmul", "matmul", {}, {input_node_0, input_node_1});
+        create_output(*graph, "output", matmul);
+    }
+};
+
+TEST_F(UpdateMatMulNamedAttrsTest, update_named_attrs)
+{
+    graphlib::Node *matmul_node = graph->get_node_by_name("matmul");
+    ASSERT_NE(matmul_node, nullptr) << "MatMul node not found.";
+
+    graphlib::OpNode *op_node_matmul = dynamic_cast<graphlib::OpNode *>(matmul_node);
+    ASSERT_NE(op_node_matmul, nullptr) << "Node is not of type OpNode.";
+    int requant_zp = 128;
+    passes::update_matmul_attr(op_node_matmul, requant_zp);
+    auto updated_attrs = op_node_matmul->named_attrs();
+    EXPECT_TRUE(updated_attrs.count("requant_zp")) << "Requant zp attribute not found.";
+
+    auto zp_value = std::get<int>(updated_attrs["requant_zp"]);
+    EXPECT_EQ(zp_value, requant_zp) << "Requant zp attribute does not match expected value.";
+
+    auto matmul_attrs = op_node_matmul->op_attrs();
+    ASSERT_FALSE(matmul_attrs.empty()) << "MatMul attributes should not be empty.";
+    EXPECT_EQ(std::get<int>(matmul_attrs.back()), requant_zp) << "Requant zp not correctly appended to op_attrs.";
+}
+
+struct UpdateConvAttrsTest : testing::Test
+{
+    graphlib::Graph *graph;
+    graphlib::OpNode *conv_node;
+
+    UpdateConvAttrsTest()
+    {
+        graph = new graphlib::Graph(graphlib::IRLevel::IR_TT_FORGE, "UpdateConvAttrsTest");
+
+        graphlib::Shape shape_0 = graphlib::Shape::create({1, 256, 224, 224});
+        tt::graphlib::InputNode *input_node_0 = create_input(*graph, "input_0", shape_0);
+
+        graphlib::Shape weight_shape = graphlib::Shape::create({256, 256, 3, 3});
+        tt::graphlib::InputNode *weight_node = create_input(*graph, "weight", weight_shape);
+
+        conv_node = add_node<graphlib::PyOpNode>(
+            *graph, "conv2d", "conv2d", {3, 3, 1, 1, 0, 0, 1, 1, 1}, {input_node_0, weight_node});
+        auto named_attrs = conv_node->named_attrs();
+        named_attrs["channel_last"] = false;
+        named_attrs["padding_top"] = 1;
+        named_attrs["padding_bottom"] = 1;
+        named_attrs["padding_left"] = 1;
+        named_attrs["padding_right"] = 1;
+        named_attrs["stride_height"] = 1;
+        named_attrs["stride_width"] = 1;
+        named_attrs["dilation_height"] = 1;
+        named_attrs["dilation_width"] = 1;
+
+        conv_node->overwrite_named_attrs(named_attrs);
+        create_output(*graph, "out", conv_node);
+    }
+};
+
+TEST_F(UpdateConvAttrsTest, update_padding_attrs)
+{
+    graphlib::Node *conv = graph->get_node_by_name("conv2d");
+    ASSERT_NE(conv, nullptr) << "Conv2d node not found.";
+
+    graphlib::OpNode *op_node_conv = dynamic_cast<graphlib::OpNode *>(conv);
+    ASSERT_NE(op_node_conv, nullptr) << "Node is not of type OpNode.";
+
+    std::vector<int> new_padding = {2, 3, 4, 5};
+
+    passes::update_conv_attr(op_node_conv, new_padding);
+
+    auto updated_attrs = op_node_conv->op_type().named_attrs;
+
+    EXPECT_TRUE(updated_attrs.count("padding")) << "Padding attribute not found in named attributes.";
+    auto updated_padding = std::get<std::vector<int>>(updated_attrs["padding"]);
+
+    EXPECT_EQ(updated_padding, new_padding) << "Padding attribute does not match the expected values.";
+
+    auto conv_attrs = op_node_conv->op_attrs();
+    int pad_idx_offset = 4;
+    for (size_t i = 0; i < 4; i++)
+    {
+        EXPECT_EQ(std::get<int>(conv_attrs[pad_idx_offset + i]), new_padding[i])
+            << "Padding value at index " << i << " does not match the expected value.";
+    }
+}
+
+struct UpdateReduceAttrsTest : testing::Test
+{
+    graphlib::Graph *graph;
+    graphlib::OpNode *reduce_node;
+
+    UpdateReduceAttrsTest() { graph = new graphlib::Graph(graphlib::IRLevel::IR_TT_FORGE, "UpdateReduceAttrs"); }
+
+   protected:
+    graphlib::OpNode *create_graph(const std::string &reduce_op, int reduce_dim, const graphlib::Shape &input_shape)
+    {
+        auto input_node = create_input(*graph, "input", input_shape);
+
+        reduce_node = add_node<graphlib::PyOpNode>(
+            *graph,
+            reduce_op,
+            reduce_op,
+            {
+                reduce_dim,
+            },
+            {input_node});
+        auto &named_attrs = reduce_node->named_attrs();
+        named_attrs["dim"] = reduce_dim;
+        reduce_node->overwrite_named_attrs(named_attrs);
+        create_output(*graph, "out", reduce_node);
+
+        return reduce_node;
+    }
+};
+
+TEST_F(UpdateReduceAttrsTest, ReduceSumDim)
+{
+    std::string reduce_op = "reduce_sum";
+    int reduce_dim = 1;
+    graphlib::Shape input_shape = graphlib::Shape::create({1, 512, 160});
+    graphlib::Shape expected_shape = graphlib::Shape::create({1, 1, 160});
+
+    auto reduce_node = create_graph(reduce_op, reduce_dim, input_shape);
+
+    passes::update_reduce_attr(reduce_node, reduce_dim);
+
+    auto updated_attrs = reduce_node->named_attrs();
+    ASSERT_TRUE(updated_attrs.count("dim"));
+    EXPECT_EQ(std::get<int>(updated_attrs["dim"]), reduce_dim);
+}
+
+TEST_F(UpdateReduceAttrsTest, ReduceMaxDim)
+{
+    std::string reduce_op = "reduce_max";
+    int reduce_dim = 2;
+    graphlib::Shape input_shape = graphlib::Shape::create({1, 512, 160});
+    graphlib::Shape expected_shape = graphlib::Shape::create({1, 512, 1});
+
+    auto reduce_node = create_graph(reduce_op, reduce_dim, input_shape);
+
+    passes::update_reduce_attr(reduce_node, reduce_dim);
+
+    auto updated_attrs = reduce_node->named_attrs();
+
+    ASSERT_TRUE(updated_attrs.count("dim"));
+    EXPECT_EQ(std::get<int>(updated_attrs["dim"]), reduce_dim);
+}
+
+struct UpdateGroupedReduceAvgTest : testing::Test
+{
+    graphlib::Graph *graph;
+    graphlib::OpNode *reduce_node;
+
+    UpdateGroupedReduceAvgTest()
+    {
+        graph = new graphlib::Graph(graphlib::IRLevel::IR_TT_FORGE, "UpdateGroupedReduceAvg");
+    }
+
+   protected:
+    graphlib::OpNode *create_graph(
+        const std::string &reduce_op, const std::vector<int> &attr, const graphlib::Shape &input_shape)
+    {
+        auto input_node = create_input(*graph, "input", input_shape);
+        reduce_node =
+            add_node<graphlib::PyOpNode>(*graph, reduce_op, reduce_op, {attr[0], attr[1], attr[2]}, {input_node});
+        auto &named_attrs = reduce_node->named_attrs();
+        named_attrs["reduce_dim"] = attr[0];
+        named_attrs["groups"] = attr[1];
+        named_attrs["keep_dims"] = attr[2];
+        reduce_node->overwrite_named_attrs(named_attrs);
+
+        create_output(*graph, "out", reduce_node);
+
+        return reduce_node;
+    }
+};
+
+TEST_F(UpdateGroupedReduceAvgTest, GroupedReduceAvgDim)
+{
+    std::string reduce_op = "grouped_reduce_avg";
+    std::vector<int> attr = {1, 4, 1};
+    graphlib::Shape input_shape = graphlib::Shape::create({1, 512, 160});
+    graphlib::Shape expected_shape = graphlib::Shape::create({1, 4, 160});
+
+    auto reduce_node = create_graph(reduce_op, attr, input_shape);
+
+    passes::update_grouped_reduce_avg_attr(reduce_node, attr[0]);
+
+    auto updated_attrs = reduce_node->named_attrs();
+
+    ASSERT_TRUE(updated_attrs.count("reduce_dim"));
+    EXPECT_EQ(std::get<int>(updated_attrs["reduce_dim"]), attr[0]);
+}


### PR DESCRIPTION
Fixes #704 
overwrite_op_attrs has been deprecated and replaced with op specific named attr functions.
overwrite_op_named_attrs has been created to update both attrs and named attrs , the specific attribute to be updated in named attrs will be passed through update function of corresponding op (reshape, concat, select, reduce, matmul etc.)

update_reshape_attr -> Updates shape attribute in attrs and named attrs
update_select_attr ->  Updates select_dim, begin, length, and stride attributes in attrs and named_attrs
update_reduce_attr -> Updates the reduce_dim attribute in attrs and named_attrs
update_concat_attr -> Updates the dim attribute in attrs and named_attrs
update_grouped_reduce_avg -> Updates reduce_dim and other attributes in attrs and named_attrs
update_conv_attr -> Updates padding attributes in attrs and named_attrs for a conv2d operation.
update_matmul_attr -> Updates the requant_zp attribute in attrs and named_attrs
update_vstack_attr -> Updates the slice_size attribute in attrs and named_attrs