### PR TITLE
[consteval] enable during training

### DIFF
--- a/forge/csrc/graph_lib/utils.cpp
+++ b/forge/csrc/graph_lib/utils.cpp
@@ -2155,8 +2155,8 @@ void ConstEvalGraph::autograd()
 bool is_consteval_capable_input_type(Node *node)
 {
     graphlib::InputNode *input = dynamic_cast<graphlib::InputNode *>(node);
-    return input and (input->is_parameter() or input->is_constant()) and
-           not node->as<graphlib::TaggedNode>()->has_tag("dont_consteval");
+    return input && (input->is_parameter() || input->is_constant()) &&
+           !node->as<graphlib::TaggedNode>()->has_tag("dont_consteval");
 }
 
 bool is_consteval_capable_op(Graph *graph, Node *node, bool allow_forks)
@@ -2210,6 +2210,11 @@ bool is_consteval_capable_input_no_operand_forks(Graph *graph, InputNode *input)
 
     std::vector<Node *> users = graph->data_users(input);
     std::vector<Edge> user_edges = graph->user_data_edges(input);
+
+    if (input->requires_grad() && graph->training())
+    {
+        return false;
+    }
 
     // If there is only one user then check if that op is consteval capable
     if (users.size() == 1)

--- a/forge/csrc/passes/consteval.cpp
+++ b/forge/csrc/passes/consteval.cpp
@@ -30,6 +30,11 @@ static bool input_can_consteval(graphlib::Graph *graph, graphlib::InputNode *inp
         return false;
     };
 
+    if (input->requires_grad() && graph->training())
+    {
+        return false;
+    }
+
     // Generally we don't want to consteval broadcast or repeat as it
     // causes the input to blow up in size with duplicated data
     auto is_broadcast_or_repeat = [](graphlib::Node *n)


### PR DESCRIPTION
Enables consteval pass when compiling for training, by disabling consteval on inputs which require gradients (when training is on).

Fixing up the const eval during runtime - removing the unnecessary (legacy) checks for epoch type.

Moving the consteval pass to be executed just before `pre_lowering` pass.

Closes #293