### PR TITLE
Stop tracking of 2/3 of target models due to CI limitations

### DIFF
--- a/forge/test/models/pytorch/audio/stereo/test_stereo.py
+++ b/forge/test/models/pytorch/audio/stereo/test_stereo.py
@@ -21,6 +21,9 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_stereo(record_forge_property, variant):
+    if variant != "facebook/musicgen-small":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="stereo", variant=variant)
 

--- a/forge/test/models/pytorch/audio/whisper/test_whisper_0.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper_0.py
@@ -97,6 +97,9 @@ def generate_model_whisper_congen_hf_pytorch(variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_whisper(record_forge_property, variant):
+    if variant != "openai/whisper-tiny":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="whisper", variant=variant)
 

--- a/forge/test/models/pytorch/audio/whisper/test_whisper_3.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper_3.py
@@ -40,6 +40,8 @@ class Wrapper(torch.nn.Module):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["openai/whisper-large-v3-turbo"])
 def test_whisper_large_v3_speech_translation(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="whisper", variant=variant, task=Task.SPEECH_TRANSLATE

--- a/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
+++ b/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
@@ -105,6 +105,8 @@ variants = ["dandelin/vilt-b32-mlm"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_vilt_maskedlm_hf_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="vilt", variant=variant, task=Task.MASKED_LM, source=Source.HUGGINGFACE

--- a/forge/test/models/pytorch/text/albert/test_albert.py
+++ b/forge/test/models/pytorch/text/albert/test_albert.py
@@ -23,6 +23,9 @@ variants = ["v1", "v2"]
 @pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.parametrize("size", sizes, ids=sizes)
 def test_albert_masked_lm_pytorch(record_forge_property, size, variant):
+    if size != "base" and variant != "v1":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="albert", variant=f"{size}_{variant}", task=Task.MASKED_LM
@@ -65,6 +68,9 @@ variants = ["v1", "v2"]
 @pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.parametrize("size", sizes, ids=sizes)
 def test_albert_token_classification_pytorch(record_forge_property, size, variant):
+    if size != "base" and variant != "v1":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="albert", variant=f"{size}_{variant}", task=Task.TOKEN_CLASSIFICATION

--- a/forge/test/models/pytorch/text/bert/test_bert.py
+++ b/forge/test/models/pytorch/text/bert/test_bert.py
@@ -89,6 +89,8 @@ def generate_model_bert_qa_hf_pytorch(variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["bert-large-cased-whole-word-masking-finetuned-squad"])
 def test_bert_question_answering_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="bert", variant=variant, task=Task.QA)
 
@@ -127,6 +129,8 @@ def generate_model_bert_seqcls_hf_pytorch(variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["textattack/bert-base-uncased-SST-2"])
 def test_bert_sequence_classification_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="bert", variant=variant, task=Task.SEQUENCE_CLASSIFICATION
@@ -173,6 +177,8 @@ def generate_model_bert_tkcls_hf_pytorch(variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["dbmdz/bert-large-cased-finetuned-conll03-english"])
 def test_bert_token_classification_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="bert", variant=variant, task=Task.TOKEN_CLASSIFICATION

--- a/forge/test/models/pytorch/text/codegen/test_codegen.py
+++ b/forge/test/models/pytorch/text/codegen/test_codegen.py
@@ -15,14 +15,17 @@ from test.utils import download_model
 
 variants = [
     "Salesforce/codegen-350M-mono",
-    # "Salesforce/codegen-350M-multi", # Currently not supported
-    # "Salesforce/codegen-350M-nl", # Currently not supported
+    "Salesforce/codegen-350M-multi",
+    "Salesforce/codegen-350M-nl",
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_codegen(record_forge_property, variant):
+    if variant != "Salesforce/codegen-350M-mono":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="codegen", variant=variant, task=Task.CAUSAL_LM)
 

--- a/forge/test/models/pytorch/text/distilbert/test_distilbert.py
+++ b/forge/test/models/pytorch/text/distilbert/test_distilbert.py
@@ -22,6 +22,9 @@ variants = ["distilbert-base-uncased", "distilbert-base-cased", "distilbert-base
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_distilbert_masked_lm_pytorch(record_forge_property, variant):
+    if variant != "distilbert-base-uncased":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="distilbert", variant=variant, task=Task.MASKED_LM
@@ -62,6 +65,8 @@ def test_distilbert_masked_lm_pytorch(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["distilbert-base-cased-distilled-squad"])
 def test_distilbert_question_answering_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="distilbert", variant=variant, task=Task.QA)
 
@@ -106,6 +111,8 @@ def test_distilbert_question_answering_pytorch(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["distilbert-base-uncased-finetuned-sst-2-english"])
 def test_distilbert_sequence_classification_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="distilbert", variant=variant, task=Task.SEQUENCE_CLASSIFICATION
@@ -142,6 +149,8 @@ def test_distilbert_sequence_classification_pytorch(record_forge_property, varia
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["Davlan/distilbert-base-multilingual-cased-ner-hrl"])
 def test_distilbert_token_classification_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="distilbert", variant=variant, task=Task.TOKEN_CLASSIFICATION

--- a/forge/test/models/pytorch/text/dpr/test_dpr.py
+++ b/forge/test/models/pytorch/text/dpr/test_dpr.py
@@ -24,6 +24,9 @@ variants = ["facebook/dpr-ctx_encoder-single-nq-base", "facebook/dpr-ctx_encoder
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_dpr_context_encoder_pytorch(record_forge_property, variant):
+    if variant != "facebook/dpr-ctx_encoder-single-nq-base":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="dpr", variant=variant, suffix="context_encoder")
 
@@ -63,6 +66,8 @@ variants = ["facebook/dpr-question_encoder-single-nq-base", "facebook/dpr-questi
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_dpr_question_encoder_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="dpr", variant=variant, suffix="question_encoder"
@@ -109,6 +114,8 @@ variants = ["facebook/dpr-reader-single-nq-base", "facebook/dpr-reader-multiset-
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_dpr_reader_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="dpr", variant=variant, suffix="reader")
 

--- a/forge/test/models/pytorch/text/gptneo/test_gptneo.py
+++ b/forge/test/models/pytorch/text/gptneo/test_gptneo.py
@@ -26,6 +26,9 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_gptneo_causal_lm(record_forge_property, variant):
+    if variant != "EleutherAI/gpt-neo-125M":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="gptneo", variant=variant, task=Task.CAUSAL_LM)
 
@@ -84,6 +87,8 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_gptneo_sequence_classification(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="gptneo", variant=variant, task=Task.SEQUENCE_CLASSIFICATION

--- a/forge/test/models/pytorch/text/llama/test_llama3.py
+++ b/forge/test/models/pytorch/text/llama/test_llama3.py
@@ -131,6 +131,8 @@ LlamaModel._update_causal_mask = _update_causal_mask
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_llama3_causal_lm(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="llama3", variant=variant, task=Task.CAUSAL_LM)
 
@@ -175,6 +177,8 @@ def test_llama3_causal_lm(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_llama3_sequence_classification(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="llama3", variant=variant, task=Task.SEQUENCE_CLASSIFICATION

--- a/forge/test/models/pytorch/text/opt/test_opt.py
+++ b/forge/test/models/pytorch/text/opt/test_opt.py
@@ -22,6 +22,9 @@ variants = ["facebook/opt-125m", "facebook/opt-350m", "facebook/opt-1.3b"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_opt_causal_lm(record_forge_property, variant):
+    if variant != "facebook/opt-125m":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="opt", variant=variant, task=Task.CAUSAL_LM)
 
@@ -68,6 +71,8 @@ def test_opt_causal_lm(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_opt_qa(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="opt", variant=variant, task=Task.QA)
 
@@ -110,6 +115,8 @@ def test_opt_qa(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_opt_sequence_classification(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="opt", variant=variant, task=Task.SEQUENCE_CLASSIFICATION

--- a/forge/test/models/pytorch/text/phi2/test_phi2.py
+++ b/forge/test/models/pytorch/text/phi2/test_phi2.py
@@ -22,6 +22,9 @@ variants = ["microsoft/phi-2", "microsoft/phi-2-pytdml"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_phi2_clm(record_forge_property, variant):
+    if variant != "microsoft/phi-2":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="phi2", variant=variant, task=Task.CAUSAL_LM)
 
@@ -68,6 +71,8 @@ def test_phi2_clm(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_phi2_token_classification(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="phi2", variant=variant, task=Task.TOKEN_CLASSIFICATION
@@ -106,6 +111,8 @@ def test_phi2_token_classification(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_phi2_sequence_classification(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="phi2", variant=variant, task=Task.SEQUENCE_CLASSIFICATION

--- a/forge/test/models/pytorch/text/phi3/test_phi3.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3.py
@@ -68,6 +68,8 @@ def test_phi3_causal_lm(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_token_classification(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="phi3", variant=variant, task=Task.TOKEN_CLASSIFICATION
@@ -107,6 +109,8 @@ def test_phi3_token_classification(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_sequence_classification(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="phi3", variant=variant, task=Task.SEQUENCE_CLASSIFICATION

--- a/forge/test/models/pytorch/text/qwen/test_qwen.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen.py
@@ -68,6 +68,8 @@ def parse_chat_completion(text: str):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["Qwen/Qwen1.5-0.5B-Chat"])
 def test_qwen1_5_chat(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="qwen1.5", variant=variant)
 

--- a/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
@@ -24,6 +24,9 @@ variants = [
 @pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
 def test_qwen_clm(record_forge_property, variant):
+    if variant != "Qwen/Qwen2.5-Coder-0.5B":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="qwen_coder", variant=variant, task=Task.CAUSAL_LM

--- a/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
@@ -25,6 +25,9 @@ variants = [
 @pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
 def test_qwen_clm(record_forge_property, variant):
+    if variant != "Qwen/Qwen2.5-0.5B":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="qwen_v2", variant=variant, task=Task.CAUSAL_LM)
 

--- a/forge/test/models/pytorch/text/roberta/test_roberta.py
+++ b/forge/test/models/pytorch/text/roberta/test_roberta.py
@@ -53,6 +53,8 @@ def test_roberta_masked_lm(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["cardiffnlp/twitter-roberta-base-sentiment"])
 def test_roberta_sentiment_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="roberta", variant=variant, task=Task.SEQUENCE_CLASSIFICATION

--- a/forge/test/models/pytorch/text/t5/test_t5.py
+++ b/forge/test/models/pytorch/text/t5/test_t5.py
@@ -101,6 +101,9 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_t5_generation(record_forge_property, variant):
+    if variant != "t5-small":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="t5", variant=variant, task=Task.TEXT_GENERATION)
 

--- a/forge/test/models/pytorch/text/xglm/test_xglm.py
+++ b/forge/test/models/pytorch/text/xglm/test_xglm.py
@@ -16,6 +16,9 @@ variants = ["facebook/xglm-564M", "facebook/xglm-1.7B"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_xglm_causal_lm(record_forge_property, variant):
+    if variant != "facebook/xglm-564M":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="xglm", variant=variant, task=Task.CAUSAL_LM)
 

--- a/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
+++ b/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
@@ -50,6 +50,8 @@ def test_nbeats_with_seasonality_basis(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["generic_basis"])
 def test_nbeats_with_generic_basis(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="nbeats", variant=variant)
 
@@ -73,6 +75,8 @@ def test_nbeats_with_generic_basis(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["trend_basis"])
 def test_nbeats_with_trend_basis(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="nbeats", variant=variant)
 

--- a/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
+++ b/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
@@ -60,6 +60,8 @@ def test_alexnet_torchhub(record_forge_property):
 
 @pytest.mark.nightly
 def test_alexnet_osmr(record_forge_property):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="alexnet", source=Source.OSMR)
 

--- a/forge/test/models/pytorch/vision/bts/test_bts.py
+++ b/forge/test/models/pytorch/vision/bts/test_bts.py
@@ -27,6 +27,9 @@ variants = ["densenet161_bts", "densenet121_bts"]
 @pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.nightly
 def test_bts_pytorch(record_forge_property, variant):
+    if variant != "densenet161_bts":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="bts", variant=variant)
 

--- a/forge/test/models/pytorch/vision/ddrnet/test_ddrnet.py
+++ b/forge/test/models/pytorch/vision/ddrnet/test_ddrnet.py
@@ -26,6 +26,9 @@ variants = ["ddrnet23s", "ddrnet23", "ddrnet39"]
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_ddrnet_pytorch(record_forge_property, variant):
+    if variant != "ddrnet23s":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="ddrnet", variant=variant)
 

--- a/forge/test/models/pytorch/vision/deit/test_deit.py
+++ b/forge/test/models/pytorch/vision/deit/test_deit.py
@@ -41,6 +41,9 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_deit_imgcls_hf_pytorch(record_forge_property, variant):
+    if variant != "facebook/deit-base-patch16-224":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="deit", variant=variant, task=Task.IMAGE_CLASSIFICATION

--- a/forge/test/models/pytorch/vision/densenet/test_densenet.py
+++ b/forge/test/models/pytorch/vision/densenet/test_densenet.py
@@ -21,6 +21,9 @@ variants = ["densenet121", "densenet121_hf_xray"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_densenet_121_pytorch(record_forge_property, variant):
+    if variant == "densenet121":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="densenet", variant=variant)
 

--- a/forge/test/models/pytorch/vision/detr/test_detr.py
+++ b/forge/test/models/pytorch/vision/detr/test_detr.py
@@ -44,6 +44,8 @@ def test_detr_detection(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["facebook/detr-resnet-50-panoptic"])
 def test_detr_segmentation(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="detr", variant=variant, task=Task.SEMANTIC_SEGMENTATION

--- a/forge/test/models/pytorch/vision/dla/test_dla.py
+++ b/forge/test/models/pytorch/vision/dla/test_dla.py
@@ -41,6 +41,9 @@ variants = list(variants_func.keys())
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_dla_pytorch(record_forge_property, variant):
+    if variant != "dla34":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="dla", variant=variant)
 

--- a/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
@@ -48,6 +48,9 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_efficientnet_timm(record_forge_property, variant):
+    if variant != "efficientnet_b0":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="efficientnet", variant=variant, source=Source.TIMM
@@ -108,6 +111,9 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_efficientnet_torchvision(record_forge_property, variant):
+    if variant != "efficientnet_b0":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="efficientnet", variant=variant, source=Source.TORCHVISION

--- a/forge/test/models/pytorch/vision/hrnet/test_hrnet.py
+++ b/forge/test/models/pytorch/vision/hrnet/test_hrnet.py
@@ -80,6 +80,9 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_hrnet_osmr_pytorch(record_forge_property, variant):
+    if variant != "hrnet_w18_small_v1":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="hrnet", variant=variant, source=Source.OSMR)
 
@@ -151,6 +154,9 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_hrnet_timm_pytorch(record_forge_property, variant):
+    if variant != "hrnet_w18_small":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="hrnet", variant=variant, source=Source.TIMM)
 

--- a/forge/test/models/pytorch/vision/inception/test_inception_v4.py
+++ b/forge/test/models/pytorch/vision/inception/test_inception_v4.py
@@ -54,6 +54,8 @@ def generate_model_inceptionV4_imgcls_timm_pytorch(variant):
 
 @pytest.mark.nightly
 def test_inception_v4_timm_pytorch(record_forge_property):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="inception", variant="v4", source=Source.TIMM)
 

--- a/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
+++ b/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
@@ -33,6 +33,9 @@ varaints = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", varaints, ids=varaints)
 def test_mlp_mixer_timm_pytorch(record_forge_property, variant):
+    if variant != "mixer_b16_224":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="mlp_mixer", variant=variant, source=Source.TIMM)
 

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -185,6 +185,8 @@ def generate_model_mobilenetV2_imgcls_timm_pytorch(variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["mobilenetv2_100"])
 def test_mobilenetv2_timm(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="mobilenetv2", variant=variant, source=Source.TIMM
@@ -236,6 +238,8 @@ variants = ["google/deeplabv3_mobilenet_v2_1.0_513"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_mobilenetv2_deeplabv3(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="mobilnetv2", variant=variant, source=Source.HUGGINGFACE

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
@@ -38,7 +38,10 @@ variants = ["mobilenet_v3_large", "mobilenet_v3_small"]
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
-def test_mobilenetv3_basic(record_forge_property, variant):
+def test_mobilenetv3_basic(mobilenet_v3_small, variant):
+    if variant != "mobilenet_v3_large":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="mobilenetv3", variant=variant, source=Source.TORCH_HUB
@@ -92,6 +95,8 @@ variants = ["mobilenetv3_large_100", "mobilenetv3_small_100"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_mobilenetv3_timm(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="mobilnetv3", source=Source.TIMM, variant=variant

--- a/forge/test/models/pytorch/vision/openpose/test_openpose.py
+++ b/forge/test/models/pytorch/vision/openpose/test_openpose.py
@@ -48,6 +48,9 @@ def generate_model_openpose_posdet_custom_pytorch(variant):
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_openpose_basic(record_forge_property, variant):
+    if variant != "body_basic":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="openpose", variant=variant)
 

--- a/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
+++ b/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
@@ -48,6 +48,9 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_perceiverio_for_image_classification_pytorch(record_forge_property, variant):
+    if variant != "deepmind/vision-perceiver-conv":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="perceiverio", variant=variant, task=Task.IMAGE_CLASSIFICATION

--- a/forge/test/models/pytorch/vision/regnet/test_regnet.py
+++ b/forge/test/models/pytorch/vision/regnet/test_regnet.py
@@ -37,6 +37,8 @@ def test_regnet(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["facebook/regnet-y-040"])
 def test_regnet_img_classification(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="regnet", variant=variant, task=Task.IMAGE_CLASSIFICATION

--- a/forge/test/models/pytorch/vision/resnet/test_resnet.py
+++ b/forge/test/models/pytorch/vision/resnet/test_resnet.py
@@ -86,6 +86,8 @@ def generate_model_resnet_imgcls_timm_pytorch(variant):
 
 @pytest.mark.nightly
 def test_resnet_timm(record_forge_property):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="resnet", source=Source.TIMM, variant="50")
 

--- a/forge/test/models/pytorch/vision/resnext/test_resnext.py
+++ b/forge/test/models/pytorch/vision/resnext/test_resnext.py
@@ -66,6 +66,8 @@ def test_resnext_101_torchhub_pytorch(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["resnext101_32x8d_wsl"])
 def test_resnext_101_32x8d_fb_wsl_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="resnext", source=Source.TORCH_HUB, variant=variant
@@ -92,6 +94,8 @@ def test_resnext_101_32x8d_fb_wsl_pytorch(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["resnext14_32x4d"])
 def test_resnext_14_osmr_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="resnext", source=Source.OSMR, variant=variant)
 
@@ -115,6 +119,8 @@ def test_resnext_14_osmr_pytorch(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["resnext26_32x4d"])
 def test_resnext_26_osmr_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="resnext", source=Source.OSMR, variant=variant)
 
@@ -138,6 +144,8 @@ def test_resnext_26_osmr_pytorch(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["resnext50_32x4d"])
 def test_resnext_50_osmr_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="resnext", source=Source.OSMR, variant=variant)
 
@@ -161,6 +169,8 @@ def test_resnext_50_osmr_pytorch(record_forge_property, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["resnext101_64x4d"])
 def test_resnext_101_osmr_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="resnext", source=Source.OSMR, variant=variant)
 

--- a/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
+++ b/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
@@ -27,6 +27,8 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_retinanet(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="retinanet", variant=variant)
 

--- a/forge/test/models/pytorch/vision/segformer/test_segformer.py
+++ b/forge/test/models/pytorch/vision/segformer/test_segformer.py
@@ -28,6 +28,9 @@ variants_img_classification = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants_img_classification)
 def test_segformer_image_classification_pytorch(record_forge_property, variant):
+    if variant != "nvidia/mit-b0":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="segformer", variant=variant, task=Task.IMAGE_CLASSIFICATION
@@ -69,6 +72,8 @@ variants_semseg = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants_semseg)
 def test_segformer_semantic_segmentation_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="segformer", variant=variant, suffix=Task.SEMANTIC_SEGMENTATION

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -72,6 +72,8 @@ def test_swin_v2_tiny_4_256_hf_pytorch(record_forge_property, variant):
 @pytest.mark.skip_model_analysis
 @pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
 def test_swin_v2_tiny_image_classification(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="swin", variant=variant, task=Task.IMAGE_CLASSIFICATION
@@ -97,6 +99,8 @@ def test_swin_v2_tiny_image_classification(record_forge_property, variant):
 @pytest.mark.skip_model_analysis
 @pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
 def test_swin_v2_tiny_masked(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="swin", variant=variant, task=Task.MASKED_IMAGE_MODELLING

--- a/forge/test/models/pytorch/vision/unet/test_unet.py
+++ b/forge/test/models/pytorch/vision/unet/test_unet.py
@@ -85,6 +85,8 @@ def get_imagenet_sample():
 @pytest.mark.skip(reason="Model script not found")
 @pytest.mark.nightly
 def test_unet_holocron_pytorch(record_forge_property):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="unet", variant="holocron")
 
@@ -134,6 +136,8 @@ def generate_model_unet_imgseg_smp_pytorch(variant):
 
 @pytest.mark.nightly
 def test_unet_qubvel_pytorch(record_forge_property):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="unet", variant="qubvel")
 
@@ -186,6 +190,8 @@ def generate_model_unet_imgseg_torchhub_pytorch(variant):
 
 @pytest.mark.nightly
 def test_unet_torchhub_pytorch(record_forge_property):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="unet")
 

--- a/forge/test/models/pytorch/vision/vgg/test_vgg.py
+++ b/forge/test/models/pytorch/vision/vgg/test_vgg.py
@@ -26,6 +26,9 @@ variants = ["vgg11", "vgg13", "vgg16", "vgg19", "bn_vgg19", "bn_vgg19b"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_vgg_osmr_pytorch(record_forge_property, variant):
+    if variant != "vgg11":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="vgg", variant=variant)
 
@@ -66,6 +69,8 @@ def test_vgg_osmr_pytorch(record_forge_property, variant):
 
 @pytest.mark.nightly
 def test_vgg_19_hf_pytorch(record_forge_property):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="vgg", variant="19", source=Source.HUGGINGFACE)
 
@@ -133,6 +138,8 @@ def preprocess_timm_model(model_name):
 
 @pytest.mark.nightly
 def test_vgg_bn19_timm_pytorch(record_forge_property):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     variant = "vgg19_bn"
 
     # Build Module Name
@@ -155,6 +162,8 @@ def test_vgg_bn19_timm_pytorch(record_forge_property):
 
 @pytest.mark.nightly
 def test_vgg_bn19_torchhub_pytorch(record_forge_property):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="vgg", variant="vgg19_bn", source=Source.TORCH_HUB

--- a/forge/test/models/pytorch/vision/vit/test_vit.py
+++ b/forge/test/models/pytorch/vision/vit/test_vit.py
@@ -36,6 +36,9 @@ variants = ["google/vit-base-patch16-224", "google/vit-large-patch16-224"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_vit_classify_224_hf_pytorch(record_forge_property, variant):
+    if variant != "google/vit-base-patch16-224":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH,

--- a/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
@@ -31,6 +31,9 @@ varaints = ["vovnet27s", "vovnet39", "vovnet57"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", varaints, ids=varaints)
 def test_vovnet_osmr_pytorch(record_forge_property, variant):
+    if variant != "vovnet27s":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="vovnet", variant=variant, source=Source.OSMR)
 
@@ -54,6 +57,8 @@ def generate_model_vovnet39_imgcls_stigma_pytorch():
 
 @pytest.mark.nightly
 def test_vovnet_v1_39_stigma_pytorch(record_forge_property):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     variant = "vovnet39"
 
     # Build Module Name
@@ -80,6 +85,8 @@ def generate_model_vovnet57_imgcls_stigma_pytorch(variant):
 
 @pytest.mark.nightly
 def test_vovnet_v1_57_stigma_pytorch(record_forge_property):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     variant = "vovnet_v1_57"
 
     # Build Module Name
@@ -109,6 +116,8 @@ variants = ["ese_vovnet19b_dw", "ese_vovnet39b", "ese_vovnet99b"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_vovnet_timm_pytorch(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="vovnet", variant=variant)
 

--- a/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
+++ b/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
@@ -47,6 +47,9 @@ variants = ["wide_resnet50_2", "wide_resnet101_2"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_wideresnet_pytorch(record_forge_property, variant):
+    if variant != "wide_resnet50_2":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="wideresnet", variant=variant)
 
@@ -85,6 +88,8 @@ variants = ["wide_resnet50_2", "wide_resnet101_2"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_wideresnet_timm(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="wideresnet", source=Source.TIMM, variant=variant

--- a/forge/test/models/pytorch/vision/xception/test_xception.py
+++ b/forge/test/models/pytorch/vision/xception/test_xception.py
@@ -41,6 +41,9 @@ variants = ["xception", "xception41", "xception65", "xception71"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_xception_timm(record_forge_property, variant):
+    if variant != "xception":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="xception", variant=variant, source=Source.TIMM)
 

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v3.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v3.py
@@ -77,6 +77,8 @@ def generate_model_yoloV3_imgcls_holli_pytorch():
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_yolov3_holli_pytorch(record_forge_property):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="yolo_v3", variant="holli_pytorch", task=Task.IMAGE_CLASSIFICATION

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -27,6 +27,9 @@ size = ["n", "s", "m", "l", "x"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size, ids=["yolov5" + s for s in size])
 def test_yolov5_320x320(record_forge_property, size):
+    if size != "s":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH,
@@ -67,6 +70,9 @@ size = ["n", "s", "m", "l", "x"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size, ids=["yolov5" + s for s in size])
 def test_yolov5_640x640(record_forge_property, size):
+    if size != "s":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH,
@@ -103,6 +109,9 @@ def generate_model_yoloV5I480_imgcls_torchhub_pytorch(variant, size):
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size, ids=["yolov5" + s for s in size])
 def test_yolov5_480x480(record_forge_property, size):
+    if size != "s":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH,
@@ -131,6 +140,8 @@ def test_yolov5_480x480(record_forge_property, size):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["yolov5s"])
 def test_yolov5_1280x1280(record_forge_property, variant):
+    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH,

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
@@ -23,6 +23,9 @@ variants = ["yolov6n", "yolov6s", "yolov6m", "yolov6l"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_yolo_v6_pytorch(record_forge_property, variant):
+    if variant != "yolov6n":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="yolo_v6", variant=variant)
 

--- a/forge/test/models/pytorch/vision/yolo/test_yolox.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolox.py
@@ -39,6 +39,9 @@ variants = ["yolox_nano", "yolox_tiny", "yolox_s", "yolox_m", "yolox_l", "yolox_
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_yolox_pytorch(record_forge_property, variant):
+    if variant != "yolox_nano":
+        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="yolox", variant=variant)
 


### PR DESCRIPTION
Due to our current CI limitations, our nightly jobs are mostly broken. As broken nightly isn't providing any value, our best effort is to lower the number of models we're targeting and focus on solving CI limitations.

Main target should be to limit the number of variants and still keep plenty of unique architectures. That way, we'll not lower our model coverage quality even with 2/3 of variants removed as a target.

In sum, majority of CI limitations come from limited disk space, host DRAM, etc.

Fix #1043
