### PR TITLE
Revert 'reduce_avg' attribute from 'dim_arg' to 'dim' and update op_mapping

### DIFF
--- a/forge/csrc/passes/commute_utils.cpp
+++ b/forge/csrc/passes/commute_utils.cpp
@@ -1052,7 +1052,7 @@ void update_reduce_attr(graphlib::OpNode *reduce, int reduce_dim, bool keep_dim)
     attr.push_back(keep_dim);
 
     graphlib::OpType::Attrs named_attrs = reduce->named_attrs();
-    named_attrs["dim_arg"] = reduce_dim;
+    named_attrs["dim"] = reduce_dim;
     named_attrs["keep_dim"] = keep_dim;
 
     reduce->overwrite_op_named_attrs(attr, named_attrs);

--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -104,6 +104,7 @@ class AttributeMapper
     {
         // repeat_interleave configuration
         add_op_mapping("repeat_interleave", "repeats", AttributeRemap(std::nullopt, TargetType::UInt32));
+        add_op_mapping("reduce_avg", "dim", AttributeRemap("dim_arg"));
 
         // Add more default mappings here
     }

--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -102,7 +102,6 @@ class AttributeMapper
 
     void initialize_default_mappings()
     {
-        // repeat_interleave configuration
         add_op_mapping("repeat_interleave", "repeats", AttributeRemap(std::nullopt, TargetType::UInt32));
         add_op_mapping("reduce_avg", "dim", AttributeRemap("dim_arg"));
 

--- a/forge/csrc/test/passes/test_erase_inverse_ops.cpp
+++ b/forge/csrc/test/passes/test_erase_inverse_ops.cpp
@@ -571,7 +571,7 @@ struct UpdateReduceSumAttrsTest : testing::Test
             },
             {input_node});
         auto &named_attrs = reduce_node->named_attrs();
-        named_attrs["dim_arg"] = reduce_dim;
+        named_attrs["dim"] = reduce_dim;
         named_attrs["keep_dim"] = keep_dim;
         reduce_node->overwrite_named_attrs(named_attrs);
         create_output(*graph, "out", reduce_node);
@@ -594,8 +594,8 @@ TEST_F(UpdateReduceSumAttrsTest, ReduceSumDim)
 
     auto updated_attrs = reduce_node->named_attrs();
 
-    ASSERT_TRUE(updated_attrs.count("dim_arg"));
-    EXPECT_EQ(std::get<int>(updated_attrs["dim_arg"]), reduce_dim);
+    ASSERT_TRUE(updated_attrs.count("dim"));
+    EXPECT_EQ(std::get<int>(updated_attrs["dim"]), reduce_dim);
 
     ASSERT_TRUE(updated_attrs.count("keep_dim"));
     EXPECT_EQ(std::get<bool>(updated_attrs["keep_dim"]), keep_dim);
@@ -628,7 +628,7 @@ struct UpdateReduceMaxAttrsTest : testing::Test
             },
             {input_node});
         auto &named_attrs = reduce_node->named_attrs();
-        named_attrs["dim_arg"] = reduce_dim;
+        named_attrs["dim"] = reduce_dim;
         named_attrs["stride"] = stride;
         named_attrs["keep_dim"] = keep_dim;
         reduce_node->overwrite_named_attrs(named_attrs);
@@ -653,8 +653,8 @@ TEST_F(UpdateReduceMaxAttrsTest, ReduceMaxDim)
 
     auto updated_attrs = reduce_node->named_attrs();
 
-    ASSERT_TRUE(updated_attrs.count("dim_arg"));
-    EXPECT_EQ(std::get<int>(updated_attrs["dim_arg"]), reduce_dim);
+    ASSERT_TRUE(updated_attrs.count("dim"));
+    EXPECT_EQ(std::get<int>(updated_attrs["dim"]), reduce_dim);
 
     ASSERT_TRUE(updated_attrs.count("stride"));
     EXPECT_EQ(std::get<int>(updated_attrs["stride"]), stride);

--- a/forge/forge/op/eval/forge/pooling.py
+++ b/forge/forge/op/eval/forge/pooling.py
@@ -568,14 +568,14 @@ def decompose(type, attr, dc, inputs):
                 result = dc.op_with_named_attrs(
                     "reshape", [activations], {"shape": (w, 1, y * x, cin)}, (w, 1, y * x, cin)
                 )
-                result = dc.op_with_named_attrs("reduce_avg", [result], {"dim_arg": [-2], "keep_dim": True}, (-2, True))
+                result = dc.op_with_named_attrs("reduce_avg", [result], {"dim": [-2], "keep_dim": True}, (-2, True))
                 result = dc.op_with_named_attrs("reshape", [result], {"shape": (w, 1, 1, cin)}, (w, 1, 1, cin))
             else:
                 result = dc.op_with_named_attrs(
                     "reshape", [activations], {"shape": (w, 1, cin, y * x)}, (w, 1, cin, y * x)
                 )
                 result = dc.op(TransposeTM.create(2, 3), [result])
-                result = dc.op_with_named_attrs("reduce_avg", [result], {"dim_arg": [-2], "keep_dim": True}, (-2, True))
+                result = dc.op_with_named_attrs("reduce_avg", [result], {"dim": [-2], "keep_dim": True}, (-2, True))
                 result = dc.op(TransposeTM.create(2, 3), [result])
                 result = dc.op_with_named_attrs("reshape", [result], {"shape": (w, cin, 1, 1)}, (w, cin, 1, 1))
             dc.fuse(result)
@@ -718,9 +718,7 @@ def decompose(type, attr, dc, inputs):
             d_start = i * sD
 
             depth_slice = dc.op("index", [activations], (2, d_start, d_start + kD, activations.shape[2]))
-            depth_avg = dc.op_with_named_attrs(
-                "reduce_avg", [depth_slice], {"dim_arg": [2], "keep_dim": True}, (2, True)
-            )
+            depth_avg = dc.op_with_named_attrs("reduce_avg", [depth_slice], {"dim": [2], "keep_dim": True}, (2, True))
 
             named_attrs = {
                 "kernel_height": kernel_size[1],

--- a/forge/forge/op/reduce.py
+++ b/forge/forge/op/reduce.py
@@ -58,7 +58,7 @@ def ReduceAvg(name: str, operandA: Tensor, dim: int, keep_dim: bool = True) -> T
     # if dim < 0:
     #     dim += 4
 
-    return op("reduce_avg", name, operandA, attrs=(dim, keep_dim), dim_arg=[dim], keep_dim=keep_dim).get_tensor()
+    return op("reduce_avg", name, operandA, attrs=(dim, keep_dim), dim=[dim], keep_dim=keep_dim).get_tensor()
 
 
 def GroupedReduceAvg(name: str, operandA: Tensor, dim: int, groups: int, keep_dims: bool = False) -> Tensor:


### PR DESCRIPTION
### Problem description
The previous change in [PR #1101](https://github.com/tenstorrent/tt-forge-fe/pull/1101) modified the named attribute of `reduce_avg` from `dim` to `dim_arg` to align with tt-mlir naming conventions. However, this change has been identified as problematic and needs to be reverted.

### What's changed
This PR reverts the changes introduced in [PR #1101](https://github.com/tenstorrent/tt-forge-fe/pull/1101), restoring the named attribute of `reduce_avg` back to `dim`. Additionally, the `op_mapping` has been updated from `dim` to `dim_arg` to ensure compatibility with ttir.

### Checklist
- [x] New/Existing tests provide coverage for changes
