### PR TITLE
Fix: Calling update reshape attribute function for non reshape ops

### DIFF
--- a/forge/csrc/passes/erase_inverse_ops.cpp
+++ b/forge/csrc/passes/erase_inverse_ops.cpp
@@ -275,13 +275,17 @@ void commute_and_bypass(graphlib::Graph *graph, std::vector<graphlib::Node *> co
                 auto updated_commute_shape = commute_shape;
                 updated_commute_shape[operand_dims.second] =
                     graph->node_by_id(operand_edge.producer_node_id)->shape()[operand_dims.first];
-                update_reshape_attr(op, updated_commute_shape);
+                if (op->op_name() == "reshape")
+                    update_reshape_attr(op, updated_commute_shape);
+
                 clone->set_shape(updated_commute_shape);
                 log_trace(LogGraphCompiler, "  Operand commute clone shape: {}", updated_commute_shape);
             }
             else
             {
-                update_reshape_attr(op, commute_shape);
+                if (op->op_name() == "reshape")
+                    update_reshape_attr(op, commute_shape);
+
                 clone->set_shape(commute_shape);
                 log_trace(LogGraphCompiler, "  Operand commute clone shape: {}", commute_shape);
             }


### PR DESCRIPTION
Fix: https://github.com/tenstorrent/tt-forge-fe/issues/816

This PR fixes the `update_reshape_attr called for a non-reshape operation`. This is from commute_utils in erase inverse ops logic, where this `update_reshape_attr` function called for squeeze, unsqueeze and transpose ops. So added a condition to only call this for reshape ops.

### Logs
Tested for Bart model and verified.

Log Before Fix - [test_bart_without_fix.log](https://github.com/user-attachments/files/18486202/test_bart_without_fix.log)
Log After Fix - [test_bart_with_fixt.log](https://github.com/user-attachments/files/18486199/test_bart_with_fixt.log)
