### PR TITLE
Add support for Meshgrid3D and binary_stack ops

### DIFF
--- a/forge/forge/op/__init__.py
+++ b/forge/forge/op/__init__.py
@@ -14,7 +14,6 @@ from .eltwise_binary import (
     Max,
     Min,
     Heaviside,
-    BinaryStack,
     Power,
     Greater,
     GreaterEqual,

--- a/forge/forge/op/eltwise_binary.py
+++ b/forge/forge/op/eltwise_binary.py
@@ -186,34 +186,6 @@ def Heaviside(name: str, operandA: Tensor, operandB: Union[Tensor, Parameter]) -
     return _Eltwise(name, operandA, operandB, "heaviside")
 
 
-def BinaryStack(name: str, operandA: Tensor, operandB: Union[Tensor, Parameter], dim: int) -> Tensor:
-    """
-    Elementwise max of two tensors
-
-    Parameters
-    ----------
-    name: str
-        Op name, unique to the module, or leave blank to autoset
-
-    operandA: Tensor
-        First operand
-
-    operandB: Tensor
-        Second operand
-
-    dim: int
-        Dimention on which to stack
-
-    Returns
-    -------
-    Tensor
-        Forge tensor
-
-    """
-
-    return op("binary_stack", name, operandA, operandB, attrs=(dim,)).get_tensor()
-
-
 def Power(name: str, operandA: Tensor, operandB: Union[Tensor, Parameter]) -> Tensor:
     """
     OperandA to the power of OperandB

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -34,7 +34,6 @@ op_to_module_map = {
     "maximum": "eltwise_binary",
     "minimum": "eltwise_binary",
     "heaviside": "eltwise_binary",
-    "binary_stack": "eltwise_binary",
     "power": "eltwise_binary",
     "greater": "eltwise_binary",
     "greater_equal": "eltwise_binary",

--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -1346,14 +1346,15 @@ def decompose(type, attr, dc, inputs):
 
             curr_sub_sub_slice = sub_sub_slices[0]
             for sub_sub_slice in sub_sub_slices[1:]:
-                curr_sub_sub_slice = dc.op("binary_stack", [curr_sub_sub_slice, sub_sub_slice], (-1,))
-
+                curr_sub_slice = dc.op_with_named_attrs(
+                    "concatenate", [curr_sub_sub_slice, sub_sub_slice], {"dim": -1}, (-1,)
+                )
             sub_slices.append(curr_sub_sub_slice)
 
         curr_sub_slice = dc.op(TransposeTM.create(-2, -1), [sub_slices[0]])
         for sub_slice in sub_slices[1:]:
             sub_slice = dc.op(TransposeTM.create(-2, -1), [sub_slice])
-            curr_sub_slice = dc.op("binary_stack", [curr_sub_slice, sub_slice], (-1,))
+            curr_sub_slice = dc.op_with_named_attrs("concatenate", [curr_sub_slice, sub_slice], {"dim": -1}, (-1,))
 
         result = dc.op(TransposeTM.create(-2, -1), [curr_sub_slice])
         dc.fuse(result)

--- a/forge/forge/op_repo/forge_operators.py
+++ b/forge/forge/op_repo/forge_operators.py
@@ -63,7 +63,6 @@ _OPERATORS = [
     OperatorDefinition("maximum", "forge.op.Max", 2),
     OperatorDefinition("minimum", "forge.op.Min", 2),
     OperatorDefinition("heaviside", "forge.op.Heaviside", 2),
-    OperatorDefinition("binary_stack", "forge.op.BinaryStack", 2),
     OperatorDefinition("power", "forge.op.Power", 2),
     OperatorDefinition("greater", "forge.op.Greater", 2),
     OperatorDefinition("greater_equal", "forge.op.GreaterEqual", 2),

--- a/forge/forge/tvm.py
+++ b/forge/forge/tvm.py
@@ -31,17 +31,6 @@ import sys
 import json
 
 
-def populate_binary_stack_attrs(graph, nid, attrs):
-    node = graph["nodes"][nid]
-    input_shape = graph["nodes"][node["inputs"][0][0]]["forge_shape"]
-    node_shape = node["forge_shape"]
-
-    for dim, (i, o) in enumerate(zip(input_shape, node_shape)):
-        if i != o:
-            attrs.append(dim - len(input_shape))
-            break
-
-
 def populate_conv2d_attrs(graph, nid, attrs):
     node = graph["nodes"][nid]
     strides = [int(stride) for stride in node["attrs"]["strides"][0]]
@@ -498,7 +487,6 @@ tvm_to_forge_op_map = {
     "add": "add",
     "argmax": "argmax",
     "broadcast_to": "broadcast",
-    "forge.binary_stack": "binary_stack",
     "forge.forge_conv2d_with_bias": "conv2d",
     "forge.concatenate": "concatenate",
     "forge.hslice": "hslice",
@@ -548,7 +536,6 @@ compound_forge_ops = [
 ops_needing_attributes = {
     "argmax": populate_argmax_attrs,
     "avg_pool2d": populate_avgpool2d_attrs,
-    "binary_stack": populate_binary_stack_attrs,
     "broadcast": populate_broadcast_attrs,
     "clip": populate_clip_transpose_attrs,
     "concatenate": populate_concatenate_attrs,

--- a/forge/forge/tvm_calls/relay/op/utils.py
+++ b/forge/forge/tvm_calls/relay/op/utils.py
@@ -129,46 +129,6 @@ def is_transpose_reshape_reshape_hstack(call):
     return _is_transpose_reshape_hstack_helper(t_axes, r_newshape, r_input_shape)
 
 
-def is_stack_reshape_reshape_to_binary_stack(call):
-    dim = len(call.checked_type.shape)
-    stack_axis = call.args[0].attrs.axis.value
-    if stack_axis < 0:
-        stack_axis = stack_axis + dim
-
-    input_shape = [int(dim) for dim in call.args[0].args[0][0].checked_type.shape]
-    output_shape = [int(dim) for dim in call.checked_type.shape]
-
-    # if input_shape == output_shape:
-    #     return False
-
-    works = all(
-        [
-            (dim != stack_axis and i == o) or (dim == stack_axis and o == 2 * i)
-            for dim, (i, o) in enumerate(zip(input_shape, output_shape))
-        ]
-    )
-    return works
-
-
-def is_concat_reshape_reshape_to_binary_stack(call):
-    dim = len(call.checked_type.shape)
-    concat_axis = call.args[0].attrs.axis - 1  # decrement by 1 because inputs are unsqueezed first
-    if concat_axis < 0:
-        concat_axis = concat_axis + dim
-
-    for operand in call.args[0].args[0]:
-        if operand.op.name != "reshape":
-            return False
-
-    input_shape = [int(dim) for dim in call.args[0].args[0][0].args[0].checked_type.shape]
-    output_shape = [int(dim) for dim in call.checked_type.shape]
-
-    works = all(
-        [i == o or (dim == concat_axis and o == 2 * i) for dim, (i, o) in enumerate(zip(input_shape, output_shape))]
-    )
-    return works
-
-
 def match_einsum_pattern(pattern, query):
     query = query.replace(" ", "")
     pattern = pattern.replace(" ", "")

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -543,22 +543,6 @@ pytorch_ops_needing_arguments = {
 }
 
 
-def populate_binary_stack_args(graph, nid, compiler_cfg):
-    args = []
-    node = graph["nodes"][nid]
-    input_shape = graph["nodes"][node["inputs"][0][0]]["forge_shape"]
-    node_shape = node["forge_shape"]
-
-    for dim, (i, o) in enumerate(zip(input_shape, node_shape)):
-        if i != o:
-            args = [
-                ("dim", f"{dim - len(input_shape)}"),
-            ]
-            return args
-
-    return args
-
-
 def populate_conv2d_args(graph, nid, compiler_cfg):
     args = []
     node = graph["nodes"][nid]
@@ -1727,7 +1711,6 @@ tvm_to_forge_op_map = {
     "power": "power",
     "nn.prelu": "prelu",
     "forge.adv_index": "adv_index",
-    "forge.binary_stack": "binary_stack",
     "forge.forge_conv2d_transpose_with_bias": "conv2d_transpose",
     "forge.forge_conv2d_with_bias": "conv2d",
     "forge.concatenate": "concatenate",
@@ -1774,7 +1757,6 @@ forge_op_to_function_name = {
     "avg_pool1d": "forge.op.AvgPool1d",
     "avg_pool2d": "forge.op.AvgPool2d",
     "avg_pool3d": "forge.op.AvgPool3d",
-    "binary_stack": "forge.op.BinaryStack",
     "broadcast": "forge.op.Broadcast",
     "cast": "forge.op.Cast",  # Datatype cast
     "clip": "forge.op.Clip",
@@ -1855,7 +1837,6 @@ forge_ops_needing_arguments = {
     "avg_pool1d": populate_avgpool1d_args,
     "avg_pool2d": populate_avgpool2d_args,
     "avg_pool3d": populate_avgpool3d_args,
-    "binary_stack": populate_binary_stack_args,
     "broadcast": populate_broadcast_args,
     "cast": populate_cast_args,
     "clip": populate_clip_transpose_args,


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-forge-fe/issues/1219
- https://github.com/tenstorrent/tt-forge-fe/issues/1218


### Problem description

- Due to the Reason mentioned [here](https://github.com/tenstorrent/tt-forge-fe/issues/1218#issuecomment-2656626885), pcc drop observed in binary_stack operation at Framework vs. Forge codegen verification and PETR(https://github.com/tenstorrent/tt-forge-fe/issues/955) requires [Meshgrid3D](https://github.com/megvii-research/PETR/blob/f7525f93467a33707ef401c587a52d5e7b34de74/projects/mmdet3d_plugin/models/dense_heads/petr_head.py#L300C30-L300C44).


### What's changed

**Binary stack** 

-  Binary stack removed from Forge.

**Meshgrid**

- Added decomposition for it using explicit broadcasting

**Logs:**

- [meshgrid_test_cases.log](https://github.com/user-attachments/files/19011238/feb27_mesh_rc.log)
- [binary_stack_test_cases.log](https://github.com/user-attachments/files/19011237/feb27_bs_fixed_final_issue.log)

**Note:** 

- Initially pixel shuffle decomposition depends on binary_stack. As we are removing binary_stack from forge, I replaced binary stack using concatenate in `forge/forge/op/eval/forge/tm.py`. and above replacement validated by below experiment

- below test case gives same result before & after our change

- [pixel_shuffle_before_binary_stack_removal.log](https://github.com/user-attachments/files/19050153/mar3_ps_bs_fix.log)
- [pixel_shuffle_after_binary_stack_removal.log](https://github.com/user-attachments/files/19050152/mar3_ps_after_bs_fix.log)



```
@pytest.mark.push
@pytest.mark.parametrize("input_shape, scale_factor", [
    ((1, 256, 4, 128), 2),
    ((3, 32, 10, 10), 4),
    ((2, 98, 6, 6), 7),
])
def test_pixel_shuffle(input_shape, scale_factor):
    class PixelShuffleModel(nn.Module):
        def __init__(self, scale_factor):
            super().__init__()
            self.model = nn.PixelShuffle(scale_factor)

        def forward(self, x):
            return self.model(x)

    inputs = [torch.randn(*input_shape)]
    framework_model = PixelShuffleModel(scale_factor)
    framework_model.eval()
    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
    verify(inputs, framework_model, compiled_model)
```



