### PR TITLE
Fix model analysis weekly pipeline failures

### DIFF
--- a/.github/workflows/model-analysis-weekly.yml
+++ b/.github/workflows/model-analysis-weekly.yml
@@ -74,6 +74,9 @@ jobs:
           cmake --build ${{ steps.strings.outputs.build-output-dir }}
 
       - name: Run Model Analysis Script
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          HF_HUB_DISABLE_PROGRESS_BARS: 1
         shell: bash
         run: |
           source env/activate

--- a/forge/test/models/pytorch/audio/stereo/test_stereo.py
+++ b/forge/test/models/pytorch/audio/stereo/test_stereo.py
@@ -30,6 +30,8 @@ def test_stereo(variant):
     input_ids, attn_mask, decoder_input_ids = load_inputs(framework_model, processor)
     inputs = [input_ids, attn_mask, decoder_input_ids]
 
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, module_name="pt_" + str(variant.split("/")[-1].replace("-", "_"))
+    )
 
     verify(inputs, framework_model, compiled_model)

--- a/forge/test/models/pytorch/multimodal/clip/test_clip.py
+++ b/forge/test/models/pytorch/multimodal/clip/test_clip.py
@@ -44,4 +44,6 @@ def test_clip_pytorch(test_device):
     text_model = CLIPTextWrapper(model)
     inputs = [inputs[0], inputs[2]]
 
-    compiled_model = forge.compile(text_model, sample_inputs=inputs, module_name="pt_clip_text_model")
+    compiled_model = forge.compile(
+        text_model, sample_inputs=inputs, module_name="pt_" + str(model_ckpt.split("/")[-1].replace("-", "_")) + "_text"
+    )

--- a/forge/test/models/pytorch/text/mistral/test_mistral.py
+++ b/forge/test/models/pytorch/text/mistral/test_mistral.py
@@ -68,7 +68,11 @@ def test_mistral(variant, test_device):
     sample_inputs = tokenizer(prompt, return_tensors="pt")["input_ids"]
     inputs = [sample_inputs]
 
-    compiled_model = forge.compile(module, sample_inputs=inputs, module_name="pt_mistral")
+    compiled_model = forge.compile(
+        module,
+        sample_inputs=inputs,
+        module_name="pt_" + str(variant.split("/")[-1].replace("-", "_").replace(".", "_")),
+    )
 
 
 variants = ["mistralai/Mistral-7B-v0.1"]

--- a/scripts/model_analysis.py
+++ b/scripts/model_analysis.py
@@ -125,17 +125,10 @@ common_failure_matching_rules_list = [
             MatchingExceptionRule(
                 "Convert tt-forge attribute to an MLIR attribute", ["RuntimeError", "Unhandled attribute type"]
             ),
-            MatchingExceptionRule(
-                "ttmetal vs Forge Output Data mismatch",
-                ["AssertionError", "assert False", "where False = all([False])"],
-            ),
-            MatchingExceptionRule(
-                "Forge Verification Data mismatch",
-                ["ValueError", "forge/forge/verify/verify.py", "Data mismatch (compare_with_golden)"],
-            ),
+            MatchingExceptionRule("Runtime Datatype Unsupported", ["RuntimeError", "Unhandled dtype Bool"]),
             # Compiled model Runtime
             MatchingExceptionRule(
-                "Runtime Data mismatch", ["RuntimeError", "Tensor", "data type mismatch: expected", "got"]
+                "Runtime Datatype mismatch", ["RuntimeError", "Tensor", "data type mismatch: expected", "got"]
             ),
             MatchingExceptionRule(
                 "Runtime Shape mismatch", ["RuntimeError", "Tensor", "shape mismatch: expected", "got"]
@@ -190,6 +183,14 @@ common_failure_matching_rules_list = [
     MatchingCompilerComponentException(
         CompilerComponent.TT_METAL,
         [
+            MatchingExceptionRule(
+                "TT-Metal vs Forge Output Data mismatch",
+                [
+                    "ValueError",
+                    "Data mismatch -> AutomaticValueChecker (compare_with_golden): framework_model",
+                    ", compiled_model",
+                ],
+            ),
             MatchingExceptionRule(
                 "ttnn.tilize validation",
                 [
@@ -332,6 +333,41 @@ common_failure_matching_rules_list = [
                     "tt-metal/ttnn/cpp/ttnn/operations/core/work_split/work_split_tilize.hpp",
                     "logical_shape.rank() >= 2 && logical_shape.rank() <= 4",
                     "Only 2D, 3D, and 4D tensors are supported",
+                ],
+            ),
+            MatchingExceptionRule(
+                "ttnn softmax",
+                [
+                    "RuntimeError",
+                    "tt-metal/ttnn/cpp/ttnn/operations/moreh/moreh_softmax/device/moreh_softmax_device_operation.cpp",
+                    "input.get_dtype() == DataType::BFLOAT16 || input.get_dtype() == DataType::BFLOAT8_B",
+                    "Inputs must be of bfloat16 or bfloat8_b type",
+                ],
+            ),
+            MatchingExceptionRule(
+                "ttnn unsqueeze_to_4D",
+                [
+                    "RuntimeError",
+                    "tt-metal/ttnn/cpp/ttnn/operations/core/core.cpp",
+                    "Tensor rank is greater than 4",
+                ],
+            ),
+            MatchingExceptionRule(
+                "ttnn matmul",
+                [
+                    "RuntimeError",
+                    "tt-metal/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp",
+                    "(input_tensor_a.get_legacy_shape()[-1] / in0_tile_shape[1]) % program_config.in0_block_w == 0",
+                    "Kt must be divisible by in0_block_w",
+                ],
+            ),
+            MatchingExceptionRule(
+                "tt-metal ncrisc build",
+                [
+                    "RuntimeError",
+                    "tt-metal/tt_metal/impl/program/program.cpp",
+                    "Failed to generate binaries for reader_conv_activations_padded_with_halo_3x3_weights_v2",
+                    "ncrisc build failed",
                 ],
             ),
         ],


### PR DESCRIPTION
The PR will fix below issues found in the Model Analysis Weekly pipeline - [Link](https://github.com/tenstorrent/tt-forge-fe/actions/runs/12482523195)
   1. Unique Op tests are not generated for models like Llama, Gemma and mistral because of the Huggingface access token issue so adding the HF_Token as env in the model analysis weekly yml 
   2. Update the exception rule by checking the failed test logs of the [unknown compiler component or N/A ](https://github.com/tenstorrent/tt-forge-fe/blob/main/model_analysis_docs/ModelsInfo.md)
   3. Add the module_name for the stereo model and update the module_name for the mistral and clip model in the compile function