### PR TITLE
Enable Llama prefil

### DIFF
--- a/forge/test/mlir/llama/tests/test_llama_embedding.py
+++ b/forge/test/mlir/llama/tests/test_llama_embedding.py
@@ -10,9 +10,10 @@ from forge.verify.verify import verify
 
 
 @pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
-@pytest.mark.xfail()
 @pytest.mark.push
 def test_llama_embedding(model_path):
+    if model_path == "meta-llama/Llama-3.2-1B":
+        pytest.xfail("meta-llama/Llama-3.2-1B embedding is not supported yet")
     # Load Llama model and tokenizer
     framework_model, _ = load_model(model_path)
 
@@ -20,8 +21,9 @@ def test_llama_embedding(model_path):
     framework_model = framework_model.model.embed_tokens
 
     # Input samples
+    # cast input_ids to int32 since int64 causes embedding op data mismatch. Tracking issue: https://github.com/tenstorrent/tt-forge-fe/issues/952
     inputs = [
-        torch.randint(0, vocab_size, (1, 12)),  # Input token IDs
+        torch.randint(0, vocab_size, (1, 12), dtype=torch.int32),  # Input token IDs
     ]
 
     # Compile the model

--- a/forge/test/mlir/test_ops.py
+++ b/forge/test/mlir/test_ops.py
@@ -1447,7 +1447,6 @@ def test_sqrt(x_shape, y_shape):
 # @pytest.mark.parametrize("vocab_size", [2048, 16384, 32000])
 # @pytest.mark.parametrize("token_num", [1, 7, 32])
 # @pytest.mark.parametrize("embedding_dim", [128, 512, 3200])
-@pytest.mark.xfail(reason="ttnn.embedding op fails while reshaping the input_tensor in TILE_LAYOUT")
 @pytest.mark.parametrize("vocab_size", [32000])
 @pytest.mark.parametrize("token_num", [12])
 @pytest.mark.parametrize("embedding_dim", [3200])


### PR DESCRIPTION
    - Add tvm workaround for casting embedding weights to from float32 to bfloat16.
    - Remove xfail from llama prefil test.
    - Cast input indices, for prefil of llama, from int64 to int32 (To avoid data mismatch caused by int64), and add the tracking issue.