### PR TITLE
[train] support loss on device

### DIFF
--- a/forge/csrc/autograd/autograd.cpp
+++ b/forge/csrc/autograd/autograd.cpp
@@ -176,10 +176,11 @@ void autograd_engine::create_backward_graph(const grad_map &requires_grad_map)
 
             else
             {
-                // Normal outputs, which will require a loss input to bring its gradient in
+                // Normal outputs, which will require an input (either from loss.backward() or submodule.backward())
+                // to bring its gradient in.
                 auto input_node = graph->add_node(
                     graphlib::create_node<graphlib::InputNode>(
-                        "loss_" + node->name(), graphlib::InputNodeType::Loss, false),
+                        "gradient_" + node->name(), graphlib::InputNodeType::Gradient, false),
                     graph->get_subgraph_id_for_node(node->id()));
 
                 input_node->set_shape(node->shape());
@@ -232,7 +233,7 @@ void autograd_engine::create_backward_graph(const grad_map &requires_grad_map)
                 graph->get_subgraph_id_for_node(node->id()));
             nop_node->set_shape(node->shape());
             nop_node->set_epoch_type(graphlib::NodeEpochType::Backward);
-            nop_node->set_output_df(nop_node->output_df());
+            nop_node->set_output_df(node->output_df());
 
             Edge nop_edge(out_grad->id(), 0, nop_node->id(), 0, graphlib::EdgeType::kData);
             graph->add_edge(nop_edge);

--- a/forge/csrc/graph_lib/graph.cpp
+++ b/forge/csrc/graph_lib/graph.cpp
@@ -849,22 +849,17 @@ std::vector<std::string> Graph::get_ordered_target_names() const
 
 std::vector<std::string> Graph::get_ordered_input_gradient_names() const
 {
-    std::vector<std::string> ordered_outputs;
+    std::vector<std::string> input_grads;
+    input_grads.reserve(this->ordered_module_input_node_ids_.size());
     for (auto input_node_id : this->ordered_module_input_node_ids_)
     {
         Node *node = node_by_id(input_node_id);
-        if (!node->as<graphlib::InputNode>()->requires_grad())
-            continue;
-
-        std::vector<Edge> gradients =
-            user_edges(node, [](Edge edge) { return edge.edge_type == EdgeType::kAutogradInputToGradientOut; });
-        if (not gradients.empty())
+        if (node->as<InputNode>()->is_gradient())
         {
-            TT_ASSERT(gradients.size() == 1, "Each input with requires_grad should have exactly one bw output");
-            ordered_outputs.push_back(node_by_id(gradients[0].consumer_node_id)->name());
+            input_grads.push_back(node->name());
         }
     }
-    return ordered_outputs;
+    return input_grads;
 }
 
 std::vector<Node *> Graph::ordered_intermediates() const

--- a/forge/csrc/graph_lib/node_types.cpp
+++ b/forge/csrc/graph_lib/node_types.cpp
@@ -540,6 +540,7 @@ std::string InputNode::input_type_string() const
     {
         case InputNodeType::Accumulator: return "accumulator";
         case InputNodeType::Activation: return "input";
+        case InputNodeType::Gradient: return "gradient";
         case InputNodeType::Loss: return "loss";
         case InputNodeType::Parameter: return "parameter";
         case InputNodeType::Constant: return "constant";
@@ -579,6 +580,7 @@ std::ostream &operator<<(std::ostream &out, InputNodeType t)
     {
         case InputNodeType::Parameter: out << "InputNodeType::Parameter"; break;
         case InputNodeType::Constant: out << "InputNodeType::Constant"; break;
+        case InputNodeType::Gradient: out << "InputNodeType::Gradient"; break;
         case InputNodeType::Accumulator: out << "InputNodeType::Accumulator"; break;
         case InputNodeType::Activation: out << "InputNodeType::Activation"; break;
         case InputNodeType::Loss: out << "InputNodeType::Loss"; break;

--- a/forge/csrc/graph_lib/node_types.hpp
+++ b/forge/csrc/graph_lib/node_types.hpp
@@ -156,12 +156,13 @@ class BufferingQueueNode : public QueueNode
 
 enum InputNodeType
 {
-    Parameter,
-    Constant,
     Accumulator,
     Activation,
+    Constant,
+    Gradient,
     Loss,
     OptimizerParameter,
+    Parameter,
     Target,
 };
 
@@ -209,6 +210,7 @@ class InputNode : public QueueNode
 
     bool is_constant() const { return input_type_ == Constant; }
     bool is_parameter() const { return input_type_ == Parameter; }
+    bool is_gradient() const { return input_type_ == Gradient; }
     bool is_loss() const { return input_type_ == Loss; }
     bool is_target() const { return input_type_ == Target; }
     bool is_accumulator() const { return input_type_ == Accumulator; }
@@ -774,6 +776,7 @@ inline std::string to_string(InputNodeType t)
     {
         case InputNodeType::Parameter: return "parameter";
         case InputNodeType::Constant: return "constant";
+        case InputNodeType::Gradient: return "gradient";
         case InputNodeType::Accumulator: return "accumulator";
         case InputNodeType::Activation: return "activation";
         case InputNodeType::Loss: return "loss";

--- a/forge/forge/module.py
+++ b/forge/forge/module.py
@@ -43,6 +43,7 @@ class Module:
             self.name: str = name
         self.device: Optional["Device"] = None
         self.input_names = []
+        self.is_loss = False
         register_module(self)
 
     def __repr__(self):

--- a/forge/forge/op/eval/forge/reduce.py
+++ b/forge/forge/op/eval/forge/reduce.py
@@ -320,7 +320,8 @@ def backward(type, attr, ac, operand, inputs, output, grad):
     if type == "reduce_avg":
         dim = attr[0]
         size = ac.get_shape(inputs[0])[dim]
-        return ac.op("multiply", (grad, ac.constant(1 / size)))
+        broadcast = ac.op("broadcast", (grad,), (dim, size))
+        return ac.op("multiply", (broadcast, ac.constant(1 / size)))
 
     if type == "grouped_reduce_avg":
         dim = attr[0]

--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -943,7 +943,7 @@ def backward(type, attr, ac, operand, inputs, output, grad):
 
         dim = attr[0]
         input_ndim = attr[1]
-        return ac.op("squeeze", (grad,), attributes=(dim,))
+        return ac.op("squeeze", (grad,), (dim,), {"dim": dim})
 
     elif type == "squeeze":
         assert len(attr) == 1

--- a/forge/forge/op/loss.py
+++ b/forge/forge/op/loss.py
@@ -16,6 +16,10 @@ class CrossEntropyLoss(ForgeModule):
     loss = reduce_avg(-1 * sum(labels * log(softmax(predictions)), dim=-1), dim=0)
     """
 
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.is_loss = True
+
     def forward(self, predictions, labels):
         assert predictions.ndim() == 2, f"Predictions must be a 2D tensor. Got {predictions.ndim()}."
         assert (
@@ -49,6 +53,7 @@ class L1Loss(ForgeModule):
     def __init__(self, name: str, reduction: str = "avg"):
         super().__init__(name)
         self.reduction = reduction
+        self.is_loss = True
 
     def forward(self, prediction, labels):
         diff = Abs("abs", Subtract("sub", prediction, labels))

--- a/forge/test/mlir/mnist/training/test_training.py
+++ b/forge/test/mlir/mnist/training/test_training.py
@@ -7,12 +7,14 @@ import time
 
 import torch
 from torch import nn
+from loguru import logger
 
 import forge
+from forge.op.loss import CrossEntropyLoss, L1Loss
 from ..utils import *
 from forge.op.eval.common import compare_with_golden
 from forge.verify.config import VerifyConfig
-from loguru import logger
+from forge.tensor import to_forge_tensors
 
 
 @pytest.mark.push
@@ -38,9 +40,7 @@ def test_mnist_training():
 
     # Define optimizer and instruct it to compile and run on TT device
     framework_optimizer = torch.optim.SGD(framework_model.parameters(), lr=learning_rate)
-    tt_model = forge.compile(
-        framework_model, sample_inputs=[torch.rand(batch_size, 784)], loss=loss_fn, optimizer=framework_optimizer
-    )
+    tt_model = forge.compile(framework_model, sample_inputs=[torch.rand(batch_size, 784)], training=True)
 
     logger.info("Starting training loop... (logger will be disabled)")
     logger.disable("")
@@ -123,7 +123,7 @@ def test_forge_vs_torch_gradients(freeze_layer):
 
     sample_inputs = [torch.ones(batch_size, in_features, dtype=dtype)]
 
-    tt_model = forge.compile(forge_model, sample_inputs=sample_inputs, loss=loss_fn)
+    tt_model = forge.compile(forge_model, sample_inputs=sample_inputs, training=True)
 
     X = torch.ones(batch_size, in_features, dtype=dtype)
     y = torch.zeros(batch_size, out_features, dtype=dtype)
@@ -180,7 +180,7 @@ def test_forge_vs_torch():
     forge_optimizer = torch.optim.SGD(forge_model.parameters(), lr=learning_rate)
 
     tt_model = forge.compile(
-        forge_model, sample_inputs=[torch.ones(batch_size, 784, dtype=dtype)], loss=loss_fn, optimizer=forge_optimizer
+        forge_model, sample_inputs=[torch.ones(batch_size, 784, dtype=dtype)], optimizer=forge_optimizer, training=True
     )
 
     test_loader, train_loader = load_dataset(batch_size, dtype=dtype)
@@ -254,3 +254,79 @@ def test_forge_vs_torch():
 
     print(f"Validation accuracy for Torch: {torch_val_acc} in epoch {early_stop.get_best_model()}")
     print(f"Validation accuracy for Forge: {forge_val_acc} in epoch {early_stop.get_best_model()}")
+
+
+@pytest.mark.push
+def test_loss_device():
+    torch.manual_seed(0)
+
+    # Config
+    num_epochs = 3
+    batch_size = 1
+    learning_rate = 0.001
+
+    # Limit number of batches to run - quicker test
+    limit_num_batches = 1000
+
+    # Load dataset
+    test_loader, train_loader = load_dataset(batch_size)
+
+    # Load TensorBoard writer (for logging)
+    writer = load_tb_writer("forge_mnist")
+
+    framework_model = MNISTLinear(bias=False)
+    framework_optimizer = torch.optim.SGD(framework_model.parameters(), lr=learning_rate)
+
+    tt_model = forge.compile(framework_model, sample_inputs=[torch.rand(batch_size, 784)], training=True)
+
+    loss_fn = CrossEntropyLoss(name="cross_entropy_loss")
+
+    loss_inputs = [torch.rand(batch_size, 10).requires_grad_(True), torch.rand(batch_size, 10)]
+    loss_inputs = to_forge_tensors(loss_inputs)
+
+    tt_loss = forge.compile(loss_fn, sample_inputs=loss_inputs, attach_to=tt_model, training=True)
+
+    logger.info("Starting training loop... (logger will be disabled)")
+    logger.disable("")
+    for epoch_idx in range(num_epochs):
+        # Reset gradients (every epoch) - since our batch size is currently 1,
+        # we accumulate gradients across multiple batches (limit_num_batches),
+        # and then run the optimizer.
+        framework_optimizer.zero_grad()
+
+        total_loss = 0
+        for batch_idx, (data, target) in enumerate(train_loader):
+
+            # Create target tensor and leave on CPU
+            target = nn.functional.one_hot(target, num_classes=10).float()
+
+            # Forward pass (prediction) on device
+            pred = tt_model(data)[0]
+            golden_pred = framework_model(data)
+            assert compare_with_golden(golden_pred, pred, VerifyConfig(pcc=0.95))
+
+            loss = tt_loss(pred, target)
+            total_loss += loss[0].item()
+
+            # Run backward pass on device
+            tt_loss.backward()
+
+            if batch_idx >= limit_num_batches:
+                break
+
+        print(f"epoch: {epoch_idx} loss: {total_loss}")
+
+        # Adjust weights (on CPU)
+        framework_optimizer.step()
+
+    test_loss = 0
+    for batch_idx, (data, target) in enumerate(test_loader):
+        pred = tt_model(data)[0]
+        target = nn.functional.one_hot(target, num_classes=10).float()
+
+        test_loss += tt_loss(pred, target)[0]
+
+        if batch_idx == 1000:
+            break
+
+    print(f"Test (total) loss: {test_loss}")

--- a/forge/test/mlir/test_features.py
+++ b/forge/test/mlir/test_features.py
@@ -129,9 +129,7 @@ def test_batch_size_training(batch_size, in_features, out_features):
 
     loss_fn = torch.nn.CrossEntropyLoss()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.001)
-    tt_model = forge.compile(
-        model, sample_inputs=[torch.rand(batch_size, in_features)], loss=loss_fn, optimizer=optimizer
-    )
+    tt_model = forge.compile(model, sample_inputs=[torch.rand(batch_size, in_features)], optimizer=optimizer)
 
     optimizer.zero_grad()
 

--- a/forge/test/mlir/test_training.py
+++ b/forge/test/mlir/test_training.py
@@ -30,7 +30,7 @@ def test_torch_training():
     loss_fn = torch.nn.MSELoss()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
 
-    tt_model = forge.compile(model, sample_inputs=[torch.rand(shape)], loss=loss_fn, optimizer=optimizer)
+    tt_model = forge.compile(model, sample_inputs=[torch.rand(shape)], optimizer=optimizer)
 
     num_epochs = 20
 


### PR DESCRIPTION
Part of the changes for initial version of executing training e2e on device. Changes to follow after this one will focus on the optimizer.

With this change, the loss module and the model can be compiled separately and executed on the TT device (both forward and backward passes). Example:

```python
tt_model = forge.compile(framework_model,
        sample_inputs=[inputs], training=True)

loss_fn = CrossEntropyLoss(name="cross_entropy_loss")
tt_loss = forge.compile(loss_fn, sample_inputs=loss_inputs,
        attach_to=tt_model, training=True)

# Forward pass is executed as before
#
# The following will execute the whole backward pass from the loss
# outputs down to the model backward pass.
tt_loss.backward()
```

Note: change to the API
- main compile function is modified to accept `training` parameter. To indicate wheter to compile the module for training.
- also, loss module is removed as an argument to the compile function

For some reason, the gradient inputs in the previous stack were represented as `InputNodeType::Loss`. I have added a new type of input `Gradient`. The removal of the `Loss` input type is to be done as a follow up change since there are some uses of it spread around in the code base. Issue #829

To tie the gradients from the `loss.backward()` to the `module.backward()` we need to "attach" the model to the loss module when compiling the loss. This is done by passing the module to be attached into the compile function (`attach_to` parameter).

Note: this doesn't work in general case, when there are multiple gradients being passed between modules - because currently we don't have a mechanism to know which gradient output to tie to which gradient input.

Closes #177