### PR TITLE
add support for avgpool3d using avgpool2d

### DIFF
--- a/forge/forge/op/__init__.py
+++ b/forge/forge/op/__init__.py
@@ -5,7 +5,7 @@
 from .matmul import Matmul, SparseMatmul
 
 from .convolution import Conv2d, Conv2dTranspose, Conv3d
-from .pooling import MaxPool1d, MaxPool2d, MaxPool3d, AvgPool1d, AvgPool2d
+from .pooling import MaxPool1d, MaxPool2d, MaxPool3d, AvgPool1d, AvgPool2d, AvgPool3d
 from .eltwise_binary import (
     Add,
     Divide,

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -117,6 +117,7 @@ op_to_module_map = {
     "max_pool3d": "pooling",
     "avg_pool1d": "pooling",
     "avg_pool2d": "pooling",
+    "avg_pool3d": "pooling",
     "constant": "constant",
     "resize2d": "resize",
     "resize3d": "resize",

--- a/forge/forge/op/eval/forge/pooling.py
+++ b/forge/forge/op/eval/forge/pooling.py
@@ -293,6 +293,41 @@ def eval(type, attr, ops):
         if channel_last:
             result = result.permute(0, 2, 3, 1)
 
+    elif type == "avg_pool3d":
+
+        kernel_size = [attr[0], attr[1], attr[2]]
+        stride = [attr[3], attr[4], attr[5]]
+        dilation = attr[6]
+        ceil_mode = attr[7]
+        padding = [attr[8], attr[9], attr[10], attr[11], attr[12], attr[13]]
+        count_include_pad = attr[-2]
+        channel_last = attr[-1]
+
+        assert padding[0] == padding[1] and padding[2] == padding[3] and padding[4] == padding[5], (
+            f"Padding values must be symmetric. Got: "
+            f"pad_front={padding[0]}, pad_back={padding[1]}, "
+            f"pad_top={padding[2]}, pad_bottom={padding[3]}, "
+            f"pad_left={padding[4]}, pad_right={padding[5]}"
+        )
+
+        padding = [padding[0], padding[2], padding[4]]
+
+        if channel_last:
+            activations = activations.permute(0, 4, 1, 2, 3)
+
+        result = torch.nn.functional.avg_pool3d(
+            activations,
+            kernel_size=kernel_size,
+            stride=stride,
+            padding=padding,
+            ceil_mode=bool(ceil_mode),
+            count_include_pad=count_include_pad,
+            divisor_override=None,
+        )
+
+        if channel_last:
+            result = result.permute(0, 2, 3, 4, 1)
+
     return result
 
 
@@ -372,8 +407,12 @@ def shape(type, attr, ops):
             result = (activations[0], activations[1], y, x)
 
         return result, []
-    elif type == "max_pool3d":
-        assert len(attr) == 17, f"Got len(attr) = {len(attr)} for type: {type}"
+
+    elif type == "max_pool3d" or "avg_pool3d":
+
+        assert (len(attr) == 17 and type == "max_pool3d") or (
+            type == "avg_pool3d" and len(attr) == 16
+        ), f"Got len(attr) = {len(attr)} for type: {type}"
         kernel_size = [attr[0], attr[1], attr[2]]
         stride = [attr[3], attr[4], attr[5]]
         dilation = attr[6]
@@ -588,6 +627,94 @@ def decompose(type, attr, dc, inputs):
                 result = dc.op_with_named_attrs(
                     "reshape", [result], {"shape": (w, cin, y_out, x_out)}, (w, cin, y_out, x_out)
                 )
+
+        dc.fuse(result)
+
+    elif type == "avg_pool3d":
+        # Slice the input tensor along the depth dimension.
+        #     - Input shape: (B, C, D_in, H_in, W_in)
+        #     - After depth slicing: (B, C, kD, H_in, W_in)
+        # Then, the depth dimension is averaged across, reducing it to a single depth slice.
+        #     - After averaging along depth: (B, C, 1, H_in, W_in)
+        # A 2D pooling operation is applied along the spatial dimensions (H_in, W_in).
+        #     - After 2D pooling: (B, C, H_out, W_out)
+        # To match the final output shape, we add an extra singleton dimension to depth.
+        #     - After unsqueeze: (B, C, 1, H_out, W_out)
+        # Finally, the outputs from the depth slices are concatenated.
+        #     - Final shape after all concatenations: (B, C, D_out, H_out, W_out)
+
+        kernel_size = [attr[0], attr[1], attr[2]]
+        stride = [attr[3], attr[4], attr[5]]
+        dilation = attr[6]
+        ceil_mode = attr[7]
+        padding = [attr[8], attr[9], attr[10], attr[11], attr[12], attr[13]]
+        count_include_pad = attr[-2]
+        channel_last = attr[-1]
+
+        activations = inputs[0]
+
+        w, cin, din, y, x = (
+            activations.shape.v,
+            activations.shape.w,
+            activations.shape.z,
+            activations.shape.r,
+            activations.shape.c,
+        )
+
+        kD, kH, kW = kernel_size
+        sD, sH, sW = stride
+
+        pad_d1, pad_h1, pad_w1, pad_d2, pad_h2, pad_w2 = padding
+
+        out_depth = (din - kD + pad_d1 + pad_d2) // sD + 1
+        out_height = (y - kH + pad_h1 + pad_h2) // sH + 1
+        out_width = (x - kW + pad_w1 + pad_w2) // sW + 1
+
+        result = dc.tensor(torch.zeros((activations.shape[0], cin, 0, out_height, out_width)))
+
+        for i in range(out_depth):
+
+            d_start = i * sD
+
+            depth_slice = dc.op("index", [activations], (2, d_start, d_start + kD, activations.shape[2]))
+            depth_avg = dc.op_with_named_attrs("reduce_avg", [depth_slice], {"dim": 2, "keep_dim": True}, (2,))
+
+            named_attrs = {
+                "kernel_height": kernel_size[1],
+                "kernel_width": kernel_size[2],
+                "stride_height": stride[1],
+                "stride_width": stride[2],
+                "dilation": dilation,
+                "ceil_mode": ceil_mode,
+                "padding_left": padding[1],
+                "padding_right": padding[2],
+                "padding_top": padding[4],
+                "padding_bottom": padding[5],
+                "count_include_pad": count_include_pad,
+                "channel_last": channel_last,
+            }
+
+            attr = (
+                kernel_size[1],
+                kernel_size[2],
+                stride[1],
+                stride[2],
+                dilation,
+                ceil_mode,
+                padding[1],
+                padding[2],
+                padding[4],
+                padding[5],
+                count_include_pad,
+                channel_last,
+            )
+
+            depth_avg_pooled = dc.op_with_named_attrs("avg_pool2d", [depth_avg], named_attrs, attr)
+
+            depth_avg_pooled = dc.op_with_named_attrs(
+                "unsqueeze", [depth_avg_pooled], {"dim": 2}, (0, len(depth_avg_pooled.shape))
+            )
+            result = dc.op_with_named_attrs("concatenate", [result, depth_avg_pooled], {"dim": (2)}, (2,))
 
         dc.fuse(result)
 

--- a/forge/forge/op/pooling.py
+++ b/forge/forge/op/pooling.py
@@ -278,3 +278,61 @@ def AvgPool2d(
         activations,
         attrs=attrs,  # 1 is placeholder for dilation
     ).get_tensor()
+
+
+def AvgPool3d(
+    name: str,
+    activations: Tensor,
+    kernel_size: Union[int, Tuple[int, int, int]],
+    stride: int = 1,
+    padding: Union[int, str] = "same",
+    ceil_mode: bool = False,
+    count_include_pad: bool = True,
+    divisor_override: float = None,
+    channel_last: bool = False,
+) -> Tensor:
+    """
+    Avgpool3d transformation on input activations
+    Parameters
+    ----------
+    name: str
+        Op name, unique to the module, or leave blank to autoset
+    activations: Tensor
+        Input activations of shape (N, Cin, iD, iH, iW)
+    kernel_size:
+        Size of pooling region
+    """
+    assert divisor_override is None, f"divisor_override={divisor_override} is not supported. Please set it to None."
+    assert isinstance(
+        kernel_size, (int, tuple, list)
+    ), f"Invalid type for kernel_size: {type(kernel_size)}. Expected an int or tuple/list of integers"
+
+    if isinstance(stride, int):
+        stride = [stride] * 3
+
+    if isinstance(kernel_size, int):
+        kernel_size = [kernel_size] * 3
+    elif isinstance(kernel_size, Tuple):
+        kernel_size = list(kernel_size)
+    if padding == "same":
+
+        padding = [
+            kernel_size[2] // 2,
+            kernel_size[2] // 2,
+            kernel_size[1] // 2,
+            kernel_size[1] // 2,
+            kernel_size[0] // 2,
+            kernel_size[0] // 2,
+        ]
+    if isinstance(padding, int):
+        padding = [padding] * 6  # [left, right, top, bottom, front, back]
+
+    dilation = 1  # Only as place holder to standardize interface with MaxPool3d
+    attrs = kernel_size + stride + [dilation, ceil_mode] + padding + [count_include_pad] + [channel_last]
+
+    return op(
+        "avg_pool3d",
+        name,
+        activations,
+        attrs=attrs,  # 1 is placeholder for dilation
+    ).get_tensor()

--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -15,6 +15,45 @@ from forge.tensor import to_forge_tensors, to_pt_tensors
 
 
 @pytest.mark.parametrize(
+    "shape, kernel_size, stride",
+    [
+        ((1, 1, 100, 54, 54), (5, 1, 1), (1, 1, 1)),
+        ((1, 2, 5, 5, 5), (3, 3, 3), (2, 2, 2)),
+        ((1, 4, 100, 54, 54), (3, 1, 1), (1, 1, 1)),
+        ((1, 8, 32, 16, 16), (4, 1, 1), (1, 1, 1)),
+        ((1, 1, 100, 54, 54), (5, 1, 1), (5, 1, 1)),
+        ((1, 4, 10, 4, 4), (1, 1, 1), (1, 1, 1)),
+        ((1, 16, 32, 16, 16), (8, 1, 1), (3, 3, 3)),
+    ],
+)
+@pytest.mark.push
+def test_avgpool3d(shape, kernel_size, stride):
+    class AvgPool3D(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            return nn.functional.avg_pool3d(x, kernel_size=kernel_size, stride=stride)
+
+    compiler_cfg = forge.config._get_global_compiler_config()
+    compiler_cfg.compile_depth = (
+        forge.CompileDepth.SPLIT_GRAPH
+    )  # Due to #https://github.com/tenstorrent/tt-mlir/issues/1343
+    inputs = [torch.rand(shape)]
+
+    framework_model = AvgPool3D()
+    fw_out = framework_model(*inputs)
+
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    if compiler_cfg.compile_depth == forge.CompileDepth.FULL:
+        co_out = compiled_model(*inputs)
+        co_out = [co.to("cpu") for co in co_out]
+        fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+        assert all([compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])
+
+
+@pytest.mark.parametrize(
     "input_shape, kernel_size, stride_size, padding, ceil_mode",
     [
         pytest.param(


### PR DESCRIPTION
This PR fixes https://github.com/tenstorrent/tt-forge-fe/issues/713

Following **Avgpool3d Decomposition** logic inspired from this [suggestion](https://github.com/tenstorrent/tt-forge-fe/pull/714#issuecomment-2478619385)

- Input tensor is sliced along the depth dimension
- average computed along the depth slice
- avg_pool2d is applied on the pooled depth slice
- pooled depth slice is unsqueezed to add the depth dimension.
- processed depth slice is concatenated along the depth dimension

**shapes after each operation**

- Input Shape: (B, C, D_in, H_in, W_in)
- After Depth Slicing: (B, C, kD, H_in, W_in)
- After Averaging Along Depth: (B, C, 1, H_in, W_in)
- After 2D Pooling: (B, C, H_out, W_out)
- After Unsqueeze: (B, C, 1, H_out, W_out) 
- Final shape After all Concatenation: (B, C, D_out, H_out, W_out)

**Pseudocode**

  ```
  def forward(self, x):

    k_d, k_h, k_w = self.kernel_size
    s_d, s_h, s_w = self.stride
    batch, channels, depth, height, width = x.shape
    out_depth = (depth - k_d) // s_d + 1
    out_height = (height - k_h) // s_h + 1
    out_width = (width - k_w) // s_w + 1

    output = torch.zeros((batch, channels, 0, out_height, out_width))

    for i in range(out_depth):
        d_start = i * s_d
        depth_slice = x.narrow(2, d_start, k_d)
        depth_avg = torch.mean(depth_slice, dim=2)
        depth_avg_pooled = F.avg_pool2d(depth_avg, kernel_size=(k_h, k_w), stride=(s_h, s_w))
        depth_avg_pooled = depth_avg_pooled.unsqueeze(2)
        output = torch.cat((output, depth_avg_pooled), dim=2)
    
    return output

```

- This decomposition faced Dim related assertion failure at MLIR compile stage  which leads to seg fault - https://github.com/tenstorrent/tt-mlir/issues/1343. so instead of xfail , compile depth is set
