### PR TITLE
Share FailingRulesConverter

### DIFF
--- a/forge/test/operators/pytorch/eltwise_binary/failing_rules.py
+++ b/forge/test/operators/pytorch/eltwise_binary/failing_rules.py
@@ -12,6 +12,7 @@ from test.operators.utils import TestCollection
 from test.operators.utils import TestResultFailing
 from test.operators.utils import FailingReasons
 from test.operators.utils import TestCollectionCommon
+from test.operators.utils import FailingRulesConverter
 
 
 class FailingRulesData:
@@ -399,44 +400,47 @@ class FailingRulesData:
         ),
     ]
 
-    ne = [
-        # PCC check fails for all input sources and buggy shapes
-        common[0],
-        # PCC check fails for CONST_EVAL_PASS and buggy shapes
-        common[1],
-        # PCC check fails for FROM_HOST and all int dev data formats
-        common[2],
-        # fmt: off
-        # Exceptions for failing_rules[1]
-        (InputSource.FROM_ANOTHER_OP,   (1, 1),             None,                               None,   None),
-        (InputSource.FROM_HOST,         (1, 1),             None,                               None,   None),
-        (InputSource.FROM_DRAM_QUEUE,   (1, 1),             None,                               None,   None),
-        # Exceptions for failing_rules[3]
-        (InputSource.FROM_HOST,         (1, 4),             forge.DataFormat.Int8,              None,   None),
-        (InputSource.FROM_HOST,         (1, 2, 3, 4),       forge.DataFormat.RawUInt32,         None,   None),
-        (InputSource.FROM_HOST,         (1, 2, 3, 4),       forge.DataFormat.Int32,             None,   None),
-        # PCC check fails for Int8
-        (InputSource.FROM_DRAM_QUEUE,   None,               forge.DataFormat.Int8,              None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        (InputSource.CONST_EVAL_PASS,   None,               forge.DataFormat.Int8,              None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        # Exceptions for PCC check fails for Int8
-        (InputSource.FROM_DRAM_QUEUE,   (1, 4),             forge.DataFormat.Int8,              None,   None),
-        # PCC check fails for buggy shapes
-        (InputSource.FROM_HOST,         (1, 1000),          None,                               None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        (InputSource.FROM_DRAM_QUEUE,   (1, 1000),          None,                               None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        (InputSource.FROM_HOST,         (5, 11, 64, 1),     None,                               None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        (InputSource.FROM_DRAM_QUEUE,   (5, 11, 64, 1),     None,                               None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        # PCC check fails for buggy shapes
-        (InputSource.FROM_HOST,         (11, 45, 17),       [forge.DataFormat.Int8, None],      None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        (InputSource.FROM_DRAM_QUEUE,   (11, 45, 17),       [forge.DataFormat.Int8, None],      None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        (InputSource.FROM_HOST,         (1, 11, 45, 17),    [forge.DataFormat.Int8, None],      None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        (InputSource.FROM_DRAM_QUEUE,   (1, 11, 45, 17),    [forge.DataFormat.Int8, None],      None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        # PCC check fails for buggy shapes
-        (InputSource.FROM_HOST,         (45, 17),           forge.DataFormat.Float16_b,         None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        (InputSource.FROM_DRAM_QUEUE,   (45, 17),           forge.DataFormat.Float16_b,         None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        (InputSource.FROM_HOST,         (1, 45, 17),        forge.DataFormat.Float16_b,         None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        (InputSource.FROM_DRAM_QUEUE,   (1, 45, 17),        forge.DataFormat.Float16_b,         None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
-        # fmt: on
-    ]
+    ne = FailingRulesConverter.build_rules(
+        [
+            # PCC check fails for all input sources and buggy shapes
+            common[0],
+            # PCC check fails for CONST_EVAL_PASS and buggy shapes
+            common[1],
+            # PCC check fails for FROM_HOST and all int dev data formats
+            common[2],
+            # fmt: off
+            # Exceptions for failing_rules[1]
+            (InputSource.FROM_ANOTHER_OP,   (1, 1),             None,                               None,   None),
+            (InputSource.FROM_HOST,         (1, 1),             None,                               None,   None),
+            (InputSource.FROM_DRAM_QUEUE,   (1, 1),             None,                               None,   None),
+            # Exceptions for failing_rules[3]
+            (InputSource.FROM_HOST,         (1, 4),             forge.DataFormat.Int8,              None,   None),
+            (InputSource.FROM_HOST,         (1, 2, 3, 4),       forge.DataFormat.RawUInt32,         None,   None),
+            (InputSource.FROM_HOST,         (1, 2, 3, 4),       forge.DataFormat.Int32,             None,   None),
+            # PCC check fails for Int8
+            (InputSource.FROM_DRAM_QUEUE,   None,               forge.DataFormat.Int8,              None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            (InputSource.CONST_EVAL_PASS,   None,               forge.DataFormat.Int8,              None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            # Exceptions for PCC check fails for Int8
+            (InputSource.FROM_DRAM_QUEUE,   (1, 4),             forge.DataFormat.Int8,              None,   None),
+            # PCC check fails for buggy shapes
+            (InputSource.FROM_HOST,         (1, 1000),          None,                               None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            (InputSource.FROM_DRAM_QUEUE,   (1, 1000),          None,                               None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            (InputSource.FROM_HOST,         (5, 11, 64, 1),     None,                               None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            (InputSource.FROM_DRAM_QUEUE,   (5, 11, 64, 1),     None,                               None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            # PCC check fails for buggy shapes
+            (InputSource.FROM_HOST,         (11, 45, 17),       [forge.DataFormat.Int8, None],      None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            (InputSource.FROM_DRAM_QUEUE,   (11, 45, 17),       [forge.DataFormat.Int8, None],      None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            (InputSource.FROM_HOST,         (1, 11, 45, 17),    [forge.DataFormat.Int8, None],      None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            (InputSource.FROM_DRAM_QUEUE,   (1, 11, 45, 17),    [forge.DataFormat.Int8, None],      None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            # PCC check fails for buggy shapes
+            (InputSource.FROM_HOST,         (45, 17),           forge.DataFormat.Float16_b,         None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            (InputSource.FROM_DRAM_QUEUE,   (45, 17),           forge.DataFormat.Float16_b,         None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            (InputSource.FROM_HOST,         (1, 45, 17),        forge.DataFormat.Float16_b,         None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            (InputSource.FROM_DRAM_QUEUE,   (1, 45, 17),        forge.DataFormat.Float16_b,         None,   TestResultFailing(failing_reason=FailingReasons.DATA_MISMATCH)),
+            # fmt: on
+        ],
+        params=["input_source", "input_shape", "dev_data_format", "math_fidelity", "result_failing"],
+    )
 
     gt = [
         # PCC check fails for all input sources and buggy shapes

--- a/forge/test/operators/utils/__init__.py
+++ b/forge/test/operators/utils/__init__.py
@@ -21,6 +21,7 @@ from .plan import TestPlan
 from .plan import TestSuite
 from .plan import TestQuery
 from .plan import TestPlanUtils
+from .plan import FailingRulesConverter
 from .plan import TestPlanScanner
 from .test_data import TestCollectionCommon
 from .failing_reasons import FailingReasons
@@ -49,6 +50,7 @@ __all__ = [
     "TestSuite",
     "TestQuery",
     "TestPlanUtils",
+    "FailingRulesConverter",
     "TestPlanScanner",
     "TestCollectionCommon",
     "FailingReasons",


### PR DESCRIPTION
Move FailingRulesConverter to shared utils
Extend FailingRulesConverter with kwargs support
Specify list of params for failing rule