### PR TITLE
Set run-name for collect data jobs

### DIFF
--- a/.github/workflows/produce_data.yml
+++ b/.github/workflows/produce_data.yml
@@ -11,6 +11,8 @@ on:
     types:
       - completed
 
+run-name: "Collect data for workflow_run.id ${{ github.event.workflow_run.id }} run_attempt ${{ github.event.workflow_run.run_attempt }}"
+
 jobs:
   produce-cicd-data:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Ticket
N/A

### Problem description
It is hard to connect workflows and collect data jobs, set job name to show for which run we are collecting data

### What's changed
Dynamically set run-name for collect data jobs

### Checklist
- [ x] New/Existing tests provide coverage for changes
