### PR TITLE
Skip gemma2b and falcon 7B variant

### DIFF
--- a/forge/test/models/pytorch/text/falcon/test_falcon.py
+++ b/forge/test/models/pytorch/text/falcon/test_falcon.py
@@ -61,6 +61,8 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_falcon_3(record_forge_property, variant):
 
+    if variant == "tiiuae/Falcon3-Mamba-7B-Base":
+        pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 36 GB)")
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="falcon3", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE

--- a/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
@@ -20,6 +20,8 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_gemma_2b(record_forge_property, variant):
+    pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 48 GB)")
+
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH,


### PR DESCRIPTION
Skipping these two models as memory usage is exceeding 32 GB in host DRAM.
```
Gemma-2B (google/gemma-2b)
Min: 20570.27 MB
Max: 49831.41 MB
Avg: 21559.41 MB
```
```
Falcon3 (tiiuae/Falcon3-Mamba-7B-Base)
Min: 9901.01 MB
Max: 36931.30 MB
Avg: 35950.59 MB
```