### PR TITLE
Expand code-owners list #963

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,9 @@
+# General
 * @nvukobratTT @pilkicTT @dgolubovicTT
+
+# CI/CD
 /.github/ @vmilosevic
+
+# Models
+## PyTorch
+forge/test/models/pytorch @vkovinicTT @mstojkovicTT


### PR DESCRIPTION
- Include Vanja and Mateja in PyTorch model ownership

Fix #963 