### PR TITLE
[test] revert increased tolerance

### DIFF
--- a/forge/test/mlir/mnist/training/test_training.py
+++ b/forge/test/mlir/mnist/training/test_training.py
@@ -146,7 +146,7 @@ def test_mnist_training_with_grad_accumulation():
             total_loss += loss.item()
 
             golden_loss = loss_fn(golden_pred, target)
-            assert torch.allclose(loss, golden_loss, rtol=0.13)
+            assert torch.allclose(loss, golden_loss, rtol=1e-1)
 
             # Run backward pass on device
             loss.backward()


### PR DESCRIPTION
For one of the previous uplifts, we have increased `rtol` in one of the tests to unblock the uplift.

Latest metal contains a change which sets `HiFi4` by default for matmuls which have `float32` operands. This improves the accuracy, so decrease the tolerance value.