### PR TITLE
Add no-skips argument in unique ops config generation subprocess run method in model analysis

### DIFF
--- a/scripts/model_analysis/unique_ops_utils.py
+++ b/scripts/model_analysis/unique_ops_utils.py
@@ -53,7 +53,7 @@ def generate_and_export_unique_ops_tests(
             logger.info(f"Running the tests : {test}")
             try:
                 result = subprocess.run(
-                    ["pytest", test, "-vss", pytest_argument],
+                    ["pytest", test, "-vss", pytest_argument, "--no-skips"],
                     capture_output=True,
                     text=True,
                     check=True,


### PR DESCRIPTION
In [this PR](https://github.com/tenstorrent/tt-forge-fe/pull/1044), we skipped some of the model variants due to CI limitation and those model variants will also be skipped in the model analysis pipeline. To avoid skipping the model variants in model analysis, added `--no-skips` argument in the subprocess run method in extraction and generation of unique ops config test function(i.e `generate_and_export_unique_ops_tests in scripts/model_analysis/unique_ops_utils.py`)