### PR TITLE
Unsqueeze pytorch operator test plan

### DIFF
--- a/forge/test/operators/pytorch/tm/test_unsqueeze.py
+++ b/forge/test/operators/pytorch/tm/test_unsqueeze.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import math
+import torch
+import random
+
+from typing import List, Dict
+from loguru import logger
+
+from forge.verify.config import VerifyConfig
+
+from forge.verify.value_checkers import AllCloseValueChecker
+
+from test.operators.utils import InputSourceFlags, VerifyUtils
+from test.operators.utils import InputSource
+from test.operators.utils import TestVector
+from test.operators.utils import TestPlan
+from test.operators.utils.compat import TestDevice
+from test.operators.utils import TestCollection
+from test.operators.utils import TestCollectionCommon
+from test.operators.utils import ValueRanges
+
+from test.operators.pytorch.eltwise_unary import ModelFromAnotherOp, ModelDirect, ModelConstEvalPass
+
+
+class TestVerification:
+
+    MODEL_TYPES = {
+        InputSource.FROM_ANOTHER_OP: ModelFromAnotherOp,
+        InputSource.FROM_HOST: ModelDirect,
+        InputSource.FROM_DRAM_QUEUE: ModelDirect,
+        InputSource.CONST_EVAL_PASS: ModelConstEvalPass,
+    }
+
+    @classmethod
+    def verify(
+        cls,
+        test_device: TestDevice,
+        test_vector: TestVector,
+        input_params: List[Dict] = [],
+        warm_reset: bool = False,
+    ):
+
+        input_source_flag: InputSourceFlags = None
+        if test_vector.input_source in (InputSource.FROM_DRAM_QUEUE,):
+            input_source_flag = InputSourceFlags.FROM_DRAM
+
+        operator = getattr(torch, test_vector.operator)
+        kwargs = test_vector.kwargs if test_vector.kwargs else {}
+
+        model_type = cls.MODEL_TYPES[test_vector.input_source]
+        pytorch_model = (
+            model_type(operator, test_vector.input_shape, kwargs)
+            if test_vector.input_source in (InputSource.CONST_EVAL_PASS,)
+            else model_type(operator, kwargs)
+        )
+
+        input_shapes = tuple([test_vector.input_shape])
+
+        logger.trace(f"***input_shapes: {input_shapes}")
+
+        VerifyUtils.verify(
+            model=pytorch_model,
+            test_device=test_device,
+            input_shapes=input_shapes,
+            input_params=input_params,
+            input_source_flag=input_source_flag,
+            dev_data_format=test_vector.dev_data_format,
+            math_fidelity=test_vector.math_fidelity,
+            warm_reset=warm_reset,
+            value_range=ValueRanges.SMALL,
+            deprecated_verification=False,
+            verify_config=VerifyConfig(value_checker=AllCloseValueChecker()),
+        )
+
+
+class TestParamsData:
+
+    __test__ = False
+
+    test_plan: TestPlan = None
+
+    @classmethod
+    def generate_kwargs(cls, test_vector: TestVector):
+
+        dim = len(test_vector.input_shape)
+        dims = list(range(-dim - 1, dim + 1))
+
+        for i in dims:
+            yield {"dim": i}
+
+
+TestParamsData.test_plan = TestPlan(
+    verify=lambda test_device, test_vector: TestVerification.verify(
+        test_device,
+        test_vector,
+    ),
+    collections=[
+        # Test operators with all shapes and input sources collection:
+        TestCollection(
+            operators=["unsqueeze"],
+            input_sources=TestCollectionCommon.all.input_sources,
+            input_shapes=TestCollectionCommon.all.input_shapes,
+            kwargs=lambda test_vector: TestParamsData.generate_kwargs(test_vector),
+        ),
+        # Test Data formats collection:
+        TestCollection(
+            operators=["unsqueeze"],
+            input_sources=TestCollectionCommon.single.input_sources,
+            input_shapes=TestCollectionCommon.single.input_shapes,
+            kwargs=lambda test_vector: TestParamsData.generate_kwargs(test_vector),
+            dev_data_formats=[
+                item
+                for item in TestCollectionCommon.all.dev_data_formats
+                if item not in TestCollectionCommon.single.dev_data_formats
+            ],
+            math_fidelities=TestCollectionCommon.single.math_fidelities,
+        ),
+        # Test Math fidelities collection:
+        TestCollection(
+            operators=["unsqueeze"],
+            input_sources=TestCollectionCommon.single.input_sources,
+            input_shapes=TestCollectionCommon.single.input_shapes,
+            kwargs=lambda test_vector: TestParamsData.generate_kwargs(test_vector),
+            dev_data_formats=TestCollectionCommon.single.dev_data_formats,
+            math_fidelities=TestCollectionCommon.all.math_fidelities,
+        ),
+    ],
+    failing_rules=[],  # No failing rules for this test plan
+)
+
+
+def get_test_plans() -> List[TestPlan]:
+    return [TestParamsData.test_plan]

--- a/forge/test/operators/pytorch/tm/test_unsqueeze.py
+++ b/forge/test/operators/pytorch/tm/test_unsqueeze.py
@@ -85,11 +85,10 @@ class TestParamsData:
     @classmethod
     def generate_kwargs(cls, test_vector: TestVector):
 
+        rng = random.Random(math.prod(test_vector.input_shape))
         dim = len(test_vector.input_shape)
-        dims = list(range(-dim - 1, dim + 1))
 
-        for i in dims:
-            yield {"dim": i}
+        yield {"dim": rng.randint(-dim - 1, dim)}
 
 
 TestParamsData.test_plan = TestPlan(


### PR DESCRIPTION
Test plan for pytorch unsqueeze operator.

Local run (no failing rules):
_`16 failed, 2582 passed in 938.44s (0:15:38)`_