### PR TITLE
[CI] reorganize workflows to use python wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,121 @@
+name: Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      mlir_override:
+        description: 'Git SHA of commit in tenstorrent/tt-mlir or branch name'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      mlir_override:
+        description: 'Git SHA of commit in tenstorrent/tt-mlir or branch name'
+        required: false
+        type: string
+      docker-image:
+        description: 'Docker image to use for build'
+        required: true
+        type: string
+
+permissions:
+  packages: write
+  checks: write
+  pull-requests: write # only required if `comment: true` was enabled
+
+jobs:
+
+  forge-build:
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+          - runs-on: [runner]
+
+    runs-on:
+      - in-service
+      - ${{ matrix.build.runs-on }}
+
+    container:
+      image: ${{ inputs.docker-image }}
+
+    steps:
+
+    - name: Fetch job id
+      id: fetch-job-id
+      uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
+      with:
+        job_name: "${{ github.job }}"
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      env:
+        JOB_ID: ${{ steps.fetch-job-id.outputs.job_id }}
+      run: |
+        echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
+        echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
+
+    - name: Git safe dir
+      run: |
+        git config --system --add safe.directory ${{ steps.strings.outputs.work-dir }}
+        chown -R root:root ${{ steps.strings.outputs.work-dir }}
+
+    - uses: actions/checkout@v4
+      with:
+          submodules: recursive
+          clean: true
+          fetch-depth: 0 # Fetch all history and tags
+
+    # Clean everything from submodules (needed to avoid issues
+    # with cmake generated files leftover from previous builds)
+    - name: Cleanup submodules
+      run: |
+          git submodule foreach --recursive git clean -ffdx
+          git submodule foreach --recursive git reset --hard
+
+    - name: Update submodule if mlir_override is set
+      if: ${{ inputs.mlir_override }}
+      run: |
+        cd third_party/tt-mlir
+        git fetch
+        git checkout ${{ inputs.mlir_override }}
+        branch_name=$(git rev-parse --abbrev-ref HEAD)
+        commit_sha=$(git rev-parse HEAD)
+        commit_title=$(git log -1 --pretty=%s)
+        echo "Branch name: $branch_name"
+        echo "Commit SHA: $commit_sha"
+        echo "Commit title: $commit_title"
+        echo "::notice::Using tt-mlir branch: $branch_name, commit: $commit_sha, title: $commit_title"
+        cd ../..
+
+    - name: ccache
+      uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        create-symlink: true
+        key: ${{ matrix.build.runs-on }}-runtime-${{ matrix.build.enable_runtime }}
+
+    - name: Build (creates tvm and tt-forge-fe wheels)
+      shell: bash
+      run: |
+        source env/activate
+        python3 setup.py bdist_wheel
+        cd third_party/tvm/python
+        python3 setup.py bdist_wheel
+        cd ../../..
+        cp third_party/tvm/python/dist/*.whl dist/
+
+    - name: Run Unit Tests
+      shell: bash
+      run: |
+        source env/activate
+        pip install dist/forge*.whl --force-reinstall
+        cmake --build ${{ steps.strings.outputs.build-output-dir }} -- run_unit_tests
+
+    - name: Upload Build
+      uses: actions/upload-artifact@v4
+      if: success() || failure()
+      with:
+        name: forge-wheel
+        path: dist/*.whl

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -7,12 +7,30 @@ on:
 
 jobs:
   docker-build:
-    uses: ./.github/workflows/build-and-test.yml
+      uses: ./.github/workflows/build-image.yml
+      secrets: inherit
+  build:
+    needs: docker-build
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  test:
+    needs:
+      - docker-build
+      - build
+    uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
       test_mark: 'nightly'
       test_group_cnt: 4
       test_group_ids: '[1,2,3,4]'
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
   perf-benchmark:
+    needs:
+      - docker-build
+      - build
     uses: ./.github/workflows/perf-benchmark.yml
     secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -22,10 +22,23 @@ jobs:
     uses: ./.github/workflows/pre-commit.yml
     secrets: inherit
   docker-build:
-    uses: ./.github/workflows/build-and-test.yml
+      uses: ./.github/workflows/build-image.yml
+      secrets: inherit
+  build:
+    needs: docker-build
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      mlir_override: ${{ inputs.mlir_override }}
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  test:
+    needs:
+      - docker-build
+      - build
+    uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
       test_mark: 'push'
       test_group_cnt: 2
       test_group_ids: '[1,2]'
-      mlir_override: ${{ inputs.mlir_override }}
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -1,18 +1,17 @@
-name: Build and Test
+name: Perf benchmark
 
 on:
-  workflow_dispatch:
   workflow_call:
+    inputs:
+      docker-image:
+        description: 'Docker image to use for build'
+        required: true
+        type: string
 
 jobs:
 
-  docker-build:
-    uses: ./.github/workflows/build-image.yml
-    secrets: inherit
+  run-perf-benchmarks:
 
-  build-and-run-perf:
-
-    needs: docker-build
     strategy:
       fail-fast: false
     runs-on:
@@ -21,7 +20,7 @@ jobs:
       - performance
 
     container:
-      image: ${{ needs.docker-build.outputs.docker-image }}
+      image: ${{ inputs.docker-image }}
       options: --device /dev/tenstorrent/0
       volumes:
         - /dev/hugepages:/dev/hugepages
@@ -31,23 +30,20 @@ jobs:
         - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
     steps:
 
+    - name: Fetch job id
+      id: fetch-job-id
+      uses: tenstorrent/tt-github-actions/.github/actions/job_id@main
+      with:
+        job_name: "${{ github.job }}"
+
     - name: Set reusable strings
       id: strings
       shell: bash
       env:
-        job-name: "${{ github.job }}"
+        JOB_ID: ${{ steps.fetch-job-id.outputs.job_id }}
       run: |
         echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
         echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
-
-        # Github job context unfortunately doesn't contain job_id, this is the workaround how to fetch it using GH API
-        echo "Expected job name: ${{ env.job-name }}"
-        JOB_ID=$(curl -s -H "Authorization: token ${{ secrets.GH_TOKEN }}" \
-          "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}/jobs" | \
-          jq -r '.jobs[] | select(.name | contains("${{ env.job-name }}")) | .id ')
-        echo "Current job id: $JOB_ID"
-
-        echo "job-id=$JOB_ID" >> "$GITHUB_OUTPUT"
         echo "perf_report_path=forge-benchmark-e2e-mnist_$JOB_ID.json" >> "$GITHUB_OUTPUT"
 
     - name: Git safe dir
@@ -55,7 +51,12 @@ jobs:
 
     - uses: actions/checkout@v4
       with:
-          submodules: recursive
+          sparse-checkout: |
+            env/
+            forge/test
+            pytest.ini
+            conftest.py
+            .test_durations
           fetch-depth: 0 # Fetch all history and tags
 
     # Clean everything from submodules (needed to avoid issues
@@ -65,24 +66,17 @@ jobs:
           git submodule foreach --recursive git clean -ffdx
           git submodule foreach --recursive git reset --hard
 
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
       with:
-        create-symlink: true
-        key: runner-runtime--
+        name: forge-wheel
 
-    - name: Build
+    - name: Install wheel
       shell: bash
       run: |
         source env/activate
-        cmake -G Ninja \
-        -B ${{ steps.strings.outputs.build-output-dir }} \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_C_COMPILER=clang \
-        -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        cmake --build ${{ steps.strings.outputs.build-output-dir }}
+        pip install tvm*.whl --force-reinstall
+        pip install forge*.whl --force-reinstall
 
     - name: Run Perf Benchmark
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,32 +1,6 @@
-name: Build and Test
+name: Test
 
 on:
-  workflow_dispatch:
-    inputs:
-      test_mark:
-        description: 'Test mark to run'
-        required: true
-        default: 'push'
-        type: choice
-        options:
-          - push
-          - nightly
-          - nightly_sweeps
-          - push or nightly
-      mlir_override:
-        description: 'Git SHA of commit in tenstorrent/tt-mlir or branch name'
-        required: false
-        type: string
-      test_group_cnt:
-        description: 'Test group count'
-        required: true
-        default: 2
-        type: number
-      test_group_ids:
-        description: 'Test group ids'
-        required: true
-        default: '[1,2]'
-        type: string
   workflow_call:
     inputs:
       test_mark:
@@ -34,10 +8,6 @@ on:
         required: false
         default: 'push'
         type: string
-      mlir_override:
-        description: 'Git SHA of commit in tenstorrent/tt-mlir or branch name'
-        required: false
-        type: string
       test_group_cnt:
         description: 'Test group count'
         required: false
@@ -47,6 +17,10 @@ on:
         description: 'Test group ids'
         required: false
         default: '[1,2]'
+        type: string
+      docker-image:
+        description: 'Docker image to use for build'
+        required: true
         type: string
 
 permissions:
@@ -55,18 +29,17 @@ permissions:
   pull-requests: write # only required if `comment: true` was enabled
 
 jobs:
-  docker-build:
-    uses: ./.github/workflows/build-image.yml
-    secrets: inherit
 
-  build-and-test:
+  run-tests:
 
-    needs: docker-build
     strategy:
       fail-fast: false
       matrix:
         build:
-          - runs-on: runner
+          [
+            {runs-on: n150 },
+            {runs-on: n300 },
+          ]
         test_group_id: ${{ fromJson(inputs.test_group_ids) }}
 
     runs-on:
@@ -74,7 +47,7 @@ jobs:
       - ${{ matrix.build.runs-on }}
 
     container:
-      image: ${{ needs.docker-build.outputs.docker-image }}
+      image: ${{ inputs.docker-image }}
       options: --device /dev/tenstorrent/0
       volumes:
         - /dev/hugepages:/dev/hugepages
@@ -82,7 +55,6 @@ jobs:
         - /etc/udev/rules.d:/etc/udev/rules.d
         - /lib/modules:/lib/modules
         - /opt/tt_metal_infra/provisioning/provisioning_env:/opt/tt_metal_infra/provisioning/provisioning_env
-        - /mnt/dockercache:/mnt/dockercache
     steps:
 
     - name: Fetch job id
@@ -100,14 +72,18 @@ jobs:
         echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
         echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
         echo "test_report_path=reports/report_$JOB_ID.xml" >> "$GITHUB_OUTPUT"
-        echo "perf_report_path=reports/forge-benchmark-e2e-mnist_$JOB_ID.json" >> "$GITHUB_OUTPUT"
 
     - name: Git safe dir
       run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
 
     - uses: actions/checkout@v4
       with:
-          submodules: recursive
+          sparse-checkout: |
+            env/
+            forge/test
+            pytest.ini
+            conftest.py
+            .test_durations
           fetch-depth: 0 # Fetch all history and tags
 
     # Clean everything from submodules (needed to avoid issues
@@ -117,45 +93,17 @@ jobs:
           git submodule foreach --recursive git clean -ffdx
           git submodule foreach --recursive git reset --hard
 
-    - name: Update submodule if mlir_override is set
-      if: ${{ inputs.mlir_override }}
-      run: |
-        cd third_party/tt-mlir
-        git fetch
-        git checkout ${{ inputs.mlir_override }}
-        branch_name=$(git rev-parse --abbrev-ref HEAD)
-        commit_sha=$(git rev-parse HEAD)
-        commit_title=$(git log -1 --pretty=%s)
-        echo "Branch name: $branch_name"
-        echo "Commit SHA: $commit_sha"
-        echo "Commit title: $commit_title"
-        echo "::notice::Using tt-mlir branch: $branch_name, commit: $commit_sha, title: $commit_title"
-        cd ../..
-
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
       with:
-        create-symlink: true
-        key: ${{ matrix.build.runs-on }}-runtime-${{ matrix.build.enable_runtime }}-${{ env.SDK_VERSION }}
+        name: forge-wheel
 
-    - name: Build
+    - name: Install wheel
       shell: bash
       run: |
         source env/activate
-        cmake -G Ninja \
-        -B ${{ steps.strings.outputs.build-output-dir }} \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_C_COMPILER=clang \
-        -DCMAKE_CXX_COMPILER=clang++ \
-        -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-        -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
-        cmake --build ${{ steps.strings.outputs.build-output-dir }}
-
-    - name: Run Unit Tests
-      shell: bash
-      run: |
-        source env/activate
-        cmake --build ${{ steps.strings.outputs.build-output-dir }} -- run_unit_tests
+        pip install tvm*.whl --force-reinstall
+        pip install forge*.whl --force-reinstall
 
     - name: Run Test
       env:


### PR DESCRIPTION
Before this change, we had `build-and-test` workflow which coupled building and testing. Which means if we would want to split tests into more groups or add more testing (both on `n150` and `n300`) each of those jobs would waste time on building everything from scratch.

With this change we now have one `forge-build` job which creates both `tt-tvm` and `tt-forge-fe` wheels, which will then be reused by all of the testing jobs. Both `nightly` and `on PR` runs are udpated.

Additionally, we will run all tests on both `n150` and `n300` cards to have better test coverage. In the past, we've had blind spots where some of the tests were passing on `n150` and failing on `n300`.

In the future, the plan is to add workflows for `debug` build, test coverage runs, etc.

Closes #200