### PR TITLE
uplift tt-mlir @ fa326aa

### DIFF
--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -306,7 +306,7 @@ def test_flatten(shape):
     framework_model = Flatten()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model)
+    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
 
 
 @pytest.mark.parametrize("operand_and_cast_dtype", [(torch.float32, torch.int32), (torch.int32, torch.float32)])
@@ -1196,17 +1196,11 @@ def test_softmax():
             (4, 64),
             0,
             False,
-            marks=pytest.mark.xfail(
-                reason="Index is out of bounds for the rank, should be between 0 and 0 however is 18446744073709551615"
-            ),
         ),
         pytest.param(
             (32, 32),
             -2,
             False,
-            marks=pytest.mark.xfail(
-                reason="Index is out of bounds for the rank, should be between 0 and 0 however is 18446744073709551615"
-            ),
         ),
         pytest.param((2, 32, 32), 0, False, marks=pytest.mark.xfail(reason="tt:exception Unsupported dim")),
         ((1, 64, 32), 2, False),
@@ -1274,17 +1268,11 @@ def test_reduce_sum(input_shape, dim, keepdim):
             (4, 64),
             0,
             False,
-            marks=pytest.mark.xfail(
-                reason="Index is out of bounds for the rank, should be between 0 and 0 however is 18446744073709551615"
-            ),
         ),
         pytest.param(
             (32, 32),
             -2,
             False,
-            marks=pytest.mark.xfail(
-                reason="Index is out of bounds for the rank, should be between 0 and 0 however is 18446744073709551615"
-            ),
         ),
         pytest.param((2, 32, 32), 0, False, marks=pytest.mark.xfail(reason="tt:exception Unsupported dim")),
         ((1, 64, 32), 2, False),

--- a/forge/test/mlir/test_ops_tf.py
+++ b/forge/test/mlir/test_ops_tf.py
@@ -101,39 +101,7 @@ def test_conv2d(
     co_out = [co.to("cpu").to(fw_out[0].dtype) for co in co_out]
     co_out[0] = co_out[0].reshape(fw_out[0].shape)
 
-    ok = compare_with_golden(fw_out[0], co_out[0])
-
-    # We have some combinations of test params for which the PCC check fails.
-    # They can't be marked as xfail as they are a combination of multiple test params.
-    # So, manually simulating the xfail behaviour here...
-    test_param = (
-        batch_size,
-        output_channels,
-        input_channels,
-        input_height,
-        input_width,
-        filter_height,
-        filter_width,
-        stride_h,
-        stride_w,
-    )
-    if (
-        test_param
-        in [
-            (1, 64, 64, 56, 56, 3, 3, 1, 1),
-            (1, 128, 128, 56, 56, 3, 3, 2, 2),
-            (1, 64, 64, 8, 8, 3, 3, 1, 1),
-            (1, 64, 64, 16, 16, 3, 3, 1, 1),
-            (1, 256, 64, 56, 56, 1, 1, 2, 2),
-        ]
-        and activations_dtype == tf.bfloat16
-        and weights_dtype == tf.float32
-    ):
-        if ok:
-            pytest.fail("Test passed but expected to fail (simulating xpass)")
-        pytest.xfail("PCC check failed")
-
-    assert ok
+    assert compare_with_golden(fw_out[0], co_out[0])
 
 
 @pytest.mark.push


### PR DESCRIPTION
- remove xfail mark for tests that are now passing
- for flatten op tests change verification to pcc only