### PR TITLE
[test] reduce batch size for mnist training

### DIFF
--- a/forge/test/mlir/mnist/training/test_training.py
+++ b/forge/test/mlir/mnist/training/test_training.py
@@ -29,7 +29,7 @@ def test_mnist_training():
 
     # Set training hyperparameters
     num_epochs = 3
-    batch_size = 2048
+    batch_size = 1024
     learning_rate = 0.001
 
     # Load dataset


### PR DESCRIPTION
The `test_mnist_training` is failing on n300 machines, due to a bug in ttnn. Reduce the batch size so that the test can pass.

Filed an issue in tt-metal:
https://github.com/tenstorrent/tt-metal/issues/16348