### PR TITLE
[train] fix param tensor references

### DIFF
--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -1378,12 +1378,9 @@ def compare_tensors(t0, t1):
 def const_eval_tensor(inputs, consteval_trace, input_name, is_forge=True):
     contains_recorded_operations = consteval_trace[input_name]
     if contains_recorded_operations:
-        value = consteval_input(
-            consteval_trace,
-            input_name,
-            inputs,
-            is_forge,
-        )
+        value = detach_tensors(
+            [consteval_input(consteval_trace, input_name, inputs, is_forge)], fix_non_contiguos=True
+        )[0]
     else:
         value = pad_pytorch_tensor_to_forge(inputs[input_name], []) if is_forge else inputs[input_name]
     # cast if necessary
@@ -1426,17 +1423,12 @@ def get_post_const_eval_tensors(
             constant_nodes, device_constant_and_parameters, consteval_trace, input_name, is_forge
         )
 
-        post_const_eval_constants[input_name] = detach_tensors(
-            [
-                const_eval_tensor(
-                    inputs,
-                    consteval_trace,
-                    input_name,
-                    is_forge,
-                )
-            ],
-            fix_non_contiguos=True,
-        )[0]
+        post_const_eval_constants[input_name] = const_eval_tensor(
+            inputs,
+            consteval_trace,
+            input_name,
+            is_forge,
+        )
 
     return post_const_eval_constants
 


### PR DESCRIPTION
Remove the `.detach()` call when storing the tensor which doesn't have the consteval trace. This makes the tensor in our runtime, and its analagous tensor in torch, share the same reference. So, any changes in the underlaying data will be reflected in both our runtime and torch.

Before this change, the tensors were not referencing the same object, but they still shared the data - that is the reason why the optimizer on cpu (torch) worked even before. However, if we would change the underlaying data of our tensor (via `our_tensor.data = new_data`), as is the case with running optimizer on the device, this would not reflect on the original tensor (in torch).

Add assertions to make sure we are sharing the same tensor with torch.

Also, fixes an issue with the registering the hooks for multiple gradients (lambda was taking the gradient id by ref instead of by value).