### PR TITLE
Use "/mnt/dockercache/huggingface" for huggingface cache

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -178,7 +178,6 @@ jobs:
                --group ${{ matrix.test_group_id }} \
                --splitting-algorithm least_duration \
                -m "${{ inputs.test_mark }}" \
-               -n 1 \ # Force pytest-xdist process isolation
                --junit-xml=${{ steps.strings.outputs.test_report_path }} \
                2>&1 | tee pytest.log
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -82,6 +82,7 @@ jobs:
         - /etc/udev/rules.d:/etc/udev/rules.d
         - /lib/modules:/lib/modules
         - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
+        - /mnt/dockercache:/mnt/dockercache
     steps:
 
     - name: Set reusable strings
@@ -163,6 +164,7 @@ jobs:
     - name: Run Test
       env:
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        HF_HOME: /mnt/dockercache/huggingface
         HF_HUB_DISABLE_PROGRESS_BARS: 1
         FORGE_DISABLE_REPORTIFY_DUMP: 1
       shell: bash

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -178,6 +178,7 @@ jobs:
                --group ${{ matrix.test_group_id }} \
                --splitting-algorithm least_duration \
                -m "${{ inputs.test_mark }}" \
+               -n 1 \ # Force pytest-xdist process isolation
                --junit-xml=${{ steps.strings.outputs.test_report_path }} \
                2>&1 | tee pytest.log
 


### PR DESCRIPTION
Our self hosted runners (forge-*) now have mounted shared 1TB volume at path Use "/mnt/dockercache" and we can use  "/mnt/dockercache/huggingface" location for hugging face cache. With this, cache will be shared across runners.
This helps with disk space issues on self-hosted runners and will speed up tests as they dont need to download HF models every time.
On BM runners this will be local folder at same path.