### PR TITLE
Remove one value from parameter 'number of operands' used in tests

### DIFF
--- a/forge/test/operators/pytorch/eltwise_nary/test_concatenate.py
+++ b/forge/test/operators/pytorch/eltwise_nary/test_concatenate.py
@@ -237,7 +237,7 @@ class TestCollectionData:
         numbers_of_operands=[
             2,
             3,
-            7,
+            # 7,  # consume too much memory
             # 15, # consume too much memory
         ],
         dev_data_formats=TestCollectionCommon.all.dev_data_formats,


### PR DESCRIPTION
Remove value '7' from test parameter 'number of operands' that cause problem with memory during nightly sweeps

Relates to Bug #867 