### PR TITLE
Enable the FORGE_DISABLE_REPORTIFY_DUMP flag to avoid dumping reportify graph in CI

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -164,6 +164,7 @@ jobs:
       env:
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
         HF_HUB_DISABLE_PROGRESS_BARS: 1
+        FORGE_DISABLE_REPORTIFY_DUMP: 1
       shell: bash
       run: |
         source env/activate


### PR DESCRIPTION
The reportify graph in TVM and tt-forge-fe are dumped by default and we can avoid dumping the reportify graphs by enabling the FORGE_DISABLE_REPORTIFY_DUMP flag to handle disk space limitation in CI.