### PR TITLE
Extract op_norm block from the model to bypass dynamic shape issues in densenet121_hf_xray

### DIFF
--- a/forge/test/models/pytorch/vision/densenet/test_densenet.py
+++ b/forge/test/models/pytorch/vision/densenet/test_densenet.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import torch
+import torch.nn as nn
 import torchxrayvision as xrv
+from torchxrayvision.models import fix_resolution, op_norm
 
 import forge
 from forge.verify.verify import verify
@@ -16,6 +18,19 @@ from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = ["densenet121", "densenet121_hf_xray"]
+
+
+class densenet_xray_wrapper(nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, x):
+        x = fix_resolution(x, 224, self.model)
+        features = self.model.features2(x)
+        out = self.model.classifier(features)
+        out = torch.sigmoid(out)
+        return out
 
 
 @pytest.mark.nightly
@@ -42,7 +57,8 @@ def test_densenet_121_pytorch(record_forge_property, variant):
         img_tensor = get_input_img()
     else:
         model_name = "densenet121-res224-all"
-        framework_model = download_model(xrv.models.get_model, model_name)
+        model = download_model(xrv.models.get_model, model_name)
+        framework_model = densenet_xray_wrapper(model)
         img_tensor = get_input_img_hf_xray()
 
     # STEP 3: Run inference on Tenstorrent device
@@ -53,6 +69,12 @@ def test_densenet_121_pytorch(record_forge_property, variant):
 
     # Model Verification
     verify(inputs, framework_model, compiled_model)
+
+    if variant == "densenet121_hf_xray":
+        # Inference
+        output = compiled_model(*inputs)
+        # post processing
+        outputs = op_norm(output[0], model.op_threshs)
 
 
 @pytest.mark.nightly


### PR DESCRIPTION
### Problem description

- densenet121_hf_xray encountered  below error on latest main. 

```
2025-02-20 07:29:47.838 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2238 - Encountered unsupported op node type: argwhere, on device: tt
2025-02-20 07:29:47.838 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2238 - Encountered unsupported op node type: argwhere, on device: tt
2025-02-20 07:29:47.838 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2238 - Encountered unsupported op node type: scatter_elements, on device: tt
2025-02-20 07:29:47.838 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2238 - Encountered unsupported op node type: argwhere, on device: tt
2025-02-20 07:29:47.838 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2238 - Encountered unsupported op node type: argwhere, on device: tt
2025-02-20 07:29:47.838 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2238 - Encountered unsupported op node type: scatter_elements, on device: tt

E AssertionError: Encountered unsupported op types. Check error logs for more details
```

- The root cause is this [block](https://github.com/mlmed/torchxrayvision/blob/11c53a046ea7335cf3b132d61c22af81290748d5/torchxrayvision/models.py#L375C1-L398C23), which introduces unsupported ops like argwhere and scatter_elements.


- Question marks in [traced_graph](https://github.com/user-attachments/files/18885536/feb20_densenet_xray_org_issue.log) indicates the presence of dynamic shapes at end of the model. the above mentioned block is the root cause of this issue also

### What's changed

- Moved the op_norm block out of the model to bypass dynamic shape issues. - [traced_graph_after_fix.log](https://github.com/user-attachments/files/18885632/feb20_densenet_xray_fix.log)

- Since the problematic block has been moved out of the model, Forge no longer requires support for those ops.

