### PR TITLE
Fixed decompositions which uses unsqueeze (passed dim attribute)

### DIFF
--- a/forge/forge/op/eval/forge/convolution.py
+++ b/forge/forge/op/eval/forge/convolution.py
@@ -135,7 +135,7 @@ class Conv2d(PyOp):
 
         if bias is not None and len(bias.shape) < len(activations.shape):
             while len(bias.shape) < len(activations.shape):
-                bias = dc.op("unsqueeze", [bias], (0, len(bias.shape)))
+                bias = dc.op_with_named_attrs("unsqueeze", [bias], {"dim": 0}, (0, len(bias.shape)))
 
         is_bias_unchanged = bias is None or bias == inputs[2]
 
@@ -309,7 +309,7 @@ class Conv2dTranspose(PyOp):
 
         if bias is not None and len(bias.shape) < len(activations.shape):
             while len(bias.shape) < len(activations.shape):
-                bias = dc.op("unsqueeze", [bias], (0, len(bias.shape)))
+                bias = dc.op_with_named_attrs("unsqueeze", [bias], {"dim": 0}, (0, len(bias.shape)))
 
         is_bias_unchanged = bias is None or bias == inputs[2]
 

--- a/forge/forge/op/eval/forge/quantize.py
+++ b/forge/forge/op/eval/forge/quantize.py
@@ -274,12 +274,20 @@ def decompose(type, attr, dc, inputs):
         if len(scale_shape) == 1:
             # Match ndim with actiavtion
             for i in range(0, left_ndim):
-                scale = dc.op("unsqueeze", [scale], attrs=(0, len(scale_shape)), output_df=scale.output_df)
+                scale = dc.op_with_named_attrs(
+                    "unsqueeze", [scale], {"dim": 0}, attrs=(0, len(scale_shape)), output_df=scale.output_df
+                )
+
                 scale_shape = [1] + scale_shape
             for i in range(0, right_ndim):
-                scale = dc.op(
-                    "unsqueeze", [scale], attrs=(len(scale_shape), len(scale_shape)), output_df=scale.output_df
+                scale = dc.op_with_named_attrs(
+                    "unsqueeze",
+                    [scale],
+                    {"dim": len(scale_shape)},
+                    attrs=(len(scale_shape), len(scale_shape)),
+                    output_df=scale.output_df,
                 )
+
                 scale_shape = scale_shape + [1]
 
         out = dc.op(

--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -1032,7 +1032,7 @@ def decompose(type, attr, dc, inputs):
         if is_one_dim:
             # If input is a one-dimensional tensor, reshape it to a 2D tensor with one dimension equal to 1
             # and the other equal to the length. Use unsqueeze to add a dimension to the tensor.
-            act = dc.op("unsqueeze", [act], (0, len(act.shape)))
+            act = dc.op_with_named_attrs("unsqueeze", [act], {"dim": 0}, (0, len(act.shape)))
 
         row_indices = list(range(start, stop, stride))
 

--- a/forge/test/mlir/operators/indexing/test_advanced_slicing.py
+++ b/forge/test/mlir/operators/indexing/test_advanced_slicing.py
@@ -48,11 +48,6 @@ def test_select(input_dim_index):
     [
         pytest.param(
             (torch.arange(10.0), [3, 3, 4], 0),  # 1D tensor  # Sizes to split  # Dimension to split along
-            marks=pytest.mark.xfail(
-                reason="- Emmiting mlir for function forward"
-                + "loc(\"index_0.dc.unsqueeze.0\"(\"forward\":4294967295:28)): error: 'ttir.unsqueeze' op requires attribute 'dim'"
-                + 'loc("SplitModule":0:0): error: module verification failed.'
-            ),
         ),
         pytest.param(
             (torch.arange(20.0).reshape(4, 5), 2, 0),  # 2D tensor  # Number of parts  # Dimension to split along

--- a/forge/test/mlir/operators/indexing/test_basic_slicing.py
+++ b/forge/test/mlir/operators/indexing/test_basic_slicing.py
@@ -22,11 +22,6 @@ from forge.verify.verify import verify
         pytest.param((torch.arange(10, dtype=torch.float32), slice(3, None)), id="slice_from_index_three_to_end"),
     ],
 )
-@pytest.mark.xfail(
-    reason="Emmiting mlir for function forward"
-    + "loc(\"index_1.dc.unsqueeze.0\"(\"forward\":4294967295:29)): error: 'ttir.unsqueeze' op requires attribute 'dim'"
-    + 'loc("SlicingModule":0:0): error: module verification failed'
-)
 @pytest.mark.push
 def test_slicing(input_tensor_slice):
     input_tensor, slicing = input_tensor_slice


### PR DESCRIPTION
### Problem description
When ops were decomposing, one of the ops they were decomposing into was `unsqueeze` op which lacked `dim` attribute.
### What's changed
Added `dim` attribute to the decomposed `unsqueeze` op and also updated tests, since they are passing now - yaaay