### PR TITLE
Remove global compiler config dependency in model_analysis

### DIFF
--- a/forge/forge/config.py
+++ b/forge/forge/config.py
@@ -352,6 +352,12 @@ class CompilerConfig:
         if "FORGE_SCHEDULER_POLICY" in os.environ:
             self.scheduler_policy = os.environ["FORGE_SCHEDULER_POLICY"]
 
+        if "FORGE_TVM_GENERATE_UNIQUE_OPS_TESTS" in os.environ:
+            self.tvm_generate_unique_ops_tests = bool(int(os.environ["FORGE_TVM_GENERATE_UNIQUE_OPS_TESTS"]))
+
+        if "FORGE_EXTRACT_TVM_UNIQUE_OPS_CONFIG" in os.environ:
+            self.extract_tvm_unique_ops_config = bool(int(os.environ["FORGE_EXTRACT_TVM_UNIQUE_OPS_CONFIG"]))
+
         if "FORGE_EXPORT_TVM_UNIQUE_OPS_CONFIG_DETAILS" in os.environ:
             self.export_tvm_unique_ops_config_details = bool(
                 int(os.environ["FORGE_EXPORT_TVM_UNIQUE_OPS_CONFIG_DETAILS"])

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -2789,7 +2789,6 @@ def compile_tvm_to_python(
                     current_module_name,
                     framework,
                     contains_incompatible_np_floats,
-                    delete_inputs,
                     node_name_to_node_type,
                     params,
                     constants,

--- a/forge/forge/tvm_unique_op_generation.py
+++ b/forge/forge/tvm_unique_op_generation.py
@@ -508,7 +508,6 @@ def extract_and_generate_unique_ops_tests(
     current_module_name,
     framework,
     contains_incompatible_np_floats,
-    delete_inputs,
     node_name_to_node_type,
     params,
     constants,
@@ -563,7 +562,7 @@ def extract_and_generate_unique_ops_tests(
                 framework,
                 module_directory=f"generated_modules/unique_ops/{current_module_name}",
                 contains_incompatible_np_floats=contains_incompatible_np_floats,
-                delete_inputs=delete_inputs,
+                delete_inputs=False,
             )
             writer.write_header(include_pytest_imports=True)
 

--- a/forge/test/conftest.py
+++ b/forge/test/conftest.py
@@ -101,18 +101,6 @@ def clear_forge():
 
 def pytest_addoption(parser):
     parser.addoption(
-        "--generate-unique-ops-tests",
-        action="store_true",
-        default=False,
-        help="Generate unique ops tests for the given model",
-    )
-    parser.addoption(
-        "--extract-tvm-unique-ops-config",
-        action="store_true",
-        default=False,
-        help="Extract the tvm unique op configuration for the given model",
-    )
-    parser.addoption(
         "--silicon-only", action="store_true", default=False, help="run silicon tests only, skip golden/model"
     )
     parser.addoption("--no-silicon", action="store_true", default=False, help="skip silicon tests")
@@ -178,27 +166,6 @@ def pytest_addoption(parser):
 def runslow(request):
    return request.config.getoption("--runslow")
 """
-
-
-@pytest.fixture(autouse=True, scope="session")
-def initialize_global_compiler_configuration_based_on_pytest_args(pytestconfig):
-    """
-    Set the global compiler config options for the test session
-    which will generate op tests for the given model.
-    """
-    compiler_cfg = _get_global_compiler_config()
-
-    compiler_cfg.tvm_generate_unique_ops_tests = pytestconfig.getoption("--generate-unique-ops-tests")
-
-    compiler_cfg.extract_tvm_unique_ops_config = pytestconfig.getoption("--extract-tvm-unique-ops-config")
-
-    if compiler_cfg.tvm_generate_unique_ops_tests or compiler_cfg.extract_tvm_unique_ops_config:
-        # For running standalone tests, we need to retain the generated python files
-        # together with stored model parameters
-        compiler_cfg.retain_tvm_python_files = True
-
-        # Required to prevent early tensor deallocation
-        compiler_cfg.enable_op_level_comparision = True
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/scripts/model_analysis/run_analysis_and_generate_md_files.py
+++ b/scripts/model_analysis/run_analysis_and_generate_md_files.py
@@ -784,7 +784,7 @@ def create_statistics_report_markdown_file(
         compiler_component_failure_analysis.get_compiler_component_and_failure_details()
     )
     table_rows = []
-    for compiler_component in CompilerComponent:
+    for compiler_component in compiler_component_failure_analysis.keys():
         if compiler_component != CompilerComponent.UNKNOWN:
             component_name = MarkDownWriter.get_component_names_for_header(compiler_component)
             for failure, model_variant_names in compiler_component_failure_analysis[compiler_component].items():

--- a/scripts/model_analysis/unique_ops_utils.py
+++ b/scripts/model_analysis/unique_ops_utils.py
@@ -38,11 +38,6 @@ def generate_and_export_unique_ops_tests(
         else:
             model_name_to_tests[model_name].append(test)
 
-    if extract_tvm_unique_ops_config:
-        pytest_argument = "--extract-tvm-unique-ops-config"
-    else:
-        pytest_argument = "--generate-unique-ops-tests"
-
     # Generate unique op test for the all collected test and save the models unique ops test information in the unique_ops_output_directory_path
     model_output_dir_paths = []
     for model_name, tests in model_name_to_tests.items():
@@ -53,12 +48,14 @@ def generate_and_export_unique_ops_tests(
             logger.info(f"Running the tests : {test}")
             try:
                 result = subprocess.run(
-                    ["pytest", test, "-vss", pytest_argument, "--no-skips"],
+                    ["pytest", test, "-vss", "--no-skips"],
                     capture_output=True,
                     text=True,
                     check=True,
                     env=dict(
                         os.environ,
+                        FORGE_TVM_GENERATE_UNIQUE_OPS_TESTS="1" if not extract_tvm_unique_ops_config else "0",
+                        FORGE_EXTRACT_TVM_UNIQUE_OPS_CONFIG="1" if extract_tvm_unique_ops_config else "0",
                         FORGE_DISABLE_REPORTIFY_DUMP="1",
                         FORGE_EXPORT_TVM_UNIQUE_OPS_CONFIG_DETAILS="1",
                         FORGE_EXPORT_TVM_UNIQUE_OPS_CONFIG_DETAILS_DIR_PATH=model_output_dir_path,

--- a/scripts/model_analysis/utils.py
+++ b/scripts/model_analysis/utils.py
@@ -143,7 +143,7 @@ class CompilerComponentFailureAnalysis:
         """
         self.compiler_component_and_failure_details = {
             compiler_component: dict(sorted(failure_details.items(), key=lambda item: len(item[1]), reverse=reverse))
-            for compiler_component, failure_details in self.compiler_component_and_failure_details.items()
+            for compiler_component, failure_details in sorted(self.compiler_component_and_failure_details.items())
         }
 
     def get_compiler_component_and_failure_details(self):


### PR DESCRIPTION
The PR removes the dependency of model analysis pipeline on global compiler config.

The `compiler_cfg.tvm_generate_unique_ops_tests` and `compiler_cfg.extract_tvm_unique_ops_config` compiler config are used for extracting the unique ops configuration from TVM and generate unique ops test for extracted configuration.

The `compiler_cfg.tvm_generate_unique_ops_tests` and `compiler_cfg.extract_tvm_unique_ops_config` compiler config are enabled through `initialize_global_compiler_configuration_based_on_pytest_args` fixture in `forge/test/conftest.py` file by specifying the `--generate-unique-ops-tests` or `--extract-tvm-unique-ops-config` pytest options while running the models test


Since [this PR](https://github.com/tenstorrent/tt-forge-fe/pull/1174) remove the global compiler configuration, removed the dependency of enabling `compiler_cfg.tvm_generate_unique_ops_tests` and `compiler_cfg.extract_tvm_unique_ops_config` compiler config through `--generate-unique-ops-tests` or `--extract-tvm-unique-ops-config` pytest options and now the `compiler_cfg.tvm_generate_unique_ops_tests` and `compiler_cfg.extract_tvm_unique_ops_config` compiler config are enabled through **FORGE_TVM_GENERATE_UNIQUE_OPS_TESTS** or **FORGE_EXTRACT_TVM_UNIQUE_OPS_CONFIG** environment variable 