### PR TITLE
Push mark for indexing tests

### DIFF
--- a/forge/test/mlir/operators/indexing/test_advanced_indexing.py
+++ b/forge/test/mlir/operators/indexing/test_advanced_indexing.py
@@ -22,6 +22,7 @@ from forge.verify.verify import verify
         ),
     ],
 )
+@pytest.mark.push
 def test_take(tensor_and_indices):
     tensor, indices = tensor_and_indices
 
@@ -68,6 +69,7 @@ def test_take(tensor_and_indices):
         ),
     ],
 )
+@pytest.mark.push
 def test_index_add(input_dim_index_source):
     input_tensor, dim, index, source = input_dim_index_source
 
@@ -109,6 +111,7 @@ def test_index_add(input_dim_index_source):
         ),
     ],
 )
+@pytest.mark.push
 def test_index_fill(input_dim_index_value):
     input_tensor, dim, index, value = input_dim_index_value
 
@@ -159,6 +162,7 @@ def test_index_fill(input_dim_index_value):
         ),
     ],
 )
+@pytest.mark.push
 def test_index_copy(input_dim_index_source):
     input_tensor, dim, index, source = input_dim_index_source
 
@@ -195,6 +199,7 @@ def test_index_copy(input_dim_index_source):
         (torch.arange(24, dtype=torch.float32).reshape(4, 3, 2), 2, torch.tensor([0, 1])),  # 3D tensor case
     ],
 )
+@pytest.mark.push
 def test_index_select(input_dim_index):
     input_tensor, dim, index = input_dim_index
 
@@ -243,6 +248,7 @@ def test_index_select(input_dim_index):
         ),
     ],
 )
+@pytest.mark.push
 def test_index_put(input_indices_values_accumulate):
     input_tensor, indices, values, accumulate = input_indices_values_accumulate
 

--- a/forge/test/mlir/operators/indexing/test_advanced_masking.py
+++ b/forge/test/mlir/operators/indexing/test_advanced_masking.py
@@ -33,6 +33,7 @@ from forge.verify.verify import verify
         ),
     ],
 )
+@pytest.mark.push
 def test_masked_select(input_tensor, mask):
     class MaskedSelectModule(torch.nn.Module):
         def __init__(self, mask):
@@ -77,6 +78,7 @@ def test_masked_select(input_tensor, mask):
         ),
     ],
 )
+@pytest.mark.push
 def test_masked_fill(input_tensor, mask, value):
     class MaskedFillModule(torch.nn.Module):
         def __init__(self, mask, value):

--- a/forge/test/mlir/operators/indexing/test_advanced_slicing.py
+++ b/forge/test/mlir/operators/indexing/test_advanced_slicing.py
@@ -20,6 +20,7 @@ from forge.verify.verify import verify
         (torch.arange(1.0, 5.0).reshape(1, 4), 1, 2),  # Wide matrix, select third column
     ],
 )
+@pytest.mark.push
 def test_select(input_dim_index):
     input_tensor, dim, index = input_dim_index
 
@@ -65,6 +66,7 @@ def test_select(input_dim_index):
         ),
     ],
 )
+@pytest.mark.push
 def test_split(input_tensor_sizes_dim):
     input_tensor, sizes_or_parts, dim = input_tensor_sizes_dim
 
@@ -102,6 +104,7 @@ def test_split(input_tensor_sizes_dim):
         ),
     ],
 )
+@pytest.mark.push
 def test_chunk(input_tensor_chunks_dim):
     input_tensor, chunks, dim = input_tensor_chunks_dim
 
@@ -182,6 +185,7 @@ def test_chunk(input_tensor_chunks_dim):
         ),
     ],
 )
+@pytest.mark.push
 def test_take(input_tensor_indices):
     input_tensor, indices = input_tensor_indices
 
@@ -244,6 +248,7 @@ def test_take(input_tensor_indices):
         ),
     ],
 )
+@pytest.mark.push
 def test_nonzero(input_tensor_as_tuple):
     input_tensor, as_tuple = input_tensor_as_tuple
 
@@ -311,6 +316,7 @@ def test_nonzero(input_tensor_as_tuple):
         ),
     ],
 )
+@pytest.mark.push
 def test_narrow(input_dim_start_length):
     input_tensor, dim, start, length = input_dim_start_length
 

--- a/forge/test/mlir/operators/indexing/test_basic_indexing.py
+++ b/forge/test/mlir/operators/indexing/test_basic_indexing.py
@@ -23,6 +23,7 @@ from forge.verify.verify import verify
         (-1, (10,)),
     ],
 )
+@pytest.mark.push
 def test_python_indexing(index_shape: Literal[0] | Literal[2] | Literal[-1]):
 
     index, shape = index_shape
@@ -68,6 +69,7 @@ def test_python_indexing(index_shape: Literal[0] | Literal[2] | Literal[-1]):
         ),
     ],
 )
+@pytest.mark.push
 def test_python_indexing_with_lists(index_shape: list[int] | list[list[int]]):
     indices, shape = index_shape
 
@@ -111,6 +113,7 @@ def test_python_indexing_with_lists(index_shape: list[int] | list[list[int]]):
         ),
     ],
 )
+@pytest.mark.push
 def test_python_indexing_with_tensors(index_shape):
     indices, shape = index_shape
 

--- a/forge/test/mlir/operators/indexing/test_basic_masking.py
+++ b/forge/test/mlir/operators/indexing/test_basic_masking.py
@@ -26,6 +26,7 @@ from forge.verify.verify import verify
         ),
     ],
 )
+@pytest.mark.push
 def test_masking_greater_than(input_tensor, param):
     class GreaterThanMaskingModule(torch.nn.Module):
         def __init__(self, param):
@@ -65,6 +66,7 @@ def test_masking_greater_than(input_tensor, param):
         ),
     ],
 )
+@pytest.mark.push
 def test_masking_modulus(input_tensor, mod_value):
     class ModulusMaskingModule(torch.nn.Module):
         def __init__(self, mod_value):
@@ -103,6 +105,7 @@ def test_masking_modulus(input_tensor, mod_value):
         ),
     ],
 )
+@pytest.mark.push
 def test_masking_combined_conditions(input_tensor, greater_param, mod_param):
     class CombinedMaskingModule(torch.nn.Module):
         def __init__(self, greater_param, mod_param):

--- a/forge/test/mlir/operators/indexing/test_basic_slicing.py
+++ b/forge/test/mlir/operators/indexing/test_basic_slicing.py
@@ -27,6 +27,7 @@ from forge.verify.verify import verify
     + "loc(\"index_1.dc.unsqueeze.0\"(\"forward\":4294967295:29)): error: 'ttir.unsqueeze' op requires attribute 'dim'"
     + 'loc("SlicingModule":0:0): error: module verification failed'
 )
+@pytest.mark.push
 def test_slicing(input_tensor_slice):
     input_tensor, slicing = input_tensor_slice
 
@@ -92,6 +93,7 @@ def test_slicing(input_tensor_slice):
         ),
     ],
 )
+@pytest.mark.push
 def test_multidimensional_slicing(input_tensor_slicing):
     input_tensor, slicing = input_tensor_slicing
 

--- a/forge/test/mlir/operators/indexing/test_indexing_ops.py
+++ b/forge/test/mlir/operators/indexing/test_indexing_ops.py
@@ -49,6 +49,7 @@ from forge.verify.verify import verify
         ),
     ],
 )
+@pytest.mark.push
 @pytest.mark.xfail(reason="NotImplementedError: The following operators are not implemented: ['aten::diagonal']")
 def test_diagonal(input_tensor, offset, dim1, dim2):
     class DiagonalModule(nn.Module):
@@ -101,6 +102,7 @@ def test_diagonal(input_tensor, offset, dim1, dim2):
         ),
     ],
 )
+@pytest.mark.push
 @pytest.mark.xfail(reason="NotImplementedError: The following operators are not implemented: ['aten::diag']")
 def test_diag(input_tensor, diagonal):
     class DiagModule(nn.Module):
@@ -159,6 +161,7 @@ def test_diag(input_tensor, diagonal):
         ),
     ],
 )
+@pytest.mark.push
 @pytest.mark.xfail(reason="NotImplementedError: The following operators are not implemented: ['aten::diag_embed']")
 def test_diag_embed(input_tensor, offset, dim1, dim2):
     class DiagEmbedModule(nn.Module):
@@ -209,6 +212,7 @@ def test_diag_embed(input_tensor, offset, dim1, dim2):
         ),
     ],
 )
+@pytest.mark.push
 @pytest.mark.xfail(reason="AssertionError: Data mismatch on output 0 between framework and Forge codegen")
 def test_triu(input_tensor, diagonal):
     class TriuModule(nn.Module):
@@ -259,6 +263,7 @@ def test_triu(input_tensor, diagonal):
         ),
     ],
 )
+@pytest.mark.push
 def test_tril(input_tensor, diagonal):
     class TrilModule(nn.Module):
         def __init__(self, diagonal):
@@ -314,6 +319,7 @@ def test_tril(input_tensor, diagonal):
     ],
 )
 @pytest.mark.xfail(reason="NotImplementedError: The following operators are not implemented: ['aten::take_along_dim']")
+@pytest.mark.push
 def test_take_along_dim(input_tensor, indices, dim):
     class TakeAlongDimModule(nn.Module):
         def __init__(self, dim):
@@ -380,6 +386,7 @@ def test_take_along_dim(input_tensor, indices, dim):
         ),
     ],
 )
+@pytest.mark.push
 def test_gather(input_tensor, index, dim, sparse_grad):
     class GatherModule(nn.Module):
         def __init__(self, dim, sparse_grad, index):
@@ -430,6 +437,7 @@ def test_gather(input_tensor, index, dim, sparse_grad):
     ],
 )
 @pytest.mark.xfail(reason="Not supported in our version of pytorch")
+@pytest.mark.push
 def test_unravel_index(indices, shape):
     class UnravelIndexModule(nn.Module):
         def __init__(self, shape):
@@ -477,6 +485,7 @@ def test_unravel_index(indices, shape):
     ],
 )
 @pytest.mark.xfail(reason="NotImplementedError: The following operators are not implemented: ['aten::put']")
+@pytest.mark.push
 def test_put(input_tensor, indices, values):
     class PutModule(nn.Module):
         def __init__(self, indices, values):
@@ -540,6 +549,7 @@ def test_put(input_tensor, indices, values):
         ),
     ],
 )
+@pytest.mark.push
 def test_unique(input_tensor, sorted, return_inverse, return_counts, dim):
     class UniqueModule(nn.Module):
         def __init__(self, sorted, return_inverse, return_counts, dim):
@@ -602,6 +612,7 @@ def test_unique(input_tensor, sorted, return_inverse, return_counts, dim):
 @pytest.mark.xfail(
     reason="NotImplementedError: The following operators are not implemented: ['aten::unique_consecutive']"
 )
+@pytest.mark.push
 def test_unique_consecutive(input_tensor, return_inverse, return_counts, dim):
     class UniqueConsecutiveModule(nn.Module):
         def __init__(self, return_inverse, return_counts, dim):
@@ -644,6 +655,7 @@ def test_unique_consecutive(input_tensor, return_inverse, return_counts, dim):
     ],
 )
 @pytest.mark.xfail(reason="BinaryOpType cannot be mapped to BcastOpMath")
+@pytest.mark.push
 def test_where(input_tensor1, input_tensor2):
     class WhereModule(nn.Module):
         def __init__(self, input2):
@@ -679,6 +691,7 @@ def test_where(input_tensor1, input_tensor2):
     ],
 )
 @pytest.mark.xfail(reason="NotImplementedError: The following operators are not implemented: ['aten::argwhere']")
+@pytest.mark.push
 def test_argwhere(input_tensor):
     class ArgwhereModule(nn.Module):
         def forward(self, x):

--- a/forge/test/mlir/operators/indexing/test_scatter_ops.py
+++ b/forge/test/mlir/operators/indexing/test_scatter_ops.py
@@ -34,6 +34,7 @@ from forge.verify.verify import verify
     ],
 )
 @pytest.mark.xfail(reason="NotImplementedError: The following operators are not implemented: ['aten::masked_scatter']")
+@pytest.mark.push
 def test_masked_scatter(input_tensor, mask, source):
     class MaskedScatterModule(torch.nn.Module):
         def __init__(self, mask, source):
@@ -105,6 +106,7 @@ def test_masked_scatter(input_tensor, mask, source):
     ],
 )
 @pytest.mark.xfail(reason="AssertionError: Encountered unsupported op types. Check error logs for more details.")
+@pytest.mark.push
 def test_scatter(input_tensor, dim, index, source):
     class ScatterModule(torch.nn.Module):
         def __init__(self, dim, index, source):
@@ -196,6 +198,7 @@ def test_scatter(input_tensor, dim, index, source):
     ],
 )
 @pytest.mark.xfail(reason="Encountered unsupported op node type: scatter_elements, on device: tt")
+@pytest.mark.push
 def test_scatter_reduce(input_tensor, dim, index, source, reduce_mode):
     class ScatterReduceModule(torch.nn.Module):
         def __init__(self, dim, index, source, reduce_mode):
@@ -262,6 +265,7 @@ def test_scatter_reduce(input_tensor, dim, index, source, reduce_mode):
     ],
 )
 @pytest.mark.xfail(reason="Encountered unsupported op node type: scatter_elements, on device: tt")
+@pytest.mark.push
 def test_scatter_add(input_tensor, dim, index, source):
     class ScatterAddModule(torch.nn.Module):
         def __init__(self, dim, index, source):
@@ -316,6 +320,7 @@ def test_scatter_add(input_tensor, dim, index, source):
 @pytest.mark.xfail(
     reason="NotImplementedError: The following operators are not implemented: ['aten::diagonal_scatter']"
 )
+@pytest.mark.push
 def test_diagonal_scatter(input_tensor, source, offset, dim1, dim2):
     class DiagonalScatterModule(torch.nn.Module):
         def __init__(self, source, offset, dim1, dim2):
@@ -359,6 +364,7 @@ def test_diagonal_scatter(input_tensor, source, offset, dim1, dim2):
     ],
 )
 @pytest.mark.xfail(reason="NotImplementedError: The following operators are not implemented: ['aten::select_scatter']")
+@pytest.mark.push
 def test_select_scatter(input_tensor, source, dim, index):
     class SelectScatterModule(torch.nn.Module):
         def __init__(self, source, dim, index):
@@ -412,6 +418,7 @@ def test_select_scatter(input_tensor, source, dim, index):
     ],
 )
 @pytest.mark.xfail(reason="NotImplementedError: The following operators are not implemented: ['aten::slice_scatter']")
+@pytest.mark.push
 def test_slice_scatter(input_tensor, src, dim, start, end, step):
     class SliceScatterModule(torch.nn.Module):
         def __init__(self, source, dim, start, end, step):


### PR DESCRIPTION
### What's changed
Just added push mark to the indexing tests in `tests/mlir/operators/indexing` folder.
