### PR TITLE
Add post processing steps for Albert, DPR, bert(masked LM), T5, Auoencoder, Whisper

### DIFF
--- a/forge/test/models/pytorch/audio/whisper/test_whisper_0.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper_0.py
@@ -37,63 +37,6 @@ variants = [
 ]
 
 
-def generate_model_whisper_congen_hf_pytorch(variant):
-    class Wrapper(torch.nn.Module):
-        def __init__(self, model):
-            super().__init__()
-            self.model = model
-
-            self.decoder_attention_mask = torch.ones((1, 1))
-
-        def forward(self, decoder_input_ids, encoder_hidden_states):
-            dec_out = self.model.model.decoder(
-                decoder_input_ids,
-                self.decoder_attention_mask,
-                encoder_hidden_states,
-            )
-            lin_out = self.model.proj_out(dec_out[0])
-
-            return lin_out
-
-    # Load model (with tokenizer and feature extractor)
-    processor = download_model(AutoProcessor.from_pretrained, variant)
-    model_config = WhisperConfig.from_pretrained(variant)
-
-    # Reduce size of model for testing
-    # model_config.use_cache = False
-    # model_config.return_dict = False
-    # model_config.decoder_attention_heads = 1
-    # model_config.decoder_layers = 1
-    # model_config.encoder_attention_heads = 1
-    # model_config.encoder_layers = 1
-    # model_config.num_hidden_layers = 1
-    # model_config.d_model = 512
-    # model_config.decoder_ffn_dim = 2048
-    # model_config.encoder_ffn_dim = 2048
-
-    framework_model = download_model(
-        WhisperForConditionalGeneration.from_pretrained,
-        variant,
-        config=model_config,
-    )
-    framework_model = Wrapper(framework_model)
-
-    # Load and preprocess sample audio
-    sample = torch.load("forge/test/models/files/samples/audio/1272-128104-0000.pt")
-    sample_audio = sample["audio"]["array"]
-
-    inputs = processor(sample_audio, return_tensors="pt")
-    input_features = inputs.input_features
-
-    # Get decoder inputs
-    decoder_input_ids = torch.tensor([[1, 1]]) * model_config.decoder_start_token_id
-    decoder_input_ids = decoder_input_ids.to(torch.int32)
-    encoder_outputs = framework_model.model.model.encoder(input_features)[0].detach()
-    encoder_outputs = encoder_outputs.to(torch.float32)
-
-    return framework_model, [decoder_input_ids, encoder_outputs]
-
-
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_whisper(record_forge_property, variant):
@@ -106,13 +49,77 @@ def test_whisper(record_forge_property, variant):
     # Record Forge Property
     record_forge_property("model_name", module_name)
 
-    framework_model, inputs = generate_model_whisper_congen_hf_pytorch(variant)
+    # Load model (with tokenizer and feature extractor)
+    processor = download_model(AutoProcessor.from_pretrained, variant)
+    model_config = WhisperConfig.from_pretrained(variant)
+    model = download_model(
+        WhisperForConditionalGeneration.from_pretrained,
+        variant,
+        config=model_config,
+    )
+    model.config.use_cache = False
+
+    # Load and preprocess sample audio
+    sample = torch.load("forge/test/models/files/samples/audio/1272-128104-0000.pt")
+    sample_audio = sample["audio"]["array"]
+
+    inputs = processor(sample_audio, return_tensors="pt")
+    input_features = inputs.input_features
+
+    # Get decoder inputs
+    decoder_start_token_tensor = torch.tensor(model.generation_config.decoder_start_token_id, dtype=torch.long)
+    decoder_input_ids = torch.ones((1, 1), dtype=torch.long) * decoder_start_token_tensor
+
+    inputs = [input_features, decoder_input_ids]
+
+    class Wrapper(torch.nn.Module):
+        def __init__(self, model):
+            super().__init__()
+            self.model = model
+
+        def forward(self, input_features, decoder_input_ids):
+            inputs = {"input_features": input_features, "decoder_input_ids": decoder_input_ids}
+            output = self.model(**inputs)
+            return output.logits
+
+    framework_model = Wrapper(model)
 
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
 
     # Model Verification
     verify(inputs, framework_model, compiled_model)
+
+    current_decoder_input_ids = decoder_input_ids
+    all_decoded_ids = decoder_input_ids
+
+    # The iteration count in for _ in range(1) is deliberately limited to 1 to prevent shape mismatches.
+    # The model has been compiled specifically for the first decoding step, where decoder_input_ids
+    # has a fixed length of (1,1) (the initial token). However, in generative models like Whisper, the length of
+    # decoder_input_ids increases with each decoding step as tokens are appended to the sequence.
+    # This dynamic increase in shape is incompatible with the static shape expected by the compiled model,
+    # leading to a runtime error if subsequent iterations are attempted.
+
+    for _ in range(1):
+
+        # Inference
+        outputs = compiled_model(input_features, current_decoder_input_ids)
+        logits = outputs[0]
+
+        # Get the next token ID (greedy decoding)
+        next_token = torch.argmax(logits[:, -1, :], dim=-1).unsqueeze(-1)
+
+        # Break if EOS token is generated
+        if next_token.item() == model.generation_config.eos_token_id:
+            break
+
+        # Append next token to sequence
+        all_decoded_ids = torch.cat([all_decoded_ids, next_token], dim=-1)
+
+        # Update decoder inputs for the next iteration
+        current_decoder_input_ids = all_decoded_ids
+
+    print("summary : ", processor.decode(all_decoded_ids[0], skip_special_tokens=True))
 
 
 @pytest.mark.skip_model_analysis

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_xl.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_xl.py
@@ -31,9 +31,6 @@ variants = ["stable-diffusion-xl-base-1.0"]
 @pytest.mark.nightly
 @pytest.mark.skip_model_analysis
 @pytest.mark.parametrize("variant", variants, ids=variants)
-@pytest.mark.xfail(
-    reason="RuntimeError: Cannot insert a Tensor that requires grad as a constant. Consider making it a parameter or input, or detaching the gradient"
-)
 def test_stable_diffusion_generation(variant):
     # Load the pipeline and set it to use the CPU
     pipe = DiffusionPipeline.from_pretrained(f"stabilityai/{variant}", torch_dtype=torch.float32)  # Use float32 for CPU

--- a/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
+++ b/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
@@ -49,7 +49,7 @@ def generate_model_vilt_question_answering_hf_pytorch(variant):
 
     embedding_output, attention_mask = text_vision_embedding_model(**encoding)
 
-    return vilt_model, [embedding_output.detach().cpu(), attention_mask.detach().cpu().to(torch.float32)], {}
+    return vilt_model, [embedding_output.detach().cpu(), attention_mask.detach().cpu().to(torch.float32)], model
 
 
 variants = ["dandelin/vilt-b32-finetuned-vqa"]
@@ -66,13 +66,21 @@ def test_vilt_question_answering_hf_pytorch(record_forge_property, variant):
     # Record Forge Property
     record_forge_property("model_name", module_name)
 
-    framework_model, inputs, _ = generate_model_vilt_question_answering_hf_pytorch(variant)
+    framework_model, inputs, model = generate_model_vilt_question_answering_hf_pytorch(variant)
 
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
 
     # Model Verification
     verify(inputs, framework_model, compiled_model)
+
+    # Inference
+    output = compiled_model(*inputs)
+
+    # Post processing
+    logits = output[0]
+    idx = logits.argmax(-1).item()
+    print("Predicted answer:", model.config.id2label[idx])
 
 
 def generate_model_vilt_maskedlm_hf_pytorch(variant):

--- a/forge/test/models/pytorch/text/bert/test_bert.py
+++ b/forge/test/models/pytorch/text/bert/test_bert.py
@@ -18,10 +18,19 @@ from test.models.utils import Framework, Task, build_module_name
 from test.utils import download_model
 
 
-def generate_model_bert_maskedlm_hf_pytorch(variant):
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", ["bert-base-uncased"])
+@pytest.mark.push
+def test_bert_masked_lm_pytorch(record_forge_property, variant):
+    # Build Module Name
+    module_name = build_module_name(framework=Framework.PYTORCH, model="bert", variant=variant, task=Task.MASKED_LM)
+
+    # Record Forge Property
+    record_forge_property("model_name", module_name)
+
     # Load Bert tokenizer and model from HuggingFace
     tokenizer = BertTokenizer.from_pretrained(variant)
-    model = BertForMaskedLM.from_pretrained(variant, return_dict=False)
+    framework_model = BertForMaskedLM.from_pretrained(variant, return_dict=False)
 
     # Load data sample
     sample_text = "The capital of France is [MASK]."
@@ -35,25 +44,22 @@ def generate_model_bert_maskedlm_hf_pytorch(variant):
         return_tensors="pt",
     )
 
-    return model, [input_tokens["input_ids"]], {}
-
-
-@pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["bert-base-uncased"])
-def test_bert_masked_lm_pytorch(record_forge_property, variant):
-    # Build Module Name
-    module_name = build_module_name(framework=Framework.PYTORCH, model="bert", variant=variant, task=Task.MASKED_LM)
-
-    # Record Forge Property
-    record_forge_property("model_name", module_name)
-
-    framework_model, inputs, _ = generate_model_bert_maskedlm_hf_pytorch(variant)
+    inputs = [input_tokens["input_ids"]]
 
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
 
     # Model Verification
     verify(inputs, framework_model, compiled_model, verify_cfg=VerifyConfig(verify_values=False))
+
+    # Inference
+    output = compiled_model(*inputs)
+
+    # post processing
+    logits = output[0]
+    mask_token_index = (input_tokens.input_ids == tokenizer.mask_token_id)[0].nonzero(as_tuple=True)[0]
+    predicted_token_id = logits[0, mask_token_index].argmax(axis=-1)
+    print("The predicted token for the [MASK] is: ", tokenizer.decode(predicted_token_id))
 
 
 def generate_model_bert_qa_hf_pytorch(variant):

--- a/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
+++ b/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 import torchvision.transforms as transforms
 from datasets import load_dataset
@@ -48,6 +52,11 @@ def test_conv_ae_pytorch(record_forge_property):
     verify(inputs, framework_model, compiled_model)
 
 
+# pretrained weights are not provided in https://github.com/udacity/deep-learning-v2-pytorch,
+# so training the model is necessary to obtain meaningful outputs.
+
+
+@pytest.mark.push
 @pytest.mark.nightly
 def test_linear_ae_pytorch(record_forge_property):
     # Build Module Name
@@ -82,3 +91,13 @@ def test_linear_ae_pytorch(record_forge_property):
 
     # Model Verification
     verify(inputs, framework_model, compiled_model)
+
+    # Inference
+    output = compiled_model(sample_tensor)
+
+    # Post processing
+    output_image = output[0].view(1, 28, 28).detach().numpy()
+    save_path = "forge/test/models/pytorch/vision/autoencoder/results"
+    os.makedirs(save_path, exist_ok=True)
+    reconstructed_image_path = f"{save_path}/reconstructed_image.png"
+    plt.imsave(reconstructed_image_path, np.squeeze(output_image), cmap="gray")


### PR DESCRIPTION
## Summary

- post processing steps added for Albert, DPR, bert(masked LM), T5, Auoencoder, Whisper
- push marker is added to all above models except whisper because it is failing on optimized graph pass due to this error `AssertionError: Eltwise binary ops must have the same shape in both inputs, or one operand must be 1 wide to broadcast: [1, 3000, 1, 384] vs [1, 384, 3000, 1] ` on latest main-> [whisper_issue.log](https://github.com/user-attachments/files/18517977/jan23_whisper_check_1.log) 
## Note :
- **Albert**  : Although we are using task-specific models like AlbertForTokenClassification, these models are pre-trained on general datasets. To make them suitable for specific tasks, they need to be fine-tuned on a labeled dataset for that task. After fine-tuning, the model's classification head (i.e., the classifier) will have the appropriate weights for the task at hand.
- **DPR** : The architectures of the DPR Context Encoder and Question Encoder are identical. Both consist of the same underlying components without any additional classification layers. The DPR Reader, on the other hand, extends this architecture by including a classifier layer, which enables it to predict spans for answers. -> [DPR_archs.log](https://github.com/user-attachments/files/18518185/archs.log)

- As a result, post-processing cannot be applied to the outputs of the Context Encoder and Question Encoder, as their outputs are embeddings rather than classifiable logits. @nvukobratTT  [comment](https://github.com/tenstorrent/tt-forge-fe/pull/1004#discussion_r1908791517) - separate test for end-to-end testing  is unnecessary since both encoding and reading functionalities are already encapsulated within the Reader module itself. 

- **Autoencode**r : [Our Linear Autoencoder implementation](https://github.com/tenstorrent/tt-forge-fe/blob/9895fdee000945c3c43bcf88dbca6d76106bcebc/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py#L52) is based on the [this](https://github.com/udacity/deep-learning-v2-pytorch/blob/master/autoencoder/linear-autoencoder/Simple_Autoencoder_Solution.ipynb). However, pretrained weights are not provided, so training the model is necessary to obtain meaningful outputs.

