### PR TITLE
Add Argument to map test-case result

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,9 @@
 # TF & some other libraries report a bunch of deprecation warnings
 [pytest]
 
+# Get testcase result
+addopts = -v
+
 # Fail on xpassed
 xfail_strict=true
 


### PR DESCRIPTION
### Problem description
It's difficult to track regression cases, since we are not able to get exact result for their respective test-cases in nightly logs

### What's changed
Added pytest argument

### Example
Current logs display as follows:
```
collected 4 items

forge/test/models/pytorch/text/bert/test_bert.py .sss                    [100%]
```

Expected logs to be display (after adding  argument "-v" ) as follows:
```
collecting ... collected 4 items

forge/test/models/pytorch/text/bert/test_bert.py::test_bert_masked_lm_pytorch[bert-base-uncased] PASSED [ 25%]
forge/test/models/pytorch/text/bert/test_bert.py::test_bert_question_answering_pytorch[bert-large-cased-whole-word-masking-finetuned-squad] SKIPPED [ 50%]
forge/test/models/pytorch/text/bert/test_bert.py::test_bert_sequence_classification_pytorch[textattack/bert-base-uncased-SST-2] SKIPPED [ 75%]
forge/test/models/pytorch/text/bert/test_bert.py::test_bert_token_classification_pytorch[dbmdz/bert-large-cased-finetuned-conll03-english] SKIPPED [100%]
```

