### PR TITLE
Skipping additional set of model tests due to the CI limitations

### DIFF
--- a/forge/test/models/pytorch/text/phi3/test_phi3.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3.py
@@ -21,6 +21,8 @@ variants = ["microsoft/phi-3-mini-4k-instruct"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_causal_lm(record_forge_property, variant):
+    pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 64 GB)")
+
     # Build Module Name
     module_name = build_module_name(framework=Framework.PYTORCH, model="phi3", variant=variant, task=Task.CAUSAL_LM)
 

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -73,6 +73,8 @@ def generate_model_mobilenetV2I96_imgcls_hf_pytorch(variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["google/mobilenet_v2_0.35_96"])
 def test_mobilenetv2_96(record_forge_property, variant):
+    pytest.skip("Hitting segmentation fault in MLIR")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="mobilenetv2", variant=variant, source=Source.HUGGINGFACE
@@ -106,6 +108,8 @@ def generate_model_mobilenetV2I160_imgcls_hf_pytorch(variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["google/mobilenet_v2_0.75_160"])
 def test_mobilenetv2_160(record_forge_property, variant):
+    pytest.skip("Hitting segmentation fault in MLIR")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="mobilenetv2", variant=variant, source=Source.HUGGINGFACE
@@ -141,6 +145,8 @@ def generate_model_mobilenetV2I244_imgcls_hf_pytorch(variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["google/mobilenet_v2_1.0_224"])
 def test_mobilenetv2_224(record_forge_property, variant):
+    pytest.skip("Hitting segmentation fault in MLIR")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="mobilenetv2", variant=variant, source=Source.HUGGINGFACE


### PR DESCRIPTION
Main reasons:
- MLIR seg faults (not CI related, but causes seg faults)
- Insuficient DRAM space