### PR TITLE
Add Weekly job for model analysis

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -23,48 +23,13 @@ on:
 
 jobs:
 
-  build-image:
-    runs-on: builder
-    outputs:
-      docker-image: ${{ steps.build.outputs.docker-image }}
-    steps:
-      - name: Fix permissions
-        shell: bash
-        run: sudo chown ubuntu:ubuntu -R $(pwd)
-
-      - uses: actions/checkout@v4
-        with:
-            submodules: recursive
-            fetch-depth: 0 # Fetch all history and tags
-
-      # Clean everything from submodules (needed to avoid issues
-      # with cmake generated files leftover from previous builds)
-      - name: Cleanup submodules
-        run: |
-          git submodule foreach --recursive git clean -ffdx
-          git submodule foreach --recursive git reset --hard
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build Docker images and output the image name
-        id: build
-        shell: bash
-        run: |
-          # Output the image name
-          set pipefail
-          .github/build-docker-images.sh | tee docker.log
-          DOCKER_CI_IMAGE=$(tail -n 1 docker.log)
-          echo "DOCKER_CI_IMAGE $DOCKER_CI_IMAGE"
-          echo "docker-image=$DOCKER_CI_IMAGE" >> "$GITHUB_OUTPUT"
+  docker-build:
+    uses: ./.github/workflows/build-image.yml
+    secrets: inherit
 
   build-and-test:
 
-    needs: build-image
+    needs: docker-build
     strategy:
       fail-fast: false
       matrix:
@@ -77,7 +42,7 @@ jobs:
       - ${{ matrix.build.runs-on }}
 
     container:
-      image: ${{ needs.build-image.outputs.docker-image }}
+      image: ${{ needs.docker-build.outputs.docker-image }}
       options: --device /dev/tenstorrent/0
       volumes:
         - /dev/hugepages:/dev/hugepages

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,51 @@
+name: Build Docker Image
+
+on:
+  workflow_dispatch:
+  workflow_call:
+    outputs:
+      docker-image:
+        description: "Built docker image name"
+        value: ${{ jobs.build-image.outputs.docker-image }}
+
+
+jobs:
+
+  build-image:
+    runs-on: builder
+    outputs:
+      docker-image: ${{ steps.build.outputs.docker-image }}
+    steps:
+      - name: Fix permissions
+        shell: bash
+        run: sudo chown ubuntu:ubuntu -R $(pwd)
+
+      - uses: actions/checkout@v4
+        with:
+            submodules: recursive
+            fetch-depth: 0 # Fetch all history and tags
+
+      # Clean everything from submodules (needed to avoid issues
+      # with cmake generated files leftover from previous builds)
+      - name: Cleanup submodules
+        run: |
+          git submodule foreach --recursive git clean -ffdx
+          git submodule foreach --recursive git reset --hard
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker images and output the image name
+        id: build
+        shell: bash
+        run: |
+          # Output the image name
+          set pipefail
+          .github/build-docker-images.sh | tee docker.log
+          DOCKER_CI_IMAGE=$(tail -n 1 docker.log)
+          echo "DOCKER_CI_IMAGE $DOCKER_CI_IMAGE"
+          echo "docker-image=$DOCKER_CI_IMAGE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/model-analysis-weekly.yml
+++ b/.github/workflows/model-analysis-weekly.yml
@@ -1,0 +1,112 @@
+name: Model Analysis Weekly
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 23 * * 5' # 11:00 PM UTC Friday (12:00 AM Saturday Serbia)
+
+jobs:
+
+  docker-build:
+    uses: ./.github/workflows/build-image.yml
+    secrets: inherit
+
+  model-analysis:
+    needs: docker-build
+    runs-on: runner
+
+    container:
+      image: ${{ needs.docker-build.outputs.docker-image }}
+      options: --device /dev/tenstorrent/0
+      volumes:
+        - /dev/hugepages:/dev/hugepages
+        - /dev/hugepages-1G:/dev/hugepages-1G
+        - /etc/udev/rules.d:/etc/udev/rules.d
+        - /lib/modules:/lib/modules
+        - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
+
+    steps:
+
+      - name: Set reusable strings
+        id: strings
+        shell: bash
+        run: |
+          echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
+          echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
+
+      - name: Git safe dir
+        run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
+
+      - uses: actions/checkout@v4
+        with:
+            submodules: recursive
+            fetch-depth: 0 # Fetch all history and tags
+
+      # Clean everything from submodules (needed to avoid issues
+      # with cmake generated files leftover from previous builds)
+      - name: Cleanup submodules
+        run: |
+            git submodule foreach --recursive git clean -ffdx
+            git submodule foreach --recursive git reset --hard
+
+      - name: ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          create-symlink: true
+          key: model-analysis-${{ runner.os }}
+
+      - name: Build
+        shell: bash
+        run: |
+          source env/activate
+          cmake -G Ninja \
+          -B ${{ steps.strings.outputs.build-output-dir }} \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_C_COMPILER=clang \
+          -DCMAKE_CXX_COMPILER=clang++ \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          cmake --build ${{ steps.strings.outputs.build-output-dir }}
+
+      - name: Run Model Analysis Script
+        shell: bash
+        run: |
+          source env/activate
+          apt install -y libgl1-mesa-glx
+          set -o pipefail # Ensures that the exit code reflects the first command that fails
+          python scripts/model_analysis.py \
+            --test_directory_or_file_path forge/test/models/pytorch \
+            --dump_failure_logs \
+            --markdown_directory_path ./model_analysis_docs \
+            --unique_ops_output_directory_path ./models_unique_ops_output \
+            2>&1 | tee model_analysis.log
+
+      - name: Upload Model Analysis Script Logs
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: model-analysis-outputs
+          path: model_analysis.log
+
+      - name: Upload Models Unique Ops test Failure Logs
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: unique-ops-logs
+          path: ./models_unique_ops_output
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: model_analysis
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          base: main
+          commit-message: "Update model analysis docs"
+          title: "Update model analysis docs"
+          body: "This PR will update model analysis docs"
+          labels: automatic_model_analysis
+          delete-branch: true
+          token: ${{ secrets.GH_TOKEN }}
+          add-paths: |
+              model_analysis_docs/

--- a/forge/forge/python_codegen.py
+++ b/forge/forge/python_codegen.py
@@ -1104,7 +1104,7 @@ class ForgeWriter(PythonWriter):
         self.wl(f'framework_output = [fw_out.to_framework("{framework}") for fw_out in framework_output]')
         self.wl("")
         self.wl(
-            "assert all([compare_with_golden(golden=fw_out, calculated=tt_out, pcc=0.99) for fw_out, tt_out in zip(framework_output, tt_output)])"
+            "assert all([compare_with_golden(golden=fw_out, calculated=tt_out) for fw_out, tt_out in zip(framework_output, tt_output)])"
         )
         self.wl("")
         self.wl("")

--- a/forge/test/conftest.py
+++ b/forge/test/conftest.py
@@ -448,3 +448,23 @@ def pytest_runtest_logreport(report):
         for key, default_value in environ_before_test.items():
             if os.environ.get(key, "") != default_value:
                 os.environ[key] = default_value
+
+
+def pytest_collection_modifyitems(config, items):
+
+    marker = config.getoption("-m")  # Get the marker from the -m option
+
+    if marker and marker == "model_analysis":  # If a marker is specified
+        print("Automatic Model Analysis Collected tests: ")
+        test_count = 0
+        for item in items:
+            if marker in item.keywords:
+                test_file_path = item.location[0]
+                test_name = item.location[2]
+                print(f"{test_file_path}::{test_name}")
+                test_count += 1
+        print(f"Automatic Model Analysis Collected test count: {test_count}")
+        if test_count == 0:  # Warn if no tests match the marker
+            print(f"Warning: No tests found with marker '{marker}'.")
+    else:
+        print(items)

--- a/forge/test/models/pytorch/audio/whisper/test_whisper_0.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper_0.py
@@ -99,6 +99,7 @@ def generate_model_whisper_congen_hf_pytorch(test_device, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_whisper(test_device, variant):
 

--- a/forge/test/models/pytorch/multimodal/clip/test_clip.py
+++ b/forge/test/models/pytorch/multimodal/clip/test_clip.py
@@ -17,6 +17,7 @@ import os
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_clip_pytorch(test_device):
 
     # Set Forge configuration parameters

--- a/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
+++ b/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
@@ -50,8 +50,9 @@ def generate_model_vilt_question_answering_hf_pytorch(test_device, variant):
 variants = ["dandelin/vilt-b32-finetuned-vqa"]
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_vilt_question_answering_hf_pytorch(variant, test_device):
     model, inputs, _ = generate_model_vilt_question_answering_hf_pytorch(
         test_device,
@@ -93,9 +94,10 @@ def generate_model_vilt_maskedlm_hf_pytorch(test_device, variant):
 variants = ["dandelin/vilt-b32-mlm"]
 
 
+@pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.xfail(reason="pcc=0.9498278562793674")
 @pytest.mark.parametrize("variant", variants, ids=variants)
-@pytest.mark.nightly
 def test_vilt_maskedlm_hf_pytorch(variant, test_device):
     model, inputs, _ = generate_model_vilt_maskedlm_hf_pytorch(
         test_device,

--- a/forge/test/models/pytorch/text/albert/test_albert.py
+++ b/forge/test/models/pytorch/text/albert/test_albert.py
@@ -12,10 +12,11 @@ sizes = ["base", "large", "xlarge", "xxlarge"]
 variants = ["v1", "v2"]
 
 
+@pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 @pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.parametrize("size", sizes, ids=sizes)
-@pytest.mark.nightly
 def test_albert_masked_lm_pytorch(size, variant, test_device):
     model_ckpt = f"albert-{size}-{variant}"
 
@@ -55,10 +56,11 @@ sizes = ["base", "large", "xlarge", "xxlarge"]
 variants = ["v1", "v2"]
 
 
+@pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 @pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.parametrize("size", sizes, ids=sizes)
-@pytest.mark.nightly
 def test_albert_token_classification_pytorch(size, variant, test_device):
 
     compiler_cfg = forge.config._get_global_compiler_config()

--- a/forge/test/models/pytorch/text/bart/test_bart.py
+++ b/forge/test/models/pytorch/text/bart/test_bart.py
@@ -23,6 +23,7 @@ class BartWrapper(torch.nn.Module):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_pt_bart_classifier(test_device):
     compiler_cfg = _get_global_compiler_config()
     compiler_cfg.compile_depth = CompileDepth.SPLIT_GRAPH

--- a/forge/test/models/pytorch/text/bert/test_bert.py
+++ b/forge/test/models/pytorch/text/bert/test_bert.py
@@ -38,8 +38,9 @@ def generate_model_bert_maskedlm_hf_pytorch(variant):
     return model, [input_tokens["input_ids"]], {}
 
 
-@pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 def test_bert_masked_lm_pytorch(test_device):
     model, inputs, _ = generate_model_bert_maskedlm_hf_pytorch("bert-base-uncased")
 
@@ -87,8 +88,9 @@ def generate_model_bert_qa_hf_pytorch(variant):
     return model, [input_tokens["input_ids"]], {}
 
 
-@pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 def test_bert_question_answering_pytorch(test_device):
     model, inputs, _ = generate_model_bert_qa_hf_pytorch("bert-large-cased-whole-word-masking-finetuned-squad")
 
@@ -128,6 +130,7 @@ def generate_model_bert_seqcls_hf_pytorch(variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_bert_sequence_classification_pytorch(test_device):
     model, inputs, _ = generate_model_bert_seqcls_hf_pytorch(
         "textattack/bert-base-uncased-SST-2",
@@ -167,8 +170,9 @@ def generate_model_bert_tkcls_hf_pytorch(variant):
     return model, [input_tokens["input_ids"]], {}
 
 
-@pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 def test_bert_token_classification_pytorch(test_device):
     model, inputs, _ = generate_model_bert_tkcls_hf_pytorch("dbmdz/bert-large-cased-finetuned-conll03-english")
 

--- a/forge/test/models/pytorch/text/codegen/test_codegen.py
+++ b/forge/test/models/pytorch/text/codegen/test_codegen.py
@@ -19,8 +19,9 @@ import torch
 from forge.op.eval.common import compare_with_golden
 
 
-@pytest.mark.xfail(reason="RuntimeError: Tensor 41 - data type mismatch: expected Float32, got BFloat16")
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.xfail(reason="RuntimeError: Tensor 41 - data type mismatch: expected Float32, got BFloat16")
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_codegen(test_device, variant):
     # Configurations

--- a/forge/test/models/pytorch/text/distilbert/test_distilbert.py
+++ b/forge/test/models/pytorch/text/distilbert/test_distilbert.py
@@ -16,6 +16,7 @@ variants = ["distilbert-base-uncased", "distilbert-base-cased", "distilbert-base
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_distilbert_masked_lm_pytorch(variant, test_device):
     # Load DistilBert tokenizer and model from HuggingFace
@@ -46,6 +47,7 @@ def test_distilbert_masked_lm_pytorch(variant, test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_distilbert_question_answering_pytorch(test_device):
     # Load Bert tokenizer and model from HuggingFace
     model_ckpt = "distilbert-base-cased-distilled-squad"
@@ -82,6 +84,7 @@ def test_distilbert_question_answering_pytorch(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_distilbert_sequence_classification_pytorch(test_device):
 
     # Load DistilBert tokenizer and model from HuggingFace
@@ -109,6 +112,7 @@ def test_distilbert_sequence_classification_pytorch(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_distilbert_token_classification_pytorch(test_device):
     # Load DistilBERT tokenizer and model from HuggingFace
     model_ckpt = "Davlan/distilbert-base-multilingual-cased-ner-hrl"

--- a/forge/test/models/pytorch/text/dpr/test_dpr.py
+++ b/forge/test/models/pytorch/text/dpr/test_dpr.py
@@ -18,8 +18,9 @@ from forge.op.eval.common import compare_with_golden
 variants = ["facebook/dpr-ctx_encoder-single-nq-base", "facebook/dpr-ctx_encoder-multiset-base"]
 
 
-@pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_dpr_context_encoder_pytorch(variant, test_device):
 
@@ -59,8 +60,9 @@ def test_dpr_context_encoder_pytorch(variant, test_device):
 variants = ["facebook/dpr-question_encoder-single-nq-base", "facebook/dpr-question_encoder-multiset-base"]
 
 
-@pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_dpr_question_encoder_pytorch(variant, test_device):
     # Load Bert tokenizer and model from HuggingFace
@@ -99,8 +101,9 @@ def test_dpr_question_encoder_pytorch(variant, test_device):
 variants = ["facebook/dpr-reader-single-nq-base", "facebook/dpr-reader-multiset-base"]
 
 
-@pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_dpr_reader_pytorch(variant, test_device):
     # Load Bert tokenizer and model from HuggingFace

--- a/forge/test/models/pytorch/text/falcon/test_falcon.py
+++ b/forge/test/models/pytorch/text/falcon/test_falcon.py
@@ -8,6 +8,7 @@ import forge
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_falcon(test_device):
 
     compiler_cfg = forge.config._get_global_compiler_config()

--- a/forge/test/models/pytorch/text/fuyu/test_fuyu_8b.py
+++ b/forge/test/models/pytorch/text/fuyu/test_fuyu_8b.py
@@ -30,6 +30,7 @@ from test.models.pytorch.text.fuyu.utils.model import (
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_fuyu8b(test_device):
     # Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()

--- a/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
@@ -254,6 +254,7 @@ def test_gemma_2b_single_decoder(test_device, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_gemma_2b(test_device, variant):
     # Random see for reproducibility

--- a/forge/test/models/pytorch/text/gpt2/test_gpt2.py
+++ b/forge/test/models/pytorch/text/gpt2/test_gpt2.py
@@ -10,8 +10,9 @@ from transformers import GPT2LMHeadModel, GPT2Tokenizer, GPT2Config
 from forge.op.eval.common import compare_with_golden
 
 
-@pytest.mark.xfail(reason="RuntimeError: Tensor 6 - data type mismatch: expected Float32, got BFloat16")
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.xfail(reason="RuntimeError: Tensor 6 - data type mismatch: expected Float32, got BFloat16")
 def test_gpt2_text_gen(test_device):
     # Load tokenizer and model from HuggingFace
     config = GPT2Config.from_pretrained("gpt2")

--- a/forge/test/models/pytorch/text/gptneo/test_gptneo.py
+++ b/forge/test/models/pytorch/text/gptneo/test_gptneo.py
@@ -23,6 +23,7 @@ variants = [
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_gptneo_causal_lm(variant, test_device):
     # Set random seed for repeatability

--- a/forge/test/models/pytorch/text/llama/test_llama3.py
+++ b/forge/test/models/pytorch/text/llama/test_llama3.py
@@ -109,8 +109,9 @@ def _update_causal_mask(
 LlamaModel._update_causal_mask = _update_causal_mask
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_llama3_causal_lm(variant, test_device):
     # Configurations
     compiler_cfg = forge.config._get_global_compiler_config()
@@ -151,8 +152,9 @@ def test_llama3_causal_lm(variant, test_device):
     )
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_llama3_sequence_classification(variant, test_device):
 
     # Configurations

--- a/forge/test/models/pytorch/text/mistral/test_mistral.py
+++ b/forge/test/models/pytorch/text/mistral/test_mistral.py
@@ -43,6 +43,7 @@ variants = ["mistralai/Mistral-7B-v0.1"]
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_mistral(variant, test_device):
 

--- a/forge/test/models/pytorch/text/opt/test_opt.py
+++ b/forge/test/models/pytorch/text/opt/test_opt.py
@@ -10,6 +10,7 @@ variants = ["facebook/opt-125m", "facebook/opt-350m", "facebook/opt-1.3b"]
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_opt_causal_lm(variant, test_device):
     # Load tokenizer and model from HuggingFace
@@ -46,6 +47,7 @@ def test_opt_causal_lm(variant, test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_opt_qa(variant, test_device):
     # Load tokenizer and model from HuggingFace
@@ -81,6 +83,7 @@ def test_opt_qa(variant, test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_opt_sequence_classification(variant, test_device):
     # Set Forge configuration parameters

--- a/forge/test/models/pytorch/text/phi2/test_phi2.py
+++ b/forge/test/models/pytorch/text/phi2/test_phi2.py
@@ -17,6 +17,7 @@ variants = ["microsoft/phi-2", "microsoft/phi-2-pytdml"]
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.xfail(reason="weights.get_dtype() == DataType::BFLOAT16")
 def test_phi2_clm(variant, test_device):
@@ -66,6 +67,7 @@ def test_phi2_clm(variant, test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 def test_phi2_token_classification(variant, test_device):
@@ -106,6 +108,7 @@ def test_phi2_token_classification(variant, test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.xfail(reason="TT_FATAL(weights.get_dtype() == DataType::BFLOAT16) in embedding op")
 def test_phi2_sequence_classification(variant, test_device):

--- a/forge/test/models/pytorch/text/phi3/test_phi3.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3.py
@@ -17,6 +17,7 @@ variants = ["microsoft/phi-3-mini-4k-instruct"]
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_causal_lm(variant, test_device):
 
@@ -61,6 +62,7 @@ def test_phi3_causal_lm(variant, test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.xfail(reason="RuntimeError: Indices tensor must be in row major layout.")
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_token_classification(variant, test_device):
@@ -101,6 +103,7 @@ def test_phi3_token_classification(variant, test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.xfail(reason="RuntimeError: Embedding Device Operation Layout Mismatch - Expected ROW_MAJOR")
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_sequence_classification(variant, test_device):

--- a/forge/test/models/pytorch/text/qwen/test_qwen.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen.py
@@ -9,6 +9,7 @@ import re
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_qwen1_5_causal_lm(test_device):
 
     # Set PyBuda configurations
@@ -58,6 +59,7 @@ def parse_chat_completion(text: str):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_qwen1_5_chat(test_device):
 
     # Set PyBuda configurations

--- a/forge/test/models/pytorch/text/roberta/test_roberta.py
+++ b/forge/test/models/pytorch/text/roberta/test_roberta.py
@@ -9,6 +9,7 @@ from transformers import AutoModelForMaskedLM, AutoTokenizer, AutoModelForSequen
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_roberta_masked_lm(test_device):
     # Load Albert tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, "xlm-roberta-base")
@@ -34,6 +35,7 @@ def test_roberta_masked_lm(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_roberta_sentiment_pytorch(test_device):
     # Load Bart tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, "cardiffnlp/twitter-roberta-base-sentiment")

--- a/forge/test/models/pytorch/text/squeezebert/test_squeezebert.py
+++ b/forge/test/models/pytorch/text/squeezebert/test_squeezebert.py
@@ -8,6 +8,7 @@ from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_squeezebert_sequence_classification_pytorch(test_device):
     # Load Bart tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, "squeezebert/squeezebert-mnli")

--- a/forge/test/models/pytorch/text/t5/test_t5.py
+++ b/forge/test/models/pytorch/text/t5/test_t5.py
@@ -95,8 +95,9 @@ variants = [
 ]
 
 
-@pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants)
 def test_t5_generation(variant, test_device):
 
     compiler_cfg = forge.config._get_global_compiler_config()

--- a/forge/test/models/pytorch/text/xglm/test_xglm.py
+++ b/forge/test/models/pytorch/text/xglm/test_xglm.py
@@ -11,6 +11,7 @@ variants = ["facebook/xglm-564M", "facebook/xglm-1.7B"]
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_xglm_causal_lm(variant, test_device):
     # Set Forge configuration parameters

--- a/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
+++ b/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
@@ -17,6 +17,7 @@ from forge.op.eval.common import compare_with_golden
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 # @pytest.mark.xfail(reason="Failing with pcc=0.82")
 def test_nbeats_with_seasonality_basis(test_device):
     compiler_cfg = forge.config._get_global_compiler_config()
@@ -44,6 +45,7 @@ def test_nbeats_with_seasonality_basis(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 # @pytest.mark.xfail(reason="Failing with pcc=0.83")
 def test_nbeats_with_generic_basis(test_device):
     compiler_cfg = forge.config._get_global_compiler_config()
@@ -65,7 +67,8 @@ def test_nbeats_with_generic_basis(test_device):
 
 
 @pytest.mark.nightly
-# @pytest.mark.xfail(eason="Failing with pcc=0.83")
+@pytest.mark.model_analysis
+# @pytest.mark.xfail(reason="Failing with pcc=0.83")
 def test_nbeats_with_trend_basis(test_device):
     compiler_cfg = forge.config._get_global_compiler_config()
 

--- a/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
+++ b/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
@@ -14,6 +14,7 @@ import os
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_alexnet_torchhub(test_device):
     # Configurations
     compiler_cfg = forge.config._get_global_compiler_config()
@@ -47,6 +48,7 @@ def test_alexnet_torchhub(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_alexnet_osmr(test_device):
     # Configurations
     compiler_cfg = forge.config._get_global_compiler_config()

--- a/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
+++ b/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
@@ -13,6 +13,7 @@ from test.models.pytorch.vision.autoencoder.utils.linear_autoencoder import Line
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_conv_ae_pytorch(test_device):
     # Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
@@ -40,6 +41,7 @@ def test_conv_ae_pytorch(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_linear_ae_pytorch(test_device):
     # Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()

--- a/forge/test/models/pytorch/vision/deit/test_deit.py
+++ b/forge/test/models/pytorch/vision/deit/test_deit.py
@@ -41,8 +41,9 @@ variants = [
 ]
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_vit_base_classify_224_hf_pytorch(variant, test_device):
     model, inputs, _ = generate_model_deit_imgcls_hf_pytorch(
         variant,

--- a/forge/test/models/pytorch/vision/densenet/test_densenet.py
+++ b/forge/test/models/pytorch/vision/densenet/test_densenet.py
@@ -14,8 +14,9 @@ from test.models.pytorch.vision.densenet.utils.densenet_utils import get_input_i
 variants = ["densenet121", "densenet121_hf_xray"]
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_densenet_121_pytorch(variant, test_device):
 
     # STEP 1: Set Forge configuration parameters
@@ -42,6 +43,7 @@ def test_densenet_121_pytorch(variant, test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_densenet_161_pytorch(test_device):
 
     # STEP 1: Set Forge configuration parameters
@@ -59,6 +61,7 @@ def test_densenet_161_pytorch(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_densenet_169_pytorch(test_device):
 
     # STEP 1: Set Forge configuration parameters
@@ -76,6 +79,7 @@ def test_densenet_169_pytorch(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_densenet_201_pytorch(test_device):
 
     # STEP 1: Set Forge configuration parameters

--- a/forge/test/models/pytorch/vision/dla/test_dla.py
+++ b/forge/test/models/pytorch/vision/dla/test_dla.py
@@ -36,8 +36,9 @@ variants_func = {
 variants = list(variants_func.keys())
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_dla_pytorch(variant, test_device):
     # Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()

--- a/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
@@ -44,8 +44,9 @@ variants = [
 ]
 
 
-@pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants)
 def test_efficientnet_timm(variant, test_device):
 
     # Configuration
@@ -102,6 +103,7 @@ variants = [
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.xfail(reason="Runtime Error: Reshape Operation Fails Due to Mismatched Tensor Volume")
 def test_efficientnet_torchvision(variant, test_device):

--- a/forge/test/models/pytorch/vision/fpn/test_fpn.py
+++ b/forge/test/models/pytorch/vision/fpn/test_fpn.py
@@ -8,6 +8,7 @@ from test.models.pytorch.vision.fpn.utils.model import FPNWrapper
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_fpn_pytorch(test_device):
     compiler_cfg = forge.config._get_global_compiler_config()
     compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH

--- a/forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py
+++ b/forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py
@@ -19,9 +19,10 @@ from forge.op.eval.common import compare_with_golden
 variants = ["ghostnet_100"]
 
 
+@pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.xfail(reason="Runtime error : Invalid arguments to reshape")
 @pytest.mark.parametrize("variant", variants, ids=variants)
-@pytest.mark.nightly
 def test_ghostnet_timm(variant, test_device):
 
     # STEP 1: Set Forge configuration parameters

--- a/forge/test/models/pytorch/vision/googlenet/test_googlenet.py
+++ b/forge/test/models/pytorch/vision/googlenet/test_googlenet.py
@@ -12,6 +12,7 @@ import os
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_googlenet_pytorch(test_device):
     # Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object

--- a/forge/test/models/pytorch/vision/hrnet/test_hrnet.py
+++ b/forge/test/models/pytorch/vision/hrnet/test_hrnet.py
@@ -82,8 +82,9 @@ variants = [
 ]
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_hrnet_osmr_pytorch(test_device, variant):
     model, inputs, _ = generate_model_hrnet_imgcls_osmr_pytorch(
         variant,
@@ -147,8 +148,9 @@ variants = [
 ]
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_hrnet_timm_pytorch(test_device, variant):
     model, inputs, _ = generate_model_hrnet_imgcls_timm_pytorch(
         variant,

--- a/forge/test/models/pytorch/vision/inception/test_inception_v4.py
+++ b/forge/test/models/pytorch/vision/inception/test_inception_v4.py
@@ -32,6 +32,7 @@ def generate_model_inceptionV4_imgcls_osmr_pytorch(variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_inception_v4_osmr_pytorch(test_device):
     model, inputs = generate_model_inceptionV4_imgcls_osmr_pytorch("inceptionv4")
     compiled_model = forge.compile(model, sample_inputs=inputs, module_name="pt_osmr_inception_v4")
@@ -48,6 +49,7 @@ def generate_model_inceptionV4_imgcls_timm_pytorch(variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_inception_v4_timm_pytorch(test_device):
     model, inputs = generate_model_inceptionV4_imgcls_timm_pytorch("inception_v4")
 

--- a/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
+++ b/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
@@ -30,8 +30,9 @@ varaints = [
 ]
 
 
-@pytest.mark.parametrize("variant", varaints, ids=varaints)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", varaints, ids=varaints)
 def test_mlp_mixer_timm_pytorch(variant, test_device):
 
     model = download_model(timm.create_model, variant, pretrained=True)

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
@@ -30,6 +30,7 @@ def generate_model_mobilenetV1_base_custom_pytorch(test_device, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.xfail(reason="RuntimeError: Invalid arguments to reshape")
 def test_mobilenetv1_basic(test_device):
     model, inputs, _ = generate_model_mobilenetV1_base_custom_pytorch(
@@ -68,6 +69,7 @@ def generate_model_mobilenetv1_imgcls_hf_pytorch(test_device, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_mobilenetv1_192(test_device):
     model, inputs, _ = generate_model_mobilenetv1_imgcls_hf_pytorch(
         test_device,
@@ -96,6 +98,7 @@ def generate_model_mobilenetV1I224_imgcls_hf_pytorch(test_device, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_mobilenetv1_224(test_device):
     model, inputs, _ = generate_model_mobilenetV1I224_imgcls_hf_pytorch(
         test_device,

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -41,6 +41,7 @@ def generate_model_mobilenetV2_imgcls_torchhub_pytorch(test_device, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_mobilenetv2_basic(test_device):
     model, inputs, _ = generate_model_mobilenetV2_imgcls_torchhub_pytorch(
         test_device,
@@ -67,6 +68,7 @@ def generate_model_mobilenetV2I96_imgcls_hf_pytorch(test_device, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_mobilenetv2_96(test_device):
     model, inputs, _ = generate_model_mobilenetV2I96_imgcls_hf_pytorch(
         test_device,
@@ -93,6 +95,7 @@ def generate_model_mobilenetV2I160_imgcls_hf_pytorch(test_device, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_mobilenetv2_160(test_device):
     model, inputs, _ = generate_model_mobilenetV2I160_imgcls_hf_pytorch(
         test_device,
@@ -121,6 +124,7 @@ def generate_model_mobilenetV2I244_imgcls_hf_pytorch(test_device, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_mobilenetv2_224(test_device):
     model, inputs, _ = generate_model_mobilenetV2I244_imgcls_hf_pytorch(
         test_device,
@@ -158,6 +162,7 @@ def generate_model_mobilenetV2_imgcls_timm_pytorch(test_device, variant):
 
 # @pytest.mark.xfail(reason="Runtime error : Invalid arguments to reshape")
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_mobilenetv2_timm(test_device):
     model, inputs, _ = generate_model_mobilenetV2_imgcls_timm_pytorch(
         test_device,
@@ -209,8 +214,9 @@ def generate_model_mobilenetV2_semseg_hf_pytorch(test_device, variant):
 variants = ["google/deeplabv3_mobilenet_v2_1.0_513"]
 
 
-@pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants)
 def test_mobilenetv2_deeplabv3(variant, test_device):
     model, inputs, _ = generate_model_mobilenetV2_semseg_hf_pytorch(
         test_device,

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
@@ -40,9 +40,10 @@ def generate_model_mobilenetV3_imgcls_torchhub_pytorch(test_device, variant):
 variants = ["mobilenet_v3_large", "mobilenet_v3_small"]
 
 
+@pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.xfail(reason="Runtime error : Invalid arguments to reshape")
 @pytest.mark.parametrize("variant", variants, ids=variants)
-@pytest.mark.nightly
 def test_mobilenetv3_basic(variant, test_device):
     model, inputs, _ = generate_model_mobilenetV3_imgcls_torchhub_pytorch(
         test_device,
@@ -93,9 +94,10 @@ def generate_model_mobilenetV3_imgcls_timm_pytorch(test_device, variant):
 variants = ["mobilenetv3_large_100", "mobilenetv3_small_100"]
 
 
+@pytest.mark.nightly
+@pytest.mark.model_analysis
 @pytest.mark.xfail(reason="Runtime error : Invalid arguments to reshape")
 @pytest.mark.parametrize("variant", variants, ids=variants)
-@pytest.mark.nightly
 def test_mobilenetv3_timm(variant, test_device):
     model, inputs, _ = generate_model_mobilenetV3_imgcls_timm_pytorch(
         test_device,

--- a/forge/test/models/pytorch/vision/monodle/test_monodle.py
+++ b/forge/test/models/pytorch/vision/monodle/test_monodle.py
@@ -11,6 +11,7 @@ import os
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_monodle_pytorch(test_device):
     # PyBuda configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()

--- a/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
+++ b/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
@@ -44,8 +44,9 @@ variants = [
 ]
 
 
-@pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants)
 def test_perceiverio_for_image_classification_pytorch(test_device, variant):
 
     # Set Forge configuration parameters

--- a/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
+++ b/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
@@ -17,6 +17,7 @@ import forge
 # Paper - https://arxiv.org/abs/1311.2524
 # Repo - https://github.com/object-detection-algorithm/R-CNN
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_rcnn_pytorch(test_device):
 
     # Load Alexnet Model

--- a/forge/test/models/pytorch/vision/resnet/test_resnet.py
+++ b/forge/test/models/pytorch/vision/resnet/test_resnet.py
@@ -47,6 +47,7 @@ def generate_model_resnet_imgcls_hf_pytorch(variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_resnet(test_device):
 
     model, inputs, _ = generate_model_resnet_imgcls_hf_pytorch(
@@ -83,6 +84,7 @@ def generate_model_resnet_imgcls_timm_pytorch(variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_resnet_timm(test_device):
     model, inputs, _ = generate_model_resnet_imgcls_timm_pytorch(
         "resnet50",

--- a/forge/test/models/pytorch/vision/resnext/test_resnext.py
+++ b/forge/test/models/pytorch/vision/resnext/test_resnext.py
@@ -14,6 +14,7 @@ import forge
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_resnext_50_torchhub_pytorch(test_device):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
@@ -32,6 +33,7 @@ def test_resnext_50_torchhub_pytorch(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_resnext_101_torchhub_pytorch(test_device):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
@@ -50,6 +52,7 @@ def test_resnext_101_torchhub_pytorch(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_resnext_101_32x8d_fb_wsl_pytorch(test_device):
 
     # STEP 1: Set Forge configuration parameters
@@ -70,6 +73,7 @@ def test_resnext_101_32x8d_fb_wsl_pytorch(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_resnext_14_osmr_pytorch(test_device):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
@@ -89,6 +93,7 @@ def test_resnext_14_osmr_pytorch(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_resnext_26_osmr_pytorch(test_device):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
@@ -107,6 +112,7 @@ def test_resnext_26_osmr_pytorch(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_resnext_50_osmr_pytorch(test_device):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
@@ -125,6 +131,7 @@ def test_resnext_50_osmr_pytorch(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_resnext_101_osmr_pytorch(test_device):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object

--- a/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
+++ b/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
@@ -22,8 +22,9 @@ variants = [
 ]
 
 
-@pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants)
 def test_retinanet(variant, test_device):
 
     # Set PyBuda configuration parameters

--- a/forge/test/models/pytorch/vision/segformer/test_segformer.py
+++ b/forge/test/models/pytorch/vision/segformer/test_segformer.py
@@ -21,8 +21,9 @@ variants_img_classification = [
 ]
 
 
-@pytest.mark.parametrize("variant", variants_img_classification)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants_img_classification)
 def test_segformer_image_classification_pytorch(test_device, variant):
 
     # Set Forge configuration parameters
@@ -56,8 +57,9 @@ variants_semseg = [
 ]
 
 
-@pytest.mark.parametrize("variant", variants_semseg)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants_semseg)
 def test_segformer_semantic_segmentation_pytorch(test_device, variant):
 
     # Set Forge configuration parameters

--- a/forge/test/models/pytorch/vision/ssd300_resnet50/test_ssd300_resnet50.py
+++ b/forge/test/models/pytorch/vision/ssd300_resnet50/test_ssd300_resnet50.py
@@ -11,6 +11,7 @@ from test.models.pytorch.vision.ssd300_resnet50.utils.image_utils import prepare
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_pytorch_ssd300_resnet50(test_device):
 
     # STEP 1 : Set Forge configuration parameters

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -13,6 +13,7 @@ import requests
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_swin_v1_tiny_4_224_hf_pytorch(test_device):
     # pytest.skip() # Working on it
     # STEP 1: Set Forge configuration parameters

--- a/forge/test/models/pytorch/vision/unet/test_unet.py
+++ b/forge/test/models/pytorch/vision/unet/test_unet.py
@@ -31,6 +31,7 @@ def generate_model_unet_imgseg_osmr_pytorch(variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_unet_osmr_cityscape_pytorch(test_device):
     model, inputs, _ = generate_model_unet_imgseg_osmr_pytorch(
         "unet_cityscapes",
@@ -112,6 +113,7 @@ def generate_model_unet_imgseg_smp_pytorch(variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_unet_qubvel_pytorch(test_device):
     model, inputs, _ = generate_model_unet_imgseg_smp_pytorch(
         None,
@@ -159,6 +161,7 @@ def generate_model_unet_imgseg_torchhub_pytorch(variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_unet_torchhub_pytorch(test_device):
     model, inputs, _ = generate_model_unet_imgseg_torchhub_pytorch(
         "unet",

--- a/forge/test/models/pytorch/vision/vgg/test_vgg.py
+++ b/forge/test/models/pytorch/vision/vgg/test_vgg.py
@@ -23,8 +23,9 @@ from torchvision import transforms
 variants = ["vgg11", "vgg13", "vgg16", "vgg19", "bn_vgg19", "bn_vgg19b"]
 
 
-@pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants)
 def test_vgg_osmr_pytorch(variant, test_device):
     # STEP 1: Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()  # load global compiler config object
@@ -57,6 +58,7 @@ def test_vgg_osmr_pytorch(variant, test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_vgg_19_hf_pytorch(test_device):
 
     # STEP 1: Set Forge configuration parameters
@@ -116,6 +118,7 @@ def preprocess_timm_model(model_name):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_vgg_bn19_timm_pytorch(test_device):
     torch.multiprocessing.set_sharing_strategy("file_system")
     model_name = "vgg19_bn"
@@ -129,6 +132,7 @@ def test_vgg_bn19_timm_pytorch(test_device):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_vgg_bn19_torchhub_pytorch(test_device):
 
     # STEP 1: Set Forge configuration parameters

--- a/forge/test/models/pytorch/vision/vit/test_vit.py
+++ b/forge/test/models/pytorch/vision/vit/test_vit.py
@@ -34,8 +34,9 @@ def generate_model_vit_imgcls_hf_pytorch(test_device, variant):
 variants = ["google/vit-base-patch16-224", "google/vit-large-patch16-224"]
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_vit_classify_224_hf_pytorch(variant, test_device):
     model, inputs, _ = generate_model_vit_imgcls_hf_pytorch(
         test_device,

--- a/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
@@ -27,8 +27,9 @@ def generate_model_vovnet_imgcls_osmr_pytorch(test_device, variant):
 varaints = ["vovnet27s", "vovnet39", "vovnet57"]
 
 
-@pytest.mark.parametrize("variant", varaints, ids=varaints)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", varaints, ids=varaints)
 def test_vovnet_osmr_pytorch(variant, test_device):
     model, inputs, _ = generate_model_vovnet_imgcls_osmr_pytorch(
         test_device,
@@ -47,8 +48,9 @@ def generate_model_vovnet39_imgcls_stigma_pytorch(test_device, variant):
     return model, [image_tensor], {}
 
 
-@pytest.mark.parametrize("enable_default_dram_parameters", [True, False])
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("enable_default_dram_parameters", [True, False])
 def test_vovnet_v1_39_stigma_pytorch(test_device, enable_default_dram_parameters):
     model, inputs, _ = generate_model_vovnet39_imgcls_stigma_pytorch(
         test_device,
@@ -70,6 +72,7 @@ def generate_model_vovnet57_imgcls_stigma_pytorch(test_device, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_vovnet_v1_57_stigma_pytorch(test_device):
     model, inputs, _ = generate_model_vovnet57_imgcls_stigma_pytorch(
         test_device,
@@ -90,8 +93,9 @@ def generate_model_vovnet_imgcls_timm_pytorch(test_device, variant):
 variants = ["ese_vovnet19b_dw", "ese_vovnet39b", "ese_vovnet99b"]
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_vovnet_timm_pytorch(variant, test_device):
     model, inputs, _ = generate_model_vovnet_imgcls_timm_pytorch(
         test_device,

--- a/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
+++ b/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
@@ -45,8 +45,9 @@ def generate_model_wideresnet_imgcls_pytorch(test_device, variant):
 variants = ["wide_resnet50_2", "wide_resnet101_2"]
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_wideresnet_pytorch(variant, test_device):
     (model, inputs,) = generate_model_wideresnet_imgcls_pytorch(
         test_device,
@@ -81,8 +82,9 @@ def generate_model_wideresnet_imgcls_timm(test_device, variant):
 variants = ["wide_resnet50_2", "wide_resnet101_2"]
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_wideresnet_timm(variant, test_device):
     (model, inputs,) = generate_model_wideresnet_imgcls_timm(
         test_device,

--- a/forge/test/models/pytorch/vision/xception/test_xception.py
+++ b/forge/test/models/pytorch/vision/xception/test_xception.py
@@ -38,8 +38,9 @@ def generate_model_xception_imgcls_timm(test_device, variant):
 variants = ["xception", "xception41", "xception65", "xception71"]
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants, ids=variants)
 def test_xception_timm(variant, test_device):
 
     (model, inputs,) = generate_model_xception_imgcls_timm(

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -24,8 +24,9 @@ def generate_model_yoloV5I320_imgcls_torchhub_pytorch(test_device, variant, size
 size = ["n", "s", "m", "l", "x"]
 
 
-@pytest.mark.parametrize("size", size, ids=["yolov5" + s for s in size])
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("size", size, ids=["yolov5" + s for s in size])
 def test_yolov5_320x320(test_device, size):
     model, inputs, _ = generate_model_yoloV5I320_imgcls_torchhub_pytorch(
         test_device,
@@ -53,8 +54,9 @@ def generate_model_yoloV5I640_imgcls_torchhub_pytorch(test_device, variant, size
 size = ["n", "s", "m", "l", "x"]
 
 
-@pytest.mark.parametrize("size", size, ids=["yolov5" + s for s in size])
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("size", size, ids=["yolov5" + s for s in size])
 def test_yolov5_640x640(test_device, size):
 
     model, inputs, _ = generate_model_yoloV5I640_imgcls_torchhub_pytorch(
@@ -78,8 +80,9 @@ def generate_model_yoloV5I480_imgcls_torchhub_pytorch(test_device, variant, size
     return model, [input_tensor], {}
 
 
-@pytest.mark.parametrize("size", size, ids=["yolov5" + s for s in size])
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("size", size, ids=["yolov5" + s for s in size])
 def test_yolov5_480x480(test_device, size):
 
     model, inputs, _ = generate_model_yoloV5I480_imgcls_torchhub_pytorch(
@@ -93,6 +96,7 @@ def test_yolov5_480x480(test_device, size):
 
 
 @pytest.mark.nightly
+@pytest.mark.model_analysis
 def test_yolov5_1280x1280(test_device):
 
     compiler_cfg = forge.config._get_global_compiler_config()

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
@@ -13,8 +13,9 @@ from test.models.pytorch.vision.yolo.utils.yolov6_utils import check_img_size, p
 variants = ["yolov6n", "yolov6s", "yolov6m", "yolov6l"]
 
 
-@pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants)
 def test_yolo_v6_pytorch(variant, test_device):
 
     # STEP 1 : Set Forge configuration parameters

--- a/forge/test/models/pytorch/vision/yolo/test_yolox.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolox.py
@@ -33,8 +33,9 @@ from test.models.pytorch.vision.yolo.utils.yolox_utils import preprocess
 variants = ["yolox_nano", "yolox_tiny", "yolox_s", "yolox_m", "yolox_l", "yolox_darknet", "yolox_x"]
 
 
-@pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
+@pytest.mark.model_analysis
+@pytest.mark.parametrize("variant", variants)
 def test_yolox_pytorch(variant, test_device):
 
     # Set PyBuda configuration parameters


### PR DESCRIPTION
Fixes #662 
1. Add new marker `model_analysis` for the models inference test present in the forge/test/models/pytorch path
2. Modified the script to collect the test based upon the marker `model_analysis`
3. Created a workflow(i.e model-analysis-weekly.yml) for running the model analysis script  which will generate markdown files and then create a PR for updating the model_analysis_docs(Markdown files).
4. Moved the build-image job in Build and Test workflow(i.e build-and-test.yml) to separate workflow, so that I can reuse the workflow for the Model Analysis Weekly workflow(i.e model-analysis-weekly.yml) 

Note: The workflow job will trigger every week on Friday at 11:00 PM UTC (Saturday at 12:00 AM Serbia time).

 