### PR TITLE
[train] fix implementation of cross entropy loss

### DIFF
--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -115,6 +115,9 @@ class TensorShape:
     def __getitem__(self, i):
         return self.dims[i]
 
+    def __eq__(self, other):
+        return self.dims == other.dims
+
 
 class TensorBase:
     def _create_const_tensor(self, value):
@@ -222,6 +225,12 @@ class Tensor(TensorBase):
         if self.has_value():
             return f"Forge Tensor: {self.value()}, {self.data_format}"
         return f"Forge Empty Tensor: {self.shape}"
+
+    def ndim(self) -> int:
+        """
+        Return tensor rank (number of dimensions)
+        """
+        return len(self.shape)
 
     @property
     def pt_data_format(self) -> torch.dtype:

--- a/forge/test/mlir/test_loss.py
+++ b/forge/test/mlir/test_loss.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+import torch
+from torch import nn
+import forge
+from forge.op.eval.common import compare_with_golden
+
+
+@pytest.mark.parametrize(
+    "prediction_shape",
+    [
+        (3, 5),
+        (32, 32),
+        (33, 127),
+        (128, 20),
+    ],
+)
+@pytest.mark.push
+def test_l1_loss(prediction_shape):
+    forge_loss = forge.op.loss.L1Loss("l1_loss")
+    torch_loss = torch.nn.L1Loss()
+
+    prediction = torch.randn(prediction_shape, requires_grad=True)
+    prediction_forge = forge.tensor.Tensor.create_from_torch(prediction)
+    target = torch.empty(prediction_shape[0], dtype=torch.long).random_(prediction_shape[1])
+    target = nn.functional.one_hot(target, num_classes=prediction_shape[1]).float()
+    target_forge = forge.tensor.Tensor.create_from_torch(target)
+
+    forge_loss = forge.compile(forge_loss, sample_inputs=[prediction_forge, target_forge])
+    forge_loss_out = forge_loss(prediction, target)
+    torch_loss_out = torch_loss(prediction, target)
+
+    assert torch.allclose(torch_loss_out, forge_loss_out[0], rtol=11e-3)
+
+
+@pytest.mark.parametrize(
+    "prediction_shape",
+    [
+        (3, 5),
+        (32, 32),
+        (33, 127),
+        (128, 20),
+    ],
+)
+@pytest.mark.push
+def test_cross_entropy_loss(prediction_shape):
+    forge_loss = forge.op.loss.CrossEntropyLoss("cross_entropy_loss")
+    torch_loss = torch.nn.CrossEntropyLoss()
+
+    prediction = torch.randn(prediction_shape, requires_grad=True)
+    prediction_forge = forge.tensor.Tensor.create_from_torch(prediction)
+    target = torch.empty(prediction_shape[0], dtype=torch.long).random_(prediction_shape[-1])
+    target = nn.functional.one_hot(target, num_classes=prediction_shape[-1]).float()
+    target_forge = forge.tensor.Tensor.create_from_torch(target)
+
+    forge_loss = forge.compile(forge_loss, sample_inputs=[prediction_forge, target_forge])
+    forge_loss_out = forge_loss(prediction, target)
+    torch_loss_out = torch_loss(prediction, target)
+
+    assert torch.allclose(torch_loss_out, forge_loss_out[0], rtol=11e-3)


### PR DESCRIPTION
Rewrite the cross entropy loss, since the existing implementation is more complex and wrong.

Fixes #784