### PR TITLE
Uplift third_party/tt-mlir to origin/main 2024-12-26

### DIFF
--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -1563,7 +1563,6 @@ def test_indexing(dim, start, stop, stride, shape):
     verify(inputs, framework_model, compiled_model)
 
 
-@pytest.mark.xfail(reason="ttnn.embedding op fails while reshaping the input_tensor in TILE_LAYOUT")
 @pytest.mark.parametrize(
     "indices_shape",
     [


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir submodule to the origin/main