### PR TITLE
[ci] remove build step from dockerfile

### DIFF
--- a/.github/Dockerfile.ci
+++ b/.github/Dockerfile.ci
@@ -32,11 +32,6 @@ RUN source env/activate && \
     cmake -B env/build env && \
     cmake --build env/build
 
-# Build project to test the container
-RUN source env/activate && \
-    cmake -G Ninja -B build . && \
-    cmake --build build
-
 FROM ghcr.io/tenstorrent/tt-forge-fe/tt-forge-fe-base-ubuntu-22-04:${FROM_TAG} AS ci
 
 # Copy the TTMLIR_TOOLCHAIN_DIR from the previous stage


### PR DESCRIPTION
There is some flakiness when building the docker image on the runners. The job by itself needs around two hours to complete and it happens occasionally that it somehow crashes the CI runner.

Removing the `tt-forge-fe` build step from the docker image. This is not needed, since the docker image is afterwards used in CI, which will verify that the build works properly.