### PR TITLE
Consistent test plan loading

### DIFF
--- a/forge/test/operators/utils/plan.py
+++ b/forge/test/operators/utils/plan.py
@@ -838,6 +838,9 @@ class TestPlanScanner:
 
         modules = cls.find_modules_in_directory(directory)
 
+        # sort modules to ensure consistent order of test plans
+        modules.sort()
+
         for module_name in modules:
             try:
                 module_name = f"{scan_package}.{module_name}"


### PR DESCRIPTION
### Problem description
By default test plans should by ordered and executed in a consistent order so sampling works consistent.

### What's changed
During scanning of python modules with test plans, python files are ordered alphabetically.
