### PR TITLE
[ci] fix on-push workflow

### DIFF
--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -7,9 +7,23 @@ on:
 
 jobs:
   docker-build:
-    uses: ./.github/workflows/build-and-test.yml
+      uses: ./.github/workflows/build-image.yml
+      secrets: inherit
+  build:
+    needs: docker-build
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      mlir_override: ${{ inputs.mlir_override }}
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  test:
+    needs:
+      - docker-build
+      - build
+    uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
       test_mark: 'push'
       test_group_cnt: 2
       test_group_ids: '[1,2]'
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}


### PR DESCRIPTION
The `on-push` workflow is broken with commit ba394b6. Fixing it to use latest build & test workflows.