### PR TITLE
Fix bugs in opt model in sequence classification task

### DIFF
--- a/forge/forge/op/eval/forge/argmax.py
+++ b/forge/forge/op/eval/forge/argmax.py
@@ -92,7 +92,10 @@ class Argmax(PyEltwiseUnaryOp):
         )
         softmax = dc.op("softmax", [mult_1], (axis, 1))
         mult_2 = dc.op("multiply", [softmax, range_tensor])
-        reduce_sum = dc.op("reduce_sum", [mult_2], (axis,))
+        reduce_sum = dc.op_with_named_attrs(
+            "reduce_sum", (mult_2,), {"dim_arg": [axis], "keep_dim": True}, (axis, True)
+        )
+
         dc.fuse(reduce_sum)
 
     def lower(self, lc, tensors, outputs):

--- a/forge/test/models/pytorch/text/opt/test_opt.py
+++ b/forge/test/models/pytorch/text/opt/test_opt.py
@@ -88,7 +88,7 @@ def test_opt_qa(variant, test_device):
 def test_opt_sequence_classification(variant, test_device):
     # Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
-    compiler_cfg.compile_depth = forge.CompileDepth.INIT_COMPILE
+    compiler_cfg.compile_depth = forge.CompileDepth.POST_INITIAL_GRAPH_PASS
 
     # Load tokenizer and model from HuggingFace
     # Variants: "facebook/opt-125m", "facebook/opt-350m", "facebook/opt-1.3b"

--- a/forge/test/models/pytorch/vision/dla/test_dla.py
+++ b/forge/test/models/pytorch/vision/dla/test_dla.py
@@ -40,8 +40,10 @@ variants = list(variants_func.keys())
 @pytest.mark.model_analysis
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_dla_pytorch(variant, test_device):
+
     # Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()
+    compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
     func = variants_func[variant]
 
     # Load data sample


### PR DESCRIPTION
## Summary

- This PR fixes https://github.com/tenstorrent/tt-forge-fe/issues/817
- After applying [this fix](https://github.com/tenstorrent/tt-tvm/pull/51) model faced `AssertionError: Reduce should have dim and keepdim parameter, and optional stride attr OR mandatory groups attr for grouped reduce.`
- After addressing that attribute issue in reduce sum op, this model failing at optimised graph pass due to https://github.com/tenstorrent/tt-forge-fe/issues/816 . DLA failing due to https://github.com/tenstorrent/tt-mlir/issues/1371 on latest main.
- So depth of those models are also changed accordingly

## Logs

- [multi_index_test_cases_before_fix.log](https://github.com/user-attachments/files/17998244/dec4_multi_index_test_cases_before_fix.log)
- [multi_index_test_cases_after_fix.log](https://github.com/user-attachments/files/18002086/dec4_multi_index_test_cases_cc.log)
- [opt_seq_cls_before_fix.log](https://github.com/user-attachments/files/17998255/dec4_opt_seq_cls_before_fix.log)
- [opt_seq_cls_after_multi_indexing_fix.log](https://github.com/user-attachments/files/18002093/dec4_opt_seq_cls_after_tvm_if.log)
- [opt_seq_cls_after_attr_fix.log](https://github.com/user-attachments/files/18002092/dec4_opt_seq_cls_after_attr_if.log)




