### PR TITLE
Add test grouping to workflow inputs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,16 @@ on:
         description: 'Git SHA of commit in tenstorrent/tt-mlir or branch name'
         required: false
         type: string
+      test_group_cnt:
+        description: 'Test group count'
+        required: true
+        default: 2
+        type: number
+      test_group_ids:
+        description: 'Test group ids'
+        required: true
+        default: '[1,2]'
+        type: string
   workflow_call:
     inputs:
       test_mark:
@@ -28,6 +38,16 @@ on:
         description: 'Git SHA of commit in tenstorrent/tt-mlir or branch name'
         required: false
         type: string
+      test_group_cnt:
+        description: 'Test group count'
+        required: false
+        default: 2
+        type: number
+      test_group_ids:
+        description: 'Test group ids'
+        required: false
+        default: '[1,2]'
+        type: string
 
 permissions:
   packages: write
@@ -35,7 +55,6 @@ permissions:
   pull-requests: write # only required if `comment: true` was enabled
 
 jobs:
-
   docker-build:
     uses: ./.github/workflows/build-image.yml
     secrets: inherit
@@ -48,7 +67,7 @@ jobs:
       matrix:
         build:
           - runs-on: runner
-        test_group_id: [1,2]
+        test_group_id: ${{ fromJson(inputs.test_group_ids) }}
 
     runs-on:
       - in-service
@@ -152,7 +171,7 @@ jobs:
         apt install -y libgl1 libglx-mesa0
         set -o pipefail # Ensures that the exit code reflects the first command that fails
         pip install pytest-split
-        pytest -m push --splits 2 \
+        pytest -m push --splits ${{ inputs.test_group_cnt }} \
                --group ${{ matrix.test_group_id }} \
                --splitting-algorithm least_duration \
                -m "${{ inputs.test_mark }}" \

--- a/.github/workflows/on-nightly-sweeps.yml
+++ b/.github/workflows/on-nightly-sweeps.yml
@@ -11,3 +11,5 @@ jobs:
     secrets: inherit
     with:
       test_mark: 'nightly_sweeps'
+      test_group_cnt: 4
+      test_group_ids: '[1,2,3,4]'

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -11,3 +11,5 @@ jobs:
     secrets: inherit
     with:
       test_mark: 'nightly'
+      test_group_cnt: 4
+      test_group_ids: '[1,2,3,4]'

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -21,6 +21,8 @@ jobs:
     secrets: inherit
     with:
       test_mark: 'push'
+      test_group_cnt: 2
+      test_group_ids: '[1,2]'
   perf-benchmark:
     needs: docker-build
     uses: ./.github/workflows/perf-benchmark.yml

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -11,3 +11,5 @@ jobs:
     secrets: inherit
     with:
       test_mark: 'push'
+      test_group_cnt: 2
+      test_group_ids: '[1,2]'


### PR DESCRIPTION
Add option to define test grouping as workflow input.
For example, this will run tests in 4 group
```
docker-build:
    uses: ./.github/workflows/build-and-test.yml
    secrets: inherit
    with:
      test_mark: 'nightly'
      test_group_cnt: 4
      test_group_ids: '[1,2,3,4]'
```