### PR TITLE
Support value range for tensors with default df

### DIFF
--- a/forge/test/operators/pytorch/eltwise_binary/test_binary.py
+++ b/forge/test/operators/pytorch/eltwise_binary/test_binary.py
@@ -134,6 +134,10 @@ class TestVerification:
         if value_range is None:
             value_range = ValueRanges.SMALL
 
+        # Old behavior when dev_data_format was not set
+        if dev_data_format is None:
+            value_range = ValueRanges.SMALL_POSITIVE
+
         operator = getattr(torch, test_vector.operator)
 
         kwargs = test_vector.kwargs if test_vector.kwargs else {}

--- a/forge/test/operators/pytorch/eltwise_unary/test_unary.py
+++ b/forge/test/operators/pytorch/eltwise_unary/test_unary.py
@@ -115,7 +115,8 @@ class TestVerification:
             math_fidelity=test_vector.math_fidelity,
             pcc=test_vector.pcc,
             warm_reset=warm_reset,
-            value_range=ValueRanges.SMALL,
+            # Old behavior when dev_data_format was not set
+            value_range=ValueRanges.SMALL if test_vector.dev_data_format is not None else ValueRanges.SMALL_POSITIVE,
         )
 
 

--- a/forge/test/operators/pytorch/matmul/test_matmul.py
+++ b/forge/test/operators/pytorch/matmul/test_matmul.py
@@ -136,7 +136,8 @@ def verify(
         input_source_flag=input_source_flag,
         dev_data_format=dev_data_format,
         math_fidelity=math_fidelity,
-        value_range=ValueRanges.SMALL,
+        # Old behavior when dev_data_format was not set
+        value_range=ValueRanges.SMALL if dev_data_format is not None else ValueRanges.SMALL_POSITIVE,
     )
 
 

--- a/forge/test/operators/pytorch/nn/test_softmax.py
+++ b/forge/test/operators/pytorch/nn/test_softmax.py
@@ -161,7 +161,8 @@ def verify(
         input_source_flag=input_source_flag,
         dev_data_format=dev_data_format,
         math_fidelity=math_fidelity,
-        value_range=ValueRanges.SMALL,
+        # Old behavior when dev_data_format was not set
+        value_range=ValueRanges.SMALL if dev_data_format is not None else ValueRanges.SMALL_POSITIVE,
     )
 
 


### PR DESCRIPTION
Value range should not be ignored in tests when data format is not specified.

Preserve original behavior for unary, binary, matmul and softmax operators