### PR TITLE
deprecate sparse matmul in bts

### DIFF
--- a/forge/test/model_demos/high_prio/cnn/pytorch/test_bts.py
+++ b/forge/test/model_demos/high_prio/cnn/pytorch/test_bts.py
@@ -27,7 +27,7 @@ def test_bts_pytorch(test_device, variant):
 
     # Set PyBuda configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
 
     # Load sample image
     image_path = "third_party/confidential_customer_models/internal/bts/files/samples/rgb_00315.jpg"


### PR DESCRIPTION
## Description

- This PR fixes https://github.com/tenstorrent/tt-forge-fe/issues/749
- In BTS model downsampling operation happening with scale factor 4 [here](https://github.com/cleinc/bts/blob/dd62221bc50ff3cbe4559a832c94776830247e2e/pytorch/bts.py#L229) & with scale factor 2 [here](https://github.com/cleinc/bts/blob/dd62221bc50ff3cbe4559a832c94776830247e2e/pytorch/bts.py#L243) on single channel input tensor of shape [1,1, 480, 640]
- Downsample op exists in [ttnn](https://docs.tenstorrent.com/ttmetal/latest/ttnn/ttnn/api/ttnn.downsample.html#ttnn.downsample) , But support for single channel input tensor is not yet done -> https://github.com/tenstorrent/tt-metal/issues/15563
-  It would be beneficial to have MLIR support for downsample op -> https://github.com/tenstorrent/tt-mlir/issues/1440


## Logs

- [bts_before_fix.log](https://github.com/user-attachments/files/17956253/nov28_bts_debug.log)
- [bts_after_fix.log](https://github.com/user-attachments/files/17956262/nov29_bts_check.log)

