### PR TITLE
[test] disable verbose logging by default

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,10 +1,7 @@
 # TF & some other libraries report a bunch of deprecation warnings
 [pytest]
 
-# Ignore specific tests
-addopts = -svv
-
-# Fail on xpadded
+# Fail on xpassed
 xfail_strict=true
 
 # Add pytest markers


### PR DESCRIPTION
Disabling verbose logging in `pytest.ini`. The CI logs are quite large and it's not possible to see test failures without opening the raw log file.
