### PR TITLE
Remove repeat decompose and map to ttnn's repeat ops respectively

### DIFF
--- a/forge/csrc/passes/consteval.cpp
+++ b/forge/csrc/passes/consteval.cpp
@@ -37,7 +37,7 @@ static bool input_can_consteval(graphlib::Graph *graph, graphlib::InputNode *inp
         graphlib::OpNode *op = dynamic_cast<graphlib::OpNode *>(n);
         if (not op)
             return false;
-        return op->op_name() == "broadcast" or op->op_name() == "repeat" or op->op_name() == "repeat_dim";
+        return op->op_name() == "broadcast" or op->op_name() == "repeat" or op->op_name() == "repeat_interleave";
     };
 
     TT_ASSERT(graphlib::is_consteval_capable_input_type(input));

--- a/forge/csrc/passes/pre_placer_forge_passes.cpp
+++ b/forge/csrc/passes/pre_placer_forge_passes.cpp
@@ -1105,7 +1105,7 @@ void constant_pre_broadcast(Graph *graph)
         {
             std::vector<graphlib::Shape> input_shapes = {current_shape};
             auto [shape, bcast_dims] = get_op_shape(op_type, input_shapes, true);
-            op_type.op = "repeat_dim";
+            op_type.op = "repeat_interleave";
             auto broadcast = graphlib::create_node<graphlib::PyOpNode>(
                 "broadcast" + std::to_string(std::get<int>(op_type.attr[0])) + "_" + input->name(), op_type);
             broadcast->set_shape(shape);

--- a/forge/forge/op/__init__.py
+++ b/forge/forge/op/__init__.py
@@ -63,6 +63,7 @@ from .tm import (
     PadTile,
     Broadcast,
     Repeat,
+    RepeatInterleave,
     AdvIndex,
     Narrow,
     Unsqueeze,

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -90,7 +90,7 @@ op_to_module_map = {
     "vstack": "tm",
     "broadcast": "tm",
     "repeat": "tm",
-    "repeat_dim": "tm",
+    "repeat_interleave": "tm",
     "conv2d_depthwise_weights": "tm",
     "conv2d_depthwise_weights_bw": "tm",
     "conv2d_grouped_weights": "tm",

--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -179,16 +179,11 @@ def eval(type, attr, ops):
         assert len(t_ops[0].shape) == len(sizes)
         return t_ops[0].repeat(*sizes)
 
-    if type == "repeat_dim":
-        assert len(attr) <= 3, "repeat should have two attributes - dim and size"
-        dim = attr[0]
-        if dim < 0:
-            dim += len(t_ops[0].shape)
-        factor = attr[1]
-        assert dim > 0, "Don't support broadcasting on w"
-        sizes = [1] * len(t_ops[0].shape)
-        sizes[dim] = factor
-        return t_ops[0].repeat(*sizes)
+    if type == "repeat_interleave":
+        assert len(attr) == 2, "repeat_interleave should have two attributes - repeats and dim"
+        repeats = attr[0]
+        dim = attr[1]
+        return t_ops[0].repeat_interleave(repeats=repeats, dim=dim)
 
     if type == "conv2d_depthwise_weights":
         weights = t_ops[0]
@@ -530,14 +525,15 @@ def shape(type, attr, ops):
         sizes = attr
         return tuple(dim * size for dim, size in zip(list(ops[0]), sizes)), []
 
-    if type == "repeat_dim":
-        assert len(attr) <= 3, "repeat should have two attributes - dim and size"
-        dim = attr[0]
+    if type == "repeat_interleave":
+        assert len(attr) <= 3, "repeat should have two attributes - repeats and dim"
+        repeats = attr[0]
+        dim = attr[1]
+
         if dim < 0:
             dim += len(ops[0])
-        factor = attr[1]
         target_shape = list(ops[0])
-        target_shape[dim] *= factor
+        target_shape[dim] *= repeats
         return tuple(target_shape), []
 
     if type == "conv2d_depthwise_weights":
@@ -783,20 +779,23 @@ def lower(type, attr, lc, ops, outputs):
         return lc.tm("broadcast", ops[0], attr)
 
     elif type == "repeat":
-        assert False, "repeat should have been decomposed into repeat_dim"
+        assert False, "repeat should have been decomposed into repeat_interleave"
 
-    elif type == "repeat_dim":
-        # Adjust the repeat dim if we're moving to more/less dimensions
-        if attr[0] < 0:
-            attr[0] += ops[0].shape.len()
+    elif type == "repeat_interleave":
+        # Adjust the repeat interleave if we're moving to more/less dimensions
+        repeats = attr[0]
+        dim = attr[1]
+
+        if dim < 0:
+            dim += ops[0].shape.len()
 
         delta = 4 - ops[0].shape.len()
-        attr[0] += delta
-        assert attr[0] >= 0 and attr[0] <= 3, f"Invalid repeat dim after lowering: {attr[0]}"
+        dim += delta
+        assert dim >= 0 and dim <= 3, f"Invalid repeat interleave after lowering: {dim}"
 
-        if attr[0] == 2:
+        if dim == 2:
             assert ops[0].shape[-2] % TILE_DIM == 0, "Repeat on R must be TILE_DIM aligned"
-        if attr[0] == 3:
+        if dim == 3:
             assert ops[0].shape[-1] % TILE_DIM == 0, "Repeat on C must be TILE_DIM aligned"
         return lc.tm("broadcast", ops[0], attr)
 
@@ -1805,45 +1804,6 @@ def decompose_post_optimize(type, attr, dc, inputs):
     # TODO: remove once backend support is available
     if type == "select":
         decompose_select(attr, dc, inputs)
-
-    elif type == "repeat":
-        sizes = attr
-        result = inputs[0]
-        for dim, factor in enumerate(sizes):
-            neg_idx = dim - len(inputs[0].shape)  # Use negative indexing
-            if factor == 1:
-                continue
-            result = dc.op("repeat_dim", [result], (neg_idx, factor))
-        dc.fuse(result)
-
-    elif type == "repeat_dim":
-        axis = attr[0]
-        if inputs[0].shape[axis] % TILE_DIM != 0 and (axis == -2 or axis == -1):
-            # Decompose repeat to spase mm
-            orig_shape = inputs[0].shape.as_list()
-            orig_dim = orig_shape[axis]
-            target_dim_size = inputs[0].shape[axis] * attr[1]
-            rounded_target_dim = align_up_tile(target_dim_size)
-            if axis == -2:
-                result = inputs[0]
-                use_sparse_mm = True
-                result = dc.op("pad_tile", [result], (-2, orig_shape[-2]))
-                i_spm = create_repeat_sparse_picker_matrix(orig_dim, attr[1])
-                result = picker_matmul(use_sparse_mm, dc, i_spm, result)
-                result = dc.op("narrow", [result], (-2, 0, target_dim_size, result.shape[-2]))
-            elif axis == -1:
-                result = inputs[0]
-                use_sparse_mm = True
-                result = dc.op("pad_tile", [result], (-1, orig_shape[-1]))
-                result = dc.op(TransposeTM.create(-2, -1), [result])
-                i_spm = create_repeat_sparse_picker_matrix(orig_dim, attr[1])
-                result = picker_matmul(use_sparse_mm, dc, i_spm, result)
-                result = dc.op(TransposeTM.create(-2, -1), [result])
-                result = dc.op("narrow", [result], (-1, 0, target_dim_size, result.shape[-1]))
-            else:
-                assert False
-
-            dc.fuse(result)
 
     elif type == "hslice":
         input_shape = inputs[0].shape.as_list()

--- a/forge/forge/op/tm.py
+++ b/forge/forge/op/tm.py
@@ -428,9 +428,20 @@ def Broadcast(name: str, operandA: Tensor, dim: int, shape: int) -> Tensor:
     return op("broadcast", name, operandA, attrs=(dim, shape, True)).get_tensor()
 
 
-def Repeat(name: str, operandA: Tensor, factors: List[int]) -> Tensor:
+def Repeat(name: str, operandA: Tensor, repeats: List[int]) -> Tensor:
     """
-    TM
+    Repeats this tensor along the specified dimensions.
+
+    >>> x = torch.tensor([1, 2, 3])
+    >>> x.repeat(4, 2)
+    tensor([[ 1,  2,  3,  1,  2,  3],
+            [ 1,  2,  3,  1,  2,  3],
+            [ 1,  2,  3,  1,  2,  3],
+            [ 1,  2,  3,  1,  2,  3]])
+
+    NOTE:
+    -----
+    This Forge.Repeat is equivalent to torch.repeat, numpy.tile, tvm.tile, and ttnn.repeat
 
     Parameters
     ----------
@@ -448,8 +459,42 @@ def Repeat(name: str, operandA: Tensor, factors: List[int]) -> Tensor:
     Tensor
         Forge tensor
     """
-    assert len(operandA.shape) == len(factors)
-    return op("repeat", name, operandA, attrs=factors).get_tensor()
+    assert len(operandA.shape) == len(repeats)
+    return op("repeat", name, operandA, attrs=repeats, repeats=repeats).get_tensor()
+
+
+def RepeatInterleave(name: str, operandA: Tensor, repeats: int, dim: int) -> Tensor:
+    """
+    Repeat elements of a tensor.
+
+    >>> x = torch.tensor([1, 2, 3])
+    >>> x.repeat_interleave(2)
+    tensor([1, 1, 2, 2, 3, 3])
+
+    NOTE:
+    -----
+    This Forge.RepeatInterleave is equivalent to torch.repeat_interleave, numpy.repeat, tvm.repeat, and ttnn.repeat_interleave
+
+    Parameters
+    ----------
+    name: str
+        Op name, unique to the module, or leave blank to autoset
+
+    operandA: Tensor
+        Input operand A
+
+    repeats: int
+        The number of repetitions for each element.
+
+    dim: int
+        The dimension along which to repeat values.
+
+    Returns
+    -------
+    Tensor
+        Forge tensor
+    """
+    return op("repeat_interleave", name, operandA, attrs=(repeats, dim), repeats=repeats, dim=dim).get_tensor()
 
 
 def Unsqueeze(name: str, operandA: Tensor, dim: int) -> Tensor:

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1363,7 +1363,17 @@ def populate_repeat_args(graph, nid, compiler_cfg):
 
     forge_shape = node["forge_shape"]
     reps = list(map(int, node["attrs"]["reps"][0]))
-    args = [("factors", f"{reps}")]
+    args = [("repeats", f"{reps}")]
+    return args
+
+
+def populate_repeat_interleave_args(graph, nid, compiler_cfg):
+    node = graph["nodes"][nid]
+
+    repeats = int(node["attrs"]["repeats"][0][0])
+    dim = int(node["attrs"]["axis"][0][0])
+
+    args = [("repeats", f"{repeats}"), ("dim", f"{dim}")]
     return args
 
 
@@ -1740,6 +1750,7 @@ tvm_to_forge_op_map = {
     "take": "take",
     "tanh": "tanh",
     "tile": "repeat",
+    "repeat": "repeat_interleave",
     "transpose": "transpose",
     "where": "where",
     "expand_dims": "unsqueeze",
@@ -1809,6 +1820,7 @@ forge_op_to_function_name = {
     "reduce_sum": "forge.op.ReduceSum",
     "relu": "forge.op.Relu",
     "repeat": "forge.op.Repeat",
+    "repeat_interleave": "forge.op.RepeatInterleave",
     "reshape": "forge.op.Reshape",
     "resize2d": "forge.op.Resize2d",
     "resize3d": "forge.op.Resize3d",
@@ -1865,6 +1877,7 @@ forge_ops_needing_arguments = {
     "reduce_max": populate_reduce_args,
     "reduce_sum": populate_reduce_args,
     "repeat": populate_repeat_args,
+    "repeat_interleave": populate_repeat_interleave_args,
     "reshape": populate_reshape_args,
     "resize2d": populate_resize2d_args,
     "resize3d": populate_resize3d_args,

--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -1913,3 +1913,82 @@ def test_remainder():
     co_out = [co.to("cpu") for co in co_out]
     fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
     assert all([compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])
+
+
+@pytest.mark.xfail(
+    reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph - repeat"
+)
+@pytest.mark.push
+def test_repeat():
+    class Repeat(nn.Module):
+        def __init__(self, repeats):
+            super().__init__()
+            self.repeats = repeats
+
+        def forward(self, x):
+            return x.repeat(*self.repeats)
+
+    inputs = [torch.rand(1, 2, 1, 4, 4)]
+
+    framework_model = Repeat(repeats=(1, 1, 4, 1, 1))
+    fw_out = framework_model(*inputs)
+
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    co_out = compiled_model(*inputs)
+
+    co_out = [co.to("cpu") for co in co_out]
+    fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+    assert all([compare_with_golden(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])
+
+
+@pytest.mark.xfail(
+    reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph - repeat_interleave"
+)
+@pytest.mark.push
+def test_expand():
+    class Expand(nn.Module):
+        def __init__(self, expand_shape):
+            super().__init__()
+            self.expand_shape = expand_shape
+
+        def forward(self, x):
+            return x.expand(*self.expand_shape)
+
+    inputs = [torch.rand(1, 2, 1, 4, 4)]
+
+    framework_model = Expand(expand_shape=(1, 2, 4, 4, 4))
+    fw_out = framework_model(*inputs)
+
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    co_out = compiled_model(*inputs)
+
+    co_out = [co.to("cpu") for co in co_out]
+    fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+    assert all([compare_with_golden(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])
+
+
+@pytest.mark.xfail(
+    reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph - repeat_interleave"
+)
+@pytest.mark.push
+def test_repeat_interleave():
+    class RepeatInterleave(nn.Module):
+        def __init__(self, repeats, dim):
+            super().__init__()
+            self.repeats = repeats
+            self.dim = dim
+
+        def forward(self, x):
+            return x.repeat_interleave(self.repeats, dim=self.dim)
+
+    inputs = [torch.rand(1, 2, 1, 4, 4)]
+
+    framework_model = RepeatInterleave(repeats=4, dim=2)
+    fw_out = framework_model(*inputs)
+
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    co_out = compiled_model(*inputs)
+
+    co_out = [co.to("cpu") for co in co_out]
+    fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+    assert all([compare_with_golden(golden=fo, calculated=co, pcc=0.99) for fo, co in zip(fw_out, co_out)])


### PR DESCRIPTION
Fix https://github.com/tenstorrent/tt-forge-fe/issues/683

### Root cause
The mismatch of number of elements between Input and output tensors is due to broadcast op which is converted to tm op in `pre lowering pass` which is part of this `convert_broadcast_ops_to_tms`. On further investigation, found that repeat op is decomposed to broadcast in `forge_passes.py` and since [repeat](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/api/ttnn.repeat.html#ttnn-repeat) & [repeat_interleave](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/api/ttnn.repeat_interleave.html#ttnn.repeat_interleave) op present in ttnn we can directly map to it through MLIR.

Since these repeat ops are not yet supported in tt-mlir, created below issues.

1. https://github.com/tenstorrent/tt-mlir/issues/1369
2. https://github.com/tenstorrent/tt-mlir/issues/1370

### Logs
[test_mistral_fail.log](https://github.com/user-attachments/files/17867719/test_mistral_fail.log)
