### PR TITLE
Add repeat op support from Forge to TTIR Lowering

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -56,6 +56,7 @@ enum class TargetType
     SourceType,
     UInt32,
     Int64,
+    DenseI64ArrayAttr,
 };
 
 struct AttributeRemap
@@ -106,6 +107,7 @@ class AttributeMapper
         add_op_mapping("repeat_interleave", "repeats", AttributeRemap(std::nullopt, TargetType::UInt32));
         add_op_mapping("reduce_avg", "dim", AttributeRemap("dim_arg"));
         add_op_mapping("cumsum", "dim", AttributeRemap(std::nullopt, TargetType::Int64));
+        add_op_mapping("repeat", "repeats", AttributeRemap("repeat_dimensions", TargetType::DenseI64ArrayAttr));
 
         // Add more default mappings here
     }
@@ -237,6 +239,10 @@ class MLIRGenerator
                     TT_ASSERT(std::get<int>(value) >= 0, "Value must be an >= 0 for conversion to uint32");
                     return builder_.getUI32IntegerAttr(static_cast<uint32_t>(std::get<int>(value)));
                 case TargetType::Int64: return builder_.getI64IntegerAttr(static_cast<int64_t>(std::get<int>(value)));
+
+                case TargetType::DenseI64ArrayAttr:
+                    return builder_.getDenseI64ArrayAttr(std::vector<int64_t>(
+                        std::get<std::vector<int>>(value).begin(), std::get<std::vector<int>>(value).end()));
                 default:
                     // If type not handled, throw an exception
                     throw std::runtime_error("Unhandled target type conversion");
@@ -636,6 +642,7 @@ class MLIRGenerator
         lowering_handler_map["remainder"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::RemainderOp>;
         lowering_handler_map["repeat_interleave"] =
             &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::RepeatInterleaveOp>;
+        lowering_handler_map["repeat"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::RepeatOp>;
         lowering_handler_map["reshape"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ReshapeOp>;
         lowering_handler_map["select"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::SelectOp>;
         lowering_handler_map["sigmoid"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::SigmoidOp>;

--- a/forge/forge/op/tm.py
+++ b/forge/forge/op/tm.py
@@ -367,7 +367,6 @@ def Repeat(name: str, operandA: Tensor, repeats: List[int]) -> Tensor:
     Tensor
         Forge tensor
     """
-    assert len(operandA.shape) == len(repeats)
     return op("repeat", name, operandA, attrs=repeats, repeats=repeats).get_tensor()
 
 

--- a/forge/test/mlir/operators/tm/test_tm.py
+++ b/forge/test/mlir/operators/tm/test_tm.py
@@ -562,11 +562,28 @@ def test_stack(input_shapes, dim):
     fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
 
 
-@pytest.mark.xfail(
-    reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph - repeat"
+@pytest.mark.parametrize(
+    ["input_shape", "repeats"],
+    [
+        pytest.param((1, 2), (10, 1)),
+        pytest.param((1, 99), (100, 1)),
+        pytest.param(
+            (1, 100),
+            (50, 2),
+            marks=pytest.mark.xfail(reason="info:Incompatible dimensions 200 and 100"),
+        ),
+        pytest.param(
+            (3,),
+            (4, 2),
+            marks=pytest.mark.xfail(reason="info:Incompatible dimensions 6 and 3"),
+        ),
+        pytest.param((4, 1, 4), (1, 10, 1)),
+        pytest.param((2, 2, 1, 2), (1, 1, 4, 1)),
+        pytest.param((1, 4, 1, 4, 4), (1, 1, 3, 1, 1)),
+    ],
 )
 @pytest.mark.push
-def test_repeat():
+def test_repeat(input_shape, repeats):
     class Repeat(nn.Module):
         def __init__(self, repeats):
             super().__init__()
@@ -575,9 +592,9 @@ def test_repeat():
         def forward(self, x):
             return x.repeat(*self.repeats)
 
-    inputs = [torch.rand(1, 2, 1, 4, 4)]
+    inputs = [torch.rand(input_shape)]
 
-    framework_model = Repeat(repeats=(1, 1, 4, 1, 1))
+    framework_model = Repeat(repeats=repeats)
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
     verify(inputs, framework_model, compiled_model)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge-fe/issues/1215

### Problem description
Add repeat op support from Forge to TTIR Lowering

### What's changed
- Added repeat op support from Forge to TTIR Lowering
- Added support for `DenseI64ArrayAttr` TargetType mapping in Repeat op
