### PR TITLE
[CI] Update HF cache dir to use mounted storage

### DIFF
--- a/.github/workflows/model-analysis.yml
+++ b/.github/workflows/model-analysis.yml
@@ -36,10 +36,12 @@ jobs:
         - /etc/udev/rules.d:/etc/udev/rules.d
         - /lib/modules:/lib/modules
         - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
+        - /mnt/dockercache:/mnt/dockercache
 
     env:
       GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
+      HF_HOME: /mnt/dockercache/huggingface
       HF_HUB_DISABLE_PROGRESS_BARS: 1
 
     steps:


### PR DESCRIPTION
As model analysis caches all model weights, it also requires extended disk storage. Therefore, we're updating location of HF cache as main source of model weights.

Fix #1099