### PR TITLE
Add option to run on-pr workflow with mlir override

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -2,6 +2,11 @@ name: On PR
 
 on:
   workflow_dispatch:
+    inputs:
+      mlir_override:
+        description: 'Git SHA of commit in tenstorrent/tt-mlir'
+        required: false
+        type: string
   pull_request:
     branches: [ "main" ]
 
@@ -23,6 +28,7 @@ jobs:
       test_mark: 'push'
       test_group_cnt: 2
       test_group_ids: '[1,2]'
+      mlir_override: ${{ inputs.mlir_override }}
   perf-benchmark:
     needs: docker-build
     uses: ./.github/workflows/perf-benchmark.yml


### PR DESCRIPTION
Add option to override tt-mlir version in On-pr workflow, and pass override value to "build-and-test" workflow