### PR TITLE
Use ecr docker base image

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM public.ecr.aws/ubuntu/ubuntu:22.04
 SHELL ["/bin/bash", "-c"]
 
 # Set environment variables


### PR DESCRIPTION
Use ecr docker base image to avoid rate limit on docker.io and error

429 Too Many Requests - Server message: toomanyrequests: 

You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit