### PR TITLE
Add ops specific failure analysis feature in model analysis

### DIFF
--- a/scripts/model_analysis/exception_rules.py
+++ b/scripts/model_analysis/exception_rules.py
@@ -100,6 +100,15 @@ common_failure_matching_rules_list = [
             MatchingExceptionRule(
                 "MLIR runtime ttnn ", ["tt::exception", "tt-mlir/runtime/lib/ttnn/runtime.cpp", "Unsupported data type"]
             ),
+            MatchingExceptionRule(
+                "mlir::AffineMap collapsedLinearAffineMap",
+                [
+                    "tt-mlir/lib/Dialect/TT/IR/TTOpsTypes.cpp",
+                    "mlir::AffineMap collapsedLinearAffineMap",
+                    "Dim does not participate in AffineMap RHS",
+                ],
+                collect_error_msg_from_line,
+            ),
         ],
     ),
     MatchingCompilerComponentException(
@@ -290,6 +299,32 @@ common_failure_matching_rules_list = [
                     "tt-metal/tt_metal/impl/program/program.cpp",
                     "Failed to generate binaries for reader_conv_activations_padded_with_halo_3x3_weights_v2",
                     "ncrisc build failed",
+                ],
+            ),
+            MatchingExceptionRule(
+                "ttnn shared operation",
+                [
+                    "RuntimeError",
+                    "ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_op.cpp",
+                    "(*this->output_mem_config.shard_spec).shape[1] * input_tensor.element_size() % hal.get_alignment(HalMemType::L1) == 0",
+                    "Shard page size must currently have L1 aligned page size",
+                ],
+            ),
+            MatchingExceptionRule(
+                "ttnn pool",
+                [
+                    "RuntimeError",
+                    "tt-metal/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp",
+                    "in_ntiles_c % MAX_TILES_PER_REDUCTION == 0",
+                    "input channels should be multiple of 8 tiles. General case TODO.",
+                ],
+            ),
+            MatchingExceptionRule(
+                "ttnn pool",
+                [
+                    "RuntimeError",
+                    "tt-metal/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp",
+                    "input_shape[3] == 16",
                 ],
             ),
         ],

--- a/scripts/model_analysis/run_analysis_and_generate_md_files.py
+++ b/scripts/model_analysis/run_analysis_and_generate_md_files.py
@@ -9,6 +9,7 @@ from loguru import logger
 import argparse
 import pandas as pd
 from typing import Dict, List, Optional
+from collections import defaultdict
 from dataclasses import dataclass
 import ast
 
@@ -41,6 +42,7 @@ class UniqueOpTestInfo:
         args (List[str]): List of Operation Arguments if any
         components (dict): A dictionary indicating the support status for each compiler component.
         failure_reason (str): The reason for failure, if any, during testing.
+        metadata (List[Dict[str, str]]): Contains list of information such as model name, variant name and framework of the unique op config
     """
 
     def __init__(
@@ -48,6 +50,7 @@ class UniqueOpTestInfo:
         op: str,
         operands: List[str],
         args: List[str],
+        metadata: List[Dict[str, str]],
     ):
         self.op = str(op)
         self.operands = operands
@@ -56,15 +59,16 @@ class UniqueOpTestInfo:
         for compiler_component in CompilerComponent:
             self.components[str(compiler_component.name)] = False
         self.failure_reason = ""
+        self.metadata = metadata
 
     @classmethod
-    def create(cls, op_name, operand_names, operand_types, operand_shapes, operand_dtypes, args):
+    def create(cls, op_name, operand_names, operand_types, operand_shapes, operand_dtypes, args, metadata):
 
         operands = cls.create_operands(operand_names, operand_types, operand_shapes, operand_dtypes)
 
         args = cls.create_args(args)
 
-        return cls(op=op_name, operands=operands, args=args)
+        return cls(op=op_name, operands=operands, args=args, metadata=metadata)
 
     @classmethod
     def create_operands(cls, operand_names, operand_types, operand_shapes, operand_dtypes):
@@ -113,6 +117,22 @@ class UniqueOpTestInfo:
                     self.components[str(compiler_component.name)] = True
 
             return None, None
+
+    def get_unique_op_test_status(self):
+        """
+        Get the unique op config test status across all the compiler component
+        """
+        unique_op_test_status = True
+        for compiler_component in CompilerComponent:
+            if compiler_component != CompilerComponent.UNKNOWN:
+                if not self.components[str(compiler_component.name)]:
+                    unique_op_test_status = False
+                    break
+
+        if unique_op_test_status and self.components[str(compiler_component.name)]:
+            unique_op_test_status = False
+
+        return unique_op_test_status
 
     def __str__(self):
         return f"UniqueOpTestInfo(op={self.op}, operands={self.operands}, args={self.args}, components={self.components}, self.failure_reason={self.failure_reason})"
@@ -182,6 +202,81 @@ class ModelVariantInfo:
             model_variant_info += f"\t\t\t\t{idx}){str(unique_op)}\n"
 
 
+def sort_failed_ops_details_by_models_affected(
+    failed_ops_details: Dict[str, List[UniqueOpTestInfo]], reverse: bool = False
+):
+    """
+    Sorts failed operations by the number of unique models affected.
+
+    This function takes a dictionary of failed operations and list of UniqueOpTestInfo objects,
+    calculates the total number of unique model variants affected for each operation, and
+    returns a new dictionary where the operations are sorted by the number of models impacted
+    (in descending or ascending order).
+
+    Args:
+        failed_ops_details (Dict[str, List[UniqueOpTestInfo]]): Dictionary of failed operation name and lists of `UniqueOpTestInfo` objects
+        reverse (bool): If set to True, it sorts in descending order (most affected models first) otherwise sorts in ascending order.
+    """
+    return {
+        op_name: failed_ops_details[op_name]
+        for op_name in sorted(
+            failed_ops_details,
+            key=lambda op: len(
+                {
+                    metadata["variant_name"]
+                    for unique_op_test_info in failed_ops_details[op]
+                    for metadata in unique_op_test_info.metadata
+                }
+            ),
+            reverse=reverse,
+        )
+    }
+
+
+def group_and_sort_failures_by_impacted_models(unique_op_test_info_list: List[UniqueOpTestInfo]):
+    """
+    Groups test cases by their failure reasons and sorts them by the number of unique models impacted.
+
+    This function takes a list of `UniqueOpTestInfo` objects, groups them by their `failure_reason`,
+    and then sorts the failure reasons based on the total number of model variants impacted
+    in descending order. Within each failure reason, the test cases are further sorted by the number
+    of unique model variants impacted.
+
+    Args:
+        unique_op_test_info_list (List[UniqueOpTestInfo]):
+            A list of `UniqueOpTestInfo` objects, where each object contains metadata about the
+            test case and its failure reason.
+    """
+
+    # Group test cases by their failure reasons
+    failures_by_reason = defaultdict(list)
+    for unique_op_test_info in unique_op_test_info_list:
+        failures_by_reason[unique_op_test_info.failure_reason].append(unique_op_test_info)
+
+    # Sort failure reasons by the total number of models impacted
+    sorted_failures_by_reason = sorted(
+        failures_by_reason.items(),
+        key=lambda item: len(
+            [metadata["variant_name"] for unique_op_test_info in item[1] for metadata in unique_op_test_info.metadata]
+        ),
+        reverse=True,
+    )
+
+    # Within each failure reason, sort test cases by the number of unique models impacted
+    sorted_failures = {
+        failure: sorted(
+            unique_op_test_info_list,
+            key=lambda unique_op_test_info: len(
+                {metadata["variant_name"] for metadata in unique_op_test_info.metadata}
+            ),
+            reverse=True,
+        )
+        for failure, unique_op_test_info_list in sorted_failures_by_reason
+    }
+
+    return sorted_failures
+
+
 def run_models_unique_op_tests(unique_operations, unique_ops_output_directory_path, dump_failure_logs):
     """
     Run unique op configuration test that has been collected across all the models and populate the test result in the model variants
@@ -190,6 +285,8 @@ def run_models_unique_op_tests(unique_operations, unique_ops_output_directory_pa
     models_details = {}
 
     compiler_component_failure_analysis = CompilerComponentFailureAnalysis()
+
+    failed_ops_details = {}
 
     # Iterate over each unique operation
     for forge_op_function_name in sorted(unique_operations):
@@ -224,6 +321,7 @@ def run_models_unique_op_tests(unique_operations, unique_ops_output_directory_pa
                     operand_shapes=operand_shapes,
                     operand_dtypes=operand_dtypes,
                     args=args,
+                    metadata=model_variant_info_list,
                 )
 
                 # Extract the test file path
@@ -299,10 +397,12 @@ def run_models_unique_op_tests(unique_operations, unique_ops_output_directory_pa
                 except subprocess.TimeoutExpired as e:
                     elapsed_time = time.time() - start_time
 
+                    # Map the unique op test timeout issue for the UNKNOWN compiler component.
+                    matched_compiler_component = CompilerComponent.UNKNOWN
                     error_message = "Test timed out after 180 seconds"
-                    matched_compiler_component, match_err_msg = unique_op_test_info.update_compiler_components(
-                        error_message
-                    )
+                    match_err_msg = "[UNKNOWN] " + error_message
+                    unique_op_test_info.components[str(matched_compiler_component.name)] = True
+                    unique_op_test_info.failure_reason = match_err_msg
 
                     logger.info(f"\tFailed ({elapsed_time:.2f} seconds) due to {error_message}")
 
@@ -372,6 +472,13 @@ def run_models_unique_op_tests(unique_operations, unique_ops_output_directory_pa
                             unique_ops=[unique_op_test_info],
                         )
 
+                # Update the operation name and unique_op_test_info object inside the failed_ops_details dict if the current unique operation config is failed
+                if not unique_op_test_info.get_unique_op_test_status():
+                    if unique_op_test_info.op in failed_ops_details.keys():
+                        failed_ops_details[unique_op_test_info.op].append(unique_op_test_info)
+                    else:
+                        failed_ops_details[unique_op_test_info.op] = [unique_op_test_info]
+
     # Calculate and update the compiler support rates for each component for all the model variants
     for variant_name, model_variant_info in models_details.items():
         for compiler_component in CompilerComponent:
@@ -392,10 +499,13 @@ def run_models_unique_op_tests(unique_operations, unique_ops_output_directory_pa
     # Sort a list of ModelVariantInfo objects first by model_name and then by variant_name.
     model_variant_info_list = sort_model_variant_info_list(model_variant_info_list)
 
+    # Sort failed ops details dictionary by number of model variants failed/affected in descending order
+    failed_ops_details = sort_failed_ops_details_by_models_affected(failed_ops_details, reverse=True)
+
     # Sort the failure reasons for each compiler component based on the number of associated model variant names.
     compiler_component_failure_analysis.sort_by_model_variant_names_length(reverse=True)
 
-    return model_variant_info_list, compiler_component_failure_analysis
+    return model_variant_info_list, failed_ops_details, compiler_component_failure_analysis
 
 
 def generate_markdown(
@@ -413,7 +523,7 @@ def generate_markdown(
     markdown_writer = MarkDownWriter(markdown_file_name, markdown_file_dir_path)
 
     # Write a heading for the HTML table
-    markdown_writer.write_html_table_heading(table_heading)
+    markdown_writer.write_html_heading(table_heading)
 
     if lines_after_table_heading is not None:
         for line in lines_after_table_heading:
@@ -633,53 +743,78 @@ def calculate_top_n_blocked_models(model_variant_info_list: List[ModelVariantInf
 
 
 def create_statistics_report_markdown_file(
-    model_variant_info_list, compiler_component_failure_analysis, markdown_directory_path
+    model_variant_info_list: List[ModelVariantInfo],
+    failed_ops_details: Dict[str, List[UniqueOpTestInfo]],
+    compiler_component_failure_analysis: CompilerComponentFailureAnalysis,
+    markdown_directory_path: str,
 ):
 
     """
-    Create a markdown report summarizing compiler statistics and failure analysis.
+    Create a markdown report summarizing compiler statistics, failure analysis, and operation-specific failure details.
+
+    This function generates a detailed markdown report containing:
+    1. Compiler component failure analysis.
+    2. Compiler-specific model statistics.
+    3. Ops-specific failure statistics.
+    4. Detailed operation failure reports.
 
     Args:
-        model_variant_info_list (list): A list of model variant information objects.
+        model_variant_info_list (List[ModelVariantInfo]): A list of model variant information objects contains model name, variant name and framework of the model, support rates for each compiler component etc.
+        failed_ops_details (Dict[str, List[UniqueOpTestInfo]]): A dictionary mapping operation names to list of unique ops test info object
         compiler_component_failure_analysis (CompilerComponentFailureAnalysis):
             Object containing failure analysis for compiler components.
-        markdown_directory_path (str): Directory path where the markdown report will be saved.
+        markdown_directory_path (str): The directory path where the markdown report files will be saved.
     """
 
+    # Initialize the markdown report file and directory paths
     statistics_report_markdown_file_name = "compiler_analysis_report"
     statistics_report_directory_path = os.path.join(markdown_directory_path, "stats")
+
+    # Create a markdown writer object to handle markdown content generation
     markdown_writer = MarkDownWriter(statistics_report_markdown_file_name, statistics_report_directory_path)
 
-    # Create failure analysis table
+    # 1) Create compiler failure analysis table
+    # Define html table heading and description for the compiler failure analysis table
     table_heading = "Compiler Component Failure Analysis by Model Impacts"
+    table_description = "The table highlights the failures encountered in different compiler components, the number of models impacted by each failure, and the specific models affected."
+
+    # Define html table headers and rows for the compiler failure analysis table
     table_headers = ["Compiler Component", "Failure", "Number of Impacted Models", "Impacted Models"]
     compiler_component_failure_analysis = (
         compiler_component_failure_analysis.get_compiler_component_and_failure_details()
     )
     table_rows = []
-    for compiler_component, failure_details in compiler_component_failure_analysis.items():
-        component_name = MarkDownWriter.get_component_names_for_header(compiler_component)
-        for failure, model_variant_names in failure_details.items():
-            model_variant_names_html_list = [
-                f"<li>{model_variant_name}</li>" for model_variant_name in model_variant_names
-            ]
-            model_variant_names_html_list = "<ul>" + "".join(model_variant_names_html_list) + "</ul>"
-            table_rows.append(
-                [
-                    component_name,
-                    failure,
-                    len(model_variant_names),
-                    model_variant_names_html_list,
-                ]
-            )
+    for compiler_component in CompilerComponent:
+        if compiler_component != CompilerComponent.UNKNOWN:
+            component_name = MarkDownWriter.get_component_names_for_header(compiler_component)
+            for failure, model_variant_names in compiler_component_failure_analysis[compiler_component].items():
+                table_rows.append(
+                    [
+                        component_name,
+                        failure,
+                        len(model_variant_names),
+                        MarkDownWriter.create_html_list(items=model_variant_names),
+                    ]
+                )
 
-    # Write the failure analysis table to markdown
-    markdown_writer.write_html_table_heading(table_heading)
+    # Write the contents for the compiler failure analysis table in markdown file
+    markdown_writer.write_html_heading(heading=table_heading)
+    markdown_writer.write_html_table_description(table_description=table_description)
     markdown_writer.write_html_table(table_headers=table_headers, table_rows=table_rows, rowspan_columns=[0])
 
-    # Create compiler statistics table
+    # 2) Create compiler specific model statistics table
+    # Define html table heading, table description and column description for the compiler specific model statistics table
     top_blocked_models_count = 10
     table_heading = "Compiler-Specific Model Statistics"
+    table_description = "The table summarizes model performance across three compiler components: Forge-Fe, MLIR, and Metalium. It highlights the count of models that passed for each component, along with their respective pass rates, average pass rates and the top 10 models with the lowest pass rates."
+    table_column_description = {
+        "Models Passed": "The count of models that achieved a 100% success rate for a specific compiler component.",
+        "Pass Rate (%)": "The percentage of models that successfully passed a specific compiler component, calculated as (Models Passed / Total Number of Models) × 100",
+        "Average Pass Rate (%)": "The mean pass rate for a compiler component, determined by dividing the sum of pass rates of individual models by the total number of models.",
+        f"Top-{top_blocked_models_count} Blocked Models (pass rate in %)": f"A list of the {top_blocked_models_count} models with the lowest pass rates for a specific compiler component, including their exact pass rate percentages.",
+    }
+
+    # Define html table headers and rows for the compiler specific model statistics table
     table_headers = {
         f"Total no of models : {len(model_variant_info_list)}": [
             "Compiler Component",
@@ -689,6 +824,7 @@ def create_statistics_report_markdown_file(
             f"Top-{top_blocked_models_count} Blocked Models (pass rate in %)",
         ]
     }
+    # Calculate statistical data and generate rows for the table
     statistical_data = calculate_statistical_data(model_variant_info_list=model_variant_info_list)
     compiler_top_n_blocked_models = calculate_top_n_blocked_models(
         model_variant_info_list=model_variant_info_list, n=top_blocked_models_count
@@ -698,26 +834,127 @@ def create_statistics_report_markdown_file(
         if compiler_component != CompilerComponent.UNKNOWN:
             component_name = MarkDownWriter.get_component_names_for_header(compiler_component)
             blocked_model_variant_names = compiler_top_n_blocked_models[compiler_component]
-            blocked_model_variant_names = [
-                f"<li>{blocked_model_variant_name}</li>" for blocked_model_variant_name in blocked_model_variant_names
-            ]
-            blocked_model_variant_names = "<ul>" + "".join(blocked_model_variant_names) + "</ul>"
             table_rows.append(
                 [
                     component_name,
                     str(statistical_data[compiler_component]["models_pass_count"]),
                     str(statistical_data[compiler_component]["models_pass_percentage"]) + " %",
                     str(statistical_data[compiler_component]["average_pass_percentage"]) + " %",
-                    blocked_model_variant_names,
+                    MarkDownWriter.create_html_list(items=blocked_model_variant_names),
                 ]
             )
 
-    # Write the compiler statistics table to markdown
-    markdown_writer.write_html_table_heading(table_heading)
+    # Write the compiler specific model statistics table in markdown file
+    markdown_writer.write_html_heading(heading=table_heading)
+    markdown_writer.write_html_table_description(table_description=table_description)
+    markdown_writer.write_html_table_column_description(table_column_description=table_column_description)
     markdown_writer.write_html_table(table_headers=table_headers, table_rows=table_rows)
 
-    # Close the markdown file
+    # Directory path for specifying the operation failure reports
+    ops_specific_statistics_dir_path = os.path.join(markdown_directory_path, "ops")
+
+    remove_directory(directory_path=ops_specific_statistics_dir_path)
+
+    # 3) Create ops specific failure statistics table
+    # Define html table heading and description for ops specific failure statistics table
+    table_heading = "Ops-Specific Failure Statistics"
+    table_description = "This table provides detailed insights into operation specific statistics, highlighting the number of failed models for each operation and the associated models that encountered issues. Click on an Operation name to view its detailed analysis"
+
+    # Define html table headers and rows for  ops specific failure statistics table
+    table_headers = ["ID", "Operation Name", "Number of failed models", "Failed Models"]
+    table_rows = []
+
+    # Generate rows for ops-specific failure statistics
+    for op_idx, (op_name, unique_op_test_info_list) in enumerate(failed_ops_details.items(), start=1):
+        failed_model_variants = sorted(
+            list(
+                set(
+                    [
+                        op_metadata["variant_name"]
+                        for unique_op_test_info in unique_op_test_info_list
+                        for op_metadata in unique_op_test_info.metadata
+                    ]
+                )
+            )
+        )
+        table_rows.append(
+            [
+                str(op_idx),
+                MarkDownWriter.create_html_link(
+                    link_text=op_name,
+                    url_or_path=os.path.join("../ops", op_name.lower() + ".md"),
+                ),
+                len(failed_model_variants),
+                MarkDownWriter.create_html_list(items=failed_model_variants),
+            ]
+        )
+
+    # Write the Ops Specific Failure statistics table in markdown file
+    markdown_writer.write_html_heading(heading=table_heading)
+    markdown_writer.write_html_table_description(table_description=table_description)
+    markdown_writer.write_html_table(table_headers=table_headers, table_rows=table_rows)
+
+    # Close the statistical report markdown file
     markdown_writer.close_file()
+
+    # 4) Detailed Operation Failure Reports
+    # Create individual markdown files for each failed operation
+    for op_name, unique_op_test_info_list in failed_ops_details.items():
+
+        # Html table heading and description for operations failures report table
+        table_heading = f"Comprehensive Report on {op_name} Operation Failures and Affected Models"
+        table_description = f"The table presents a detailed summary of {op_name.lower()} operation failures, including failure descriptions, the total number of affected models, and the specific models impacted. It also provides insights into the operand configurations and associated arguments for each failure, delivering a comprehensive view of the encountered issues."
+
+        # Write table heading, description, header and rows for each failed operation as markdown file
+        table_headers = {
+            "Failure Insight and Impacted Models": [
+                "ID",
+                "Failure Description",
+                "Total Number of Models Affected",
+                "Number of Models Affected",
+                "Affected Models",
+            ],
+            f"{op_name.title()} Operation Details": ["Operands", "Arguments"],
+        }
+
+        markdown_writer = MarkDownWriter(op_name.lower(), ops_specific_statistics_dir_path)
+        markdown_writer.write_html_heading(heading=table_heading)
+        markdown_writer.write_html_table_description(table_description=table_description)
+
+        table_rows = []
+        failed_model_variants = set()
+        failure_reason_and_unique_op_test_info_list = group_and_sort_failures_by_impacted_models(
+            unique_op_test_info_list
+        )
+        for idx, (failure_reason, unique_op_test_info_list) in enumerate(
+            failure_reason_and_unique_op_test_info_list.items(), start=1
+        ):
+            total_num_of_models_affected = len(
+                [
+                    op_metadata["variant_name"]
+                    for unique_op_test_info in unique_op_test_info_list
+                    for op_metadata in unique_op_test_info.metadata
+                ]
+            )
+            for unique_op_test_info in unique_op_test_info_list:
+                op_metadata_list = unique_op_test_info.metadata
+                affected_model_variants = list(set([op_metadata["variant_name"] for op_metadata in op_metadata_list]))
+                table_rows.append(
+                    [
+                        str(idx),
+                        failure_reason,
+                        total_num_of_models_affected,
+                        len(affected_model_variants),
+                        MarkDownWriter.create_html_list(items=affected_model_variants),
+                        "<br><div align='center'>X</div>".join(unique_op_test_info.operands),
+                        "<br>".join(unique_op_test_info.args),
+                    ]
+                )
+
+        # Write detailed failure data for the current operation
+        markdown_writer.write_html_table(table_headers=table_headers, table_rows=table_rows, rowspan_columns=[0, 1, 2])
+
+        markdown_writer.close_file()
 
 
 def main():
@@ -766,7 +1003,7 @@ def main():
         unique_ops_config_file_path=unique_ops_config_across_all_models_file_path,
     )
 
-    model_variant_info_list, compiler_component_failure_analysis = run_models_unique_op_tests(
+    model_variant_info_list, failed_ops_details, compiler_component_failure_analysis = run_models_unique_op_tests(
         unique_operations=unique_operations,
         unique_ops_output_directory_path=args.unique_ops_output_directory_path,
         dump_failure_logs=args.dump_failure_logs,
@@ -778,6 +1015,7 @@ def main():
 
     create_statistics_report_markdown_file(
         model_variant_info_list=model_variant_info_list,
+        failed_ops_details=failed_ops_details,
         compiler_component_failure_analysis=compiler_component_failure_analysis,
         markdown_directory_path=args.markdown_directory_path,
     )


### PR DESCRIPTION
Fixes #1067 

1. Added Ops specific failure statistics table contains failed operations name across all the models in model analysis, number of model variants failed for each operation, failed model variant names and by clicking on the failed operation will get comprehensive report.
<img width="1279" alt="Screenshot 2025-01-23 at 1 30 09 PM" src="https://github.com/user-attachments/assets/54cb5f51-ac8c-40af-b671-a1ba1e89c49c" />


2) Added Comprehensive Report on Operation Failures and Affected Models table for each failed operation which contains operand details with argument if any and failure for the particular operation config and no of model variants affected by the respective failure and its model variant name. 
<img width="1151" alt="Screenshot 2025-01-23 at 1 30 29 PM" src="https://github.com/user-attachments/assets/0a593c0b-262b-4452-8747-e9db61f56b27" />


3) Added table description for all the table in [model_analysis_docs_new/stats/compiler_analysis_report.md](https://github.com/tenstorrent/tt-forge-fe/blob/pchandrasekaran/ops_specific_feature/model_analysis_docs_new/stats/compiler_analysis_report.md) file


Ops Specific failure statistics feauture - [Preview](https://github.com/tenstorrent/tt-forge-fe/blob/pchandrasekaran/ops_specific_feature/model_analysis_docs_new/stats/compiler_analysis_report.md#ops-specific-failure-statistics)

4) Added the exception rules for the UNKNOWN compiler component failure  based upon the [latest model analysis doc ](https://github.com/tenstorrent/tt-forge-fe/blob/main/model_analysis_docs/ModelsInfo.md)and [model_unique_ops_test](https://github.com/tenstorrent/tt-forge-fe/actions/runs/12860690367) artifacts.

Note:
Before Merging this PR, will remove [model_analysis_docs_new](https://github.com/tenstorrent/tt-forge-fe/tree/pchandrasekaran/ops_specific_feature/model_analysis_docs_new) folder, it is created for preview
