### PR TITLE
Switch to new dylib structure (split compiler + runtime dylibs) for ttmlir

### DIFF
--- a/forge/csrc/CMakeLists.txt
+++ b/forge/csrc/CMakeLists.txt
@@ -87,7 +87,8 @@ target_link_libraries(ttforge_csrc PRIVATE
     LLVM
     MLIR
 
-    TTMLIR
+    TTMLIRCompiler
+    TTMLIRRuntime
 
     xml2
     curses

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,10 @@ class CMakeBuild(build_ext):
         self.spawn(["cmake", "--build", str(build_dir)])
         self.spawn(["cmake", "--install", str(build_dir)])
 
+        # NOTE: Workaround for regression in tt-mlir,
+        # Remove once tt-mlir#2129 is merged.
+        self.copy_tree(cwd / "lib", str(install_dir / "lib"))
+
 
 with open("README.md", "r") as f:
     long_description = f.read()


### PR DESCRIPTION
### Problem description
Making some changes to tt-mlir to avoid static linking.  This entails splitting TTMLIR.so into 2 parts, this is trivial PR to change so we link both these parts (compiler + runtime) so instead of master so

### What's changed
Very little, TTMLIR -> TTMLIRCompiler & TTMLIRRuntime in a cmake file

### Checklist
- [X] Clean CI run
https://github.com/tenstorrent/tt-forge-fe/actions/runs/13080436376 
