### PR TITLE
Adapt to removal of global compiler config in sweep tests

### DIFF
--- a/forge/test/operators/utils/compat.py
+++ b/forge/test/operators/utils/compat.py
@@ -13,6 +13,7 @@ from typing import Optional, List, Union
 from forge import ForgeModule, Module, DepricatedVerifyConfig
 from forge.tensor import to_pt_tensors
 from forge.op_repo import TensorShape
+from forge.config import CompilerConfig
 from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.config import VerifyConfig
@@ -303,6 +304,7 @@ def create_torch_inputs(
 def verify_module_for_inputs_deprecated(
     model: Module,
     inputs: List[torch.Tensor],
+    compiler_cfg: CompilerConfig,
     pcc: Optional[float] = None,
     dev_data_format: forge.DataFormat = None,
     convert_to_forge: bool = True,  # explicit conversion to forge data format
@@ -315,7 +317,7 @@ def verify_module_for_inputs_deprecated(
     else:
         forge_inputs = inputs
 
-    compiled_model = forge.compile(model, sample_inputs=forge_inputs)
+    compiled_model = forge.compile(model, sample_inputs=forge_inputs, compiler_cfg=compiler_cfg)
     co_out = compiled_model(*forge_inputs)
 
     # TODO check output data format type
@@ -338,6 +340,7 @@ def verify_module_for_inputs_deprecated(
 def verify_module_for_inputs(
     model: Module,
     inputs: List[torch.Tensor],
+    compiler_cfg: CompilerConfig,
     verify_config: Optional[VerifyConfig] = VerifyConfig(),
     dev_data_format: forge.DataFormat = None,
     convert_to_forge: bool = True,  # explicit conversion to forge data format
@@ -348,7 +351,7 @@ def verify_module_for_inputs(
     else:
         forge_inputs = inputs
 
-    compiled_model = forge.compile(model, sample_inputs=forge_inputs)
+    compiled_model = forge.compile(model, sample_inputs=forge_inputs, compiler_cfg=compiler_cfg)
     verify(inputs, model, compiled_model, verify_config)
 
 

--- a/forge/test/operators/utils/utils.py
+++ b/forge/test/operators/utils/utils.py
@@ -22,6 +22,7 @@ from forge.op_repo import TensorShape
 from forge.verify import TestKind  # , verify_module
 from forge._C import MathFidelity
 
+from forge.config import CompilerConfig
 from forge.verify.config import VerifyConfig
 
 from .compat import TestDevice
@@ -93,16 +94,21 @@ class CompilerUtils:
     """Utility functions for Forge compiler configuration"""
 
     @staticmethod
-    def set_input_source(input_source_flag: InputSourceFlag):
+    def set_input_source(input_source_flag: InputSourceFlag, compiler_cfg: CompilerConfig):
         """Set compiler configuration for input source"""
+        # Not existing in the compiler, after global config removal
+        # compiler_cfg.input_queues_on_host = input_source_flag.input_queues_on_host
+        # if input_source_flag.set_default_dram_parameters:
+        #     compiler_cfg.default_dram_parameters = input_source_flag.default_dram_parameters
+
         # NOP since we don't use this flag in the compiler, currently.
         pass
 
     @staticmethod
-    def set_math_fidelity(math_fidelity: MathFidelity):
+    def set_math_fidelity(math_fidelity: MathFidelity, compiler_cfg: CompilerConfig):
         """Set compiler configuration for math fidelity"""
-        # NOP since we don't use this flag in the compiler, currently.
-        pass
+        # Currently not respected/supported in the compiler
+        compiler_cfg.default_math_fidelity = math_fidelity
 
 
 class DeviceUtils:
@@ -155,7 +161,10 @@ class VerifyUtils:
             skip_forge_verification: Skip verification with Forge module
         """
 
+        compiler_cfg = CompilerConfig()
+
         cls.setup(
+            compiler_cfg=compiler_cfg,
             input_source_flag=input_source_flag,
             math_fidelity=math_fidelity,
             warm_reset=warm_reset,
@@ -172,6 +181,7 @@ class VerifyUtils:
             cls.verify_module_for_inputs_deprecated(
                 model=model,
                 inputs=inputs,
+                compiler_cfg=compiler_cfg,
                 pcc=pcc,
                 dev_data_format=dev_data_format,
                 convert_to_forge=convert_to_forge,
@@ -186,6 +196,7 @@ class VerifyUtils:
             cls.verify_module_for_inputs(
                 model=model,
                 inputs=inputs,
+                compiler_cfg=compiler_cfg,
                 verify_config=verify_config,
                 dev_data_format=dev_data_format,
                 convert_to_forge=convert_to_forge,
@@ -194,6 +205,7 @@ class VerifyUtils:
     @classmethod
     def setup(
         cls,
+        compiler_cfg: CompilerConfig,
         input_source_flag: InputSourceFlags = None,
         math_fidelity: forge.MathFidelity = None,
         warm_reset: bool = False,
@@ -202,10 +214,10 @@ class VerifyUtils:
             DeviceUtils.warm_reset()
 
         if input_source_flag:
-            CompilerUtils.set_input_source(input_source_flag.value)
+            CompilerUtils.set_input_source(input_source_flag.value, compiler_cfg)
 
         if math_fidelity:
-            CompilerUtils.set_math_fidelity(math_fidelity)
+            CompilerUtils.set_math_fidelity(math_fidelity, compiler_cfg)
 
         # if dev_data_format:
         #     input_params.append({"dev_data_format": dev_data_format})
@@ -233,6 +245,7 @@ class VerifyUtils:
         cls,
         model: Module,
         inputs: List[torch.Tensor],
+        compiler_cfg: CompilerConfig,
         pcc: Optional[float] = None,
         dev_data_format: forge.DataFormat = None,
         convert_to_forge: bool = True,  # explicit conversion to forge data format
@@ -241,6 +254,7 @@ class VerifyUtils:
         verify_module_for_inputs_deprecated(
             model=model,
             inputs=inputs,
+            compiler_cfg=compiler_cfg,
             pcc=pcc,
             dev_data_format=dev_data_format,
             convert_to_forge=convert_to_forge,
@@ -251,6 +265,7 @@ class VerifyUtils:
         cls,
         model: Module,
         inputs: List[torch.Tensor],
+        compiler_cfg: CompilerConfig,
         verify_config: Optional[VerifyConfig] = VerifyConfig(),
         dev_data_format: forge.DataFormat = None,
         convert_to_forge: bool = True,  # explicit conversion to forge data format
@@ -259,6 +274,7 @@ class VerifyUtils:
         verify_module_for_inputs(
             model=model,
             inputs=inputs,
+            compiler_cfg=compiler_cfg,
             verify_config=verify_config,
             dev_data_format=dev_data_format,
             convert_to_forge=convert_to_forge,


### PR DESCRIPTION
### Ticket

Fix for #147 

### Problem description
Global compiler configuration completely removed in #1174.
Parameters input_queues_on_host and default_dram_parameters removed.
Parameter default_math_fidelity still exists, though still not respected.

### What's changed
Maintain (instantiate and pass) CompilerConfig through sweep test verification.

### Checklist
- [ ] New/Existing tests provide coverage for changes
