### PR TITLE
[tests] add loss tests to CI

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -26,6 +26,10 @@ testpaths =
     # Features
     forge/test/mlir/test_features.py
 
+    # Training
+    forge/test/mlir/test_loss.py
+    forge/test/mlir/test_training.py
+
     # API
     forge/test/test_api.py
 
@@ -35,7 +39,6 @@ testpaths =
     # MNIST Linear
     forge/test/mlir/mnist/test_inference.py
     forge/test/mlir/mnist/training/test_training.py
-    forge/test/mlir/test_training.py
 
     # Llama
     forge/test/mlir/llama/test_llama_inference.py::test_llama_inference


### PR DESCRIPTION
Adding `test_loss.py` to the CI. Issues with reduction ops with padded tensors (in ttnn) seem to have been resolved.