### PR TITLE
Enhance the model analysis markdown generation

### DIFF
--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -50,3 +50,4 @@ keras>=2.13.1
 pytorch_forecasting==1.0.0
 patool
 openpyxl==3.1.5
+GitPython==3.1.44

--- a/scripts/model_analysis/exception_rules.py
+++ b/scripts/model_analysis/exception_rules.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 from utils import CompilerComponent, MatchingExceptionRule, MatchingCompilerComponentException
+from exception_utils import collect_mlir_unsupported_ops, collect_error_msg_from_line
 
 common_failure_matching_rules_list = [
     MatchingCompilerComponentException(
@@ -25,6 +26,7 @@ common_failure_matching_rules_list = [
             MatchingExceptionRule(
                 "lower_to_mlir",
                 ["RuntimeError", "Found Unsupported operations while lowering from TTForge to TTIR in forward graph"],
+                collect_mlir_unsupported_ops,
             ),
             MatchingExceptionRule(
                 "lower_to_mlir",
@@ -39,19 +41,28 @@ common_failure_matching_rules_list = [
             MatchingExceptionRule("Runtime Datatype Unsupported", ["RuntimeError", "Unhandled dtype Bool"]),
             # Compiled model Runtime
             MatchingExceptionRule(
-                "Runtime Datatype mismatch", ["RuntimeError", "Tensor", "data type mismatch: expected", "got"]
+                "Runtime Datatype mismatch",
+                ["RuntimeError", "Tensor", "data type mismatch: expected", "got"],
+                collect_error_msg_from_line,
             ),
             MatchingExceptionRule(
                 "Runtime Shape mismatch", ["RuntimeError", "Tensor", "shape mismatch: expected", "got"]
             ),
             MatchingExceptionRule(
-                "Runtime stride mismatch", ["RuntimeError", "Tensor", "stride mismatch: expected", "got"]
+                "Runtime stride mismatch",
+                ["RuntimeError", "Tensor", "stride mismatch: expected", "got"],
+                collect_error_msg_from_line,
             ),
             MatchingExceptionRule(
                 "Runtime Input count mismatch", ["RuntimeError", "Input count mismatch: expected", "got"]
             ),
             MatchingExceptionRule(
                 "post_const_eval_tensors", ["RuntimeError", "unsupported memory format option Contiguous"]
+            ),
+            MatchingExceptionRule(
+                "TT-Metal vs Forge Output Dtype mismatch",
+                ["TypeError: Dtype mismatch: framework_model.dtype", ", compiled_model.dtype"],
+                collect_error_msg_from_line,
             ),
         ],
     ),

--- a/scripts/model_analysis/exception_utils.py
+++ b/scripts/model_analysis/exception_utils.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from typing import List
+
+
+def collect_mlir_unsupported_ops(rule_tokens: List[str], error_message: str):
+    unsupported_ops = []
+    collect_ops_status = False
+    for line in error_message.split("\n"):
+        if "Unsupported Ops at: RUN_MLIR_COMPILER stage" in line:
+            collect_ops_status = True
+        elif "FAILED" in line or "==== FAILURES ====" in line:
+            collect_ops_status = False
+            break
+        elif collect_ops_status and "Input_shape" not in line and "Attributes" not in line:
+            unsupported_ops.append(line.strip())
+    if len(unsupported_ops) != 0:
+        matched_exception = " ".join(rule_tokens)
+        matched_exception += " Unsupported Ops: "
+        matched_exception += str(", ".join(unsupported_ops))
+    return matched_exception
+
+
+def collect_error_msg_from_line(rule_tokens: List[str], error_message: str):
+    matched_exception = ""
+    for line in error_message.split("\n"):
+        if all([True if token in line else False for token in rule_tokens]):
+            matched_exception += line
+            break
+    return matched_exception

--- a/scripts/model_analysis/markdown.py
+++ b/scripts/model_analysis/markdown.py
@@ -6,8 +6,9 @@ from loguru import logger
 import pandas as pd
 from tabulate import tabulate
 from enum import Enum
-from typing import Dict, List
+from typing import Any, Dict, List, Optional, Union
 from utils import CompilerComponent
+from collections import defaultdict
 
 
 class HtmlSymbol(Enum):
@@ -35,6 +36,7 @@ class MarkDownWriter:
         os.makedirs(self.markdown_file_dir_path, exist_ok=True)
         if open_file:
             self.file = open(os.path.join(self.markdown_file_dir_path, self.markdown_file), "w")
+        self.tab = "\t"
 
     def write(self, data: str):
         self.file.write(data)
@@ -84,8 +86,147 @@ class MarkDownWriter:
         ]
         table_df.columns = pd.MultiIndex.from_tuples(top_headers)
 
-        html_table = table_df.to_html(index=False, na_rep=" ", justify="center", escape=False)
+        table_df.index = pd.RangeIndex(start=1, stop=int(len(table_df) + 1), step=1)
 
+        html_table = table_df.to_html(index=True, na_rep=" ", justify="center", escape=False)
+
+        self.write_line(html_table)
+
+    def generate_html_table_header(self, headers: Union[List[str], Dict[str, Any]], text_align: str):
+        """
+        Generates the HTML table header with multi-level support.
+
+        Args:
+            headers (Union[List[str], Dict[str, Any]]): The structure of the table headers, which can be a nested dictionary or a simple list.
+            text_align (str): The text alignment style for the headers (e.g., 'left', 'center', 'right').
+
+        Returns:
+            str: The generated HTML string for the table header.
+        """
+
+        def calculate_colspan(header):
+            """Recursively calculate the colspan for a header."""
+            if isinstance(header, dict):
+                return sum(calculate_colspan(value) for value in header.values())
+            elif isinstance(header, list):
+                return len(header)
+            return 1
+
+        def generate_rows(headers, current_level=0, rows=None):
+            """Generate all rows for the HTML table header."""
+            if rows is None:
+                rows = []
+            if len(rows) <= current_level:
+                rows.append([])
+
+            for key, value in headers.items():
+                colspan = calculate_colspan(value)
+                rows[current_level].append(f'<th colspan="{colspan}">{key}</th>\n')
+                if isinstance(value, dict):
+                    generate_rows(value, current_level + 1, rows)
+                elif isinstance(value, list):
+                    if len(rows) <= current_level + 1:
+                        rows.append([])
+                    for header in value:
+                        rows[current_level + 1].append(f"<th>{header}</th>\n")
+
+            return rows
+
+        # Initialize the HTML table header
+        html = f"{self.tab}<thead>\n"
+
+        if isinstance(headers, dict):
+            # Generate rows dynamically based on input structure
+            rows = generate_rows(headers)
+        elif isinstance(headers, list):
+            rows = [f"<th>{header}</th>\n" for header in headers]
+            rows = [rows]
+
+        # Add rows to the HTML table header
+        for row in rows:
+            html += f'{self.tab*2}<tr style="text-align: {text_align};">\n{self.tab*3}'
+            html += f"{self.tab*3}".join(row)
+            html += f"{self.tab*2}</tr>\n"
+
+        # Close the table header
+        html += f"{self.tab}</thead>\n"
+
+        return html
+
+    def generate_html_table_body(self, rows: List[List[Any]], rowspan_columns: Optional[List[int]] = None):
+        """
+        Generates the HTML table body with optional rowspan support.
+
+        Args:
+            rows (List[List[Any]]): The table rows, where each row is a list of cell values.
+            rowspan_columns (Optional[List[int]]): List of column indices to apply rowspan.
+
+        Returns:
+            str: The generated HTML string for the table body.
+        """
+
+        def calculate_rowspans(rows, rowspan_columns):
+            """Calculate rowspan for each cell in the specified columns."""
+            rowspan_info = defaultdict(lambda: defaultdict(int))
+            for col in rowspan_columns:
+                prev_value = None
+                prev_index = None
+                for i, row in enumerate(rows):
+                    if row[col] == prev_value:
+                        rowspan_info[prev_index][col] += 1
+                        rowspan_info[i][col] = 0  # Current row shouldn't render this cell
+                    else:
+                        rowspan_info[i][col] = 1
+                        prev_value = row[col]
+                        prev_index = i
+            return rowspan_info
+
+        # If no rowspan columns are provided, default to an empty list
+        if rowspan_columns is None:
+            rowspan_columns = []
+
+        # Calculate rowspans
+        rowspan_info = calculate_rowspans(rows, rowspan_columns)
+
+        # # Build the HTML table
+        html = f"{self.tab}<tbody>\n"
+
+        for i, row in enumerate(rows):
+            html += f"{self.tab*2}<tr>\n"
+            for j, cell in enumerate(row):
+                if j in rowspan_columns and rowspan_info[i][j] > 0:
+                    html += f'{self.tab*3}<td rowspan="{rowspan_info[i][j]}">{cell}</td>\n'
+                elif j not in rowspan_columns or rowspan_info[i][j] == 1:
+                    html += f"{self.tab*3}<td>{cell}</td>\n"
+            html += f"{self.tab*2}</tr>\n"
+
+        html += f"{self.tab}<tbody>\n"
+        return html
+
+    def write_html_table(
+        self,
+        table_headers: Union[List[str], Dict[str, Any]],
+        table_rows: List[List[Any]],
+        border: int = 2,
+        header_text_align: str = "center",
+        rowspan_columns: Optional[List[int]] = None,
+    ):
+        """
+        Generates HTML table based upon the table_headers and table_rows provided
+
+        Args:
+            table_headers (Union[List[str], Dict[str, Any]]): The table headers structure.
+            table_rows (List[List[Any]]): The table rows.
+            border (int): The border width for the table.
+            header_text_align (str): The text alignment for the headers.
+            rowspan_columns (Optional[List[int]]): Columns to apply rowspan.
+        """
+        html_table_header = self.generate_html_table_header(table_headers, header_text_align)
+        html_table_body = self.generate_html_table_body(table_rows, rowspan_columns)
+        html_table = f'<table border="{border}">\n'
+        html_table += html_table_header
+        html_table += html_table_body
+        html_table += "</table>"
         self.write_line(html_table)
 
     @classmethod


### PR DESCRIPTION
Fixes #981 

1. Added error message for the UNKNOWN Compiler Component or N/A in addition to the question mark symbol.
<img width="1122" alt="Screenshot 2025-01-17 at 11 10 14 AM" src="https://github.com/user-attachments/assets/bff335e9-4db5-4302-9e80-6c5217a567d6" />

2. Added row ids for the [model_analysis_docs/ModelsInfo.md](https://github.com/tenstorrent/tt-forge-fe/blob/main/model_analysis_docs/ModelsInfo.md) file and other sub markdown files tables - [Preview](https://github.com/tenstorrent/tt-forge-fe/blob/pchandrasekaran/enhance_model_analysis/model_analysis_docs_new/Models/albert/pt_albert_base_v1_mlm.md)
3. Added the commit id on which the model analysis is triggered and last updated date and time in GST above the [model_analysis_docs/ModelsInfo.md](https://github.com/tenstorrent/tt-forge-fe/blob/main/model_analysis_docs/ModelsInfo.md) table - [preview](https://github.com/tenstorrent/tt-forge-fe/blob/pchandrasekaran/enhance_model_analysis/model_analysis_docs_new/ModelsInfo.md#:~:text=Last%20updated%20date,Commit%20Id%20%3A%202b3e0f0969f1aaa33b639735a97f293e64c63d3f)
4. Sorted the [model_analysis_docs/ModelsInfo.md](https://github.com/tenstorrent/tt-forge-fe/blob/main/model_analysis_docs/ModelsInfo.md) table in alphabetical order by model name first and then by variant name - [preview](https://github.com/tenstorrent/tt-forge-fe/blob/pchandrasekaran/enhance_model_analysis/model_analysis_docs_new/ModelsInfo.md)
5. Added a feature to sort issues for each component (FFE, MLIR, TTNN) based on the number of models they block which  helps to prioritize which issues to focus first - [preview](https://github.com/tenstorrent/tt-forge-fe/blob/pchandrasekaran/enhance_model_analysis/model_analysis_docs_new/statistics_report.md#compiler-component-failure-analysis-by-model-impacts)
5. Added a feature to have statistical data about no of models passed for each compiler component, no of models passed in percetange for each compiler component and average pass percentage for each compiler component - [preview](https://github.com/tenstorrent/tt-forge-fe/blob/pchandrasekaran/enhance_model_analysis/model_analysis_docs_new/statistics_report.md#compiler-specific-model-statistics)


Preview of new model analysis doc after enhancement
1. [ModelsInfo.md](https://github.com/tenstorrent/tt-forge-fe/blob/pchandrasekaran/enhance_model_analysis/model_analysis_docs_new/ModelsInfo.md)
2. [statistics_report.md](https://github.com/tenstorrent/tt-forge-fe/blob/pchandrasekaran/enhance_model_analysis/model_analysis_docs_new/statistics_report.md)

Note:
Before merging the PR, will remove the [model_analysis_docs_new](https://github.com/tenstorrent/tt-forge-fe/tree/pchandrasekaran/enhance_model_analysis/model_analysis_docs_new) folder, it is created for preview.
