### PR TITLE
Remove xfail from Unsqueeze ResNet test

### DIFF
--- a/forge/test/mlir/resnet/test_resnet_unique_ops.py
+++ b/forge/test/mlir/resnet/test_resnet_unique_ops.py
@@ -105,7 +105,7 @@ def test_matmul_resnet(outer_dim_x, outer_dim_y, inner_dim):
     framework_model = Matmul()
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
-    verify(inputs, framework_model, compiled_model, VerifyConfig(verify_allclose=False))
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
@@ -138,9 +138,6 @@ def test_matmul_resnet(outer_dim_x, outer_dim_y, inner_dim):
     ],
 )
 @pytest.mark.push
-@pytest.mark.xfail(
-    reason="RuntimeError: Failed to run MLIR compiler pass pipeline. error: 'ttnn.reshape' op Shape attribute size must match output tensor rank. Tracking on: https://github.com/tenstorrent/tt-mlir/issues/1577"
-)
 def test_unsqueeze_resnet(input_shape, dim):
     class Unsqueeze(nn.Module):
         def __init__(self):

--- a/pytest.ini
+++ b/pytest.ini
@@ -43,6 +43,7 @@ testpaths =
 
     # Resnet
     forge/test/mlir/resnet/test_resnet_inference.py::test_resnet_inference
+    forge/test/mlir/resnet/test_resnet_unique_ops.py
 
     # Benchmark
     # MNIST Linear


### PR DESCRIPTION
- Remove xfail from Unsqueeze ResNet test since it passes now. 
- Adding test_resnet_unique_ops.py to pytest.ini
Closes [ISSUE](https://github.com/tenstorrent/tt-mlir/issues/1577). 