### PR TITLE
Fix the model analysis pipeline failure in embedding op

### DIFF
--- a/forge/forge/tvm_unique_op_generation.py
+++ b/forge/forge/tvm_unique_op_generation.py
@@ -815,7 +815,13 @@ def extract_and_generate_unique_ops_tests(
                     pytest_metadata = {}
                     if op_name == "embedding":
                         # Calculate embedding op indicies tensor maximum value based upon the num_embeddings of the weight tensor.
-                        pytest_metadata["max_int"] = int(operand_shapes[1][0]) - 1
+                        if all_params_const and isinstance(operand_shapes[1], str):
+                            # If both operands of the embedding op are parameter/constant,
+                            # take the num_embeddings from the  params(i.e Dict[nid, Tuple(name, shape, require_grad, dtype)])
+                            _, param_tuple = get_param_const(operand_shapes[1])
+                            pytest_metadata["max_int"] = int(param_tuple[1][0]) - 1
+                        else:
+                            pytest_metadata["max_int"] = int(operand_shapes[1][0]) - 1
 
                     if len(pytest_metadata) != 0:
                         pytest_metadata_list.append(pytest_metadata)


### PR DESCRIPTION
The PR addresses the [model analysis pipeline failure](https://github.com/tenstorrent/tt-forge-fe/actions/runs/13371914501/job/37342194926) related to extracting max_int from operand_shapes in the embedding op.

If all operands of the op are parameters or constants, operand_shapes are updated with their names to reference actual tensor values in the test function. In such cases, operand_shapes contain parameter and constant names instead of shapes. As a result, max_int should be derived from the parameter shape, which can be extracted from
params: Dict[nid, Tuple(name, shape, require_grad, dtype)]
 
 Failure:
```
                         if op_name == "embedding":
                            # Calculate embedding op indicies tensor maximum value based upon the num_embeddings of the weight tensor.
>                           pytest_metadata["max_int"] = int(operand_shapes[1][0]) - 1
E                           ValueError: invalid literal for int() with base 10: 'm'
```

Tested the fix by triggering the model analysis pipeline for audio based pytorch models:  https://github.com/tenstorrent/tt-forge-fe/actions/runs/13390556078/job/37397132738