### PR TITLE
Add support for upsample2d in lower to mlir

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -654,6 +654,7 @@ class MLIRGenerator
         lowering_handler_map["tanh"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::TanhOp>;
         lowering_handler_map["transpose"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::TransposeOp>;
         lowering_handler_map["unsqueeze"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::UnsqueezeOp>;
+        lowering_handler_map["upsample2d"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::Upsample2dOp>;
     }
 };
 

--- a/forge/forge/op/__init__.py
+++ b/forge/forge/op/__init__.py
@@ -72,7 +72,7 @@ from .tm import (
 from .constant import Constant
 from .nn import Softmax, Layernorm, LogSoftmax, Batchnorm, MaxPool2dModule
 from .eltwise_nary import Concatenate, Where, IndexCopy, Stack, Interleave
-from .resize import Resize2d, Resize3d
+from .resize import Resize2d, Resize3d, Upsample2d
 from .embedding import Embedding
 from .dram_queue import DRAMQueue
 from .quantize import Quantize, Dequantize, Requantize, ForgeRequantize

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -123,6 +123,7 @@ op_to_module_map = {
     "constant": "constant",
     "resize2d": "resize",
     "resize3d": "resize",
+    "upsample2d": "resize",
     "dram_queue": "dram_queue",
     "softmax": "nn",
     "log_softmax": "nn",

--- a/forge/forge/op/resize.py
+++ b/forge/forge/op/resize.py
@@ -62,6 +62,44 @@ def Resize2d(
     return result
 
 
+def Upsample2d(
+    name: str, operandA: Tensor, scale_factor: int, mode: str = "nearest", channel_last: bool = False
+) -> Tensor:
+    """
+    Upsample 2D operation
+
+    Parameters
+    ----------
+    name: str
+        Op name, unique to the module, or leave blank to autoset
+
+    operandA: Tensor
+        Input operand A
+
+    scale_factor: int
+        multiplier for spatial size.
+
+    mode: str
+        the upsampling algorithm
+
+    Returns
+    -------
+    Tensor
+        Forge tensor
+    """
+    result: Tensor = op(
+        "upsample2d",
+        name,
+        operandA,
+        attrs=(scale_factor, mode, channel_last),
+        scale_factor=scale_factor,
+        mode=mode,
+        channel_last=channel_last,
+    ).get_tensor()
+
+    return result
+
+
 def Resize3d(
     name: str,
     operandA: Tensor,

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1762,6 +1762,7 @@ tvm_to_forge_op_map = {
     "qnn.requantize": "requantize",
     "qnn.dense": "matmul",
     "atan": "atan",
+    "upsample2d": "upsample2d",
 }
 
 forge_op_to_function_name = {
@@ -1847,6 +1848,7 @@ forge_op_to_function_name = {
     "dequantize": "forge.op.Dequantize",
     "requantize": "forge.op.Requantize",
     "atan": "forge.op.Atan",
+    "upsample2d": "forge.op.Upsample2d",
 }
 forge_ops_needing_arguments = {
     "argmax": populate_argmax_args,

--- a/forge/test/mlir/operators/nn/test_nn.py
+++ b/forge/test/mlir/operators/nn/test_nn.py
@@ -188,11 +188,12 @@ def test_maxpool2d(input_shape, kernel_size, stride_size, padding, ceil_mode):
 @pytest.mark.parametrize(
     "shape, mode",
     [
-        ((1, 2048, 7, 7), "nearest"),
-        ((1, 2048, 7, 7), "bilinear"),
+        pytest.param((1, 2048, 7, 7), "nearest"),
+        pytest.param(
+            (1, 2048, 7, 7), "bilinear", marks=pytest.mark.xfail(reason="Runtime Error TTNN: info: Unsupported mode ")
+        ),
     ],
 )
-@pytest.mark.xfail(reason="Found Unsupported operations while lowering from TTForge to TTIR in forward graph")
 @pytest.mark.push
 def test_interpolate(shape, mode):
     class Interpolate(nn.Module):


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge-fe/issues/667

### Problem description
Add support for upsample2d in lower to mlir.

### What's changed
Decompose upsample2D cases of resize2d op to upsample2d and map to ttir.Upsample2dOP