### PR TITLE
Reshape operator failing rules

### DIFF
--- a/forge/test/operators/pytorch/tm/test_reshape_ids_failed_allclose_value_checker.txt
+++ b/forge/test/operators/pytorch/tm/test_reshape_ids_failed_allclose_value_checker.txt
@@ -1,230 +1,296 @@
-reshape-FROM_ANOTHER_OP-{'shape': (4, 1, 1)}-(1, 4)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (10, 10)}-(1, 100)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (500, 1, 1)}-(1, 500)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (16, 2, 1, 2)}-(1, 64)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (2, 48)}-(1, 96)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (3, 1, 1, 1)}-(1, 3)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (4, 3, 1)}-(3, 4)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (51, 15)}-(45, 17)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (16, 2, 1, 2)}-(64, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (10000, 1)}-(10, 1000)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (2480, 4)}-(9920, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (625, 8, 2)}-(10000, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (2, 16, 64)}-(32, 64)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (1, 64, 1, 240)}-(160, 96)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (1, 697)}-(17, 41)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (6, 2)}-(1, 3, 4)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (15, 17, 3)}-(1, 45, 17)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (23, 1, 1, 1)}-(1, 1, 23)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (50, 16, 125)}-(1, 1000, 100)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (2500, 1, 4)}-(1, 10, 1000)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (2, 4960)}-(1, 9920, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (5, 125, 4, 4)}-(1, 10000, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (4, 512)}-(1, 32, 64)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (1, 1536, 10)}-(1, 160, 96)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (1, 697)}-(1, 17, 41)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (1, 3, 1, 89)}-(1, 89, 3)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (3, 1, 8)}-(2, 3, 4)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (255, 11, 3)}-(11, 45, 17)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (1, 1, 253)}-(11, 1, 23)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (22, 4, 8)}-(11, 64, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (2, 1250, 400)}-(100, 100, 100)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (1, 10, 40, 2500)}-(10, 1000, 100)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (25, 4000)}-(10, 10000, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (1, 65536)}-(32, 32, 64)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (8, 3840, 2, 16)}-(64, 160, 96)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (89, 1, 39)}-(13, 89, 3)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (1, 1, 253)}-(1, 11, 1, 23)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (11, 1, 64)}-(1, 11, 64, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (25000, 20, 2, 1)}-(1, 100, 100, 100)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (1250, 800)}-(1, 10, 1000, 100)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (25, 200, 2)}-(1, 1, 10, 1000)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (1, 320, 1, 31)}-(1, 1, 9920, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (10, 250, 10, 4)}-(1, 10, 10000, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (4, 2, 8192)}-(1, 32, 32, 64)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (15360, 16, 4)}-(1, 64, 160, 96)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (51, 1, 495)}-(3, 11, 45, 17)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (6, 1, 8)}-(2, 2, 3, 4)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (1012, 1)}-(4, 11, 1, 23)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (110, 2, 16, 1)}-(5, 11, 64, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (32, 93750, 2)}-(6, 100, 100, 100)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (625, 448, 1, 25)}-(7, 10, 1000, 100)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (64, 5, 1, 279)}-(9, 1, 9920, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (50, 625, 32, 1)}-(10, 10, 10000, 1)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (40, 294912)}-(12, 64, 160, 96)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (143, 697)}-(13, 11, 17, 41)-None-None
-reshape-FROM_ANOTHER_OP-{'shape': (7, 2, 3471)}-(14, 13, 89, 3)-None-None
-reshape-FROM_HOST-{'shape': (4, 1, 1)}-(1, 4)-None-None
-reshape-FROM_HOST-{'shape': (10, 10)}-(1, 100)-None-None
-reshape-FROM_HOST-{'shape': (500, 1, 1)}-(1, 500)-None-None
-reshape-FROM_HOST-{'shape': (16, 2, 1, 2)}-(1, 64)-None-None
-reshape-FROM_HOST-{'shape': (2, 48)}-(1, 96)-None-None
-reshape-FROM_HOST-{'shape': (3, 1, 1, 1)}-(1, 3)-None-None
-reshape-FROM_HOST-{'shape': (4, 3, 1)}-(3, 4)-None-None
-reshape-FROM_HOST-{'shape': (51, 15)}-(45, 17)-None-None
-reshape-FROM_HOST-{'shape': (16, 2, 1, 2)}-(64, 1)-None-None
-reshape-FROM_HOST-{'shape': (10000, 1)}-(10, 1000)-None-None
-reshape-FROM_HOST-{'shape': (2480, 4)}-(9920, 1)-None-None
-reshape-FROM_HOST-{'shape': (625, 8, 2)}-(10000, 1)-None-None
-reshape-FROM_HOST-{'shape': (2, 16, 64)}-(32, 64)-None-None
-reshape-FROM_HOST-{'shape': (1, 64, 1, 240)}-(160, 96)-None-None
-reshape-FROM_HOST-{'shape': (1, 697)}-(17, 41)-None-None
-reshape-FROM_HOST-{'shape': (6, 2)}-(1, 3, 4)-None-None
-reshape-FROM_HOST-{'shape': (15, 17, 3)}-(1, 45, 17)-None-None
-reshape-FROM_HOST-{'shape': (23, 1, 1, 1)}-(1, 1, 23)-None-None
-reshape-FROM_HOST-{'shape': (50, 16, 125)}-(1, 1000, 100)-None-None
-reshape-FROM_HOST-{'shape': (2500, 1, 4)}-(1, 10, 1000)-None-None
-reshape-FROM_HOST-{'shape': (2, 4960)}-(1, 9920, 1)-None-None
-reshape-FROM_HOST-{'shape': (5, 125, 4, 4)}-(1, 10000, 1)-None-None
-reshape-FROM_HOST-{'shape': (4, 512)}-(1, 32, 64)-None-None
-reshape-FROM_HOST-{'shape': (1, 1536, 10)}-(1, 160, 96)-None-None
-reshape-FROM_HOST-{'shape': (1, 697)}-(1, 17, 41)-None-None
-reshape-FROM_HOST-{'shape': (1, 3, 1, 89)}-(1, 89, 3)-None-None
-reshape-FROM_HOST-{'shape': (3, 1, 8)}-(2, 3, 4)-None-None
-reshape-FROM_HOST-{'shape': (255, 11, 3)}-(11, 45, 17)-None-None
-reshape-FROM_HOST-{'shape': (1, 1, 253)}-(11, 1, 23)-None-None
-reshape-FROM_HOST-{'shape': (22, 4, 8)}-(11, 64, 1)-None-None
-reshape-FROM_HOST-{'shape': (2, 1250, 400)}-(100, 100, 100)-None-None
-reshape-FROM_HOST-{'shape': (1, 10, 40, 2500)}-(10, 1000, 100)-None-None
-reshape-FROM_HOST-{'shape': (25, 4000)}-(10, 10000, 1)-None-None
-reshape-FROM_HOST-{'shape': (1, 65536)}-(32, 32, 64)-None-None
-reshape-FROM_HOST-{'shape': (8, 3840, 2, 16)}-(64, 160, 96)-None-None
-reshape-FROM_HOST-{'shape': (89, 1, 39)}-(13, 89, 3)-None-None
-reshape-FROM_HOST-{'shape': (1, 1, 253)}-(1, 11, 1, 23)-None-None
-reshape-FROM_HOST-{'shape': (11, 1, 64)}-(1, 11, 64, 1)-None-None
-reshape-FROM_HOST-{'shape': (25000, 20, 2, 1)}-(1, 100, 100, 100)-None-None
-reshape-FROM_HOST-{'shape': (1250, 800)}-(1, 10, 1000, 100)-None-None
-reshape-FROM_HOST-{'shape': (25, 200, 2)}-(1, 1, 10, 1000)-None-None
-reshape-FROM_HOST-{'shape': (1, 320, 1, 31)}-(1, 1, 9920, 1)-None-None
-reshape-FROM_HOST-{'shape': (10, 250, 10, 4)}-(1, 10, 10000, 1)-None-None
-reshape-FROM_HOST-{'shape': (4, 2, 8192)}-(1, 32, 32, 64)-None-None
-reshape-FROM_HOST-{'shape': (15360, 16, 4)}-(1, 64, 160, 96)-None-None
-reshape-FROM_HOST-{'shape': (51, 1, 495)}-(3, 11, 45, 17)-None-None
-reshape-FROM_HOST-{'shape': (6, 1, 8)}-(2, 2, 3, 4)-None-None
-reshape-FROM_HOST-{'shape': (1012, 1)}-(4, 11, 1, 23)-None-None
-reshape-FROM_HOST-{'shape': (110, 2, 16, 1)}-(5, 11, 64, 1)-None-None
-reshape-FROM_HOST-{'shape': (32, 93750, 2)}-(6, 100, 100, 100)-None-None
-reshape-FROM_HOST-{'shape': (625, 448, 1, 25)}-(7, 10, 1000, 100)-None-None
-reshape-FROM_HOST-{'shape': (64, 5, 1, 279)}-(9, 1, 9920, 1)-None-None
-reshape-FROM_HOST-{'shape': (50, 625, 32, 1)}-(10, 10, 10000, 1)-None-None
-reshape-FROM_HOST-{'shape': (40, 294912)}-(12, 64, 160, 96)-None-None
-reshape-FROM_HOST-{'shape': (143, 697)}-(13, 11, 17, 41)-None-None
-reshape-FROM_HOST-{'shape': (7, 2, 3471)}-(14, 13, 89, 3)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (4, 1, 1)}-(1, 4)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (10, 10)}-(1, 100)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (500, 1, 1)}-(1, 500)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (16, 2, 1, 2)}-(1, 64)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (2, 48)}-(1, 96)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (3, 1, 1, 1)}-(1, 3)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (4, 3, 1)}-(3, 4)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (51, 15)}-(45, 17)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (16, 2, 1, 2)}-(64, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (10000, 1)}-(10, 1000)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (2480, 4)}-(9920, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (625, 8, 2)}-(10000, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (2, 16, 64)}-(32, 64)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (1, 64, 1, 240)}-(160, 96)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (1, 697)}-(17, 41)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (6, 2)}-(1, 3, 4)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (15, 17, 3)}-(1, 45, 17)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (23, 1, 1, 1)}-(1, 1, 23)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (50, 16, 125)}-(1, 1000, 100)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (2500, 1, 4)}-(1, 10, 1000)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (2, 4960)}-(1, 9920, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (5, 125, 4, 4)}-(1, 10000, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (4, 512)}-(1, 32, 64)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (1, 1536, 10)}-(1, 160, 96)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (1, 697)}-(1, 17, 41)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (1, 3, 1, 89)}-(1, 89, 3)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (3, 1, 8)}-(2, 3, 4)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (255, 11, 3)}-(11, 45, 17)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (1, 1, 253)}-(11, 1, 23)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (22, 4, 8)}-(11, 64, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (2, 1250, 400)}-(100, 100, 100)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (1, 10, 40, 2500)}-(10, 1000, 100)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (25, 4000)}-(10, 10000, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (1, 65536)}-(32, 32, 64)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (8, 3840, 2, 16)}-(64, 160, 96)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (89, 1, 39)}-(13, 89, 3)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (1, 1, 253)}-(1, 11, 1, 23)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (11, 1, 64)}-(1, 11, 64, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (25000, 20, 2, 1)}-(1, 100, 100, 100)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (1250, 800)}-(1, 10, 1000, 100)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (25, 200, 2)}-(1, 1, 10, 1000)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (1, 320, 1, 31)}-(1, 1, 9920, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (10, 250, 10, 4)}-(1, 10, 10000, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (4, 2, 8192)}-(1, 32, 32, 64)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (15360, 16, 4)}-(1, 64, 160, 96)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (51, 1, 495)}-(3, 11, 45, 17)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (6, 1, 8)}-(2, 2, 3, 4)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (1012, 1)}-(4, 11, 1, 23)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (110, 2, 16, 1)}-(5, 11, 64, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (32, 93750, 2)}-(6, 100, 100, 100)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (625, 448, 1, 25)}-(7, 10, 1000, 100)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (64, 5, 1, 279)}-(9, 1, 9920, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (50, 625, 32, 1)}-(10, 10, 10000, 1)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (40, 294912)}-(12, 64, 160, 96)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (143, 697)}-(13, 11, 17, 41)-None-None
-reshape-FROM_DRAM_QUEUE-{'shape': (7, 2, 3471)}-(14, 13, 89, 3)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (4, 1, 1)}-(1, 4)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (10, 10)}-(1, 100)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (500, 1, 1)}-(1, 500)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (16, 2, 1, 2)}-(1, 64)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (2, 48)}-(1, 96)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (3, 1, 1, 1)}-(1, 3)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (4, 3, 1)}-(3, 4)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (51, 15)}-(45, 17)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (16, 2, 1, 2)}-(64, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (10000, 1)}-(10, 1000)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (2480, 4)}-(9920, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (625, 8, 2)}-(10000, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (2, 16, 64)}-(32, 64)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (1, 64, 1, 240)}-(160, 96)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (1, 697)}-(17, 41)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (6, 2)}-(1, 3, 4)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (15, 17, 3)}-(1, 45, 17)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (23, 1, 1, 1)}-(1, 1, 23)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (50, 16, 125)}-(1, 1000, 100)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (2500, 1, 4)}-(1, 10, 1000)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (2, 4960)}-(1, 9920, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (5, 125, 4, 4)}-(1, 10000, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (4, 512)}-(1, 32, 64)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (1, 1536, 10)}-(1, 160, 96)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (1, 697)}-(1, 17, 41)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (1, 3, 1, 89)}-(1, 89, 3)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (3, 1, 8)}-(2, 3, 4)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (255, 11, 3)}-(11, 45, 17)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (1, 1, 253)}-(11, 1, 23)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (22, 4, 8)}-(11, 64, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (2, 1250, 400)}-(100, 100, 100)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (1, 10, 40, 2500)}-(10, 1000, 100)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (25, 4000)}-(10, 10000, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (1, 65536)}-(32, 32, 64)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (8, 3840, 2, 16)}-(64, 160, 96)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (89, 1, 39)}-(13, 89, 3)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (1, 1, 253)}-(1, 11, 1, 23)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (11, 1, 64)}-(1, 11, 64, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (25000, 20, 2, 1)}-(1, 100, 100, 100)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (1250, 800)}-(1, 10, 1000, 100)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (25, 200, 2)}-(1, 1, 10, 1000)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (1, 320, 1, 31)}-(1, 1, 9920, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (10, 250, 10, 4)}-(1, 10, 10000, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (4, 2, 8192)}-(1, 32, 32, 64)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (15360, 16, 4)}-(1, 64, 160, 96)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (51, 1, 495)}-(3, 11, 45, 17)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (6, 1, 8)}-(2, 2, 3, 4)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (1012, 1)}-(4, 11, 1, 23)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (110, 2, 16, 1)}-(5, 11, 64, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (32, 93750, 2)}-(6, 100, 100, 100)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (625, 448, 1, 25)}-(7, 10, 1000, 100)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (64, 5, 1, 279)}-(9, 1, 9920, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (50, 625, 32, 1)}-(10, 10, 10000, 1)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (40, 294912)}-(12, 64, 160, 96)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (143, 697)}-(13, 11, 17, 41)-None-None
-reshape-CONST_EVAL_PASS-{'shape': (7, 2, 3471)}-(14, 13, 89, 3)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 2, 2)}-(1, 4)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (17, 1)}-(1, 17)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 23, 1, 1)}-(1, 23)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (25, 4)}-(1, 100)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (5, 10, 10)}-(1, 500)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 2, 4, 8)}-(1, 64)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (24, 4)}-(1, 96)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 2, 6)}-(3, 4)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (3, 255, 1)}-(45, 17)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 2, 4, 8)}-(64, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (20, 10, 50)}-(100, 100)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (20, 100, 50)}-(1000, 100)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (20, 10, 50)}-(10, 1000)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (31, 320)}-(9920, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (20, 10, 50)}-(10000, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (8, 16, 16)}-(32, 64)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (15360,)}-(160, 96)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 697, 1)}-(17, 41)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (3, 89, 1)}-(89, 3)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 2, 6)}-(1, 3, 4)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (3, 255, 1)}-(1, 45, 17)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 23, 1, 1)}-(1, 1, 23)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 2, 4, 8)}-(1, 64, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (20, 10, 50)}-(1, 100, 100)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (20, 100, 50)}-(1, 1000, 100)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (20, 10, 50)}-(1, 10, 1000)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (31, 320)}-(1, 9920, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (20, 10, 50)}-(1, 10000, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (8, 16, 16)}-(1, 32, 64)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (15360,)}-(1, 160, 96)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 697, 1)}-(1, 17, 41)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (3, 89, 1)}-(1, 89, 3)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (2, 2, 2, 3)}-(2, 3, 4)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (33, 255)}-(11, 45, 17)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 23, 11)}-(11, 1, 23)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (2, 176, 2)}-(11, 64, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (12500, 80)}-(100, 100, 100)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (12500, 80)}-(10, 1000, 100)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (20, 100, 50)}-(10, 10000, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (8, 64, 128, 1)}-(32, 32, 64)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (16, 1, 48, 1280)}-(64, 160, 96)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 697, 11)}-(11, 17, 41)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 3471)}-(13, 89, 3)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (33, 255)}-(1, 11, 45, 17)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 23, 11)}-(1, 11, 1, 23)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (2, 176, 2)}-(1, 11, 64, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (12500, 80)}-(1, 100, 100, 100)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (12500, 80)}-(1, 10, 1000, 100)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (20, 10, 50)}-(1, 1, 10, 1000)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (31, 320)}-(1, 1, 9920, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (20, 100, 50)}-(1, 10, 10000, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (8, 64, 128, 1)}-(1, 32, 32, 64)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (16, 1, 48, 1280)}-(1, 64, 160, 96)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 697, 11)}-(1, 11, 17, 41)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 3471)}-(1, 13, 89, 3)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (1, 25245)}-(3, 11, 45, 17)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (48,)}-(2, 2, 3, 4)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (11, 2, 2, 23)}-(4, 11, 1, 23)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (22, 4, 4, 10)}-(5, 11, 64, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (5, 48, 25, 1000)}-(6, 100, 100, 100)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (160, 500)}-(8, 1, 10, 1000)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (89280,)}-(9, 1, 9920, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (12500, 80)}-(10, 10, 10000, 1)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (4, 8, 8, 2816)}-(11, 32, 32, 64)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (64, 64, 2880)}-(12, 64, 160, 96)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (13, 1, 7667)}-(13, 11, 17, 41)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (178, 13, 21, 1)}-(14, 13, 89, 3)-None-None
+reshape-FROM_HOST-{'shape': (1, 2, 2)}-(1, 4)-None-None
+reshape-FROM_HOST-{'shape': (17, 1)}-(1, 17)-None-None
+reshape-FROM_HOST-{'shape': (1, 23, 1, 1)}-(1, 23)-None-None
+reshape-FROM_HOST-{'shape': (25, 4)}-(1, 100)-None-None
+reshape-FROM_HOST-{'shape': (5, 10, 10)}-(1, 500)-None-None
+reshape-FROM_HOST-{'shape': (1, 2, 4, 8)}-(1, 64)-None-None
+reshape-FROM_HOST-{'shape': (24, 4)}-(1, 96)-None-None
+reshape-FROM_HOST-{'shape': (1, 2, 6)}-(3, 4)-None-None
+reshape-FROM_HOST-{'shape': (3, 255, 1)}-(45, 17)-None-None
+reshape-FROM_HOST-{'shape': (1, 2, 4, 8)}-(64, 1)-None-None
+reshape-FROM_HOST-{'shape': (20, 10, 50)}-(100, 100)-None-None
+reshape-FROM_HOST-{'shape': (20, 100, 50)}-(1000, 100)-None-None
+reshape-FROM_HOST-{'shape': (20, 10, 50)}-(10, 1000)-None-None
+reshape-FROM_HOST-{'shape': (31, 320)}-(9920, 1)-None-None
+reshape-FROM_HOST-{'shape': (20, 10, 50)}-(10000, 1)-None-None
+reshape-FROM_HOST-{'shape': (8, 16, 16)}-(32, 64)-None-None
+reshape-FROM_HOST-{'shape': (15360,)}-(160, 96)-None-None
+reshape-FROM_HOST-{'shape': (1, 697, 1)}-(17, 41)-None-None
+reshape-FROM_HOST-{'shape': (3, 89, 1)}-(89, 3)-None-None
+reshape-FROM_HOST-{'shape': (1, 2, 6)}-(1, 3, 4)-None-None
+reshape-FROM_HOST-{'shape': (3, 255, 1)}-(1, 45, 17)-None-None
+reshape-FROM_HOST-{'shape': (1, 23, 1, 1)}-(1, 1, 23)-None-None
+reshape-FROM_HOST-{'shape': (1, 2, 4, 8)}-(1, 64, 1)-None-None
+reshape-FROM_HOST-{'shape': (20, 10, 50)}-(1, 100, 100)-None-None
+reshape-FROM_HOST-{'shape': (20, 100, 50)}-(1, 1000, 100)-None-None
+reshape-FROM_HOST-{'shape': (20, 10, 50)}-(1, 10, 1000)-None-None
+reshape-FROM_HOST-{'shape': (31, 320)}-(1, 9920, 1)-None-None
+reshape-FROM_HOST-{'shape': (20, 10, 50)}-(1, 10000, 1)-None-None
+reshape-FROM_HOST-{'shape': (8, 16, 16)}-(1, 32, 64)-None-None
+reshape-FROM_HOST-{'shape': (15360,)}-(1, 160, 96)-None-None
+reshape-FROM_HOST-{'shape': (1, 697, 1)}-(1, 17, 41)-None-None
+reshape-FROM_HOST-{'shape': (3, 89, 1)}-(1, 89, 3)-None-None
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(2, 3, 4)-None-None
+reshape-FROM_HOST-{'shape': (33, 255)}-(11, 45, 17)-None-None
+reshape-FROM_HOST-{'shape': (1, 23, 11)}-(11, 1, 23)-None-None
+reshape-FROM_HOST-{'shape': (2, 176, 2)}-(11, 64, 1)-None-None
+reshape-FROM_HOST-{'shape': (12500, 80)}-(100, 100, 100)-None-None
+reshape-FROM_HOST-{'shape': (12500, 80)}-(10, 1000, 100)-None-None
+reshape-FROM_HOST-{'shape': (20, 100, 50)}-(10, 10000, 1)-None-None
+reshape-FROM_HOST-{'shape': (8, 64, 128, 1)}-(32, 32, 64)-None-None
+reshape-FROM_HOST-{'shape': (16, 1, 48, 1280)}-(64, 160, 96)-None-None
+reshape-FROM_HOST-{'shape': (1, 697, 11)}-(11, 17, 41)-None-None
+reshape-FROM_HOST-{'shape': (1, 3471)}-(13, 89, 3)-None-None
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-None-None
+reshape-FROM_HOST-{'shape': (33, 255)}-(1, 11, 45, 17)-None-None
+reshape-FROM_HOST-{'shape': (1, 23, 11)}-(1, 11, 1, 23)-None-None
+reshape-FROM_HOST-{'shape': (2, 176, 2)}-(1, 11, 64, 1)-None-None
+reshape-FROM_HOST-{'shape': (12500, 80)}-(1, 100, 100, 100)-None-None
+reshape-FROM_HOST-{'shape': (12500, 80)}-(1, 10, 1000, 100)-None-None
+reshape-FROM_HOST-{'shape': (20, 10, 50)}-(1, 1, 10, 1000)-None-None
+reshape-FROM_HOST-{'shape': (31, 320)}-(1, 1, 9920, 1)-None-None
+reshape-FROM_HOST-{'shape': (20, 100, 50)}-(1, 10, 10000, 1)-None-None
+reshape-FROM_HOST-{'shape': (8, 64, 128, 1)}-(1, 32, 32, 64)-None-None
+reshape-FROM_HOST-{'shape': (16, 1, 48, 1280)}-(1, 64, 160, 96)-None-None
+reshape-FROM_HOST-{'shape': (1, 697, 11)}-(1, 11, 17, 41)-None-None
+reshape-FROM_HOST-{'shape': (1, 3471)}-(1, 13, 89, 3)-None-None
+reshape-FROM_HOST-{'shape': (1, 25245)}-(3, 11, 45, 17)-None-None
+reshape-FROM_HOST-{'shape': (48,)}-(2, 2, 3, 4)-None-None
+reshape-FROM_HOST-{'shape': (11, 2, 2, 23)}-(4, 11, 1, 23)-None-None
+reshape-FROM_HOST-{'shape': (22, 4, 4, 10)}-(5, 11, 64, 1)-None-None
+reshape-FROM_HOST-{'shape': (5, 48, 25, 1000)}-(6, 100, 100, 100)-None-None
+reshape-FROM_HOST-{'shape': (160, 500)}-(8, 1, 10, 1000)-None-None
+reshape-FROM_HOST-{'shape': (89280,)}-(9, 1, 9920, 1)-None-None
+reshape-FROM_HOST-{'shape': (12500, 80)}-(10, 10, 10000, 1)-None-None
+reshape-FROM_HOST-{'shape': (4, 8, 8, 2816)}-(11, 32, 32, 64)-None-None
+reshape-FROM_HOST-{'shape': (64, 64, 2880)}-(12, 64, 160, 96)-None-None
+reshape-FROM_HOST-{'shape': (13, 1, 7667)}-(13, 11, 17, 41)-None-None
+reshape-FROM_HOST-{'shape': (178, 13, 21, 1)}-(14, 13, 89, 3)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 2, 2)}-(1, 4)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (17, 1)}-(1, 17)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 23, 1, 1)}-(1, 23)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (25, 4)}-(1, 100)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (5, 10, 10)}-(1, 500)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 2, 4, 8)}-(1, 64)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (24, 4)}-(1, 96)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 2, 6)}-(3, 4)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (3, 255, 1)}-(45, 17)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 2, 4, 8)}-(64, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (20, 10, 50)}-(100, 100)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (20, 100, 50)}-(1000, 100)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (20, 10, 50)}-(10, 1000)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (31, 320)}-(9920, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (20, 10, 50)}-(10000, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (8, 16, 16)}-(32, 64)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (15360,)}-(160, 96)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 697, 1)}-(17, 41)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (3, 89, 1)}-(89, 3)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 2, 6)}-(1, 3, 4)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (3, 255, 1)}-(1, 45, 17)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 23, 1, 1)}-(1, 1, 23)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 2, 4, 8)}-(1, 64, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (20, 10, 50)}-(1, 100, 100)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (20, 100, 50)}-(1, 1000, 100)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (20, 10, 50)}-(1, 10, 1000)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (31, 320)}-(1, 9920, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (20, 10, 50)}-(1, 10000, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (8, 16, 16)}-(1, 32, 64)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (15360,)}-(1, 160, 96)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 697, 1)}-(1, 17, 41)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (3, 89, 1)}-(1, 89, 3)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (2, 2, 2, 3)}-(2, 3, 4)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (33, 255)}-(11, 45, 17)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 23, 11)}-(11, 1, 23)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (2, 176, 2)}-(11, 64, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (12500, 80)}-(100, 100, 100)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (12500, 80)}-(10, 1000, 100)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (20, 100, 50)}-(10, 10000, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (8, 64, 128, 1)}-(32, 32, 64)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (16, 1, 48, 1280)}-(64, 160, 96)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 697, 11)}-(11, 17, 41)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 3471)}-(13, 89, 3)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (33, 255)}-(1, 11, 45, 17)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 23, 11)}-(1, 11, 1, 23)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (2, 176, 2)}-(1, 11, 64, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (12500, 80)}-(1, 100, 100, 100)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (12500, 80)}-(1, 10, 1000, 100)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (20, 10, 50)}-(1, 1, 10, 1000)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (31, 320)}-(1, 1, 9920, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (20, 100, 50)}-(1, 10, 10000, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (8, 64, 128, 1)}-(1, 32, 32, 64)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (16, 1, 48, 1280)}-(1, 64, 160, 96)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 697, 11)}-(1, 11, 17, 41)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 3471)}-(1, 13, 89, 3)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (1, 25245)}-(3, 11, 45, 17)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (48,)}-(2, 2, 3, 4)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (11, 2, 2, 23)}-(4, 11, 1, 23)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (22, 4, 4, 10)}-(5, 11, 64, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (5, 48, 25, 1000)}-(6, 100, 100, 100)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (160, 500)}-(8, 1, 10, 1000)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (89280,)}-(9, 1, 9920, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (12500, 80)}-(10, 10, 10000, 1)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (4, 8, 8, 2816)}-(11, 32, 32, 64)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (64, 64, 2880)}-(12, 64, 160, 96)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (13, 1, 7667)}-(13, 11, 17, 41)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (178, 13, 21, 1)}-(14, 13, 89, 3)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 2, 2)}-(1, 4)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (17, 1)}-(1, 17)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 23, 1, 1)}-(1, 23)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (25, 4)}-(1, 100)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (5, 10, 10)}-(1, 500)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 2, 4, 8)}-(1, 64)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (24, 4)}-(1, 96)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 2, 6)}-(3, 4)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (3, 255, 1)}-(45, 17)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 2, 4, 8)}-(64, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (20, 10, 50)}-(100, 100)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (20, 100, 50)}-(1000, 100)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (20, 10, 50)}-(10, 1000)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (31, 320)}-(9920, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (20, 10, 50)}-(10000, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (8, 16, 16)}-(32, 64)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (15360,)}-(160, 96)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 697, 1)}-(17, 41)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (3, 89, 1)}-(89, 3)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 2, 6)}-(1, 3, 4)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (3, 255, 1)}-(1, 45, 17)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 23, 1, 1)}-(1, 1, 23)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 2, 4, 8)}-(1, 64, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (20, 10, 50)}-(1, 100, 100)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (20, 100, 50)}-(1, 1000, 100)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (20, 10, 50)}-(1, 10, 1000)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (31, 320)}-(1, 9920, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (20, 10, 50)}-(1, 10000, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (8, 16, 16)}-(1, 32, 64)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (15360,)}-(1, 160, 96)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 697, 1)}-(1, 17, 41)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (3, 89, 1)}-(1, 89, 3)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (2, 2, 2, 3)}-(2, 3, 4)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (33, 255)}-(11, 45, 17)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 23, 11)}-(11, 1, 23)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (2, 176, 2)}-(11, 64, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (12500, 80)}-(100, 100, 100)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (12500, 80)}-(10, 1000, 100)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (20, 100, 50)}-(10, 10000, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (8, 64, 128, 1)}-(32, 32, 64)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (16, 1, 48, 1280)}-(64, 160, 96)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 697, 11)}-(11, 17, 41)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 3471)}-(13, 89, 3)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (33, 255)}-(1, 11, 45, 17)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 23, 11)}-(1, 11, 1, 23)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (2, 176, 2)}-(1, 11, 64, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (12500, 80)}-(1, 100, 100, 100)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (12500, 80)}-(1, 10, 1000, 100)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (20, 10, 50)}-(1, 1, 10, 1000)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (31, 320)}-(1, 1, 9920, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (20, 100, 50)}-(1, 10, 10000, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (8, 64, 128, 1)}-(1, 32, 32, 64)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (16, 1, 48, 1280)}-(1, 64, 160, 96)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 697, 11)}-(1, 11, 17, 41)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 3471)}-(1, 13, 89, 3)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (1, 25245)}-(3, 11, 45, 17)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (48,)}-(2, 2, 3, 4)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (11, 2, 2, 23)}-(4, 11, 1, 23)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (22, 4, 4, 10)}-(5, 11, 64, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (5, 48, 25, 1000)}-(6, 100, 100, 100)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (160, 500)}-(8, 1, 10, 1000)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (89280,)}-(9, 1, 9920, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (12500, 80)}-(10, 10, 10000, 1)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (4, 8, 8, 2816)}-(11, 32, 32, 64)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (64, 64, 2880)}-(12, 64, 160, 96)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (13, 1, 7667)}-(13, 11, 17, 41)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (178, 13, 21, 1)}-(14, 13, 89, 3)-None-None
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Bfp2-HiFi4
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Bfp2_b-HiFi4
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Bfp4-HiFi4
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Bfp4_b-HiFi4
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Bfp8-HiFi4
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Bfp8_b-HiFi4
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Float16-HiFi4
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Float32-HiFi4
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Lf8-HiFi4
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Float16_b-LoFi
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Float16_b-HiFi2
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Float16_b-HiFi3
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Float16_b-HiFi4
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Int8-HiFi4
+reshape-FROM_HOST-{'shape': (2, 2, 2, 3)}-(1, 2, 3, 4)-Int32-HiFi4
+reshape-FROM_ANOTHER_OP-{'shape': (512,)}-(8, 8, 8)-None-None
 reshape-FROM_ANOTHER_OP-{'shape': (4, 2)}-(1, 2, 2, 2)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (8,)}-(1, 2, 2, 2)-None-None
 reshape-FROM_ANOTHER_OP-{'shape': (1, -1, 3, 24, 32)}-(1, 49, 2304)-None-None
 reshape-FROM_ANOTHER_OP-{'shape': (1, 49, 6, -1)}-(1, 49, 2304)-None-None
+reshape-FROM_ANOTHER_OP-{'shape': (-1,)}-(1, 49, 2304)-None-None
 reshape-FROM_ANOTHER_OP-{'shape': (1, -1)}-(1, 49, 2304)-None-None
 reshape-FROM_ANOTHER_OP-{'shape': (3, -1)}-(3, 4, 5)-None-None
 reshape-FROM_ANOTHER_OP-{'shape': (-1, 15)}-(3, 4, 5)-None-None
@@ -245,9 +311,12 @@ reshape-FROM_ANOTHER_OP-{'shape': (1, 64, 20, 64)}-(1, 64, 1280)-None-None
 reshape-FROM_ANOTHER_OP-{'shape': (1, 64, 5, 256)}-(1, 64, 1280)-None-None
 reshape-FROM_ANOTHER_OP-{'shape': (1, 64, 40, 32)}-(1, 64, 1280)-None-None
 reshape-FROM_ANOTHER_OP-{'shape': (1, 64, 80, 16)}-(1, 64, 1280)-None-None
+reshape-FROM_HOST-{'shape': (512,)}-(8, 8, 8)-None-None
 reshape-FROM_HOST-{'shape': (4, 2)}-(1, 2, 2, 2)-None-None
+reshape-FROM_HOST-{'shape': (8,)}-(1, 2, 2, 2)-None-None
 reshape-FROM_HOST-{'shape': (1, -1, 3, 24, 32)}-(1, 49, 2304)-None-None
 reshape-FROM_HOST-{'shape': (1, 49, 6, -1)}-(1, 49, 2304)-None-None
+reshape-FROM_HOST-{'shape': (-1,)}-(1, 49, 2304)-None-None
 reshape-FROM_HOST-{'shape': (1, -1)}-(1, 49, 2304)-None-None
 reshape-FROM_HOST-{'shape': (3, -1)}-(3, 4, 5)-None-None
 reshape-FROM_HOST-{'shape': (-1, 15)}-(3, 4, 5)-None-None
@@ -268,9 +337,12 @@ reshape-FROM_HOST-{'shape': (1, 64, 20, 64)}-(1, 64, 1280)-None-None
 reshape-FROM_HOST-{'shape': (1, 64, 5, 256)}-(1, 64, 1280)-None-None
 reshape-FROM_HOST-{'shape': (1, 64, 40, 32)}-(1, 64, 1280)-None-None
 reshape-FROM_HOST-{'shape': (1, 64, 80, 16)}-(1, 64, 1280)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (512,)}-(8, 8, 8)-None-None
 reshape-FROM_DRAM_QUEUE-{'shape': (4, 2)}-(1, 2, 2, 2)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (8,)}-(1, 2, 2, 2)-None-None
 reshape-FROM_DRAM_QUEUE-{'shape': (1, -1, 3, 24, 32)}-(1, 49, 2304)-None-None
 reshape-FROM_DRAM_QUEUE-{'shape': (1, 49, 6, -1)}-(1, 49, 2304)-None-None
+reshape-FROM_DRAM_QUEUE-{'shape': (-1,)}-(1, 49, 2304)-None-None
 reshape-FROM_DRAM_QUEUE-{'shape': (1, -1)}-(1, 49, 2304)-None-None
 reshape-FROM_DRAM_QUEUE-{'shape': (3, -1)}-(3, 4, 5)-None-None
 reshape-FROM_DRAM_QUEUE-{'shape': (-1, 15)}-(3, 4, 5)-None-None
@@ -291,9 +363,12 @@ reshape-FROM_DRAM_QUEUE-{'shape': (1, 64, 20, 64)}-(1, 64, 1280)-None-None
 reshape-FROM_DRAM_QUEUE-{'shape': (1, 64, 5, 256)}-(1, 64, 1280)-None-None
 reshape-FROM_DRAM_QUEUE-{'shape': (1, 64, 40, 32)}-(1, 64, 1280)-None-None
 reshape-FROM_DRAM_QUEUE-{'shape': (1, 64, 80, 16)}-(1, 64, 1280)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (512,)}-(8, 8, 8)-None-None
 reshape-CONST_EVAL_PASS-{'shape': (4, 2)}-(1, 2, 2, 2)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (8,)}-(1, 2, 2, 2)-None-None
 reshape-CONST_EVAL_PASS-{'shape': (1, -1, 3, 24, 32)}-(1, 49, 2304)-None-None
 reshape-CONST_EVAL_PASS-{'shape': (1, 49, 6, -1)}-(1, 49, 2304)-None-None
+reshape-CONST_EVAL_PASS-{'shape': (-1,)}-(1, 49, 2304)-None-None
 reshape-CONST_EVAL_PASS-{'shape': (1, -1)}-(1, 49, 2304)-None-None
 reshape-CONST_EVAL_PASS-{'shape': (3, -1)}-(3, 4, 5)-None-None
 reshape-CONST_EVAL_PASS-{'shape': (-1, 15)}-(3, 4, 5)-None-None

--- a/forge/test/operators/utils/failing_reasons.py
+++ b/forge/test/operators/utils/failing_reasons.py
@@ -166,6 +166,9 @@ class FailingReasonsValidation:
             and "Statically allocated circular buffers on core range [(x=0,y=0) - (x=0,y=0)] grow to 2663200 B which is beyond max L1 size of 1499136 B"
             in f"{ex}",
             lambda ex: isinstance(ex, RuntimeError)
+            and "Statically allocated circular buffers on core range [(x=0,y=0) - (x=7,y=7)] grow to 28100144 B which is beyond max L1 size of 1499136 B"
+            in f"{ex}",
+            lambda ex: isinstance(ex, RuntimeError)
             and "Index is out of bounds for the rank, should be between 0 and 0 however is 1" in f"{ex}",
             lambda ex: isinstance(ex, RuntimeError)
             and "293 unique+common runtime args targeting kernel reader_concat_stick_layout_interleaved_start_id on (x=0,y=0) are too large. Max allowable is 256"


### PR DESCRIPTION
## Repro commands

Three categories of bugs detected: DATA_MISMATCH, INFERENCE_FAILED and UNSUPPORTED_DIMENSION

To reproduce actual error messages run:

```
. forge/test/operators/pytorch/test_commands.sh
run_xfail_on
```

```
OPERATORS=reshape FAILING_REASONS=INFERENCE_FAILED test_query
```

Exceptions:
  - RuntimeError: TT_THROW @ /home/vbrkic/src_bgd/ttforge/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:840: tt::exception

```
OPERATORS=reshape FAILING_REASONS=UNSUPPORTED_DIMENSION test_query
```

Exceptions:
 - tvm.error.InternalError: Traceback (most recent call last):
