### PR TITLE
Fix: 'ttir.typecast' op Result shape must match operand shapes after broadcasting

### DIFF
--- a/forge/csrc/forge_passes.cpp
+++ b/forge/csrc/forge_passes.cpp
@@ -36,6 +36,7 @@
 #include "passes/post_autograd_graph_passes.hpp"
 #include "passes/pre_lowering_passes.hpp"
 #include "passes/print_graph.hpp"
+#include "passes/remove_broadcast.hpp"
 #include "passes/remove_nops.hpp"
 #include "passes/replace_incommutable_patterns.hpp"
 #include "passes/set_tile_dim.hpp"
@@ -87,6 +88,7 @@ run_post_initial_graph_passes(
     passes::fuse_pad_conv2d(graph);
     passes::explicate_unsqueeze(graph);
     passes::fuse_conv2d_bias(graph);
+    passes::remove_broadcast(graph);
 
     auto inserted_node_id_mapping = decompose_tt_forge_graph(graph, "get_f_forge_decompose", compiler_cfg);
     auto chip_id_assignments = passes::fracture(graph, fracture_groups);

--- a/forge/csrc/passes/remove_broadcast.cpp
+++ b/forge/csrc/passes/remove_broadcast.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "remove_broadcast.hpp"
+
+#include <utils/logger.hpp>
+
+#include "graph_lib/node_types.hpp"
+#include "graph_lib/utils.hpp"
+
+namespace tt::passes
+{
+
+void remove_broadcast(graphlib::Graph *graph)
+{
+    bool updated = true;
+    while (updated)
+    {
+        updated = false;
+        for (auto *node : graphlib::topological_sort(*graph))
+        {
+            std::vector<graphlib::Edge> data_edges = graph->operand_data_edges(node);
+            for (const graphlib::Edge &data_edge : data_edges)
+            {
+                graph->get_edge_attributes(data_edge)->clear_broadcast_dims();
+                graphlib::OpNode *op = dynamic_cast<graphlib::OpNode *>(node);
+
+                auto consumer = dynamic_cast<graphlib::OpNode *>(graph->node_by_id(data_edge.consumer_node_id));
+                auto user_edges = graph->user_data_edges(node);
+
+                if (not op)
+                    continue;
+
+                if (op->op_name() == "broadcast")
+                {
+                    if (graphlib::is_eltwise_binary(consumer) or consumer->op_name() == "broadcast")
+                    {
+                        graphlib::bypass_node(graph, node, true);
+                        updated = true;
+                        break;
+                    }
+                }
+
+                if (updated)
+                    break;
+            }
+        }
+    }
+}
+
+}  // namespace tt::passes

--- a/forge/csrc/passes/remove_broadcast.hpp
+++ b/forge/csrc/passes/remove_broadcast.hpp
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+namespace tt::graphlib
+{
+class Graph;
+class OpNode;
+class Shape;
+}  // namespace tt::graphlib
+
+namespace tt::passes
+{
+void remove_broadcast(graphlib::Graph *graph);
+}


### PR DESCRIPTION
Fix: https://github.com/tenstorrent/tt-forge-fe/issues/803

### Before Changes:
![Screenshot 2024-12-20 at 2 54 36 PM](https://github.com/user-attachments/assets/97d560b7-ad28-4ea5-8f09-d2787859f70c)



### After Changes:


![Screenshot 2024-12-20 at 2 53 40 PM](https://github.com/user-attachments/assets/2a2809c4-69db-4d8c-a2aa-4bc116e41c0b)



