### PR TITLE
Fix parsing math fidelity

### DIFF
--- a/forge/test/operators/utils/plan.py
+++ b/forge/test/operators/utils/plan.py
@@ -691,6 +691,8 @@ class TestPlanUtils:
         # As last parameter in test id is math fidelity, in case of duplicated tests numeric suffix should be ignored
         if math_fidelity_part is not None and math_fidelity_part.startswith("HiFi4"):
             math_fidelity_part = "HiFi4"
+        if math_fidelity_part is not None and math_fidelity_part.startswith("None"):
+            math_fidelity_part = None
         math_fidelity = eval(f"forge._C.{math_fidelity_part}") if math_fidelity_part is not None else None
 
         return TestVector(


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Error while parsing math fidelity None when tests are duplicated

### What's changed
None1 and None2 are treated as None for math fidelity

### Checklist
- [ ] New/Existing tests provide coverage for changes
