### PR TITLE
update Llama 3.2 1B tests

### DIFF
--- a/forge/test/mlir/llama/test_llama_inference.py
+++ b/forge/test/mlir/llama/test_llama_inference.py
@@ -12,11 +12,26 @@ from test.mlir.llama.utils.utils import load_model
 
 @pytest.mark.nightly
 @pytest.mark.xfail()
-@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-def test_llama_inference(model_path):
-    if model_path == "meta-llama/Llama-3.2-1B":
-        pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b"])
+def test_llama_3b_inference(model_path):
+    # Load Model and Tokenizer
+    framework_model, tokenizer = load_model(model_path)
 
+    prompt = "Q: What is the largest animal?\nA:"
+    input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+
+    # Sanity run
+    generation_output = framework_model.generate(input_ids=input_ids, max_new_tokens=32)
+    print(tokenizer.decode(generation_output[0]))
+
+    # Compile the model
+    compiled_model = forge.compile(framework_model, input_ids)
+
+
+@pytest.mark.nightly
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
+def test_llama_32_inference(model_path):
     # Load Model and Tokenizer
     framework_model, tokenizer = load_model(model_path)
 

--- a/forge/test/mlir/llama/test_llama_inference.py
+++ b/forge/test/mlir/llama/test_llama_inference.py
@@ -29,7 +29,7 @@ def test_llama_3b_inference(model_path):
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail()
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_inference(model_path):
     # Load Model and Tokenizer

--- a/forge/test/mlir/llama/test_llama_inference.py
+++ b/forge/test/mlir/llama/test_llama_inference.py
@@ -29,7 +29,6 @@ def test_llama_3b_inference(model_path):
 
 
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_inference(model_path):
     # Load Model and Tokenizer
@@ -57,8 +56,6 @@ def test_llama_inference_no_cache_cpu(model_path):
     and tokenizer, prepare an input prompt, and generate a sequence of tokens until a specified
     maximum number of new tokens is reached or an end-of-sequence token is encountered.
     """
-    if model_path == "meta-llama/Llama-3.2-1B":
-        pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 
     # Load Llama model and tokenizer
     framework_model, tokenizer = load_model(model_path)
@@ -104,8 +101,6 @@ def test_llama_inference_cache_cpu(model_path):
     5. Generate tokens iteratively, updating the past key-values and input IDs.
     6. Decode the generated tokens into text and print the result.
     """
-    if model_path == "meta-llama/Llama-3.2-1B":
-        pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 
     # Load Llama model and tokenizer
     framework_model, tokenizer = load_model(model_path)

--- a/forge/test/mlir/llama/test_llama_inference.py
+++ b/forge/test/mlir/llama/test_llama_inference.py
@@ -29,6 +29,7 @@ def test_llama_3b_inference(model_path):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail()
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_inference(model_path):
     # Load Model and Tokenizer
@@ -45,9 +46,9 @@ def test_llama_32_inference(model_path):
     compiled_model = forge.compile(framework_model, input_ids)
 
 
-@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.skip(reason="No need to run in CI, this is PoC that should be mapped to work on device.")
 @pytest.mark.push
+@pytest.mark.skip(reason="No need to run in CI, this is PoC that should be mapped to work on device.")
+@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
 def test_llama_inference_no_cache_cpu(model_path):
     """
     This function tests the inference of the Llama 3B model without using a past-cache (KV cache).
@@ -81,9 +82,9 @@ def test_llama_inference_no_cache_cpu(model_path):
     print(generated_text)
 
 
-@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.skip(reason="No need to run in CI, this is PoC that should be mapped to work on device.")
 @pytest.mark.push
+@pytest.mark.skip(reason="No need to run in CI, this is PoC that should be mapped to work on device.")
+@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
 def test_llama_inference_cache_cpu(model_path):
     """
     This function tests the inference of the Llama 3B model using a past-cache (KV cache).

--- a/forge/test/mlir/llama/tests/test_llama_embedding.py
+++ b/forge/test/mlir/llama/tests/test_llama_embedding.py
@@ -31,7 +31,7 @@ def test_llama_3b_embedding(model_path):
 
 
 @pytest.mark.push
-@pytest.mark.xfail()
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_embedding(model_path):
     # Load Llama model and tokenizer

--- a/forge/test/mlir/llama/tests/test_llama_embedding.py
+++ b/forge/test/mlir/llama/tests/test_llama_embedding.py
@@ -31,7 +31,6 @@ def test_llama_3b_embedding(model_path):
 
 
 @pytest.mark.push
-@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_embedding(model_path):
     # Load Llama model and tokenizer

--- a/forge/test/mlir/llama/tests/test_llama_embedding.py
+++ b/forge/test/mlir/llama/tests/test_llama_embedding.py
@@ -9,13 +9,31 @@ from test.mlir.llama.utils.utils import load_model
 from forge.verify.verify import verify
 
 
-@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.xfail()
 @pytest.mark.push
-def test_llama_embedding(model_path):
-    if model_path == "meta-llama/Llama-3.2-1B":
-        pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.xfail()
+@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b"])
+def test_llama_3b_embedding(model_path):
+    # Load Llama model and tokenizer
+    framework_model, _ = load_model(model_path)
 
+    vocab_size = framework_model.config.vocab_size
+    framework_model = framework_model.model.embed_tokens
+
+    # Input samples
+    inputs = [
+        torch.randint(0, vocab_size, (1, 12)),  # Input token IDs
+    ]
+
+    # Compile the model
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    verify(inputs, framework_model, compiled_model)
+
+
+@pytest.mark.push
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
+def test_llama_32_embedding(model_path):
     # Load Llama model and tokenizer
     framework_model, _ = load_model(model_path)
 

--- a/forge/test/mlir/llama/tests/test_llama_embedding.py
+++ b/forge/test/mlir/llama/tests/test_llama_embedding.py
@@ -31,6 +31,7 @@ def test_llama_3b_embedding(model_path):
 
 
 @pytest.mark.push
+@pytest.mark.xfail()
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_embedding(model_path):
     # Load Llama model and tokenizer

--- a/forge/test/mlir/llama/tests/test_llama_lm_head.py
+++ b/forge/test/mlir/llama/tests/test_llama_lm_head.py
@@ -30,7 +30,6 @@ def test_llama_3b_lm_head(model_path):
 
 
 @pytest.mark.push
-@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_lm_head(model_path):
     # Load Llama model and tokenizer

--- a/forge/test/mlir/llama/tests/test_llama_lm_head.py
+++ b/forge/test/mlir/llama/tests/test_llama_lm_head.py
@@ -27,7 +27,7 @@ def test_llama_3b_lm_head(model_path):
     # Compile the model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.push

--- a/forge/test/mlir/llama/tests/test_llama_lm_head.py
+++ b/forge/test/mlir/llama/tests/test_llama_lm_head.py
@@ -10,12 +10,30 @@ from forge.verify.verify import verify
 from forge.verify.config import VerifyConfig
 
 
-@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
 @pytest.mark.push
-def test_llama_lm_head(model_path):
-    if model_path == "meta-llama/Llama-3.2-1B":
-        pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b"])
+def test_llama_3b_lm_head(model_path):
+    # Load Llama model and tokenizer
+    framework_model, _ = load_model(model_path)
 
+    framework_model = framework_model.lm_head
+    input_features = framework_model.in_features
+
+    # Input samples
+    inputs = [
+        torch.rand((1, 12, input_features)),  # Hidden states
+    ]
+
+    # Compile the model
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+
+
+@pytest.mark.push
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
+def test_llama_32_lm_head(model_path):
     # Load Llama model and tokenizer
     framework_model, _ = load_model(model_path)
 

--- a/forge/test/mlir/llama/tests/test_llama_lm_head.py
+++ b/forge/test/mlir/llama/tests/test_llama_lm_head.py
@@ -7,7 +7,6 @@ import pytest
 import forge
 from test.mlir.llama.utils.utils import load_model
 from forge.verify.verify import verify
-from forge.verify.config import VerifyConfig
 
 
 @pytest.mark.push

--- a/forge/test/mlir/llama/tests/test_llama_lm_head.py
+++ b/forge/test/mlir/llama/tests/test_llama_lm_head.py
@@ -30,6 +30,7 @@ def test_llama_3b_lm_head(model_path):
 
 
 @pytest.mark.push
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_lm_head(model_path):
     # Load Llama model and tokenizer

--- a/forge/test/mlir/llama/tests/test_llama_mlp.py
+++ b/forge/test/mlir/llama/tests/test_llama_mlp.py
@@ -27,7 +27,7 @@ def test_llama_3b_mlp(model_path):
     # Compile the model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.push

--- a/forge/test/mlir/llama/tests/test_llama_mlp.py
+++ b/forge/test/mlir/llama/tests/test_llama_mlp.py
@@ -30,7 +30,6 @@ def test_llama_3b_mlp(model_path):
 
 
 @pytest.mark.push
-@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_mlp(model_path):
     # Load Llama model and tokenizer

--- a/forge/test/mlir/llama/tests/test_llama_mlp.py
+++ b/forge/test/mlir/llama/tests/test_llama_mlp.py
@@ -7,7 +7,6 @@ import pytest
 import forge
 from test.mlir.llama.utils.utils import load_model
 from forge.verify.verify import verify
-from forge.verify.config import VerifyConfig
 
 
 @pytest.mark.push

--- a/forge/test/mlir/llama/tests/test_llama_mlp.py
+++ b/forge/test/mlir/llama/tests/test_llama_mlp.py
@@ -30,6 +30,7 @@ def test_llama_3b_mlp(model_path):
 
 
 @pytest.mark.push
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_mlp(model_path):
     # Load Llama model and tokenizer

--- a/forge/test/mlir/llama/tests/test_llama_mlp.py
+++ b/forge/test/mlir/llama/tests/test_llama_mlp.py
@@ -10,12 +10,30 @@ from forge.verify.verify import verify
 from forge.verify.config import VerifyConfig
 
 
-@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
 @pytest.mark.push
-def test_llama_mlp(model_path):
-    if model_path == "meta-llama/Llama-3.2-1B":
-        pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b"])
+def test_llama_3b_mlp(model_path):
+    # Load Llama model and tokenizer
+    framework_model, _ = load_model(model_path)
 
+    framework_model = framework_model.model.layers[0].mlp
+    hidden_dim = framework_model.hidden_size
+
+    # Input samples
+    inputs = [
+        torch.rand((1, 12, hidden_dim)),  # Hidden states
+    ]
+
+    # Compile the model
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+
+
+@pytest.mark.push
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
+def test_llama_32_mlp(model_path):
     # Load Llama model and tokenizer
     framework_model, _ = load_model(model_path)
 

--- a/forge/test/mlir/llama/tests/test_llama_prefil.py
+++ b/forge/test/mlir/llama/tests/test_llama_prefil.py
@@ -103,7 +103,7 @@ def test_llama_3b_prefil_on_device_decode_on_cpu(model_path):
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail()
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_prefil_on_device_decode_on_cpu(model_path):
     """

--- a/forge/test/mlir/llama/tests/test_llama_prefil.py
+++ b/forge/test/mlir/llama/tests/test_llama_prefil.py
@@ -57,8 +57,6 @@ def test_llama_prefil_on_device_decode_on_cpu(model_path):
     - The first part is the prefilling of the model on the device.
     - The second part is the decoding of the model on the CPU without KV cache.
     """
-    if model_path == "meta-llama/Llama-3.2-1B":
-        pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 
     # Load Llama model and tokenizer
     model, tokenizer = load_model(model_path, return_dict=True)

--- a/forge/test/mlir/llama/tests/test_llama_prefil.py
+++ b/forge/test/mlir/llama/tests/test_llama_prefil.py
@@ -48,10 +48,64 @@ def decode_on_cpu(model, tokenizer, input_ids, hidden_states, max_new_tokens):
     return input_ids, output_logits
 
 
-@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.xfail()
 @pytest.mark.nightly
-def test_llama_prefil_on_device_decode_on_cpu(model_path):
+@pytest.mark.xfail()
+@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b"])
+def test_llama_3b_prefil_on_device_decode_on_cpu(model_path):
+    """
+    This function tests the inference of the Llama models split into two parts:
+    - The first part is the prefilling of the model on the device.
+    - The second part is the decoding of the model on the CPU without KV cache.
+    """
+
+    # Load Llama model and tokenizer
+    model, tokenizer = load_model(model_path, return_dict=True)
+
+    # Prepare input sentence
+    prompt = "Q: What is the largest animal?\nA:"
+    input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+
+    # This is the part of the model needed for prefill; model without the last Linear layer (lm_head)
+    model_decoder = model.get_decoder()
+    compiled_decoder = forge.compile(model_decoder, sample_inputs=input_ids)
+
+    # Prefill Phase - Process the initial prompt on device
+    transformer_outputs = compiled_decoder(input_ids)
+    # Get hidden states for all tokens from the last "transformer layer".
+    hidden_states_compiled = transformer_outputs.last_hidden_state
+    hidden_states_compiled = hidden_states_compiled.to("cpu")
+
+    # Get hidden states for all tokens from the last "transformer layer" calculated on CPU.
+    hidden_states_framework = prefil_on_cpu(model, input_ids)
+
+    # Compare result of prefilling on device with the result of prefilling on CPU.
+    # Calculate the pcc for only the last vector in the hidden states tensor.
+    assert compare_with_golden(hidden_states_framework[:, -1, :], hidden_states_compiled[:, -1, :])
+
+    # Decode Phase - Generate new tokens
+    max_new_tokens = 46
+    output_ids_compiled, output_logits_compiled = decode_on_cpu(
+        model, tokenizer, input_ids, hidden_states_compiled, max_new_tokens
+    )
+    _, output_logits_framework = decode_on_cpu(model, tokenizer, input_ids, hidden_states_framework, max_new_tokens)
+
+    # Compare the logits of the generated tokens with the golden values from CPU.
+    assert all(
+        [
+            compare_with_golden(golden=out_logits_fw, calculated=out_logits_tt)
+            for out_logits_fw, out_logits_tt in zip(output_logits_framework, output_logits_compiled)
+        ]
+    )
+
+    # Generated text
+    generated_text_compiled = tokenizer.decode(output_ids_compiled[0], skip_special_tokens=True)
+    print(generated_text_compiled)
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail()
+@pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
+def test_llama_32_prefil_on_device_decode_on_cpu(model_path):
     """
     This function tests the inference of the Llama models split into two parts:
     - The first part is the prefilling of the model on the device.

--- a/forge/test/mlir/llama/tests/test_llama_rms_norm.py
+++ b/forge/test/mlir/llama/tests/test_llama_rms_norm.py
@@ -31,6 +31,7 @@ def test_llama_3b_lm_head(model_path):
 
 
 @pytest.mark.push
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_lm_head(model_path):
     # Load Llama model and tokenizer

--- a/forge/test/mlir/llama/tests/test_llama_rms_norm.py
+++ b/forge/test/mlir/llama/tests/test_llama_rms_norm.py
@@ -8,7 +8,6 @@ import pytest
 import forge
 from test.mlir.llama.utils.utils import load_model
 from forge.verify.verify import verify
-from forge.verify.config import VerifyConfig
 
 
 @pytest.mark.push

--- a/forge/test/mlir/llama/tests/test_llama_rms_norm.py
+++ b/forge/test/mlir/llama/tests/test_llama_rms_norm.py
@@ -28,7 +28,7 @@ def test_llama_3b_lm_head(model_path):
     # Compile the model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.push

--- a/forge/test/mlir/llama/tests/test_llama_rms_norm.py
+++ b/forge/test/mlir/llama/tests/test_llama_rms_norm.py
@@ -31,7 +31,6 @@ def test_llama_3b_lm_head(model_path):
 
 
 @pytest.mark.push
-@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_lm_head(model_path):
     # Load Llama model and tokenizer

--- a/forge/test/mlir/llama/tests/test_llama_rms_norm.py
+++ b/forge/test/mlir/llama/tests/test_llama_rms_norm.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
+import py
 import torch
 import pytest
 
@@ -10,12 +11,30 @@ from forge.verify.verify import verify
 from forge.verify.config import VerifyConfig
 
 
-@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
 @pytest.mark.push
-def test_llama_lm_head(model_path):
-    if model_path == "meta-llama/Llama-3.2-1B":
-        pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b"])
+def test_llama_3b_lm_head(model_path):
+    # Load Llama model and tokenizer
+    framework_model, _ = load_model(model_path)
 
+    framework_model = framework_model.model.norm
+    input_features = framework_model.weight.shape[0]
+
+    # Input samples
+    inputs = [
+        torch.rand((1, 12, input_features)),  # Hidden states
+    ]
+
+    # Compile the model
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+
+
+@pytest.mark.push
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
+def test_llama_32_lm_head(model_path):
     # Load Llama model and tokenizer
     framework_model, _ = load_model(model_path)
 

--- a/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
+++ b/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
@@ -57,6 +57,7 @@ def test_llama_3b_rotary_emb(model_path):
 
 
 @pytest.mark.push
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_rotary_emb(model_path):
     class Llama_Rotary_Embedding(torch.nn.Module):

--- a/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
+++ b/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
@@ -57,7 +57,6 @@ def test_llama_3b_rotary_emb(model_path):
 
 
 @pytest.mark.push
-@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_rotary_emb(model_path):
     class Llama_Rotary_Embedding(torch.nn.Module):

--- a/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
+++ b/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
@@ -11,9 +11,9 @@ from forge.verify.verify import verify
 from forge.verify.config import VerifyConfig
 
 
-@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
+@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b"])
 @pytest.mark.push
-def test_llama_rotary_emb(model_path):
+def test_llama_3b_rotary_emb(model_path):
     class Llama_Rotary_Embedding(torch.nn.Module):
         def __init__(self, model):
             super().__init__()
@@ -32,8 +32,52 @@ def test_llama_rotary_emb(model_path):
             query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
             return query_states, key_states
 
-    if model_path == "meta-llama/Llama-3.2-1B":
-        pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+    # Load Llama Model
+    llama_model, _ = load_model(model_path)
+
+    framework_model = Llama_Rotary_Embedding(llama_model)
+    framework_model.eval()
+
+    # Input samples
+    config = llama_model.config
+    batch_size = 1
+    q_heads = config.num_attention_heads
+    kv_heads = config.num_key_value_heads
+    query_seq_len = framework_model.seq_length
+    kv_seq_len = framework_model.seq_length
+    head_dim = config.hidden_size // config.num_attention_heads
+    inputs = [
+        torch.rand((batch_size, q_heads, query_seq_len, head_dim)),  # Query states
+        torch.rand((batch_size, kv_heads, kv_seq_len, head_dim)),  # Key states
+    ]
+
+    # Compile the model
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+
+
+@pytest.mark.push
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
+def test_llama_32_rotary_emb(model_path):
+    class Llama_Rotary_Embedding(torch.nn.Module):
+        def __init__(self, model):
+            super().__init__()
+            self.rotary_emb = model.model.layers[0].self_attn.rotary_emb
+            self.past_key_values_length = 0
+            self.seq_length = 12
+
+        def forward(self, query_states, key_states):
+            position_ids = torch.arange(
+                self.past_key_values_length,
+                self.seq_length + self.past_key_values_length,
+                dtype=torch.long,
+            )
+            position_ids = position_ids.unsqueeze(0)
+            cos, sin = self.rotary_emb(key_states, position_ids)
+            query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+            return query_states, key_states
 
     # Load Llama Model
     llama_model, _ = load_model(model_path)

--- a/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
+++ b/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
@@ -10,8 +10,8 @@ from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
 from forge.verify.verify import verify
 
 
-@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b"])
 @pytest.mark.push
+@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b"])
 def test_llama_3b_rotary_emb(model_path):
     class Llama_Rotary_Embedding(torch.nn.Module):
         def __init__(self, model):

--- a/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
+++ b/forge/test/mlir/llama/tests/test_llama_rotary_emb.py
@@ -8,7 +8,6 @@ import forge
 from test.mlir.llama.utils.utils import load_model
 from transformers.models.llama.modeling_llama import apply_rotary_pos_emb
 from forge.verify.verify import verify
-from forge.verify.config import VerifyConfig
 
 
 @pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b"])
@@ -54,7 +53,7 @@ def test_llama_3b_rotary_emb(model_path):
     # Compile the model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.push

--- a/forge/test/mlir/llama/tests/test_llama_self_attn.py
+++ b/forge/test/mlir/llama/tests/test_llama_self_attn.py
@@ -44,6 +44,7 @@ def test_llama_3b_self_attn(model_path):
 
 
 @pytest.mark.push
+@pytest.mark.xfail(reason="Unsupported Ops: repeat_interleave")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_self_attn(model_path):
     # Define wrapper function

--- a/forge/test/mlir/llama/tests/test_llama_self_attn.py
+++ b/forge/test/mlir/llama/tests/test_llama_self_attn.py
@@ -7,7 +7,6 @@ import pytest
 import forge
 from test.mlir.llama.utils.utils import load_model
 from forge.verify.verify import verify
-from forge.verify.config import VerifyConfig
 
 
 @pytest.mark.push

--- a/forge/test/mlir/llama/tests/test_llama_self_attn.py
+++ b/forge/test/mlir/llama/tests/test_llama_self_attn.py
@@ -44,7 +44,7 @@ def test_llama_3b_self_attn(model_path):
 
 
 @pytest.mark.push
-@pytest.mark.xfail(reason="Unsupported Ops: repeat_interleave")
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_self_attn(model_path):
     # Define wrapper function

--- a/forge/test/mlir/llama/tests/test_llama_self_attn.py
+++ b/forge/test/mlir/llama/tests/test_llama_self_attn.py
@@ -41,7 +41,7 @@ def test_llama_3b_self_attn(model_path):
     # Compile the model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.push

--- a/forge/test/mlir/llama/tests/test_llama_self_attn.py
+++ b/forge/test/mlir/llama/tests/test_llama_self_attn.py
@@ -10,12 +10,44 @@ from forge.verify.verify import verify
 from forge.verify.config import VerifyConfig
 
 
-@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
 @pytest.mark.push
-def test_llama_self_attn(model_path):
-    if model_path == "meta-llama/Llama-3.2-1B":
-        pytest.skip("Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b"])
+def test_llama_3b_self_attn(model_path):
+    # Define wrapper function
+    class SelfAttention(torch.nn.Module):
+        def __init__(self, model):
+            super().__init__()
+            self.model = model
 
+        def forward(self, *inputs):
+            hidden_states, _, _ = self.model(*inputs)
+
+            return hidden_states
+
+    # Load Llama model and tokenizer
+    framework_model, _ = load_model(model_path)
+    framework_model = SelfAttention(framework_model.model.layers[0].self_attn)
+
+    # Get hidden dimension
+    hidden_size = framework_model.model.config.hidden_size
+
+    # Input samples
+    inputs = [
+        torch.rand((1, 12, hidden_size)),  # Hidden states
+        torch.ones((1, 1, 12, 12)),  # Attention mask
+        torch.arange(12).unsqueeze(0).float(),  # Position IDs
+    ]
+
+    # Compile the model
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+
+
+@pytest.mark.push
+@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
+@pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
+def test_llama_32_self_attn(model_path):
     # Define wrapper function
     class SelfAttention(torch.nn.Module):
         def __init__(self, model):

--- a/forge/test/mlir/llama/tests/test_llama_self_attn.py
+++ b/forge/test/mlir/llama/tests/test_llama_self_attn.py
@@ -44,7 +44,6 @@ def test_llama_3b_self_attn(model_path):
 
 
 @pytest.mark.push
-@pytest.mark.skip(reason="Skipping test for Llama-3.2-1B model, waiting for new transformers version.")
 @pytest.mark.parametrize("model_path", ["meta-llama/Llama-3.2-1B"])
 def test_llama_32_self_attn(model_path):
     # Define wrapper function

--- a/pytest.ini
+++ b/pytest.ini
@@ -37,7 +37,7 @@ testpaths =
     forge/test/mlir/test_training.py
 
     # Llama
-    forge/test/mlir/llama/test_llama_inference.py::test_llama_inference
+    forge/test/mlir/llama/test_llama_inference.py
     forge/test/mlir/llama/tests
 
     # Resnet


### PR DESCRIPTION
I have removed the `@pytest.mark.skip` decorators from tests related to Llama 3.2. Additionally, I have separated the Llama 3b and Llama 3.2 tests to allow for independent testing.

fixes: #922