### PR TITLE
Improve test verification

### DIFF
--- a/forge/test/operators/utils/__init__.py
+++ b/forge/test/operators/utils/__init__.py
@@ -7,6 +7,7 @@ from .datatypes import ValueRange
 from .datatypes import ValueRanges
 from .datatypes import FrameworkDataFormat
 from .utils import ShapeUtils
+from .utils import TensorUtils
 from .utils import InputSourceFlag, InputSourceFlags
 from .utils import CompilerUtils
 from .utils import DeviceUtils
@@ -39,6 +40,7 @@ __all__ = [
     "ValueRanges",
     "FrameworkDataFormat",
     "ShapeUtils",
+    "TensorUtils",
     "InputSourceFlag",
     "InputSourceFlags",
     "CompilerUtils",

--- a/forge/test/operators/utils/compat.py
+++ b/forge/test/operators/utils/compat.py
@@ -249,27 +249,6 @@ class TestTensorsUtils:
         return value_range
 
 
-# TODO remove this method, used only in RGG
-# Compatibility method for verifying models
-def verify_module_old(
-    model: Module,
-    input_shapes: List[TensorShape],
-    pcc: Optional[float] = None,
-    dev_data_format: FrameworkDataFormat = None,
-    value_range: Optional[Union[ValueRanges, ValueRange, OperatorParameterTypes.RangeValue]] = None,
-    random_seed: int = 42,
-    convert_to_forge: bool = True,  # explicit conversion to forge data format
-):
-
-    logger.debug(
-        f"Verifying model class: {model.__class__.__name__}({model.__class__.__base__.__module__}.{model.__class__.__base__.__name__}) input_shapes: {input_shapes}"
-    )
-
-    inputs = create_torch_inputs(input_shapes, dev_data_format, value_range, random_seed)
-
-    verify_module_for_inputs(model, inputs, pcc, dev_data_format, convert_to_forge)
-
-
 # TODO move to class TestTensorsUtils
 def create_torch_inputs(
     input_shapes: List[TensorShape],

--- a/forge/test/operators/utils/compat.py
+++ b/forge/test/operators/utils/compat.py
@@ -14,6 +14,7 @@ from forge import ForgeModule, Module, DepricatedVerifyConfig
 from forge.tensor import to_pt_tensors
 from forge.op_repo import TensorShape
 from forge.config import CompilerConfig
+from forge.tensor import to_forge_tensors
 from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.config import VerifyConfig
@@ -248,6 +249,10 @@ class TestTensorsUtils:
             pass
         return value_range
 
+    def convert_to_forge_tensors(inputs: List[torch.Tensor], dev_data_format: forge.DataFormat) -> List[forge.Tensor]:
+        # return [forge.Tensor.create_from_torch(input, dev_data_format=dev_data_format) for input in inputs]
+        return to_forge_tensors(inputs)
+
 
 # TODO move to class TestTensorsUtils
 def create_torch_inputs(
@@ -292,7 +297,7 @@ def verify_module_for_inputs_deprecated(
     fw_out = model(*inputs)
 
     if convert_to_forge:
-        forge_inputs = [forge.Tensor.create_from_torch(input, dev_data_format=dev_data_format) for input in inputs]
+        forge_inputs = TestTensorsUtils.convert_to_forge_tensors(inputs, dev_data_format)
     else:
         forge_inputs = inputs
 
@@ -326,12 +331,12 @@ def verify_module_for_inputs(
 ):
 
     if convert_to_forge:
-        forge_inputs = [forge.Tensor.create_from_torch(input, dev_data_format=dev_data_format) for input in inputs]
+        forge_inputs = TestTensorsUtils.convert_to_forge_tensors(inputs, dev_data_format)
     else:
         forge_inputs = inputs
 
     compiled_model = forge.compile(model, sample_inputs=forge_inputs, compiler_cfg=compiler_cfg)
-    verify(inputs, model, compiled_model, verify_config)
+    verify(forge_inputs, model, compiled_model, verify_config)
 
 
 def verify_module_for_inputs_torch(

--- a/forge/test/operators/utils/utils.py
+++ b/forge/test/operators/utils/utils.py
@@ -33,7 +33,9 @@ from .compat import (
     verify_module_for_inputs_deprecated,
     verify_module_for_inputs_torch,
 )
-from .datatypes import ValueRanges
+from .datatypes import ValueRange, ValueRanges
+from .datatypes import OperatorParameterTypes
+from .datatypes import FrameworkDataFormat
 from .features import TestFeaturesConfiguration
 
 
@@ -70,6 +72,21 @@ class ShapeUtils:
             else:
                 shapes_with_ids.append(pytest.param(shape.values[0], marks=shape.marks, id=f"shape={shape.values[0]}"))
         return shapes_with_ids
+
+
+class TensorUtils:
+    def create_torch_constant(
+        input_shape: TensorShape,
+        reduce_microbatch: bool = False,
+        dev_data_format: FrameworkDataFormat = None,
+        value_range: Optional[Union[ValueRanges, ValueRange, OperatorParameterTypes.RangeValue]] = None,
+        random_seed: Optional[int] = None,
+    ) -> torch.Tensor:
+        input_shape = ShapeUtils.reduce_microbatch_size(input_shape) if reduce_microbatch else input_shape
+
+        constant = create_torch_inputs([input_shape], dev_data_format, value_range, random_seed)[0]
+
+        return constant
 
 
 @dataclass(frozen=True)

--- a/forge/test/operators/utils/utils.py
+++ b/forge/test/operators/utils/utils.py
@@ -252,11 +252,14 @@ class VerifyUtils:
                 convert_to_forge=convert_to_forge,
             )
         elif skip_forge_verification:
-            verify_module_for_inputs_torch(
-                model=model,
-                inputs=inputs,
-                verify_config=verify_config,
-            )
+            if isinstance(model, ForgeModule):
+                logger.warning("Nothing to validate while skipping Forge verification for Forge module")
+            else:
+                verify_module_for_inputs_torch(
+                    model=model,
+                    inputs=inputs,
+                    verify_config=verify_config,
+                )
         else:
             verify_module_for_inputs(
                 model=model,

--- a/forge/test/operators/utils/utils.py
+++ b/forge/test/operators/utils/utils.py
@@ -131,6 +131,7 @@ class VerifyUtils:
         test_device: TestDevice,
         input_shapes: List[TensorShape],
         input_params: List[Dict] = [],
+        compiler_cfg: CompilerConfig = CompilerConfig(),
         pcc: Optional[float] = None,
         input_source_flag: InputSourceFlags = None,
         dev_data_format: forge.DataFormat = None,
@@ -150,6 +151,7 @@ class VerifyUtils:
             test_device: TestDevice
             input_shapes: List of input shapes
             input_params: List of input parameters
+            compiler_cfg: Compiler configuration
             pcc: PCC value for verification
             input_source_flag: Input source flag
             dev_data_format: Data format
@@ -161,8 +163,6 @@ class VerifyUtils:
             verify_config: Verification configuration
             skip_forge_verification: Skip verification with Forge module
         """
-
-        compiler_cfg = CompilerConfig()
 
         cls.setup(
             compiler_cfg=compiler_cfg,

--- a/forge/test/operators/utils/utils.py
+++ b/forge/test/operators/utils/utils.py
@@ -135,7 +135,7 @@ class VerifyUtils:
         pcc: Optional[float] = None,
         input_source_flag: InputSourceFlags = None,
         dev_data_format: forge.DataFormat = None,
-        convert_to_forge: bool = True,  # explicit conversion to forge data format
+        convert_to_forge: Optional[bool] = None,
         math_fidelity: forge.MathFidelity = None,
         value_range: Optional[ValueRanges] = None,
         random_seed: Optional[int] = None,
@@ -155,6 +155,7 @@ class VerifyUtils:
             pcc: PCC value for verification
             input_source_flag: Input source flag
             dev_data_format: Data format
+            convert_to_forge: Convert input tensors to Forge data format
             math_fidelity: Math fidelity
             value_range: Value range of input tensors
             random_seed: Random seed
@@ -163,6 +164,14 @@ class VerifyUtils:
             verify_config: Verification configuration
             skip_forge_verification: Skip verification with Forge module
         """
+
+        # Conclude if we should convert to forge data format
+        if convert_to_forge is None:
+            if deprecated_verification:
+                convert_to_forge = True
+            else:
+                if isinstance(model, ForgeModule):
+                    convert_to_forge = True
 
         cls.setup(
             compiler_cfg=compiler_cfg,

--- a/forge/test/operators/utils/utils.py
+++ b/forge/test/operators/utils/utils.py
@@ -178,30 +178,17 @@ class VerifyUtils:
             random_seed=random_seed,
         )
 
-        if deprecated_verification:
-            cls.verify_module_for_inputs_deprecated(
-                model=model,
-                inputs=inputs,
-                compiler_cfg=compiler_cfg,
-                pcc=pcc,
-                dev_data_format=dev_data_format,
-                convert_to_forge=convert_to_forge,
-            )
-        elif skip_forge_verification:
-            verify_module_for_inputs_torch(
-                model=model,
-                inputs=inputs,
-                verify_config=verify_config,
-            )
-        else:
-            cls.verify_module_for_inputs(
-                model=model,
-                inputs=inputs,
-                compiler_cfg=compiler_cfg,
-                verify_config=verify_config,
-                dev_data_format=dev_data_format,
-                convert_to_forge=convert_to_forge,
-            )
+        cls.verify_module_for_inputs(
+            model=model,
+            inputs=inputs,
+            compiler_cfg=compiler_cfg,
+            pcc=pcc,
+            verify_config=verify_config,
+            dev_data_format=dev_data_format,
+            convert_to_forge=convert_to_forge,
+            deprecated_verification=deprecated_verification,
+            skip_forge_verification=skip_forge_verification,
+        )
 
     @classmethod
     def setup(
@@ -242,44 +229,43 @@ class VerifyUtils:
         return inputs
 
     @classmethod
-    def verify_module_for_inputs_deprecated(
-        cls,
-        model: Module,
-        inputs: List[torch.Tensor],
-        compiler_cfg: CompilerConfig,
-        pcc: Optional[float] = None,
-        dev_data_format: forge.DataFormat = None,
-        convert_to_forge: bool = True,  # explicit conversion to forge data format
-    ):
-
-        verify_module_for_inputs_deprecated(
-            model=model,
-            inputs=inputs,
-            compiler_cfg=compiler_cfg,
-            pcc=pcc,
-            dev_data_format=dev_data_format,
-            convert_to_forge=convert_to_forge,
-        )
-
-    @classmethod
     def verify_module_for_inputs(
         cls,
         model: Module,
         inputs: List[torch.Tensor],
         compiler_cfg: CompilerConfig,
-        verify_config: Optional[VerifyConfig] = VerifyConfig(),
+        pcc: Optional[float] = None,
+        verify_config: Optional[VerifyConfig] = None,
         dev_data_format: forge.DataFormat = None,
         convert_to_forge: bool = True,  # explicit conversion to forge data format
+        deprecated_verification: bool = True,
+        skip_forge_verification: bool = TestFeaturesConfiguration.SKIP_FORGE_VERIFICATION,
     ):
 
-        verify_module_for_inputs(
-            model=model,
-            inputs=inputs,
-            compiler_cfg=compiler_cfg,
-            verify_config=verify_config,
-            dev_data_format=dev_data_format,
-            convert_to_forge=convert_to_forge,
-        )
+        if deprecated_verification:
+            verify_module_for_inputs_deprecated(
+                model=model,
+                inputs=inputs,
+                compiler_cfg=compiler_cfg,
+                pcc=pcc,
+                dev_data_format=dev_data_format,
+                convert_to_forge=convert_to_forge,
+            )
+        elif skip_forge_verification:
+            verify_module_for_inputs_torch(
+                model=model,
+                inputs=inputs,
+                verify_config=verify_config,
+            )
+        else:
+            verify_module_for_inputs(
+                model=model,
+                inputs=inputs,
+                compiler_cfg=compiler_cfg,
+                verify_config=verify_config,
+                dev_data_format=dev_data_format,
+                convert_to_forge=convert_to_forge,
+            )
 
 
 class LoggerUtils:


### PR DESCRIPTION
### Ticket
#313 

### Problem description
Extend sweep verification to support Forge models

### What's changed
Remove obsoleted verify_module_old
Unify verify_module_for_inputs
Fix skip_forge_verification for forge models
Added param compiler_cfg to VerifyUtils.verify
Conversion via to_forge_tensors
Concluding convert_to_forge
TensorUtils.create_torch_constant


### Checklist
- [ ] New/Existing tests provide coverage for changes
