### PR TITLE
Correct naming for model name property #1049

### DIFF
--- a/forge/test/models/pytorch/audio/stereo/test_stereo.py
+++ b/forge/test/models/pytorch/audio/stereo/test_stereo.py
@@ -28,7 +28,7 @@ def test_stereo(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="stereo", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, processor = load_model(variant)
 

--- a/forge/test/models/pytorch/audio/whisper/test_whisper_0.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper_0.py
@@ -104,7 +104,7 @@ def test_whisper(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="whisper", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs = generate_model_whisper_congen_hf_pytorch(variant)
 
@@ -124,7 +124,7 @@ def test_whisper_pipeline(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="whisper", variant=variant, suffix="pipeline")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Configurations
     compiler_cfg = forge.config._get_global_compiler_config()
@@ -187,7 +187,7 @@ def test_whisper_encoder(record_forge_property, test_device, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="whisper", variant=variant, suffix="encoder")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Configurations
     compiler_cfg = _get_global_compiler_config()

--- a/forge/test/models/pytorch/audio/whisper/test_whisper_1.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper_1.py
@@ -48,7 +48,7 @@ def test_whisper_dec_past_cache(record_forge_property, test_device, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="whisper", variant=variant, suffix="pipeline")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     model, inputs, other = generate_model_whisper_decoder_past_cache(variant)
     compile_inputs = other["compile_inputs"]
@@ -87,7 +87,7 @@ def test_whisper_enc_dec(record_forge_property, test_device, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="whisper", variant=variant, suffix="enc_dec")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     compiler_cfg = _get_global_compiler_config()
     compiler_cfg.enable_tvm_cpu_fallback = False  # Run full model on silicon
@@ -325,7 +325,7 @@ def test_whisper_enc_dec_pipeline(record_forge_property, test_device, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     compiler_cfg = _get_global_compiler_config()
     compiler_cfg.enable_tvm_cpu_fallback = False  # Run full model on silicon

--- a/forge/test/models/pytorch/audio/whisper/test_whisper_3.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper_3.py
@@ -48,7 +48,7 @@ def test_whisper_large_v3_speech_translation(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     processor = WhisperProcessor.from_pretrained(variant)
     framework_model = WhisperForConditionalGeneration.from_pretrained(variant)

--- a/forge/test/models/pytorch/multimodal/clip/test_clip.py
+++ b/forge/test/models/pytorch/multimodal/clip/test_clip.py
@@ -21,7 +21,7 @@ def test_clip_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="clip", variant=variant, suffix="text")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load processor and model from HuggingFace
     model = download_model(CLIPModel.from_pretrained, variant, torchscript=True)

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion.py
@@ -19,7 +19,7 @@ def test_stable_diffusion_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="stable_diffusion", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     batch_size = 1
 

--- a/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
+++ b/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
@@ -64,7 +64,7 @@ def test_vilt_question_answering_hf_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_vilt_question_answering_hf_pytorch(variant)
 
@@ -113,7 +113,7 @@ def test_vilt_maskedlm_hf_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_vilt_maskedlm_hf_pytorch(variant)
 

--- a/forge/test/models/pytorch/text/albert/test_albert.py
+++ b/forge/test/models/pytorch/text/albert/test_albert.py
@@ -32,7 +32,7 @@ def test_albert_masked_lm_pytorch(record_forge_property, size, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     model_ckpt = f"albert-{size}-{variant}"
 
@@ -77,7 +77,7 @@ def test_albert_token_classification_pytorch(record_forge_property, size, varian
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # NOTE: These model variants are pre-trined only. They need to be fine-tuned
     # on a downstream task. Code is for demonstration purposes only.

--- a/forge/test/models/pytorch/text/bart/test_bart.py
+++ b/forge/test/models/pytorch/text/bart/test_bart.py
@@ -33,7 +33,7 @@ def test_pt_bart_classifier(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     model = download_model(BartForSequenceClassification.from_pretrained, variant, torchscript=True)
     tokenizer = download_model(BartTokenizer.from_pretrained, variant, pad_to_max_length=True)

--- a/forge/test/models/pytorch/text/bert/test_bert.py
+++ b/forge/test/models/pytorch/text/bert/test_bert.py
@@ -45,7 +45,7 @@ def test_bert_masked_lm_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="bert", variant=variant, task=Task.MASKED_LM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_bert_maskedlm_hf_pytorch(variant)
 
@@ -95,7 +95,7 @@ def test_bert_question_answering_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="bert", variant=variant, task=Task.QA)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_bert_qa_hf_pytorch(variant)
 
@@ -137,7 +137,7 @@ def test_bert_sequence_classification_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_bert_seqcls_hf_pytorch(variant)
 
@@ -185,7 +185,7 @@ def test_bert_token_classification_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_bert_tkcls_hf_pytorch(variant)
 

--- a/forge/test/models/pytorch/text/codegen/test_codegen.py
+++ b/forge/test/models/pytorch/text/codegen/test_codegen.py
@@ -30,7 +30,7 @@ def test_codegen(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="codegen", variant=variant, task=Task.CAUSAL_LM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load model (with tokenizer)
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/distilbert/test_distilbert.py
+++ b/forge/test/models/pytorch/text/distilbert/test_distilbert.py
@@ -31,7 +31,7 @@ def test_distilbert_masked_lm_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load DistilBert tokenizer and model from HuggingFace
     # Variants: distilbert-base-uncased, distilbert-base-cased,
@@ -71,7 +71,7 @@ def test_distilbert_question_answering_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="distilbert", variant=variant, task=Task.QA)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load Bert tokenizer and model from HuggingFace
     tokenizer = download_model(DistilBertTokenizer.from_pretrained, variant)
@@ -119,7 +119,7 @@ def test_distilbert_sequence_classification_pytorch(record_forge_property, varia
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load DistilBert tokenizer and model from HuggingFace
     tokenizer = download_model(DistilBertTokenizer.from_pretrained, variant)
@@ -157,7 +157,7 @@ def test_distilbert_token_classification_pytorch(record_forge_property, variant)
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load DistilBERT tokenizer and model from HuggingFace
     tokenizer = download_model(DistilBertTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/dpr/test_dpr.py
+++ b/forge/test/models/pytorch/text/dpr/test_dpr.py
@@ -31,7 +31,7 @@ def test_dpr_context_encoder_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="dpr", variant=variant, suffix="context_encoder")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load Bert tokenizer and model from HuggingFace
     # Variants: facebook/dpr-ctx_encoder-single-nq-base, facebook/dpr-ctx_encoder-multiset-base
@@ -74,7 +74,7 @@ def test_dpr_question_encoder_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load Bert tokenizer and model from HuggingFace
     # Variants: facebook/dpr-question_encoder-single-nq-base, facebook/dpr-question_encoder-multiset-base
@@ -120,7 +120,7 @@ def test_dpr_reader_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="dpr", variant=variant, suffix="reader")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load Bert tokenizer and model from HuggingFace
     # Variants: facebook/dpr-reader-single-nq-base, facebook/dpr-reader-multiset-base

--- a/forge/test/models/pytorch/text/falcon/test_falcon.py
+++ b/forge/test/models/pytorch/text/falcon/test_falcon.py
@@ -20,7 +20,7 @@ def test_falcon(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="falcon", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     tokenizer = AutoTokenizer.from_pretrained(variant)
     model = FalconForCausalLM.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/fuyu/test_fuyu_8b.py
+++ b/forge/test/models/pytorch/text/fuyu/test_fuyu_8b.py
@@ -38,7 +38,7 @@ def test_fuyu8b(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="fuyu", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     config = FuyuConfig.from_pretrained(variant)
     config_dict = config.to_dict()
@@ -95,7 +95,7 @@ def test_fuyu8b_past_cache(record_forge_property, variant, test_device):
     module_name = build_module_name(framework=Framework.PYTORCH, model="fuyu", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Set Forge configuration parameters
     compiler_cfg = forge.config._get_global_compiler_config()

--- a/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
@@ -62,7 +62,7 @@ def test_gemma_2b_rotary_embedding(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Random see for reproducibility
     torch.manual_seed(42)
@@ -108,7 +108,7 @@ def test_gemma_2b_rms_norm(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="gemma", variant=variant, suffix="rms_norm")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Random see for reproducibility
     torch.manual_seed(42)
@@ -153,7 +153,7 @@ def test_gemma_2b_attention(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="gemma", variant=variant, suffix="attention")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Random see for reproducibility
     torch.manual_seed(42)
@@ -200,7 +200,7 @@ def test_gemma_2b_mlp(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="gemma", variant=variant, suffix="mlp")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Random see for reproducibility
     torch.manual_seed(42)
@@ -246,7 +246,7 @@ def test_gemma_2b_single_decoder(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Random see for reproducibility
     torch.manual_seed(42)
@@ -291,7 +291,7 @@ def test_gemma_2b(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="gemma", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Random see for reproducibility
     torch.manual_seed(42)
@@ -340,7 +340,7 @@ def test_gemma_2b_gen(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="gemma", variant=variant, suffix="gen")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Random seed for reproducibility
     torch.manual_seed(42)
@@ -405,7 +405,7 @@ def test_gemma_2b_1x1_gen(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="gemma", variant=variant, suffix="gen_1x1")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Random seed for reproducibility
     torch.manual_seed(42)

--- a/forge/test/models/pytorch/text/gpt2/test_gpt2.py
+++ b/forge/test/models/pytorch/text/gpt2/test_gpt2.py
@@ -21,7 +21,7 @@ def test_gpt2_text_gen(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load tokenizer and model from HuggingFace
     config = GPT2Config.from_pretrained(variant)
@@ -80,7 +80,7 @@ def test_gpt2_past_cache(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     compiler_cfg = forge.config._get_global_compiler_config()
     compiler_cfg.compile_subgraphs = True

--- a/forge/test/models/pytorch/text/gptneo/test_gptneo.py
+++ b/forge/test/models/pytorch/text/gptneo/test_gptneo.py
@@ -33,7 +33,7 @@ def test_gptneo_causal_lm(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="gptneo", variant=variant, task=Task.CAUSAL_LM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Set random seed for repeatability
     torch.manual_seed(42)
@@ -95,7 +95,7 @@ def test_gptneo_sequence_classification(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load tokenizer and model from HuggingFace
     # Variants: # EleutherAI/gpt-neo-125M, EleutherAI/gpt-neo-1.3B,

--- a/forge/test/models/pytorch/text/llama/test_llama3.py
+++ b/forge/test/models/pytorch/text/llama/test_llama3.py
@@ -137,7 +137,7 @@ def test_llama3_causal_lm(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="llama3", variant=variant, task=Task.CAUSAL_LM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load model (with tokenizer)
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
@@ -185,7 +185,7 @@ def test_llama3_sequence_classification(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load model (with tokenizer)
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/mistral/test_mistral.py
+++ b/forge/test/models/pytorch/text/mistral/test_mistral.py
@@ -27,7 +27,7 @@ def test_mistral_decoder_layer(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="mistral", variant=variant, suffix="decoder")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     model = AutoModelForCausalLM.from_pretrained(variant, device_map="auto")
     model.eval()
@@ -61,7 +61,7 @@ def test_mistral(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="mistral", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     configuration = MistralConfig()
     configuration.sliding_window = None
@@ -104,7 +104,7 @@ def test_mistral_decode(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="mistral", variant=variant, suffix="decode")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     configuration = MistralConfig()
     configuration.sliding_window = None
@@ -174,7 +174,7 @@ def test_mistral_kv_cache(record_forge_property, variant, test_device):
     module_name = build_module_name(framework=Framework.PYTORCH, model="mistral", variant=variant, suffix="kv_cache")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     configuration = MistralConfig()
     configuration.sliding_window = None

--- a/forge/test/models/pytorch/text/opt/test_opt.py
+++ b/forge/test/models/pytorch/text/opt/test_opt.py
@@ -29,7 +29,7 @@ def test_opt_causal_lm(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="opt", variant=variant, task=Task.CAUSAL_LM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load tokenizer and model from HuggingFace
     # Variants: "facebook/opt-125m", "facebook/opt-350m", "facebook/opt-1.3b"
@@ -77,7 +77,7 @@ def test_opt_qa(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="opt", variant=variant, task=Task.QA)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load tokenizer and model from HuggingFace
     # Variants: "facebook/opt-125m", "facebook/opt-350m", "facebook/opt-1.3b"
@@ -123,7 +123,7 @@ def test_opt_sequence_classification(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load tokenizer and model from HuggingFace
     # Variants: "facebook/opt-125m", "facebook/opt-350m", "facebook/opt-1.3b"

--- a/forge/test/models/pytorch/text/phi2/test_phi2.py
+++ b/forge/test/models/pytorch/text/phi2/test_phi2.py
@@ -29,7 +29,7 @@ def test_phi2_clm(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="phi2", variant=variant, task=Task.CAUSAL_LM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load PhiConfig from pretrained variant, disable return_dict and caching.
     config = PhiConfig.from_pretrained(variant)
@@ -79,7 +79,7 @@ def test_phi2_token_classification(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # PhiConfig from pretrained variant, disable return_dict and caching.
     config = PhiConfig.from_pretrained(variant)
@@ -119,7 +119,7 @@ def test_phi2_sequence_classification(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # PhiConfig from pretrained variant, disable return_dict and caching.
     config = PhiConfig.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/phi3/test_phi3.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3.py
@@ -27,7 +27,7 @@ def test_phi3_causal_lm(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="phi3", variant=variant, task=Task.CAUSAL_LM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Phi3Config from pretrained variant, disable return_dict and caching.
     config = Phi3Config.from_pretrained(variant)
@@ -78,7 +78,7 @@ def test_phi3_token_classification(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Phi3Config from pretrained variant, disable return_dict and caching.
     config = Phi3Config.from_pretrained(variant)
@@ -119,7 +119,7 @@ def test_phi3_sequence_classification(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Phi3Config from pretrained variant, disable return_dict and caching.
     config = Phi3Config.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/qwen/test_qwen.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen.py
@@ -20,7 +20,7 @@ def test_qwen1_5_causal_lm(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="qwen1.5", variant=variant, task=Task.CAUSAL_LM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Setup model configuration
     config = Qwen2Config.from_pretrained(variant)
@@ -74,7 +74,7 @@ def test_qwen1_5_chat(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="qwen1.5", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Setup model configuration
     config = Qwen2Config.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
@@ -33,7 +33,7 @@ def test_qwen_clm(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load model and tokenizer
     framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu")

--- a/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
@@ -32,7 +32,7 @@ def test_qwen_clm(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="qwen_v2", variant=variant, task=Task.CAUSAL_LM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load model and tokenizer
     framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu")

--- a/forge/test/models/pytorch/text/roberta/test_roberta.py
+++ b/forge/test/models/pytorch/text/roberta/test_roberta.py
@@ -23,7 +23,7 @@ def test_roberta_masked_lm(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="roberta", variant=variant, task=Task.MASKED_LM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load Albert tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
@@ -61,7 +61,7 @@ def test_roberta_sentiment_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load Bart tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/squeezebert/test_squeezebert.py
+++ b/forge/test/models/pytorch/text/squeezebert/test_squeezebert.py
@@ -20,7 +20,7 @@ def test_squeezebert_sequence_classification_pytorch(record_forge_property, vari
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load Bart tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/t5/test_t5.py
+++ b/forge/test/models/pytorch/text/t5/test_t5.py
@@ -25,7 +25,7 @@ def test_t5_loop_tiny_tile(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="t5", variant=variant, suffix="loop_tiny_tile")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     import os
 
@@ -108,7 +108,7 @@ def test_t5_generation(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="t5", variant=variant, task=Task.TEXT_GENERATION)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load tokenizer and model from HuggingFace
     # Variants: t5-small, t5-base, t5-large
@@ -205,7 +205,7 @@ def test_t5_past_cache_enc_dec(record_forge_property, variant, test_device):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     import os
 
@@ -375,7 +375,7 @@ def test_t5_past_cache_forge_pipeline(record_forge_property, variant, test_devic
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     import os
 
@@ -717,7 +717,7 @@ def test_t5_forge_pipeline(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="t5", variant=variant, suffix="forge_pipe")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Too slow for post-commit ci
 
@@ -772,7 +772,7 @@ def test_t5_small_tiny_tile(record_forge_property, test_device):
     module_name = build_module_name(framework=Framework.PYTORCH, model="t5", variant=variant, suffix="small_tiny_tile")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     import os
 

--- a/forge/test/models/pytorch/text/xglm/test_xglm.py
+++ b/forge/test/models/pytorch/text/xglm/test_xglm.py
@@ -23,7 +23,7 @@ def test_xglm_causal_lm(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="xglm", variant=variant, task=Task.CAUSAL_LM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     config = XGLMConfig.from_pretrained(variant)
     config_dict = config.to_dict()

--- a/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
+++ b/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
@@ -24,7 +24,7 @@ def test_nbeats_with_seasonality_basis(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="nbeats", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     x, x_mask = get_electricity_dataset_input()
 
@@ -56,7 +56,7 @@ def test_nbeats_with_generic_basis(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="nbeats", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     x, x_mask = get_electricity_dataset_input()
 
@@ -81,7 +81,7 @@ def test_nbeats_with_trend_basis(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="nbeats", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     x, x_mask = get_electricity_dataset_input()
 

--- a/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
+++ b/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
@@ -24,7 +24,7 @@ def test_alexnet_torchhub(record_forge_property):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load model
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "alexnet", pretrained=True)
@@ -66,7 +66,7 @@ def test_alexnet_osmr(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="alexnet", source=Source.OSMR)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load model
     framework_model = download_model(ptcv_get_model, "alexnet", pretrained=True)

--- a/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
+++ b/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
@@ -19,7 +19,7 @@ def test_conv_ae_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="autoencoder", variant="conv")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Instantiate model
     # NOTE: The model has not been pre-trained or fine-tuned.
@@ -54,7 +54,7 @@ def test_linear_ae_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="autoencoder", variant="linear")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Instantiate model
     # NOTE: The model has not been pre-trained or fine-tuned.

--- a/forge/test/models/pytorch/vision/blazebase/test_blazepose.py
+++ b/forge/test/models/pytorch/vision/blazebase/test_blazepose.py
@@ -29,7 +29,7 @@ def test_blazepose_detector_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="blazepose", variant="detector")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load BlazePose Detector
     framework_model = BlazePose()
@@ -61,7 +61,7 @@ def test_blazepose_regressor_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="blazepose", variant="regressor")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load BlazePose Landmark Regressor
     framework_model = BlazePoseLandmark()
@@ -84,7 +84,7 @@ def test_blaze_palm_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="blazepose", variant="palm")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load BlazePalm Detector
     framework_model = BlazePalm()
@@ -117,7 +117,7 @@ def test_blaze_hand_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="blazepose", variant="hand")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load BlazePalm Detector
     framework_model = BlazeHandLandmark()

--- a/forge/test/models/pytorch/vision/bts/test_bts.py
+++ b/forge/test/models/pytorch/vision/bts/test_bts.py
@@ -34,7 +34,7 @@ def test_bts_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="bts", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load sample image
     image_path = "third_party/confidential_customer_models/internal/bts/files/samples/rgb_00315.jpg"

--- a/forge/test/models/pytorch/vision/ddrnet/test_ddrnet.py
+++ b/forge/test/models/pytorch/vision/ddrnet/test_ddrnet.py
@@ -33,7 +33,7 @@ def test_ddrnet_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="ddrnet", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     if variant == "ddrnet23s":
@@ -93,7 +93,7 @@ def test_ddrnet_semantic_segmentation_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # prepare model
     if variant == "ddrnet23s_cityscapes":

--- a/forge/test/models/pytorch/vision/deit/test_deit.py
+++ b/forge/test/models/pytorch/vision/deit/test_deit.py
@@ -50,7 +50,7 @@ def test_deit_imgcls_hf_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_deit_imgcls_hf_pytorch(
         variant,

--- a/forge/test/models/pytorch/vision/densenet/test_densenet.py
+++ b/forge/test/models/pytorch/vision/densenet/test_densenet.py
@@ -28,7 +28,7 @@ def test_densenet_121_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="densenet", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     if variant == "densenet121":
@@ -56,7 +56,7 @@ def test_densenet_161_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="densenet", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "densenet161", pretrained=True)
@@ -79,7 +79,7 @@ def test_densenet_169_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="densenet", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "densenet169", pretrained=True)
@@ -103,7 +103,7 @@ def test_densenet_201_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="densenet", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "densenet201", pretrained=True)

--- a/forge/test/models/pytorch/vision/detr/test_detr.py
+++ b/forge/test/models/pytorch/vision/detr/test_detr.py
@@ -23,7 +23,7 @@ def test_detr_detection(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load the model
     framework_model = DetrForObjectDetection.from_pretrained(variant)
@@ -52,7 +52,7 @@ def test_detr_segmentation(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load the model
     framework_model = DetrForSegmentation.from_pretrained(variant)

--- a/forge/test/models/pytorch/vision/dla/test_dla.py
+++ b/forge/test/models/pytorch/vision/dla/test_dla.py
@@ -48,7 +48,7 @@ def test_dla_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="dla", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     func = variants_func[variant]
 

--- a/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
@@ -57,7 +57,7 @@ def test_efficientnet_timm(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load model
     framework_model = download_model(timm.create_model, variant, pretrained=True)
@@ -120,7 +120,7 @@ def test_efficientnet_torchvision(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load model
     if variant == "efficientnet_b0":

--- a/forge/test/models/pytorch/vision/efficientnet/test_efficientnet_lite.py
+++ b/forge/test/models/pytorch/vision/efficientnet/test_efficientnet_lite.py
@@ -21,7 +21,7 @@ def test_efficientnet_lite_0_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="efficientnet", variant="lite_0")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Model load in Forge
     model_name = "efficientnet_lite0"
@@ -49,7 +49,7 @@ def test_efficientnet_lite_1_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="efficientnet", variant="lite_1")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Model load in Forge
     model_name = "efficientnet_lite1"
@@ -77,7 +77,7 @@ def test_efficientnet_lite_2_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="efficientnet", variant="lite_2")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Model load in Forge
     model_name = "efficientnet_lite2"
@@ -105,7 +105,7 @@ def test_efficientnet_lite_3_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="efficientnet", variant="lite_3")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Model load in Forge
     model_name = "efficientnet_lite3"
@@ -133,7 +133,7 @@ def test_efficientnet_lite_4_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="efficientnet", variant="lite_4")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Model load in Forge
     model_name = "efficientnet_lite4"

--- a/forge/test/models/pytorch/vision/fchardnet/test_fchardnet.py
+++ b/forge/test/models/pytorch/vision/fchardnet/test_fchardnet.py
@@ -23,7 +23,7 @@ def test_fchardnet(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="fchardnet")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load and pre-process image
     image_path = "tt-forge-fe/forge/test/model_demos/high_prio/cnn/pytorch/model2/pytorch/pidnet/image/road_scenes.png"

--- a/forge/test/models/pytorch/vision/fpn/test_fpn.py
+++ b/forge/test/models/pytorch/vision/fpn/test_fpn.py
@@ -17,7 +17,7 @@ def test_fpn_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="fpn", source=Source.TORCHVISION)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load FPN model
     framework_model = FPNWrapper()

--- a/forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py
+++ b/forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py
@@ -25,7 +25,7 @@ def test_ghostnet_timm(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="ghostnet", variant=variant, source=Source.TIMM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(timm.create_model, variant, pretrained=True)

--- a/forge/test/models/pytorch/vision/googlenet/test_googlenet.py
+++ b/forge/test/models/pytorch/vision/googlenet/test_googlenet.py
@@ -20,7 +20,7 @@ def test_googlenet_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="googlenet")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Create Forge module from PyTorch model
     # Two ways to load the same model

--- a/forge/test/models/pytorch/vision/hardnet/test_hardnet.py
+++ b/forge/test/models/pytorch/vision/hardnet/test_hardnet.py
@@ -30,7 +30,7 @@ def test_hardnet_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="hardnet", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # load only the model architecture without pre-trained weights.
     framework_model = torch.hub.load("PingoLH/Pytorch-HarDNet", variant, pretrained=False)

--- a/forge/test/models/pytorch/vision/hrnet/test_hrnet.py
+++ b/forge/test/models/pytorch/vision/hrnet/test_hrnet.py
@@ -87,7 +87,7 @@ def test_hrnet_osmr_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="hrnet", variant=variant, source=Source.OSMR)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_hrnet_imgcls_osmr_pytorch(
         variant,
@@ -161,7 +161,7 @@ def test_hrnet_timm_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="hrnet", variant=variant, source=Source.TIMM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_hrnet_imgcls_timm_pytorch(
         variant,

--- a/forge/test/models/pytorch/vision/inception/test_inception_v4.py
+++ b/forge/test/models/pytorch/vision/inception/test_inception_v4.py
@@ -35,7 +35,7 @@ def test_inception_v4_osmr_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="inception", variant="v4", source=Source.OSMR)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs = generate_model_inceptionV4_imgcls_osmr_pytorch("inceptionv4")
 
@@ -60,7 +60,7 @@ def test_inception_v4_timm_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="inception", variant="v4", source=Source.TIMM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs = generate_model_inceptionV4_imgcls_timm_pytorch("inception_v4")
 

--- a/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
+++ b/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
@@ -40,7 +40,7 @@ def test_mlp_mixer_timm_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="mlp_mixer", variant=variant, source=Source.TIMM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model = download_model(timm.create_model, variant, pretrained=True)
     config = resolve_data_config({}, model=model)

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
@@ -31,7 +31,7 @@ def test_mobilenetv1_basic(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="mobilenet_v1", variant="basic")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV1_base_custom_pytorch()
 
@@ -69,7 +69,7 @@ def test_mobilenetv1_192(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetv1_imgcls_hf_pytorch(variant)
 
@@ -106,7 +106,7 @@ def test_mobilenetv1_224(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV1I224_imgcls_hf_pytorch(variant)
 

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1_ssd.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1_ssd.py
@@ -21,7 +21,7 @@ def test_mobilenet_v1_ssd_pytorch_1x1(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="mobilenet", variant="ssd")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load PASCAL VOC dataset class labels
     label_path = "mobilenetv1_ssd/models/voc-model-labels.txt"

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -46,7 +46,7 @@ def test_mobilenetv2_basic(record_forge_property):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV2_imgcls_torchhub_pytorch()
 
@@ -81,7 +81,7 @@ def test_mobilenetv2_96(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV2I96_imgcls_hf_pytorch(variant)
 
@@ -116,7 +116,7 @@ def test_mobilenetv2_160(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV2I160_imgcls_hf_pytorch(variant)
 
@@ -153,7 +153,7 @@ def test_mobilenetv2_224(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV2I244_imgcls_hf_pytorch(variant)
 
@@ -199,7 +199,7 @@ def test_mobilenetv2_timm(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV2_imgcls_timm_pytorch(variant)
 
@@ -252,7 +252,7 @@ def test_mobilenetv2_deeplabv3(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV2_semseg_hf_pytorch(variant)
 

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
@@ -48,7 +48,7 @@ def test_mobilenetv3_basic(mobilenet_v3_small, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV3_imgcls_torchhub_pytorch(
         variant,
@@ -103,7 +103,7 @@ def test_mobilenetv3_timm(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV3_imgcls_timm_pytorch(
         variant,

--- a/forge/test/models/pytorch/vision/monodepth2/test_monodepth2.py
+++ b/forge/test/models/pytorch/vision/monodepth2/test_monodepth2.py
@@ -33,7 +33,7 @@ def test_monodepth2(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="monodepth2", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # prepare model and input
     download_model(variant)

--- a/forge/test/models/pytorch/vision/monodle/test_monodle.py
+++ b/forge/test/models/pytorch/vision/monodle/test_monodle.py
@@ -19,7 +19,7 @@ def test_monodle_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="monodle")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load data sample
     url = "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"

--- a/forge/test/models/pytorch/vision/openpose/test_openpose.py
+++ b/forge/test/models/pytorch/vision/openpose/test_openpose.py
@@ -55,7 +55,7 @@ def test_openpose_basic(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="openpose", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_openpose_posdet_custom_pytorch(
         variant,
@@ -94,7 +94,7 @@ def test_openpose_osmr(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="openpose", variant=variant, source=Source.OSMR)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_openpose_posdet_osmr_pytorch(
         variant,

--- a/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
+++ b/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
@@ -57,7 +57,7 @@ def test_perceiverio_for_image_classification_pytorch(record_forge_property, var
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Sample Image
     pixel_values = get_sample_data(variant)

--- a/forge/test/models/pytorch/vision/pidnet/test_pidnet.py
+++ b/forge/test/models/pytorch/vision/pidnet/test_pidnet.py
@@ -26,7 +26,7 @@ def test_pidnet_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="pidnet", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load and pre-process image
     image_path = "tt-forge-fe/forge/test/model_demos/high_prio/cnn/pytorch/model2/pytorch/pidnet/image/road_scenes.png"

--- a/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
+++ b/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
@@ -22,7 +22,7 @@ def test_rcnn_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="rcnn")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load Alexnet Model
     framework_model = torchvision.models.alexnet(pretrained=True)

--- a/forge/test/models/pytorch/vision/regnet/test_regnet.py
+++ b/forge/test/models/pytorch/vision/regnet/test_regnet.py
@@ -18,7 +18,7 @@ def test_regnet(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="regnet", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load RegNet model
     framework_model = RegNetModel.from_pretrained("facebook/regnet-y-040")
@@ -45,7 +45,7 @@ def test_regnet_img_classification(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load the image processor and the RegNet model
     framework_model = RegNetForImageClassification.from_pretrained("facebook/regnet-y-040")

--- a/forge/test/models/pytorch/vision/resnet/test_resnet.py
+++ b/forge/test/models/pytorch/vision/resnet/test_resnet.py
@@ -49,7 +49,7 @@ def test_resnet(record_forge_property):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_resnet_imgcls_hf_pytorch(
         "microsoft/resnet-50",
@@ -92,7 +92,7 @@ def test_resnet_timm(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="resnet", source=Source.TIMM, variant="50")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_resnet_imgcls_timm_pytorch("resnet50")
 

--- a/forge/test/models/pytorch/vision/resnext/test_resnext.py
+++ b/forge/test/models/pytorch/vision/resnext/test_resnext.py
@@ -22,7 +22,7 @@ def test_resnext_50_torchhub_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", variant, pretrained=True)
@@ -47,7 +47,7 @@ def test_resnext_101_torchhub_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", variant, pretrained=True)
@@ -74,7 +74,7 @@ def test_resnext_101_32x8d_fb_wsl_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     # 4 variants
@@ -100,7 +100,7 @@ def test_resnext_14_osmr_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="resnext", source=Source.OSMR, variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(ptcv_get_model, variant, pretrained=True)
@@ -125,7 +125,7 @@ def test_resnext_26_osmr_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="resnext", source=Source.OSMR, variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(ptcv_get_model, variant, pretrained=True)
@@ -150,7 +150,7 @@ def test_resnext_50_osmr_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="resnext", source=Source.OSMR, variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(ptcv_get_model, variant, pretrained=True)
@@ -175,7 +175,7 @@ def test_resnext_101_osmr_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="resnext", source=Source.OSMR, variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(ptcv_get_model, variant, pretrained=True)

--- a/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
+++ b/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
@@ -33,7 +33,7 @@ def test_retinanet(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="retinanet", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Prepare model
     url = f"https://github.com/NVIDIA/retinanet-examples/releases/download/19.04/{variant}.zip"

--- a/forge/test/models/pytorch/vision/segformer/test_segformer.py
+++ b/forge/test/models/pytorch/vision/segformer/test_segformer.py
@@ -37,7 +37,7 @@ def test_segformer_image_classification_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Set model configurations
     config = SegformerConfig.from_pretrained(variant)
@@ -80,7 +80,7 @@ def test_segformer_semantic_segmentation_pytorch(record_forge_property, variant)
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Load the model from HuggingFace
     framework_model = SegformerForSemanticSegmentation.from_pretrained(variant)

--- a/forge/test/models/pytorch/vision/ssd300_resnet50/test_ssd300_resnet50.py
+++ b/forge/test/models/pytorch/vision/ssd300_resnet50/test_ssd300_resnet50.py
@@ -19,7 +19,7 @@ def test_pytorch_ssd300_resnet50(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="ssd300_resnet50")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2 : prepare model
     framework_model = torch.hub.load("NVIDIA/DeepLearningExamples:torchhub", "nvidia_ssd", pretrained=False)

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -26,7 +26,7 @@ def test_swin_v1_tiny_4_224_hf_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="swin", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 1: Create Forge module from PyTorch model
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
@@ -53,7 +53,7 @@ def test_swin_v2_tiny_4_256_hf_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="swin", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
     framework_model = Swinv2Model.from_pretrained(variant)
@@ -80,7 +80,7 @@ def test_swin_v2_tiny_image_classification(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
     framework_model = Swinv2ForImageClassification.from_pretrained(variant)
@@ -107,7 +107,7 @@ def test_swin_v2_tiny_masked(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
     framework_model = Swinv2ForMaskedImageModeling.from_pretrained(variant)

--- a/forge/test/models/pytorch/vision/tri/test_tri_basic_2.py
+++ b/forge/test/models/pytorch/vision/tri/test_tri_basic_2.py
@@ -28,7 +28,7 @@ def test_tri_basic_2_sematic_segmentation_pytorch(record_forge_property):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # Sample Input
     image_w = 800

--- a/forge/test/models/pytorch/vision/unet/test_unet.py
+++ b/forge/test/models/pytorch/vision/unet/test_unet.py
@@ -43,7 +43,7 @@ def test_unet_osmr_cityscape_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="unet", variant="cityscape", source=Source.OSMR)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_unet_imgseg_osmr_pytorch("unet_cityscapes")
 
@@ -91,7 +91,7 @@ def test_unet_holocron_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="unet", variant="holocron")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     from holocron.models.segmentation.unet import unet_tvvgg11
 
@@ -142,7 +142,7 @@ def test_unet_qubvel_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="unet", variant="qubvel")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_unet_imgseg_smp_pytorch(None)
 
@@ -196,7 +196,7 @@ def test_unet_torchhub_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="unet")
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_unet_imgseg_torchhub_pytorch(
         "unet",

--- a/forge/test/models/pytorch/vision/vgg/test_vgg.py
+++ b/forge/test/models/pytorch/vision/vgg/test_vgg.py
@@ -33,7 +33,7 @@ def test_vgg_osmr_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="vgg", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model = download_model(ptcv_get_model, variant, pretrained=True)
     framework_model.eval()
@@ -75,7 +75,7 @@ def test_vgg_19_hf_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="vgg", variant="19", source=Source.HUGGINGFACE)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     """
     # https://pypi.org/project/vgg-pytorch/
@@ -146,7 +146,7 @@ def test_vgg_bn19_timm_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="vgg", variant="vgg19_bn", source=Source.TIMM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     torch.multiprocessing.set_sharing_strategy("file_system")
     framework_model, image_tensor = download_model(preprocess_timm_model, variant)
@@ -170,7 +170,7 @@ def test_vgg_bn19_torchhub_pytorch(record_forge_property):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "vgg19_bn", pretrained=True)
     framework_model.eval()

--- a/forge/test/models/pytorch/vision/vit/test_vit.py
+++ b/forge/test/models/pytorch/vision/vit/test_vit.py
@@ -49,7 +49,7 @@ def test_vit_classify_224_hf_pytorch(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_vit_imgcls_hf_pytorch(variant)
 

--- a/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
@@ -38,7 +38,7 @@ def test_vovnet_osmr_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="vovnet", variant=variant, source=Source.OSMR)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_vovnet_imgcls_osmr_pytorch(variant)
 
@@ -65,7 +65,7 @@ def test_vovnet_v1_39_stigma_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="vovnet_v1", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_vovnet39_imgcls_stigma_pytorch()
 
@@ -93,7 +93,7 @@ def test_vovnet_v1_57_stigma_pytorch(record_forge_property):
     module_name = build_module_name(framework=Framework.PYTORCH, model="vovnet", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_vovnet57_imgcls_stigma_pytorch()
 
@@ -122,7 +122,7 @@ def test_vovnet_timm_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="vovnet", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_vovnet_imgcls_timm_pytorch(
         variant,

--- a/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
+++ b/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
@@ -54,7 +54,7 @@ def test_wideresnet_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="wideresnet", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     (framework_model, inputs) = generate_model_wideresnet_imgcls_pytorch(variant)
 
@@ -96,7 +96,7 @@ def test_wideresnet_timm(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     (framework_model, inputs) = generate_model_wideresnet_imgcls_timm(variant)
 

--- a/forge/test/models/pytorch/vision/xception/test_xception.py
+++ b/forge/test/models/pytorch/vision/xception/test_xception.py
@@ -48,7 +48,7 @@ def test_xception_timm(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="xception", variant=variant, source=Source.TIMM)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     (framework_model, inputs) = generate_model_xception_imgcls_timm(variant)
 

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v3.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v3.py
@@ -43,7 +43,7 @@ def test_yolov3_tiny_holli_pytorch(record_forge_property):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_yolotinyV3_imgcls_holli_pytorch()
 
@@ -85,7 +85,7 @@ def test_yolov3_holli_pytorch(record_forge_property):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_yoloV3_imgcls_holli_pytorch()
 

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -41,7 +41,7 @@ def test_yolov5_320x320(record_forge_property, size):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_yoloV5I320_imgcls_torchhub_pytorch(
         "ultralytics/yolov5",
@@ -84,7 +84,7 @@ def test_yolov5_640x640(record_forge_property, size):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_yoloV5I640_imgcls_torchhub_pytorch(
         "ultralytics/yolov5",
@@ -123,7 +123,7 @@ def test_yolov5_480x480(record_forge_property, size):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model, inputs, _ = generate_model_yoloV5I480_imgcls_torchhub_pytorch(
         "ultralytics/yolov5",
@@ -153,7 +153,7 @@ def test_yolov5_1280x1280(record_forge_property, variant):
     )
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     framework_model = download_model(torch.hub.load, "ultralytics/yolov5", variant, pretrained=True)
 

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
@@ -30,7 +30,7 @@ def test_yolo_v6_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="yolo_v6", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # STEP 2 :prepare model
     url = f"https://github.com/meituan/YOLOv6/releases/download/0.3.0/{variant}.pt"

--- a/forge/test/models/pytorch/vision/yolo/test_yolox.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolox.py
@@ -46,7 +46,7 @@ def test_yolox_pytorch(record_forge_property, variant):
     module_name = build_module_name(framework=Framework.PYTORCH, model="yolox", variant=variant)
 
     # Record Forge Property
-    record_forge_property("module_name", module_name)
+    record_forge_property("model_name", module_name)
 
     # prepare model
     weight_name = f"{variant}.pth"


### PR DESCRIPTION
Currently, we're storing invalid test property for our model tests. As consequence, model names aren't properly tracked as part of our CI and DB. This change should correct it.

Fix #1049