### PR TITLE
fix llvm config in tvm installation

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -33,7 +33,9 @@ RUN apt-get update && apt-get install -y \
     jq \
     curl \
     gh \
-    expect
+    expect \
+    libpolly-17-dev \
+    libzstd-dev
 
 # Install clang 17
 RUN wget https://apt.llvm.org/llvm.sh && \


### PR DESCRIPTION
### Ticket
Link to Github Issue (n/a)

### Problem description
1. Each tvm installation downloads llvm 13.0.0 and extracts the package, but only uses the `llvm-config` binary;
2. The downloaded version is old (released Sept. 2021), and was only for ubuntu 20.04, while forge by default works on ubuntu 22.04.

### What's changed
Our forge docker image includes llvm-config-17. We only need to pick up [a fix in apache-tvm](https://github.com/apache/tvm/commit/3b8d1a831dca3c9165168365e7e77c4e7f6746c9), and to add the necessary packages in our docker image.

I've also added the option to specify a custom llvm-config in case we want to use another version, but so far I haven't run into any issue with llvm-config-17.

### Possible issues
- Need to update tt-tvm commit hash once my branch is merged;
- Is it ok that we are not on the HEAD of main of tt-tvm?

### Checklist
- [ ] New/Existing tests provide coverage for changes
