### PR TITLE
Copy of the inputs for the evaluation during compilation

### DIFF
--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -2071,7 +2071,8 @@ def generate_forge_module(
             reload = False
 
     if verify_cfg is not None and verify_cfg.verify_forge_codegen_vs_framework:
-        framework_outputs = framework_mod.cpu_eval_forward(*pytorch_inputs)
+        eval_inputs = [eval_input.detach().clone() for eval_input in pytorch_inputs]
+        framework_outputs = framework_mod.cpu_eval_forward(*eval_inputs)
 
     if not reload:
         module_name = graph_name if counter == 0 else f"{graph_name}_{counter}"

--- a/forge/test/mlir/operators/tm/test_in_place.py
+++ b/forge/test/mlir/operators/tm/test_in_place.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+import tensorflow as tf
+
+import forge
+from forge.verify.compare import compare_with_golden
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (3, 3),
+    ],
+)
+@pytest.mark.push
+def test_in_place_torch(shape):
+    class Inplace(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            y = x + 1
+            x += 2
+
+            return x + y
+
+    input = torch.zeros(shape, requires_grad=False)
+    framework_input = input.detach().clone()
+    tt_inputs = [input]
+
+    framework_model = Inplace()
+    y = framework_model(framework_input)
+
+    compiled_model = forge.compile(framework_model, sample_inputs=tt_inputs, module_name="inplace")
+    tty = compiled_model(*tt_inputs)[0]
+
+    compare_with_golden(golden=y, calculated=tty)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (3, 3),
+    ],
+)
+@pytest.mark.push
+def test_in_place_tf(shape):
+    class Inplace(tf.keras.Model):
+        def __init__(self):
+            super().__init__()
+
+        def call(self, x):
+            y = x + 1
+            x += 2
+            return x + y
+
+    input = tf.zeros(shape)
+    framework_input = tf.identity(input)
+    tt_inputs = [input]
+
+    framework_model = Inplace()
+    y = framework_model(framework_input)
+
+    compiled_model = forge.compile(framework_model, sample_inputs=tt_inputs, module_name="inplace")
+    tty = compiled_model(*tt_inputs)[0]
+
+    # convert tensor from tf to torch
+    y = torch.tensor(y.numpy())
+
+    compare_with_golden(golden=y, calculated=tty)
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1024),
+    ],
+)
+@pytest.mark.push
+@pytest.mark.xfail(
+    reason="TT model silently computes the result for the tensor with requires_grad=True on which in-place operation has been performed"
+)
+def test_in_place_backward(shape):
+    class MatmulParam(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.p = torch.nn.Parameter(torch.rand(1024, 1024))
+            torch.nn.init.xavier_uniform_(self.p)
+
+        def forward(self, x):
+            y = torch.matmul(x, self.p)
+            x += 2  # In-place modification causing runtime error
+            return y
+
+    inputs = torch.rand(shape, requires_grad=True)
+
+    model = MatmulParam()
+    tt_model = forge.compile(model, sample_inputs=[torch.rand(shape)])
+
+    # Expect PyTorch model to raise a RuntimeError
+    with pytest.raises(
+        RuntimeError, match="a leaf Variable that requires grad is being used in an in-place operation."
+    ):
+        model(inputs)
+
+    # Expect tt_model to also raise a RuntimeError
+    with pytest.raises(RuntimeError):
+        tt_model(inputs)  # If no error is raised, the test will fail

--- a/forge/test/mlir/operators/tm/test_in_place.py
+++ b/forge/test/mlir/operators/tm/test_in_place.py
@@ -38,6 +38,8 @@ def test_in_place_torch(shape):
     tty = compiled_model(*tt_inputs)[0]
 
     compare_with_golden(golden=y, calculated=tty)
+    print(framework_input)
+    print(tt_inputs[0])
 
 
 @pytest.mark.parametrize(
@@ -71,6 +73,9 @@ def test_in_place_tf(shape):
     y = torch.tensor(y.numpy())
 
     compare_with_golden(golden=y, calculated=tty)
+
+    print(framework_input)
+    print(tt_inputs[0])
 
 
 @pytest.mark.parametrize(

--- a/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
+++ b/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
@@ -49,7 +49,7 @@ def test_mlp_mixer_timm_pytorch(record_forge_property, variant):
     record_forge_property("model_name", module_name)
 
     framework_model = download_model(timm.create_model, variant, pretrained=True)
-    config = resolve_data_config({}, model=model)
+    config = resolve_data_config({}, model=framework_model)
     transform = create_transform(**config)
 
     try:


### PR DESCRIPTION
### Summary

This PR ensures that a copy of the input tensors is created when running forward during compilation (e.g. when trying to verify outputs using forward pass of the framework model). This prevents unintended modifications to the original input tensors if in-place operations are performed during the forward pass.

In order for it to work, first this [PR](https://github.com/tenstorrent/tt-tvm/pull/60) in the `tt-tvm` needs to be merged.

### Why is this needed?
Some models perform in-place operations on input tensors during the forward pass, which can lead to unintended changes in the original inputs. By making a copy of the inputs, we ensure correctness and avoid potential issues when running forward during compilation.

Example test:
```python
    class Inplace(torch.nn.Module):
        def __init__(self):
            super().__init__()

        def forward(self, x):
            y = x + 1 
            x += 2 # in-place operation on the input that causes the inputs to change during forge.compile(...)

            return x + y
        
    input = torch.zeros(shape, requires_grad=False)
    framework_input = input.detach().clone()
    tt_inputs = [input]

    framework_model = Inplace()
    y = framework_model(framework_input)
        
    compiled_model = forge.compile(framework_model, sample_inputs=tt_inputs, module_name="inplace")
    tty = compiled_model(*tt_inputs)[0]

    compare_with_golden(golden=y, calculated=tty) # this would fail
```
❗❗❗ IMPORTANT NOTES ❗❗❗

In the training mode if the inputs require grad, pytorch will try to do the forward and will throw runtime error:
`a leaf Variable that requires grad is being used in an in-place operation.`, while the compiled model silently computes the gradients and **this need to be addressed**.

Introducing this change our compiler will not change it's input, so it will act as tensorflow (it doesn't change it's input tensor), but it is won't be aligned with pytorch which allows in-place changes of the input tensor.
   