### PR TITLE
CI Fix - Replace libgl1-mesa-glx with libgl1 libglx-mesa0

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -139,7 +139,8 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        apt install -y libgl1-mesa-glx
+        apt-get update
+        apt install -y libgl1 libglx-mesa0
         set -o pipefail # Ensures that the exit code reflects the first command that fails
         pip install pytest-split
         pytest -m push --splits 2 \

--- a/.github/workflows/model-analysis-weekly.yml
+++ b/.github/workflows/model-analysis-weekly.yml
@@ -77,7 +77,8 @@ jobs:
         shell: bash
         run: |
           source env/activate
-          apt install -y libgl1-mesa-glx
+          apt-get update
+          apt install -y libgl1 libglx-mesa0
           set -o pipefail # Ensures that the exit code reflects the first command that fails
           python scripts/model_analysis.py \
             --test_directory_or_file_path forge/test/models/pytorch \


### PR DESCRIPTION
 - Package was recently deleted gives error 404
 - Update build-and-test.yml and model-analysis-weekly.yml, and need an apt-get update too.