### PR TITLE
fix script for calculating docker tag

### DIFF
--- a/.github/get-docker-tag.sh
+++ b/.github/get-docker-tag.sh
@@ -12,8 +12,8 @@ else
     MLIR_DOCKER_TAG="default-tag"
 fi
 
-# The hash is based on the environment files
-ENV_HASH=$(find env -type f -name "*.txt" | sort | xargs cat | sha256sum | cut -d ' ' -f 1)
+# The hash is based on the environment files (filter out files that are not tracked in git).
+ENV_HASH=$(find env -type f -name "*.txt" | sort | sed 's|^\./||' | grep -Fxf <(git ls-files env/) | xargs cat | sha256sum | cut -d ' ' -f 1)
 
 # The hash is based on the Dockerfile(s)
 DOCKERFILE_HASH=$(find .github -type f -name "Dockerfile.*" | sort | xargs cat | sha256sum | cut -d ' ' -f 1)


### PR DESCRIPTION
Filter out `.txt` files in `env/` which are not tracked by git.

Otherwise, the script generates wrong hashes in repos which are not completely clean.
