### PR TITLE
Verification enhanced v2

### DIFF
--- a/forge/forge/python_codegen.py
+++ b/forge/forge/python_codegen.py
@@ -157,7 +157,6 @@ class ForgeWriter(PythonWriter):
             self.wl("from forge.verify.compare import compare_with_golden")
             self.wl("from forge.verify.verify import verify")
             self.wl("from forge.verify.config import VerifyConfig")
-            self.wl("from forge.verify.compare import compare_with_golden")
             self.wl("import pytest")
 
         if self.framework == "tensorflow":

--- a/forge/forge/python_codegen.py
+++ b/forge/forge/python_codegen.py
@@ -157,6 +157,7 @@ class ForgeWriter(PythonWriter):
             self.wl("from forge.verify.compare import compare_with_golden")
             self.wl("from forge.verify.verify import verify")
             self.wl("from forge.verify.config import VerifyConfig")
+            self.wl("from forge.verify.compare import compare_with_golden")
             self.wl("import pytest")
 
         if self.framework == "tensorflow":

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 import re
 import json
-from collections import OrderedDict
 from typing import Dict, List
 from enum import Enum
 

--- a/forge/forge/verify/compare.py
+++ b/forge/forge/verify/compare.py
@@ -35,8 +35,8 @@ def compare_with_golden(
         all_close = torch.allclose(golden, calculated, rtol=rtol, atol=atol)
         if not all_close:
             req_atol, req_rtol = compute_required_tolerances(golden, calculated)
-            logger.error("Tensor mismatch. Current rtol={}, atol={}", rtol, atol)
-            logger.error("Required to pass the test rtol={}, atol={}", req_rtol, req_atol)
+            logger.error("Tensor mismatch. Required rtol={}, atol={}", rtol, atol)
+            logger.error("Observed maximum relative diff: {}, maximum absolute diff: {}", req_rtol, req_atol)
             logger.error("Golden: (shape = {}", golden.shape)
             logger.error(golden)
             logger.error("Calculated: (shape = {}", calculated.shape)

--- a/forge/forge/verify/config.py
+++ b/forge/forge/verify/config.py
@@ -261,7 +261,9 @@ class VerifyConfig:
 
     # --- Tensor Verification Settings --- #
     enabled: bool = True  # enable/disable verification
-    verify_tensor_metadata: VerifyTensorMetadata = VerifyTensorMetadata.ALL_CHECKS
+    verify_size: bool = True  # Check output size
+    verify_dtype: bool = True  # Check output dtype
+    verify_shape: bool = True  # Check output shape
     value_checker: ValueChecker = AutomaticValueChecker()
 
     # --- Logging settings --- #

--- a/forge/forge/verify/config.py
+++ b/forge/forge/verify/config.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from enum import Enum
 import os
 
+
 import torch
 import tensorflow as tf
 import forge
@@ -13,6 +14,7 @@ import forge
 from forge._C import DataFormat
 from dataclasses_json import dataclass_json
 from forge.utils import as_json
+from forge.verify.value_checkers import ValueChecker, AutomaticValueChecker
 
 
 class TestKind(Enum):
@@ -243,6 +245,14 @@ def _set_global_verify_config(config: DepricatedVerifyConfig):
     g_compiler_config = config
 
 
+class VerifyTensorMetadata(Enum):
+    ALL_CHECKS = "all_checks"  # default
+    ONLY_SHAPE = "only_shape"
+    ONLY_DTYPE = "only_dtype"
+    ONLY_SIZE = "only_size"
+    NONE = "none"
+
+
 # TODO: 1. Add support for backward pass verification
 #       2. Add support for intermediate representation verification
 @dataclass_json
@@ -251,18 +261,8 @@ class VerifyConfig:
 
     # --- Tensor Verification Settings --- #
     enabled: bool = True  # enable/disable verification
-    verify_size: bool = True  # Check output size
-    verify_dtype: bool = True  # Check output dtype
-    verify_shape: bool = True  # Check output shape
-    verify_data: bool = True  # Check output similarity using pcc
-    verify_allclose: bool = True  # Check output similarity using allclose
-
-    # --- Thresholds and Metrics --- #
-    rtol: Dict[Any, Optional[float]] = field(default_factory=lambda: {})  # values per data format
-    atol: Dict[Any, Optional[float]] = field(default_factory=lambda: {})  # values per data format
-    relative_atol: float = 0.1  # set atol at 10% of the max value in tensor
-    pcc: Optional[float] = None  # Pearson Coefficient Check
-    dissimilarity_threshold: Optional[float] = None  # use dissimilarity check for bool tensors
+    verify_tensor_metadata: VerifyTensorMetadata = VerifyTensorMetadata.ALL_CHECKS
+    value_checker: ValueChecker = AutomaticValueChecker()
 
     # --- Logging settings --- #
     dump_tensors: bool = False  # dump tensors to the bellow path
@@ -286,37 +286,3 @@ class VerifyConfig:
     @property
     def framework_model_types(self) -> Tuple:
         return (torch.nn.Module, tf.Module, tf.keras.Model, forge.ForgeModule)
-
-    # set defaults if not set explicitly by user. Relax under silicon, focus on pcc more.
-    def __post_init__(self):
-        if isinstance(self.rtol, (int, float)):
-            # User set one value, instead of dict
-            self.rtol = {torch.float32: self.rtol, torch.float16: self.rtol, torch.bfloat16: self.rtol}
-
-        if isinstance(self.atol, (int, float)):
-            # User set one value, instead of dict
-            self.atol = {torch.float32: self.atol, torch.float16: self.atol, torch.bfloat16: self.atol}
-
-        rtol_defaults = {
-            torch.float32: 1e-05,
-            torch.float16: 1e-05,
-            torch.bfloat16: 1e-05,
-        }
-        atol_defaults = {
-            torch.float32: 1e-08,
-            torch.float16: 1e-08,
-            torch.bfloat16: 1e-08,
-        }
-
-        for dt in [torch.float32, torch.float16, torch.bfloat16]:
-            if not dt in self.rtol:
-                self.rtol[dt] = rtol_defaults[dt]
-            if not dt in self.atol:
-                self.atol[dt] = atol_defaults[dt]
-
-        if self.pcc is None:
-            self.pcc = 0.99
-
-        if self.dissimilarity_threshold is None:
-            # threshold picked empirically. We will update it as TTNN evolves
-            self.dissimilarity_threshold = 0.001

--- a/forge/forge/verify/value_checkers.py
+++ b/forge/forge/verify/value_checkers.py
@@ -54,8 +54,8 @@ class AllCloseValueChecker(ValueChecker):
             atol, rtol = compute_required_tolerances(fw_out, co_out)
             raise ValueError(
                 f"Data mismatch -> AllCloseValueChecker (all_close):\n"
-                f"- Current tolerances: rtol={self.rtol}, atol={self.atol}\n"
-                f"- Required tolerances for test to pass: rtol={rtol}, atol={atol}\n"
+                f"- Tensor mismatch. Required rtol={self.rtol}, atol={self.atol}\n"
+                f"- Observed maximum relative diff: {rtol}, maximum absolute diff: {atol}\n"
                 f"- Framework output: ({fw_out.shape})\n"
                 f"{fw_out}\n"
                 f"- Compiled model output: ({co_out.shape})\n"
@@ -63,8 +63,8 @@ class AllCloseValueChecker(ValueChecker):
             )
 
 
-class FullChecker(AutomaticValueChecker):
-    """Performs all checks including PCC and all_close."""
+class FullValueChecker(ValueChecker):
+    """Performs PCC and all_close for float tensors."""
 
     def __init__(
         self, pcc: float = 0.99, rtol: float = 1e-05, atol: float = 1e-08, dissimilarity_threshold: float = 1e-03
@@ -76,8 +76,6 @@ class FullChecker(AutomaticValueChecker):
         )
 
     def check(self, fw_out, co_out):
-        # Combines all checks (PCC and allclose)
-
         if not compare_with_golden(fw_out, co_out, self.pcc, self.rtol, self.atol, self.dissimilarity_threshold):
             raise ValueError(
                 f"Data mismatch -> FullChecker (compare_with_golden): framework_model={fw_out}, compiled_model={co_out}"
@@ -95,8 +93,8 @@ class FullChecker(AutomaticValueChecker):
             atol, rtol = compute_required_tolerances(fw_out, co_out)
             raise ValueError(
                 f"Data mismatch -> FullChecker (all_close):\n"
-                f"- Current tolerances: rtol={self.rtol}, atol={self.atol}\n"
-                f"- Required tolerances for test to pass: rtol={rtol}, atol={atol}\n"
+                f"- Tensor mismatch. Required rtol={self.rtol}, atol={self.atol}\n"
+                f"- Observed maximum relative diff: {rtol}, maximum absolute diff: {atol}\n"
                 f"- Framework output: ({fw_out.shape})\n"
                 f"{fw_out}\n"
                 f"- Compiled model output: ({co_out.shape})\n"

--- a/forge/forge/verify/value_checkers.py
+++ b/forge/forge/verify/value_checkers.py
@@ -4,7 +4,7 @@
 from abc import ABC, abstractmethod
 
 import torch
-from forge.verify.compare import compare_with_golden
+from forge.verify.compare import compare_with_golden, compute_required_tolerances
 
 
 class ValueChecker(ABC):
@@ -51,8 +51,15 @@ class AllCloseValueChecker(ValueChecker):
         ], f"AllCloseValueChecker (all_close): all_close doesn't make sense for integer/bool types"
 
         if not torch.allclose(fw_out, co_out, rtol=self.rtol, atol=self.atol):
+            atol, rtol = compute_required_tolerances(fw_out, co_out)
             raise ValueError(
-                f"Data mismatch -> AllCloseValueChecker (all_close): framework_model={fw_out}, compiled_model={co_out}"
+                f"Data mismatch -> AllCloseValueChecker (all_close):\n"
+                f"- Current tolerances: rtol={self.rtol}, atol={self.atol}\n"
+                f"- Required tolerances for test to pass: rtol={rtol}, atol={atol}\n"
+                f"- Framework output: ({fw_out.shape})\n"
+                f"{fw_out}\n"
+                f"- Compiled model output: ({co_out.shape})\n"
+                f"{co_out}"
             )
 
 
@@ -85,6 +92,13 @@ class FullChecker(AutomaticValueChecker):
             all_close_check = torch.allclose(fw_out, co_out, rtol=self.rtol, atol=self.atol)
 
         if not all_close_check:
+            atol, rtol = compute_required_tolerances(fw_out, co_out)
             raise ValueError(
-                f"Data mismatch -> FullChecker (all_close): framework_model={fw_out}, compiled_model={co_out}"
+                f"Data mismatch -> FullChecker (all_close):\n"
+                f"- Current tolerances: rtol={self.rtol}, atol={self.atol}\n"
+                f"- Required tolerances for test to pass: rtol={rtol}, atol={atol}\n"
+                f"- Framework output: ({fw_out.shape})\n"
+                f"{fw_out}\n"
+                f"- Compiled model output: ({co_out.shape})\n"
+                f"{co_out}"
             )

--- a/forge/forge/verify/value_checkers.py
+++ b/forge/forge/verify/value_checkers.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from abc import ABC, abstractmethod
+
+import torch
+from forge.verify.compare import compare_with_golden
+
+
+class ValueChecker(ABC):
+    """Abstract base class for value checking strategies."""
+
+    def __init__(self, rtol: float = 1e-05, atol: float = 1e-08):
+        self.rtol = rtol
+        self.atol = atol
+
+    @abstractmethod
+    def check(self, fw_out, co_out):
+        """Abstract method for performing the value check between two tensors."""
+        pass
+
+
+class AutomaticValueChecker(ValueChecker):
+    """Checks values automatically using PCC, all_close or rogerstanimoto based on type of the tensor.
+    if tensor is scalar all_close is used, if tensor is boolean based rogerstanimoto is used, else PCC is used."""
+
+    def __init__(
+        self, pcc: float = 0.99, rtol: float = 1e-05, atol: float = 1e-08, dissimilarity_threshold: float = 1e-03
+    ):
+        super().__init__(rtol, atol)
+        self.pcc = pcc
+        self.dissimilarity_threshold = (
+            dissimilarity_threshold  # threshold picked empirically. We will update it as TTNN evolves
+        )
+
+    def check(self, fw_out, co_out):
+        if not compare_with_golden(fw_out, co_out, self.pcc, self.rtol, self.atol, self.dissimilarity_threshold):
+            raise ValueError(
+                f"Data mismatch -> AutomaticValueChecker (compare_with_golden): framework_model={fw_out}, compiled_model={co_out}"
+            )
+
+
+class AllCloseValueChecker(ValueChecker):
+    """Checks values using torch.all_close."""
+
+    def check(self, fw_out, co_out):
+        assert fw_out.dtype not in [
+            torch.int32,
+            torch.int64,
+            torch.bool,
+        ], f"AllCloseValueChecker (all_close): all_close doesn't make sense for integer/bool types"
+
+        if not torch.allclose(fw_out, co_out, rtol=self.rtol, atol=self.atol):
+            raise ValueError(
+                f"Data mismatch -> AllCloseValueChecker (all_close): framework_model={fw_out}, compiled_model={co_out}"
+            )
+
+
+class FullChecker(AutomaticValueChecker):
+    """Performs all checks including PCC and all_close."""
+
+    def __init__(
+        self, pcc: float = 0.99, rtol: float = 1e-05, atol: float = 1e-08, dissimilarity_threshold: float = 1e-03
+    ):
+        super().__init__(rtol, atol)
+        self.pcc = pcc
+        self.dissimilarity_threshold = (
+            dissimilarity_threshold  # threshold picked empirically. We will update it as TTNN evolves
+        )
+
+    def check(self, fw_out, co_out):
+        # Combines all checks (PCC and allclose)
+
+        if not compare_with_golden(fw_out, co_out, self.pcc, self.rtol, self.atol, self.dissimilarity_threshold):
+            raise ValueError(
+                f"Data mismatch -> FullChecker (compare_with_golden): framework_model={fw_out}, compiled_model={co_out}"
+            )
+
+        all_close_check = True
+        if fw_out.dtype not in [
+            torch.int32,
+            torch.int64,
+            torch.bool,
+        ]:  # allclose doesn't make sense for integer/bool types
+            all_close_check = torch.allclose(fw_out, co_out, rtol=self.rtol, atol=self.atol)
+
+        if not all_close_check:
+            raise ValueError(
+                f"Data mismatch -> FullChecker (all_close): framework_model={fw_out}, compiled_model={co_out}"
+            )

--- a/forge/forge/verify/verify.py
+++ b/forge/forge/verify/verify.py
@@ -316,18 +316,18 @@ def verify(
     # - dtype check
     # - shape check
     # - compare with golden
-    if verify_cfg.verify_tensor_metadata in [VerifyTensorMetadata.ONLY_SIZE, VerifyTensorMetadata.ALL_CHECKS]:
+    if verify_cfg.verify_size:
         if len(fw_out) != len(co_out):
             raise ValueError(
                 f"Number of outputs from framework model and compiled model do not match: framework model has {len(fw_out)} outputs, compiled model has {len(co_out)} outputs"
             )
 
     for fw, co in zip(fw_out, co_out):
-        if verify_cfg.verify_tensor_metadata in [VerifyTensorMetadata.ONLY_DTYPE, VerifyTensorMetadata.ALL_CHECKS]:
+        if verify_cfg.verify_dtype:
             if fw.dtype != co.dtype:
                 raise TypeError(f"Dtype mismatch: framework_model.dtype={fw.dtype}, compiled_model.dtype={co.dtype}")
 
-        if verify_cfg.verify_tensor_metadata in [VerifyTensorMetadata.ONLY_SHAPE, VerifyTensorMetadata.ALL_CHECKS]:
+        if verify_cfg.verify_shape:
             if fw.shape != co.shape:
                 raise ValueError(f"Shape mismatch: framework_model.shape={fw.shape}, compiled_model.shape={co.shape}")
 

--- a/forge/forge/verify/verify.py
+++ b/forge/forge/verify/verify.py
@@ -16,12 +16,12 @@ import tensorflow as tf
 from forge.tensor import to_pt_tensors
 
 from ..tensor import Tensor, TensorShape, pad_pytorch_tensor_to_forge, narrow_forge_tensor_to_pytorch
-from .config import DepricatedVerifyConfig, VerifyConfig, should_waive_gradient
+from .config import DepricatedVerifyConfig, VerifyConfig, VerifyTensorMetadata, should_waive_gradient
 from ..config import PerfTraceLevel
 import forge._C.graph as pygraph
 from forge.tools.run_net2pipe import net2pipe
 from forge.compiled_graph_state import CompiledModel
-from forge.verify.compare import compare_with_golden, compare_tensor_to_golden
+from forge.verify.compare import compare_tensor_to_golden
 
 
 def _generate_random_losses(outputs, is_forge):
@@ -312,29 +312,23 @@ def verify(
     fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
 
     # 3rd step: verifications of outputs
+    # - size check
     # - dtype check
     # - shape check
     # - compare with golden
-    if verify_cfg.verify_size:
+    if verify_cfg.verify_tensor_metadata in [VerifyTensorMetadata.ONLY_SIZE, VerifyTensorMetadata.ALL_CHECKS]:
         if len(fw_out) != len(co_out):
             raise ValueError(
                 f"Number of outputs from framework model and compiled model do not match: framework model has {len(fw_out)} outputs, compiled model has {len(co_out)} outputs"
             )
 
     for fw, co in zip(fw_out, co_out):
-        if verify_cfg.verify_dtype:
+        if verify_cfg.verify_tensor_metadata in [VerifyTensorMetadata.ONLY_DTYPE, VerifyTensorMetadata.ALL_CHECKS]:
             if fw.dtype != co.dtype:
                 raise TypeError(f"Dtype mismatch: framework_model.dtype={fw.dtype}, compiled_model.dtype={co.dtype}")
-        if verify_cfg.verify_shape:
+
+        if verify_cfg.verify_tensor_metadata in [VerifyTensorMetadata.ONLY_SHAPE, VerifyTensorMetadata.ALL_CHECKS]:
             if fw.shape != co.shape:
                 raise ValueError(f"Shape mismatch: framework_model.shape={fw.shape}, compiled_model.shape={co.shape}")
-        if verify_cfg.verify_data:
-            if not compare_with_golden(golden=fw, calculated=co, verify_cfg=verify_cfg):
-                raise ValueError(f"Data mismatch (compare_with_golden): framework_model={fw}, compiled_model={co}")
-        if verify_cfg.verify_allclose and fw.dtype not in [
-            torch.int32,
-            torch.int64,
-            torch.bool,
-        ]:  # allclose doesn't make sense for integer/bool types
-            if not torch.allclose(fw, co, rtol=verify_cfg.rtol[fw.dtype], atol=verify_cfg.atol[fw.dtype]):
-                raise ValueError(f"Data mismatch (all_close): framework_model={fw}, compiled_model={co}")
+
+        verify_cfg.value_checker.check(fw, co)

--- a/forge/test/mlir/llama/tests/test_llama_lm_head.py
+++ b/forge/test/mlir/llama/tests/test_llama_lm_head.py
@@ -30,4 +30,4 @@ def test_llama_lm_head(model_path):
     # Compile the model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/mlir/llama/tests/test_llama_mlp.py
+++ b/forge/test/mlir/llama/tests/test_llama_mlp.py
@@ -30,4 +30,4 @@ def test_llama_mlp(model_path):
     # Compile the model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/mlir/llama/tests/test_llama_rms_norm.py
+++ b/forge/test/mlir/llama/tests/test_llama_rms_norm.py
@@ -30,4 +30,4 @@ def test_llama_lm_head(model_path):
     # Compile the model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
+++ b/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
@@ -57,4 +57,4 @@ def test_llama_rotary_emb(model_path):
     # Compile the model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/mlir/llama/tests/test_llama_self_attn.py
+++ b/forge/test/mlir/llama/tests/test_llama_self_attn.py
@@ -44,4 +44,4 @@ def test_llama_self_attn(model_path):
     # Compile the model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/mlir/llama/tests/test_specific_ops_llama32.py
+++ b/forge/test/mlir/llama/tests/test_specific_ops_llama32.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-import os
 import pytest
 
 import torch
@@ -9,6 +8,7 @@ from torch import nn
 
 import forge
 from forge.verify.config import VerifyConfig
+from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
 
@@ -39,7 +39,7 @@ def test_add(shapes):
     framework_model = Add()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -167,7 +167,7 @@ def test_matmul(shapes):
     framework_model = Matmul()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(pcc=0.95, verify_allclose=False))
+    verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95)))
 
 
 @pytest.mark.parametrize(
@@ -206,7 +206,7 @@ def test_multiply(shapes):
     framework_model = Multiply()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -215,7 +215,6 @@ def test_multiply(shapes):
         (1, 11, 2048),
     ],
 )
-@pytest.mark.xfail(reason="pcc < 0.75")
 @pytest.mark.push
 def test_reduce_avg(shapes):
     class ReduceAvg(nn.Module):
@@ -230,7 +229,7 @@ def test_reduce_avg(shapes):
     framework_model = ReduceAvg()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(pcc=0.75))
+    verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.99)))
 
 
 @pytest.mark.parametrize(
@@ -253,7 +252,7 @@ def test_sigmoid(shapes):
     framework_model = Sigmoid()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -276,7 +275,7 @@ def test_reciprocal(shapes):
     framework_model = Reciprocal()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -350,7 +349,7 @@ def test_softmax(shapes):
     framework_model = Softmax(dim)
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -434,4 +433,4 @@ def test_transpose(params):
     framework_model = Transpose(dims)
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/mlir/mnist/test_inference.py
+++ b/forge/test/mlir/mnist/test_inference.py
@@ -7,7 +7,6 @@ from .utils import *
 import forge
 import pytest
 from forge.verify.verify import verify
-from forge.verify.config import VerifyConfig
 
 
 @pytest.mark.push
@@ -18,4 +17,4 @@ def test_mnist_inference():
 
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/mlir/mnist/training/test_training.py
+++ b/forge/test/mlir/mnist/training/test_training.py
@@ -13,7 +13,6 @@ import forge
 from forge.op.loss import CrossEntropyLoss, L1Loss
 from ..utils import *
 from forge.verify.compare import compare_with_golden
-from forge.verify.config import VerifyConfig
 from forge.tensor import to_forge_tensors
 
 
@@ -69,7 +68,7 @@ def test_mnist_training():
             pred = tt_model(data)[0]
             golden_pred = framework_model(data)
             assert golden_pred.dtype == dtype
-            assert compare_with_golden(golden_pred, pred, verify_cfg=VerifyConfig(pcc=0.95))
+            assert compare_with_golden(golden_pred, pred, pcc=0.95)
 
             # Compute loss on CPU
             loss = loss_fn(pred, target)
@@ -140,7 +139,7 @@ def test_mnist_training_with_grad_accumulation():
             # Forward pass (prediction) on device
             pred = tt_model(data)[0]
             golden_pred = framework_model(data)
-            assert compare_with_golden(golden_pred, pred, verify_cfg=VerifyConfig(pcc=0.95))
+            assert compare_with_golden(golden_pred, pred, pcc=0.95)
 
             # Compute loss on CPU
             loss = loss_fn(pred, target)
@@ -384,7 +383,7 @@ def test_loss_device():
             # Forward pass (prediction) on device
             pred = tt_model(data)[0]
             golden_pred = framework_model(data)
-            assert compare_with_golden(golden_pred, pred, VerifyConfig(pcc=0.95))
+            assert compare_with_golden(golden_pred, pred, pcc=0.95)
 
             loss = tt_loss(pred, target)
             total_loss += loss[0].item()

--- a/forge/test/mlir/test_features.py
+++ b/forge/test/mlir/test_features.py
@@ -11,7 +11,6 @@ from torch import nn
 import forge
 from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
-from forge.verify.config import VerifyConfig
 
 
 @pytest.mark.push
@@ -28,7 +27,7 @@ def test_multiple_inputs():
     framework_model = MultipleInputs()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -59,7 +58,7 @@ def test_input_order(a_shape, b_shape, c_shape):
     framework_model = InputOrderWithConstants()
     compiled_model = forge.compile(framework_model, sample_inputs=[a, b, c])
 
-    verify([a, b, c], framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify([a, b, c], framework_model, compiled_model)
 
 
 @pytest.mark.parametrize("batch_size", [1, 4, 16, 32, 64])
@@ -81,7 +80,7 @@ def test_matmul_bias(batch_size, linear_features):
     framework_model = Linear()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 16, 64, 512])
@@ -103,7 +102,7 @@ def test_batch_size_inference(batch_size, in_features, out_features):
     framework_model = SimpleModel()
     compiled_model = forge.compile(framework_model, sample_inputs=[torch.rand(batch_size, in_features)])
 
-    verify(in_data, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(in_data, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize("batch_size", [1, 2, 16, 64, 512])
@@ -134,9 +133,7 @@ def test_batch_size_training(batch_size, in_features, out_features):
 
     pred = tt_model(in_data)[0]
     golden_pred = model(in_data)
-    assert compare_with_golden(
-        golden_pred, pred, verify_cfg=VerifyConfig(pcc=0.95)
-    )  # 0.95 is the minimum value for which the test passes
+    assert compare_with_golden(golden_pred, pred, pcc=0.95)  # 0.95 is the minimum value for which the test passes
 
     loss = loss_fn(pred, target)
     golden_loss = loss_fn(golden_pred, target)

--- a/forge/test/mlir/test_loss.py
+++ b/forge/test/mlir/test_loss.py
@@ -7,7 +7,6 @@ import torch
 from torch import nn
 
 import forge
-from forge.verify.compare import compare_with_golden
 
 
 @pytest.mark.parametrize(

--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -89,7 +89,7 @@ def test_index(shape, dim, index):
     framework_model = Index(index)
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -277,7 +277,7 @@ def test_power(shape):
     framework_model = power()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -334,7 +334,7 @@ def test_flatten(shape):
     framework_model = Flatten()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize("operand_and_cast_dtype", [(torch.float32, torch.int32), (torch.int32, torch.float32)])
@@ -477,7 +477,7 @@ def test_layernorm(batch_size, num_channels, height, width):
 
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -494,7 +494,7 @@ def test_gelu(shape):
     framework_model = nn.GELU()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -530,7 +530,7 @@ def test_clip(shape, min_val, max_val):
     framework_model = Clip(min_val, max_val)
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -636,7 +636,7 @@ def test_exp(shape):
     framework_model = Exp()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -682,7 +682,7 @@ def test_log(shape):
     framework_model = Log()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -891,7 +891,7 @@ def test_batchnorm2d(batch_size, num_channels, height, width):
     framework_model = nn.BatchNorm2d(num_features=num_channels)
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.push
@@ -908,7 +908,7 @@ def test_add():
     framework_model = Add()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 params = [
@@ -948,7 +948,7 @@ def test_transpose(params, data_format):
     framework_model = Transpose(dims).to(data_format)
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -1112,7 +1112,7 @@ def test_subtract():
     framework_model = Subtract()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_dtype=False, verify_allclose=False))
+    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_dtype=False))
 
 
 @pytest.mark.parametrize(
@@ -1136,7 +1136,7 @@ def test_multiply(shape):
     framework_model = Multiply()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.push
@@ -1191,7 +1191,7 @@ def test_softmax():
     framework_model = Softmax()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -1359,7 +1359,7 @@ def test_matmul(batch_size, outer_dim_x, outer_dim_y, inner_dim):
     framework_model = Matmul()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize("x_shape", [7, 32, 41])
@@ -1470,7 +1470,7 @@ def test_reciprocal(shape):
     framework_model = Reciprocal()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -1501,7 +1501,7 @@ def test_sigmoid(shape):
     framework_model = Sigmoid()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize("dim", [-1, -2, -3], ids=["-1", "-2", "-3"])
@@ -1528,7 +1528,7 @@ def test_indexing(dim, start, stop, stride, shape):
     framework_model = ForgeIndexing(dim, start, stop, stride)
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.xfail(reason="ttnn.embedding op fails while reshaping the input_tensor in TILE_LAYOUT")
@@ -1891,7 +1891,7 @@ def test_remainder():
     framework_model = Remainder()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.xfail(
@@ -1978,4 +1978,4 @@ def test_tanh(input_shape):
     framework_model = Tanh()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/mlir/test_ops_tf.py
+++ b/forge/test/mlir/test_ops_tf.py
@@ -10,7 +10,6 @@ from forge.tensor import to_pt_tensors
 from forge.verify.compare import compare_with_golden
 from forge.config import _get_global_compiler_config
 from forge.verify.verify import verify
-from forge.verify.config import VerifyConfig
 from forge._C import DataFormat
 
 
@@ -125,7 +124,7 @@ def test_dual_conv2d():
     framework_model = DualConv2d()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -187,4 +186,4 @@ def test_maxpool2d(
     framework_model = MaxPool()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/test_api.py
+++ b/forge/test/test_api.py
@@ -12,8 +12,6 @@ import tensorflow as tf
 import forge
 import forge.config
 from forge.tensor import to_forge_tensors, to_pt_tensors
-from forge.verify.verify import verify
-from forge.verify.config import VerifyConfig
 
 
 def test_torch():


### PR DESCRIPTION
In this verification we have abstract `ValueChecker` class which can be derived into:
`AutomaticValueChecker`, `AllCloseValueChecker`, `FullChecker`. Default is using `AutomaticValueChecker` so we don't have problems with `torch.allclose`.
Here if user wants to perform full verification, it can be done like this:
```
verify(inputs, fw_model, co_model, VerifyConfig(valueChecker=FullChecker()))
verify(inputs, fw_model, co_model, VerifyConfig(valueChecker=FullChecker(pcc=0.95, rtol=1e-05)))
```
The advantage of this approach is that user only sets things that will be used in verification.

**NOTE**: in this PR I also made function that will tell us which `atol` and `rtol` to use in order for check to pass.