### PR TITLE
Fix collecting operator index in test suite

### DIFF
--- a/forge/test/operators/pytorch/test_all.py
+++ b/forge/test/operators/pytorch/test_all.py
@@ -204,7 +204,7 @@ class TestParamsData:
             test_plans = [
                 test_plan
                 for test_plan in test_suite.test_plans
-                if len(list(set(test_plan.collections[0].operators) & set(operators))) > 0
+                if len(list(set(test_plan.operators) & set(operators))) > 0
             ]
             return TestSuite(test_plans)
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Querying by operator not working when operator is not used in first collection of test plan.

### What's changed
Collecting operator names from all collections of a test plan.

### Checklist
- [ ] New/Existing tests provide coverage for changes
