### PR TITLE
skip erase inverse op logic for the xglm model

### DIFF
--- a/forge/csrc/forge_passes.cpp
+++ b/forge/csrc/forge_passes.cpp
@@ -115,7 +115,8 @@ void run_optimization_graph_passes(graphlib::Graph *graph)
         passes::hoist_unsqueeze_squeeze_to_reshape(graph);
 
         bool skip_erase_redundant = false;
-        attempt_update = passes::erase_inverse_ops(graph);
+        attempt_update =
+            !env_as<bool>("FORGE_DISABLE_ERASE_INVERSE_OPS_PASS") ? passes::erase_inverse_ops(graph) : false;
         if (not attempt_update)
         {
             attempt_update = passes::insert_inverse_on_outputs(graph);

--- a/forge/test/models/pytorch/text/xglm/test_xglm.py
+++ b/forge/test/models/pytorch/text/xglm/test_xglm.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
+import os
+
 import pytest
 from transformers import AutoTokenizer, XGLMConfig, XGLMForCausalLM
 
@@ -24,6 +26,9 @@ def test_xglm_causal_lm(record_forge_property, variant):
 
     # Record Forge Property
     record_forge_property("model_name", module_name)
+
+    # Skip erase inverse ops in forge passess
+    os.environ["FORGE_DISABLE_ERASE_INVERSE_OPS_PASS"] = "1"
 
     config = XGLMConfig.from_pretrained(variant)
     config_dict = config.to_dict()


### PR DESCRIPTION
Fix: https://github.com/tenstorrent/tt-forge-fe/issues/772

This issue is due to the Erase Inverse Op Logic for the XGLM Model and it is temporarily fixed by disabling the erase inverse ops pass which results in the below issue while lowering to MLIR due to unsupported `repeat_interleave`

Currently this model blocked with below issue
```
Found Unsupported operations while lowering from TTForge to TTIR in forward graph
Unsupported Ops at: RUN_MLIR_COMPILER stage
repeat_interleave
		 Input_shape: [{1, 1, 1, 256}, ]
					 Attributes: repeat_interleave(1,0,){dim: 0, repeats: 1}
					 Attributes: repeat_interleave(1,1,){dim: 1, repeats: 1}
					 Attributes: repeat_interleave(256,2,){dim: 2, repeats: 256}
```

### Logs
[test_xglm.log](https://github.com/user-attachments/files/18485463/test_xglm.log)

For more context around this skip, please refer the discussion in this [PR](https://github.com/tenstorrent/tt-forge-fe/pull/833)
