### PR TITLE
Caching test ids loaded from files

### DIFF
--- a/forge/test/operators/pytorch/reduce/test_reduce.py
+++ b/forge/test/operators/pytorch/reduce/test_reduce.py
@@ -250,6 +250,31 @@ class TestCollectionData:
     )
 
 
+class TestIdsData:
+
+    __test__ = False  # Avoid collecting TestIdsData as a pytest test
+
+    failed_mlir_verif_error = TestPlanUtils.load_test_ids_from_file(
+        f"{os.path.dirname(__file__)}/errors/test_reduce_ids_failed_mlir_verif_error.txt"
+    )
+
+    pcc_error = TestPlanUtils.load_test_ids_from_file(
+        f"{os.path.dirname(__file__)}/errors/test_reduce_ids_pcc_error.txt"
+    )
+
+    tilize_dtype_error = TestPlanUtils.load_test_ids_from_file(
+        f"{os.path.dirname(__file__)}/errors/test_reduce_ids_tilize_dtype_error.txt"
+    )
+
+    tilize_error = TestPlanUtils.load_test_ids_from_file(
+        f"{os.path.dirname(__file__)}/errors/test_reduce_ids_tilize_error.txt"
+    )
+
+    unsupported_dim_error = TestPlanUtils.load_test_ids_from_file(
+        f"{os.path.dirname(__file__)}/errors/test_reduce_ids_unsupported_dim_error.txt"
+    )
+
+
 TestParamsData.test_plan = TestPlan(
     verify=lambda test_device, test_vector: TestVerification.verify(
         test_device,
@@ -311,38 +336,23 @@ TestParamsData.test_plan = TestPlan(
             skip_reason=FailingReasons.NOT_IMPLEMENTED,
         ),
         TestCollection(
-            criteria=lambda test_vector: test_vector.get_id()
-            in TestPlanUtils.load_test_ids_from_file(
-                f"{os.path.dirname(__file__)}/errors/test_reduce_ids_failed_mlir_verif_error.txt"
-            ),
+            criteria=lambda test_vector: test_vector.get_id() in TestIdsData.failed_mlir_verif_error,
             failing_reason=FailingReasons.COMPILATION_FAILED,
         ),
         TestCollection(
-            criteria=lambda test_vector: test_vector.get_id()
-            in TestPlanUtils.load_test_ids_from_file(
-                f"{os.path.dirname(__file__)}/errors/test_reduce_ids_pcc_error.txt"
-            ),
+            criteria=lambda test_vector: test_vector.get_id() in TestIdsData.pcc_error,
             failing_reason=FailingReasons.DATA_MISMATCH,
         ),
         TestCollection(
-            criteria=lambda test_vector: test_vector.get_id()
-            in TestPlanUtils.load_test_ids_from_file(
-                f"{os.path.dirname(__file__)}/errors/test_reduce_ids_tilize_dtype_error.txt"
-            ),
+            criteria=lambda test_vector: test_vector.get_id() in TestIdsData.tilize_dtype_error,
             failing_reason=FailingReasons.INFERENCE_FAILED,
         ),
         TestCollection(
-            criteria=lambda test_vector: test_vector.get_id()
-            in TestPlanUtils.load_test_ids_from_file(
-                f"{os.path.dirname(__file__)}/errors/test_reduce_ids_tilize_error.txt"
-            ),
+            criteria=lambda test_vector: test_vector.get_id() in TestIdsData.tilize_error,
             failing_reason=FailingReasons.INFERENCE_FAILED,
         ),
         TestCollection(
-            criteria=lambda test_vector: test_vector.get_id()
-            in TestPlanUtils.load_test_ids_from_file(
-                f"{os.path.dirname(__file__)}/errors/test_reduce_ids_unsupported_dim_error.txt"
-            ),
+            criteria=lambda test_vector: test_vector.get_id() in TestIdsData.unsupported_dim_error,
             failing_reason=FailingReasons.INFERENCE_FAILED,
         ),
     ],

--- a/forge/test/operators/pytorch/tm/test_reshape.py
+++ b/forge/test/operators/pytorch/tm/test_reshape.py
@@ -235,6 +235,15 @@ class TestParamsData:
         return target_shapes
 
 
+class TestIdsData:
+
+    __test__ = False  # Avoid collecting TestIdsData as a pytest test
+
+    failed_allclose_value_checker = TestPlanUtils.load_test_ids_from_file(
+        f"{os.path.dirname(__file__)}/test_reshape_ids_failed_allclose_value_checker.txt"
+    )
+
+
 TestParamsData.test_plan = TestPlan(
     verify=lambda test_device, test_vector: TestVerification.verify(
         test_device,
@@ -280,10 +289,7 @@ TestParamsData.test_plan = TestPlan(
     ],
     failing_rules=[
         TestCollection(
-            criteria=lambda test_vector: test_vector.get_id()
-            in TestPlanUtils.load_test_ids_from_file(
-                f"{os.path.dirname(__file__)}/test_reshape_ids_failed_allclose_value_checker.txt"
-            ),
+            criteria=lambda test_vector: test_vector.get_id() in TestIdsData.failed_allclose_value_checker,
             failing_reason=FailingReasons.DATA_MISMATCH,
         ),
         TestCollection(

--- a/forge/test/operators/utils/plan.py
+++ b/forge/test/operators/utils/plan.py
@@ -609,6 +609,7 @@ class TestPlanUtils:
     @classmethod
     def load_test_ids_from_file(cls, test_ids_file: str) -> List[str]:
         """Load test ids from a file to a list of strings"""
+        logger.trace(f"Loading test ids from file: {test_ids_file}")
         with open(test_ids_file, "r") as file:
             test_ids = file.readlines()
 


### PR DESCRIPTION
Once test ids are loaded from id files they should be cached to avoid unnecessary performance penalty