### PR TITLE
Optimize the model analysis weekly pipeline

### DIFF
--- a/forge/forge/python_codegen.py
+++ b/forge/forge/python_codegen.py
@@ -1085,7 +1085,7 @@ class ForgeWriter(PythonWriter):
         self.wl("")
         self.wl("compiled_model = compile(framework_model, sample_inputs=inputs)")
         self.wl("")
-        self.wl("verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))")
+        self.wl("verify(inputs, framework_model, compiled_model)")
         self.wl("")
         self.wl("")
         self.indent -= 1

--- a/pytest.ini
+++ b/pytest.ini
@@ -14,6 +14,7 @@ markers =
     nightly_sweeps: marks tests as nightly_sweeps
     slow: marks tests as slow               # deprecated - slow tests, should not be run in push pipeline
     run_in_pp: marks tests as run_in_pp     # deprecated - tests that should run in push pipeline
+    model_analysis: marks tests as model_analysis
 
 # Where pytest should look for tests
 testpaths =


### PR DESCRIPTION
The PR will optimise the model analysis weekly pipeline - #761 

The current model_analysis script will generate the unique op tests and running the unique op configuration test model wise instead collect the unique op test configuration from all the models and then extract unique op configuration test across all the models which will avoid running same configuration that are present in multiple models again and again.

For example, if we have add op with operands shape of (1, 32) and (1, 32) in resnet and mobilenet, will run the test only once and populate the test results in both resnet and mobilenet

