### PR TITLE
Support commuting broadcast through squeeze and unsqueeze in erase inverse ops

### DIFF
--- a/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
+++ b/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
@@ -476,7 +476,9 @@ def test_log(shape):
         ((1, 32, 32, 32), (1,)),
     ],
 )
-@pytest.mark.xfail(reason="TTNN maximum op: unsupported broadcast")
+@pytest.mark.xfail(
+    reason="TTNN maximum op: unsupported broadcast. Tracking on: https://github.com/tenstorrent/tt-metal/issues/16969"
+)
 @pytest.mark.push
 def test_maximum(shape_x, shape_y):
     class Maximum(nn.Module):


### PR DESCRIPTION
Closes #772 
Closes #816 
- Support commuting broadcast through squeeze and unsqueeze in erase inverse ops.
- Add unit test and end to end test.