### PR TITLE
Optimizer tests and states fix

### DIFF
--- a/forge/forge/compiled_graph_state.py
+++ b/forge/forge/compiled_graph_state.py
@@ -412,14 +412,12 @@ class CompiledModel:
 
         for weight_update_name in self.opt_compiled_graph_state.aliased_outputs:
             weight_name = self.opt_compiled_graph_state.aliased_outputs[weight_update_name]
-            assert self.opt_compiled_graph_state.get_parameter_tensor(
-                weight_name
-            ) is self.fwd_compiled_graph_state.get_parameter_tensor(weight_name)
-            self.fwd_compiled_graph_state.get_parameter_tensor(weight_name).data = update_param[weight_update_name].data
+            self.opt_compiled_graph_state.get_parameter_tensor(weight_name).data = update_param[weight_update_name].data
 
             # Sanity check - assert that the parameter tensors in framework module are the same as the ones in our runtime.
             for torch_name, val in self.framework_module.module.named_parameters():
                 if torch_name == weight_name:
+                    assert self.opt_compiled_graph_state.get_parameter_tensor(weight_name) is self.fwd_compiled_graph_state.get_parameter_tensor(weight_name)
                     assert self.fwd_compiled_graph_state.get_parameter_tensor(weight_name) is val
-
         self.gradient_outputs = []
+

--- a/forge/forge/optimizers.py
+++ b/forge/forge/optimizers.py
@@ -237,12 +237,14 @@ class Adam(Optimizer):
             self.set_parameters_to_optimize(parameters)
 
     def get_cpu_param_dict(self, dtype: torch.dtype, shape: Tuple[int]) -> Dict:
+        # HACK: shapes are set to the shape of the parameter because of the following issue
+        # https://github.com/tenstorrent/tt-metal/issues/16352
         if self.bias_correction:
             return {
                 "torch_mean": torch.full(shape, 0.0, dtype=dtype),
                 "torch_variance": torch.full(shape, 0.0, dtype=dtype),
-                "torch_beta1_pow": torch.full((1,), 1.0, dtype=dtype),
-                "torch_beta2_pow": torch.full((1,), 1.0, dtype=dtype),
+                "torch_beta1_pow": torch.full(shape, 1.0, dtype=dtype),
+                "torch_beta2_pow": torch.full(shape, 1.0, dtype=dtype),
             }
         else:
             return {
@@ -257,15 +259,15 @@ class Adam(Optimizer):
         torch_lr = torch.full((1,), self.learning_rate, dtype=dtype)
         if self.bias_correction:
             return {
-                "lr": Tensor.create_from_torch(torch_lr),
+                "lr": Tensor.create_from_torch(torch.full(shape, self.learning_rate, dtype=dtype)),
                 "mean": Tensor.create_from_torch(torch.full(shape, 0.0, dtype=dtype)),
                 "variance": Tensor.create_from_torch(torch.full(shape, 0.0, dtype=dtype)),
-                "beta1_pow": Tensor.create_from_torch(torch.full((1,), 1.0, dtype=dtype)),
-                "beta2_pow": Tensor.create_from_torch(torch.full((1,), 1.0, dtype=dtype)),
+                "beta1_pow": Tensor.create_from_torch(torch.full(shape, 1.0, dtype=dtype)),
+                "beta2_pow": Tensor.create_from_torch(torch.full(shape, 1.0, dtype=dtype)),
             }
         else:
             return {
-                "lr": Tensor.create_from_torch(torch_lr),
+                "lr": Tensor.create_from_torch(torch.full(shape, self.learning_rate, dtype=dtype)),
                 "mean": Tensor.create_from_torch(torch.full(shape, 0.0, dtype=dtype)),
                 "variance": Tensor.create_from_torch(torch.full(shape, 0.0, dtype=dtype)),
             }
@@ -316,12 +318,14 @@ class Adam(Optimizer):
 
         # {mean, variance} get updated in the loopback
         for parameter, opt_inputs in self.parameter_to_opt_inputs.items():
-            torch_lr = torch.full((1,), self.learning_rate, dtype=opt_inputs["lr"].pt_data_format)
+            torch_lr = torch.full(parameter.shape.as_list(), self.learning_rate, dtype=opt_inputs["lr"].pt_data_format)
             opt_inputs["lr"] = Tensor.create_from_torch(torch_lr)
 
     def generate_op_trace(self, ac, parameter, gradient):
+
+        parameter_shape = parameter.shape.as_list()
         if self.weight_decay > 0.0:
-            weight_decay = ac.constant(self.weight_decay)
+            weight_decay = ac.tensor(torch.full(parameter_shape, self.weight_decay))
         else:
             weight_decay = None
 
@@ -331,16 +335,16 @@ class Adam(Optimizer):
 
         # self.mean = self.beta1 * self.mean + one_minus_beta1 * gradient
         mean = ac.input("mean", parameter.shape, copy_consteval_operations=True)
-        beta1 = ac.constant(self.beta1)
-        one_minus_beta1 = ac.constant(1 - self.beta1)
+        beta1 = ac.tensor(torch.full(parameter_shape, self.beta1))
+        one_minus_beta1 = ac.tensor(torch.full(parameter_shape, 1 - self.beta1))
         mean_times_beta1 = ac.op("multiply", (mean, beta1))
         gradient_times_one_minus_beta1 = ac.op("multiply", (gradient, one_minus_beta1))
         updated_mean = ac.op("add", (mean_times_beta1, gradient_times_one_minus_beta1))
 
         # self.variance = self.beta2 * self.variance + one_minus_beta2 * gradient**2
         variance = ac.input("variance", parameter.shape, copy_consteval_operations=True)
-        beta2 = ac.constant(self.beta2)
-        one_minus_beta2 = ac.constant(1 - self.beta2)
+        beta2 = ac.tensor(torch.full(parameter_shape, self.beta2))
+        one_minus_beta2 = ac.tensor(torch.full(parameter_shape, 1 - self.beta2))
         variance_times_beta2 = ac.op("multiply", (variance, beta2))
         gradient_squared = ac.op("multiply", (gradient, gradient))
         gradient_squared_times_one_minus_beta2 = ac.op("multiply", (gradient_squared, one_minus_beta2))
@@ -352,15 +356,15 @@ class Adam(Optimizer):
 
         if self.bias_correction:
             # bias_correction1 = 1 - beta1 ** step
-            beta1_one = ac.constant(1.0)
-            beta1_pow = ac.input("beta1_pow", (1,), disable_consteval=True)  # stores beta1 ** step
+            beta1_one = ac.tensor(torch.full(parameter_shape, 1.0))
+            beta1_pow = ac.input("beta1_pow", parameter.shape, disable_consteval=True)  # stores beta1 ** step
             updated_beta1_pow = ac.op("multiply", (beta1_pow, beta1))
             bias_correction1 = ac.op("subtract", (beta1_one, updated_beta1_pow))
             reciprocal_bias_correction1 = ac.op(Reciprocal.create(), (bias_correction1,))
 
             # bias_correction2 = 1 - beta2 ** step
-            beta2_one = ac.constant(1.0)
-            beta2_pow = ac.input("beta2_pow", (1,), disable_consteval=True)  # stores beta2 ** step
+            beta2_one = ac.tensor(torch.full(parameter_shape, 1.0))
+            beta2_pow = ac.input("beta2_pow", parameter.shape, disable_consteval=True)  # stores beta2 ** step
             updated_beta2_pow = ac.op("multiply", (beta2_pow, beta2))
             bias_correction2 = ac.op("subtract", (beta2_one, updated_beta2_pow))
             sqrt_bias_correction2 = ac.op(Sqrt.create(), (bias_correction2,))
@@ -372,7 +376,7 @@ class Adam(Optimizer):
         else:
             sqrt_of_variance = ac.op(Sqrt.create(), (updated_variance,))
 
-        epsilon = ac.constant(self.epsilon)
+        epsilon = ac.tensor(torch.full(parameter_shape, self.epsilon))
         sqrt_of_variance_plus_epsilon = ac.op("add", (sqrt_of_variance, epsilon))
         reciprocal_of_sqrt_of_variance_plus_epsilon = ac.op(Reciprocal.create(), (sqrt_of_variance_plus_epsilon,))
 
@@ -398,7 +402,7 @@ class Adam(Optimizer):
                 mean_times_reciprocal_of_sqrt_of_variance_plus_epsilon
             )
 
-        lr = ac.input("lr", (1,))
+        lr = ac.input("lr", parameter.shape)
         parameter_delta = ac.op(
             "multiply", (mean_times_reciprocal_of_sqrt_of_variance_plus_epsilon_plus_weight_decay_times_param, lr)
         )

--- a/forge/test/mlir/mnist/training/test_training.py
+++ b/forge/test/mlir/mnist/training/test_training.py
@@ -5,6 +5,7 @@
 import pytest
 import time
 
+from test.mlir.utils import *
 import torch
 from torch import nn
 from loguru import logger

--- a/forge/test/mlir/mnist/utils.py
+++ b/forge/test/mlir/mnist/utils.py
@@ -5,6 +5,7 @@
 from datetime import datetime
 import operator
 
+from test.mlir.utils import get_param_grads
 import torch
 from torch import nn
 from torch.utils.data import DataLoader
@@ -151,18 +152,6 @@ def load_dataset(batch_size, dtype=torch.float32):
     test_loader = DataLoader(test_dataset, batch_size=batch_size, shuffle=False, drop_last=True)
 
     return test_loader, train_loader
-
-
-def get_param_grads(named_params):
-    return {name: param.grad.detach().clone() for name, param in named_params() if param.grad is not None}
-
-
-def copy_params(src, dst):
-    state_dict = src.state_dict()
-    for name, param in dst.named_parameters():
-        param.data = state_dict[name].data.detach().clone()
-
-    dst.load_state_dict(state_dict)
 
 
 def write_grads(writer, named_params, step):

--- a/forge/test/mlir/test_optimizers.py
+++ b/forge/test/mlir/test_optimizers.py
@@ -10,10 +10,13 @@ import forge
 
 def train_and_compare_optimizers(num_epochs, batch_size, shape, loss_fn, tt_model, tt_optimizer, golden_model, golden_optimizer):
     for epoch in range(num_epochs):
-        # Forward pass
+        # Generate random data
         x = torch.randn(batch_size, shape[0])
         y = torch.randn(batch_size, shape[2])
         
+        golden_optimizer.zero_grad()
+
+        # Forward pass
         gold_out = golden_model(x)
         
         loss = loss_fn(gold_out, y)
@@ -33,7 +36,7 @@ def train_and_compare_optimizers(num_epochs, batch_size, shape, loss_fn, tt_mode
 
         # Compare all the parameters
         for i, (tt_param, golden_param) in enumerate(zip(tt_model.framework_module.module.parameters(), golden_model.parameters())):
-            assert compare_with_golden(tt_param, golden_param, pcc=0.95), f"Weight mismatch at epoch {epoch}\n {tt_param}, {golden_param} and param {i}"
+            assert compare_with_golden(tt_param, golden_param, pcc=0.99), f"Weight mismatch at epoch {epoch}\n {tt_param}, {golden_param} and param {i}"
 
         print(f"Epoch: {epoch}, Loss: {loss.item()}")
 

--- a/forge/test/mlir/test_optimizers.py
+++ b/forge/test/mlir/test_optimizers.py
@@ -1,0 +1,141 @@
+
+import pytest
+from test.mlir.mnist.utils import MNISTLinear
+import torch
+import torch.nn as nn
+from forge.verify.compare import compare_with_golden
+import forge
+
+
+def copy_model_params(model1: nn.Module, model2: nn.Module):
+    for param1, param2 in zip(model1.parameters(), model2.parameters()):
+        param2.data = param1.data.clone()
+
+def get_gradients(model):
+    return [p.grad for p in model.parameters()][::-1]
+
+
+def train_and_compare_optimizers(num_epochs, batch_size, shape, loss_fn, tt_model, tt_optimizer, golden_model, golden_optimizer):
+    for epoch in range(num_epochs):
+        # Forward pass
+        x = torch.randn(batch_size, shape[0])
+        y = torch.randn(batch_size, shape[1])
+        
+        tt_out = tt_model(x)
+        gold_out = golden_model(x)
+        
+        loss = loss_fn(gold_out, y)
+        loss.backward()
+        grads = get_gradients(golden_model)
+        
+        # Copy the gradients to the tt model because only the optimizer should be tested
+        tt_model.gradient_outputs = grads
+        tt_optimizer.step()
+        golden_optimizer.step()
+
+        # Compare all the parameters
+        for i, (tt_param, golden_param) in enumerate(zip(tt_model.framework_module.module.parameters(), golden_model.parameters())):
+            assert compare_with_golden(tt_param, golden_param, pcc=0.95), f"Weight mismatch at epoch {epoch}\n {tt_param}, {golden_param} and param {i}"
+
+        print(f"Epoch: {epoch}, Loss: {loss.item()}")
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (784, 10),
+        (33, 127),
+        (128, 20),
+    ],
+)
+def test_sgd(shape):
+    torch.manual_seed(0)
+    num_epochs = 10
+    learning_rate = 0.01
+    batch_size = 64
+
+    framework_model = MNISTLinear(input_size=shape[0], output_size=shape[1], bias=False)
+    golden_model = MNISTLinear(input_size=shape[0], output_size=shape[1], bias=False)
+    
+    copy_model_params(framework_model, golden_model)
+
+    tt_optimizer = forge.optimizers.SGD(learning_rate=learning_rate)
+    golden_optimizer = torch.optim.SGD(golden_model.parameters(), lr=learning_rate)
+
+    tt_model = forge.compile(
+        framework_model, 
+        sample_inputs=[torch.randn(batch_size, shape[0])],
+        optimizer=tt_optimizer,
+        training=True
+    )
+
+    loss_fn = nn.MSELoss()
+
+    train_and_compare_optimizers(
+        num_epochs=num_epochs, 
+        batch_size=batch_size, 
+        shape=shape, 
+        loss_fn=loss_fn, 
+        tt_model=tt_model,
+        tt_optimizer=tt_optimizer, 
+        golden_model=golden_model, 
+        golden_optimizer=golden_optimizer
+    )
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (784, 10),
+        (33, 127),
+        (128, 20),
+    ],
+)
+@pytest.mark.parametrize(
+    "betas",
+    [
+        (0.9, 0.999),
+        (0.8, 0.99),
+    ],
+)
+@pytest.mark.parametrize(
+    "weight_decay",
+    [
+        0.0,
+        0.1,
+    ],
+)
+def test_adam(shape, betas, weight_decay):
+    torch.manual_seed(0)
+    num_epochs = 10
+    # Large learning rate to propagate possible errors faster
+    learning_rate = 1
+    batch_size = 64
+    eps = 1e-8
+
+    framework_model = MNISTLinear(input_size=shape[0], output_size=shape[1], bias=False)
+    golden_model = MNISTLinear(input_size=shape[0], output_size=shape[1], bias=False)
+    
+    copy_model_params(framework_model, golden_model)
+
+    tt_optimizer = forge.optimizers.Adam(learning_rate=learning_rate, epsilon=eps, beta1=betas[0], beta2=betas[1], weight_decay=weight_decay, bias_correction=True)
+    golden_optimizer = torch.optim.Adam(golden_model.parameters(), lr=learning_rate, eps=eps, betas=betas, weight_decay=weight_decay)
+
+    tt_model = forge.compile(
+        framework_model, 
+        sample_inputs=[torch.randn(batch_size, shape[0])],
+        optimizer=tt_optimizer
+    )
+
+    loss_fn = nn.MSELoss()
+
+    train_and_compare_optimizers(
+        num_epochs=num_epochs, 
+        batch_size=batch_size, 
+        shape=shape, 
+        loss_fn=loss_fn, 
+        tt_model=tt_model,
+        tt_optimizer=tt_optimizer, 
+        golden_model=golden_model, 
+        golden_optimizer=golden_optimizer
+    )

--- a/forge/test/mlir/utils.py
+++ b/forge/test/mlir/utils.py
@@ -1,0 +1,18 @@
+from typing import Dict, Callable, Any
+import torch
+from torch import nn
+
+def get_param_grads(named_params: Callable[[], Dict[str, nn.Parameter]]) -> Dict[str, torch.Tensor]:
+    grads = {}
+    for name, param in named_params():
+        if param.grad is not None:
+            grads[name] = param.grad.detach().clone()
+    return grads
+
+
+def copy_params(src: nn.Module, dst: nn.Module) -> None:
+    state_dict = src.state_dict()
+    for name, param in dst.named_parameters():
+        if name in state_dict:
+            param.data = state_dict[name].data.detach().clone()
+    dst.load_state_dict(state_dict)


### PR DESCRIPTION
This PR will add:
- Optimizer unit tests
- Fix for states update in optimizers
- Workaround for [metal issue](https://github.com/tenstorrent/tt-metal/issues/16352) hit in Adam 

I propose that we have the following testing structure:
- Optimizer unit tests (the ones in this PR) that will isolate the optimizer (copy golden gradients, compare only step)
- Integration tests that run everything besides the optimizers on host (without gradients being copied). This kind of test was added [here](https://github.com/tenstorrent/tt-forge-fe/pull/928)
- E2E tests once the loss functions problems are resolved

I think that this is thorough enough, @vladimirjovanovicTT please let me know what you think