### PR TITLE
Fix IndexError in Falcon by Supporting 4D Data Shapes with 3D Indices

### DIFF
--- a/forge/test/model_demos/high_prio/nlp/pytorch/test_falcon.py
+++ b/forge/test/model_demos/high_prio/nlp/pytorch/test_falcon.py
@@ -11,7 +11,7 @@ import forge
 def test_falcon(test_device):
 
     compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     tokenizer = AutoTokenizer.from_pretrained("tiiuae/falcon-7b-instruct")
     model = FalconForCausalLM.from_pretrained("tiiuae/falcon-7b-instruct")


### PR DESCRIPTION
## Description

- This PR fixes https://github.com/tenstorrent/tt-forge-fe/issues/507
- In falcon model, fused_qkv[..., [-2], :] ,fused_qkv[..., [-1], :]  operations on [this line](https://github.com/huggingface/transformers/blob/4c6c45ba138202f42582b5cea98126af87195a95/src/transformers/models/falcon/modeling_falcon.py#L357)  is the root cause of [this](https://github.com/tenstorrent/tt-forge-fe/issues/507) issue because indexing on 4d tensors were not handled [before](https://github.com/tenstorrent/tt-tvm/blob/932d1d42044020edb3231f0f8ecfb56f1fe10bf2/python/tvm/relay/frontend/pytorch.py#L2753).

## Logs

- [mlir_tests.log](https://github.com/user-attachments/files/17924200/nov26_mlir_nc_final.log)
- [Falcon.log](https://github.com/user-attachments/files/17924199/nov26_full_model_final_recheck_with_depth.log)

