### PR TITLE
convert const scalars into tensors

### DIFF
--- a/forge/forge/op/eval/common.py
+++ b/forge/forge/op/eval/common.py
@@ -87,7 +87,9 @@ def create_constant_tensor_from_value(
         tensor[:, :, 0:dim_r, 0:dim_c] = value
     else:
         if tensor_c == 0 and tensor_r == 0:
-            tensor = torch.tensor(value, dtype=dtype)
+            # Unsqueezing to make this a 1d tensor.
+            # Currently, the runtime expects a 1d tensor for scalar values.
+            tensor = torch.unsqueeze(torch.tensor(value, dtype=dtype), dim=0)
         elif tensor_c == 0 or tensor_r == 0:
             dim = tensor_c if tensor_r == 0 else tensor_r
             tensor = torch.zeros(dim, dtype=dtype)

--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -492,7 +492,6 @@ def test_leakyrelu(shape):
         (1, 32, 56, 56),
     ],
 )
-@pytest.mark.xfail(reason="shape mismatch: expected [1], got []")
 @pytest.mark.push
 def test_layernorm(batch_size, num_channels, height, width):
 


### PR DESCRIPTION
Currently, neither `tt-mlir` or our runtime can handle scalars properly. So, when creating constant scalars, create them as a 1d tensors of shape (1,).

Pre-requisite for #784