### PR TITLE
Cast torch input tensors to dtype that is supported in forge. 

### DIFF
--- a/forge/forge/compiled_graph_state.py
+++ b/forge/forge/compiled_graph_state.py
@@ -13,7 +13,7 @@ from typing import Dict, List, Any, Optional
 from forge._C.graph import Graph
 import forge._C.graph as pygraph
 from forge._C.runtime import run_binary, Binary
-from forge.tensor import Tensor, get_post_const_eval_tensors, to_pt_tensors, AnyTensor
+from forge.tensor import Tensor, get_post_const_eval_tensors, to_pt_tensors, cast_unsupported_torch_dtype, AnyTensor
 from forge.module import Module, PyTorchModule, AnyModule
 from forge.execution_tracker import ExecutionPhase, record_execution_phase_and_stage
 
@@ -224,6 +224,8 @@ class CompiledModel:
             Output tensors
         """
         self.inputs = [*to_pt_tensors(inputs)]
+        # After tensors are transformed to pt tensors, we have to cast them to dtypes that are actually supported by our hardware.
+        self.inputs = [cast_unsupported_torch_dtype(input_tensor) for input_tensor in self.inputs]
 
         inputs_and_parameters = [
             *self.inputs,

--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -619,6 +619,32 @@ AnyTensor: TypeAlias = FrameworkTensor | Tensor
 #         raise RuntimeError(f"{msg}: Shape {data.shape}: Row of {data.shape[-2]} encountered, which is not divisible with tile dimension of {TILE_DIM}")
 
 
+def cast_unsupported_torch_dtype(tensor: torch.Tensor):
+    """
+    Casts a PyTorch tensor to the dtype that is supported in Forge.
+
+    Args:
+        tensor (torch.Tensor): Input tensor.
+
+    Returns:
+        torch.Tensor: Tensor casted to the supported data format.
+    """
+    forge_dataformat = pytorch_dtype_to_forge_dataformat(tensor.dtype)
+
+    # Get the corresponding PyTorch dtype
+    new_dtype = forge_dataformat_to_pytorch_dtype(forge_dataformat)
+
+    # If mapping exists and is different from the current dtype, cast the tensor
+    if new_dtype and new_dtype != tensor.dtype:
+        logger.warning(
+            "Tensor dtype {} is not supported in forge. Therefore, it is casted in to {}", tensor.dtype, new_dtype
+        )
+        return tensor.to(new_dtype)
+
+    # If no change is needed, return the original tensor
+    return tensor
+
+
 def pytorch_dtype_to_forge_dataformat(dtype: torch.dtype, fp32_fallback: Optional[DataFormat] = None) -> DataFormat:
 
     if isinstance(dtype, DataFormat):

--- a/forge/test/mlir/llama/tests/test_llama_prefil.py
+++ b/forge/test/mlir/llama/tests/test_llama_prefil.py
@@ -65,8 +65,6 @@ def test_llama_prefil_on_device_decode_on_cpu(model_path):
     # Prepare input sentence
     prompt = "Q: What is the largest animal?\nA:"
     input_ids = tokenizer(prompt, return_tensors="pt").input_ids
-    # cast input_ids to int32 since int64 causes embedding op data mismatch. Tracking issue: https://github.com/tenstorrent/tt-forge-fe/issues/952
-    input_ids = input_ids.to(torch.int32)
 
     # This is the part of the model needed for prefill; model without the last Linear layer (lm_head)
     model_decoder = model.get_decoder()

--- a/forge/test/mlir/llama/tests/test_specific_ops_llama32.py
+++ b/forge/test/mlir/llama/tests/test_specific_ops_llama32.py
@@ -108,7 +108,6 @@ def test_sine(shapes):
         ((1, 11), 128256, 2048),
     ],
 )
-@pytest.mark.xfail(reason="TTNN Layout::ROW_MAJOR error")
 @pytest.mark.push
 def test_embedding(shapes):
     input_size, vocab_size, embedding_dim = shapes

--- a/forge/test/mlir/operators/nn/test_nn.py
+++ b/forge/test/mlir/operators/nn/test_nn.py
@@ -297,7 +297,7 @@ def test_embedding(vocab_size, token_num, embedding_dim):
             return self.embedding(x)
 
     inputs = [
-        torch.randint(0, vocab_size, (1, token_num)).to(torch.int32),
+        torch.randint(0, vocab_size, (1, token_num)),
     ]
 
     framework_model = Embedding()

--- a/forge/test/models/pytorch/audio/whisper/test_whisper_large_v3.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper_large_v3.py
@@ -66,7 +66,6 @@ def test_whisper_large_v3_speech_translation(record_forge_property, variant):
 
     # Get decoder inputs
     decoder_input_ids = torch.tensor([[1, 1]]) * model_config.decoder_start_token_id
-    decoder_input_ids = decoder_input_ids.to(torch.int32)
     encoder_outputs = framework_model.model.model.encoder(input_features)[0].detach()
     encoder_outputs = encoder_outputs.to(torch.float32)
     inputs = [decoder_input_ids, encoder_outputs]

--- a/forge/test/models/pytorch/multimodal/deepseek_math/test_deepseek_math_prefill.py
+++ b/forge/test/models/pytorch/multimodal/deepseek_math/test_deepseek_math_prefill.py
@@ -52,6 +52,9 @@ def decode_on_cpu(model, tokenizer, input_ids, hidden_states, max_new_tokens):
 
 
 @pytest.mark.parametrize("variant", ["deepseek-math-7b-instruct"])
+@pytest.mark.xfail(
+    reason="RuntimeError: TT_THROW @ /tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:132: tt::exception info: Out of Memory: Not enough space to allocate 180355072 B DRAM buffer across 12 banks, where each bank needs to store 15032320 B"
+)
 def test_deepseek_prefil_on_device_decode_on_cpu(variant):
     """
     This function tests the inference of the deepseek_math model split into two parts:
@@ -61,8 +64,6 @@ def test_deepseek_prefil_on_device_decode_on_cpu(variant):
 
     model_name = f"deepseek-ai/{variant}"
     model, tokenizer, input_ids = download_model_and_tokenizer(model_name)
-
-    input_ids = input_ids.to(torch.int32)
 
     # This is the part of the model needed for prefill; model without the last Linear layer (lm_head)
     model_decoder = model.get_decoder()

--- a/forge/test/models/pytorch/text/codegen/test_codegen.py
+++ b/forge/test/models/pytorch/text/codegen/test_codegen.py
@@ -65,7 +65,6 @@ def test_codegen(record_forge_property, variant):
     framework_model = Wrapper(framework_model)
 
     # Sanity run
-    input_ids = input_ids.to(torch.int32)
     attn_mask = attn_mask.to(torch.float32)
 
     inputs = [input_ids, attn_mask]

--- a/forge/test/models/pytorch/text/llama/test_llama3.py
+++ b/forge/test/models/pytorch/text/llama/test_llama3.py
@@ -161,7 +161,6 @@ def test_llama3_causal_lm(record_forge_property, variant):
     attn_mask = inputs["attention_mask"]
 
     # Get Inputs
-    input_ids = input_ids.to(torch.int32)
     attn_mask = attn_mask.to(torch.float32)
     inputs = [input_ids, attn_mask]
 

--- a/forge/test/models/pytorch/text/phi2/test_phi2.py
+++ b/forge/test/models/pytorch/text/phi2/test_phi2.py
@@ -58,7 +58,7 @@ def test_phi2_clm(record_forge_property, variant):
         truncation=True,
     )
 
-    input_ids = inputs["input_ids"].to(torch.int32)
+    input_ids = inputs["input_ids"]
     attn_mask = inputs["attention_mask"].to(torch.float32)
 
     inputs = [input_ids, attn_mask]


### PR DESCRIPTION
Remove manual casting in tests.

### Ticket
Issue #952 

### Problem description
There was a bug when input tensors have dtype that is not supported in Forge (for example int64). Compiler handled inputs like they were some lower dtype, while actual runtime tensors stayed in original dtype. This is explained in detail in issue #952

### What's changed
Now we cast torch tensor to appropriate dtype based on forge support.

