### PR TITLE
add support for nan_to_num,atan and atan2 op

### DIFF
--- a/forge/forge/op/__init__.py
+++ b/forge/forge/op/__init__.py
@@ -38,6 +38,7 @@ from .eltwise_unary import (
     Argmax,
     Abs,
     Clip,
+    Atan,
     Sine,
     Cosine,
     Tanh,

--- a/forge/forge/op/eltwise_unary.py
+++ b/forge/forge/op/eltwise_unary.py
@@ -389,6 +389,27 @@ def Sine(name: str, operandA: Tensor) -> Tensor:
     return op("sine", name, operandA).get_tensor()
 
 
+def Atan(name: str, operandA: Tensor) -> Tensor:
+    """
+    Elementwise arctangent (atan)
+
+    Parameters
+    ----------
+    name: str
+        Op name, unique to the module, or leave blank to autoset
+
+    operandA: Tensor
+        First operand
+
+    Returns
+    -------
+    Tensor
+        Forge tensor
+    """
+
+    return op("atan", name, operandA).get_tensor()
+
+
 def Cosine(name: str, operandA: Tensor) -> Tensor:
     """
     Elementwise cosine

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -58,6 +58,7 @@ op_to_module_map = {
     "cosine": Cosine,
     "abs": Abs,
     "sine": "eltwise_unary",
+    "atan": "eltwise_unary",
     "tile_broadcast": "eltwise_unary",
     "tanh": Tanh,
     "cumsum": CumulativeSum,

--- a/forge/forge/op/eval/forge/eltwise_unary.py
+++ b/forge/forge/op/eval/forge/eltwise_unary.py
@@ -135,6 +135,7 @@ def eval(type, attr, ops):
         "abs": lambda i: torch.abs(i[0]),
         "cosine": lambda i: torch.cos(i[0]),
         "sine": lambda i: torch.sin(i[0]),
+        "atan": lambda i: torch.atan(i[0]),
         "tile_broadcast": lambda i: tile_broadcast(attr, i[0]),
         "argmax": lambda i: torch.argmax(i[0], dim=attr[0] if len(attr) > 0 else None, keepdims=True),
         "tanh": lambda i: torch.tanh(i[0]),

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1777,6 +1777,7 @@ tvm_to_forge_op_map = {
     "qnn.dequantize": "dequantize",
     "qnn.requantize": "requantize",
     "qnn.dense": "matmul",
+    "atan": "atan",
 }
 
 forge_op_to_function_name = {
@@ -1861,6 +1862,7 @@ forge_op_to_function_name = {
     "quantize": "forge.op.Quantize",
     "dequantize": "forge.op.Dequantize",
     "requantize": "forge.op.Requantize",
+    "atan": "forge.op.Atan",
 }
 forge_ops_needing_arguments = {
     "argmax": populate_argmax_args,

--- a/forge/test/mlir/operators/eltwise_binary/test_eltwise_binary.py
+++ b/forge/test/mlir/operators/eltwise_binary/test_eltwise_binary.py
@@ -11,6 +11,39 @@ from forge.verify.verify import verify
 from forge.verify.config import VerifyConfig
 
 
+@pytest.mark.xfail(
+    reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph - Atan"
+)
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (300, 1),
+        (1, 6, 18),
+        (2, 2, 2),
+        (5, 5),
+        (745),
+        (1, 256, 6, 6),
+        (1, 512, 14, 14),
+        (1, 3, 224, 224),
+        (1, 34, 200, 224, 53),
+    ],
+)
+@pytest.mark.push
+def test_atan2(shape):
+    class Atan2(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x1, x2):
+            return torch.atan2(x2, x1)
+
+    inputs = [torch.randn(shape), torch.randn(shape)]
+    framework_model = Atan2()
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    verify(inputs, framework_model, compiled_model)
+
+
 @pytest.mark.parametrize(
     "shape_x, shape_y",
     [

--- a/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
+++ b/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
@@ -11,6 +11,167 @@ from forge.verify.verify import verify
 
 
 @pytest.mark.parametrize(
+    "shape, dtype",
+    [
+        pytest.param(
+            (1, 256, 6, 6),
+            torch.float32,
+            marks=pytest.mark.xfail(reason="BinaryOpType cannot be mapped to BcastOpMath"),
+        ),
+        pytest.param((512,), torch.float16),
+        pytest.param(
+            (224, 224), torch.float32, marks=pytest.mark.xfail(reason="BinaryOpType cannot be mapped to BcastOpMath")
+        ),
+        pytest.param(
+            (1, 8, 224, 224),
+            torch.float32,
+            marks=pytest.mark.xfail(reason="BinaryOpType cannot be mapped to BcastOpMath"),
+        ),
+        pytest.param((2, 128, 8, 8), torch.float16),
+        pytest.param(
+            (4, 1, 32, 32),
+            torch.float32,
+            marks=pytest.mark.xfail(reason="BinaryOpType cannot be mapped to BcastOpMath"),
+        ),
+        pytest.param((6, 1, 900, 256), torch.float16),
+        pytest.param((8, 64, 32, 32, 45), torch.float16),
+    ],
+)
+@pytest.mark.push
+def test_nan_to_num(shape, dtype):
+    class nan_to_num(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x1):
+            return torch.nan_to_num(x1)
+
+    compiler_cfg = forge.config._get_global_compiler_config()
+
+    if dtype == torch.float16:
+        # set compie depth to avoid Unsupported ttnn::DataType , Fatal Python error: Aborted
+        compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
+
+    inputs = [torch.randn(shape, dtype=dtype)]
+
+    mask_nan = torch.rand(shape, dtype=dtype) < 0.1
+    mask_posinf = torch.rand(shape, dtype=dtype) < 0.05
+    mask_neginf = torch.rand(shape, dtype=dtype) < 0.05
+
+    inputs[0][mask_nan] = float("nan")
+    inputs[0][mask_posinf] = float("inf")
+    inputs[0][mask_neginf] = float("-inf")
+
+    framework_model = nan_to_num()
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    if dtype == torch.float32:
+        verify(inputs, framework_model, compiled_model)
+
+
+@pytest.mark.parametrize(
+    "shape, dtype",
+    [
+        pytest.param(
+            (1, 256),
+            torch.float32,
+            marks=pytest.mark.xfail(
+                reason="Dtype mismatch: framework_model.dtype=torch.bool, compiled_model.dtype=torch.float32"
+            ),
+        ),
+        pytest.param(
+            (1, 512, 14, 14),
+            torch.bfloat16,
+            marks=pytest.mark.xfail(
+                reason="Dtype mismatch: framework_model.dtype=torch.bool, compiled_model.dtype=torch.bfloat16"
+            ),
+        ),
+        pytest.param(
+            (1, 3, 224),
+            torch.bfloat16,
+            marks=pytest.mark.xfail(
+                reason="Dtype mismatch: framework_model.dtype=torch.bool, compiled_model.dtype=torch.bfloat16"
+            ),
+        ),
+        pytest.param(
+            (1, 8, 224, 224),
+            torch.float32,
+            marks=pytest.mark.xfail(
+                reason="Dtype mismatch: framework_model.dtype=torch.bool, compiled_model.dtype=torch.float32"
+            ),
+        ),
+        pytest.param(
+            (1, 8, 16, 128, 128),
+            torch.bfloat16,
+            marks=pytest.mark.xfail(
+                reason="Dtype mismatch: framework_model.dtype=torch.bool, compiled_model.dtype=torch.bfloat16"
+            ),
+        ),
+        pytest.param(
+            (4, 1, 32, 32),
+            torch.float32,
+            marks=pytest.mark.xfail(
+                reason="Dtype mismatch: framework_model.dtype=torch.bool, compiled_model.dtype=torch.float32"
+            ),
+        ),
+        pytest.param(
+            (100,),
+            torch.float32,
+            marks=pytest.mark.xfail(
+                reason="Dtype mismatch: framework_model.dtype=torch.bool, compiled_model.dtype=torch.float32"
+            ),
+        ),
+        pytest.param(
+            (1, 8, 64, 32, 32),
+            torch.bfloat16,
+            marks=pytest.mark.xfail(
+                reason="Dtype mismatch: framework_model.dtype=torch.bool, compiled_model.dtype=torch.bfloat16"
+            ),
+        ),
+    ],
+)
+@pytest.mark.push
+def test_isnan(shape, dtype):
+    class isnan(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x1):
+            return torch.isnan(x1)
+
+    inputs = [torch.randn(shape, dtype=dtype)]
+    mask_nan = torch.rand(shape) < 0.1
+    inputs[0][mask_nan] = float("nan")
+
+    framework_model = isnan()
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    verify(inputs, framework_model, compiled_model)
+
+
+@pytest.mark.xfail(
+    reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph - Atan"
+)
+@pytest.mark.parametrize(
+    "shape",
+    [(888), (1, 7, 256), (3, 128, 128), (1, 10), (2, 2, 2), (5, 5), (1, 3, 224, 224), (8, 16, 32), (1, 3, 2, 544, 544)],
+)
+@pytest.mark.push
+def test_atan(shape):
+    class Atan(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x1):
+            return torch.atan(x1)
+
+    inputs = [torch.randn(shape)]
+
+    framework_model = Atan()
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    verify(inputs, framework_model, compiled_model)
+
+
+@pytest.mark.parametrize(
     "shape",
     [
         (10,),


### PR DESCRIPTION
## Summary

- This PR adds support for the ops needed for [#955]
- Both [atan](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/api/ttnn.atan.html#ttnn.atan) & [atan2 ](https://docs.tenstorrent.com/tt-metal/latest/ttnn/ttnn/api/ttnn.atan2.html#ttnn.atan2)exists in ttnn. but atan2 not exist in [tvm relay](https://tvm.apache.org/docs/reference/api/python/relay/index.html). so mapping from aten::atan2 to ttnn.atan2 is not possible till we add support for atan2 in TVM from scratch. so decomposition of atan2 using atan is done at frontend.
- Issue raised for Atan op support from MLIR side - https://github.com/tenstorrent/tt-mlir/issues/1718

## Logs

- [atan_after_fix.log](https://github.com/user-attachments/files/18351426/jan8_zz_atan_after_fix.log)
- [atan2_after_fix.log](https://github.com/user-attachments/files/18351427/jan8_zz_atan2_after_fix.log)
- [isnan_after_fix.log](https://github.com/user-attachments/files/18351429/jan8_zz_isnan_after_fix.log)
- [nan_to_num_after_fix.log](https://github.com/user-attachments/files/18379955/jan10_nan_to_num_after_fix_1.log)

