### PR TITLE
[api] add API for exporting model as c++ source

### DIFF
--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -186,6 +186,7 @@ PYBIND11_MODULE(_C, m)
         py::arg("graph"),
         py::arg("default_df_override") = std::optional<DataFormat>{});
     m.def("run_mlir_compiler", &passes::run_mlir_compiler);
+    m.def("run_mlir_compiler_to_cpp", &passes::run_mlir_compiler_to_cpp);
     m.def("split_graph", &passes::split_graph);
 
     m.def(

--- a/forge/csrc/passes/mlir_compiler.hpp
+++ b/forge/csrc/passes/mlir_compiler.hpp
@@ -14,4 +14,7 @@ namespace tt::passes
 {
 /// Public API for running MLIR passes and generating binary.
 runtime::Binary run_mlir_compiler(tt::ForgeGraphModule& module);
+
+/// Public API for lowering to MLIR, running MLIR passes and generate C++ code.
+std::string run_mlir_compiler_to_cpp(tt::ForgeGraphModule& module);
 }  // namespace tt::passes

--- a/forge/csrc/passes/mlir_passes.cpp
+++ b/forge/csrc/passes/mlir_passes.cpp
@@ -17,9 +17,10 @@
 
 namespace tt::passes
 {
-/// Public API for running MLIR passes and generating binary.
-void run_mlir_passes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module)
+
+void register_mlir_passes()
 {
+    // Static (only once) initialization of the MLIR passes.
     static bool _ = []()
     {
         // Register required passes
@@ -34,13 +35,26 @@ void run_mlir_passes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module)
         return true;
     }();
     (void)_;
+}
+
+template <MLIROutputKind output>
+void run_mlir_passes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module)
+{
+    // Register the MLIR passes.
+    register_mlir_passes();
 
     // Create a pass manager.
     mlir::PassManager pm(mlir_module.get()->getName());
 
     // Get the pipeline info for the wanted pipeline.
-    const auto pipelineInfo = mlir::PassPipelineInfo::lookup("ttir-to-ttnn-backend-pipeline");
+    static_assert(
+        output == MLIROutputKind::Flatbuffer || output == MLIROutputKind::Cpp,
+        "Handling only Flatbuffer and Cpp output correctly.");
+    constexpr auto pipeline_name =
+        (output == MLIROutputKind::Flatbuffer) ? "ttir-to-ttnn-backend-pipeline" : "ttir-to-emitc-pipeline";
+    const auto pipelineInfo = mlir::PassPipelineInfo::lookup(pipeline_name);
 
+    // Error handler for the pipeline. Will be called if there is an error during parsing of the pipeline options.
     auto err_handler = [](const mlir::Twine &location)
     {
         log_error(LogMLIRCompiler, "Error during parsing pipeline options: {}", location.str());
@@ -77,4 +91,9 @@ void run_mlir_passes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module)
     log_trace(LogMLIRCompiler, "MLIR module after running passes:\n{}", moduleStr);
 #endif
 }
+
+// Explicit templates instantiation.
+template void run_mlir_passes<MLIROutputKind::Flatbuffer>(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+template void run_mlir_passes<MLIROutputKind::Cpp>(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+
 }  // namespace tt::passes

--- a/forge/csrc/passes/mlir_passes.hpp
+++ b/forge/csrc/passes/mlir_passes.hpp
@@ -10,6 +10,15 @@ class OwningOpRef;
 
 namespace tt::passes
 {
-/// Public API for running MLIR passes and generating binary.
+
+enum class MLIROutputKind
+{
+    Flatbuffer,
+    Cpp
+};
+
+/// Public API for running MLIR passes (pipeline) depending on the desired output.
+template <MLIROutputKind output>
 void run_mlir_passes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+
 }  // namespace tt::passes

--- a/forge/forge/compile.py
+++ b/forge/forge/compile.py
@@ -393,6 +393,7 @@ def forge_compile_from_context(context: CompileContext) -> CompiledModel:
     assert context.compiled_binary is not None
 
     compiled_module = CompiledModel(
+        context.forge_module,
         fwd_compiled_graph_state,
         bwd_compiled_graph_state,
         opt_compiled_graph_state,

--- a/forge/test/test_api.py
+++ b/forge/test/test_api.py
@@ -88,3 +88,27 @@ def test_forge():
 
     if not torch.allclose(output[0], golden.to_pytorch(), rtol=1e-1):
         raise ValueError("Output does not match the golden output")
+
+
+def test_export_to_cpp():
+    class Add(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x1, x2):
+            return torch.add(x1, x2)
+
+    model = Add()
+    shape = (1, 1024, 32)
+    inputs = [torch.rand(shape), torch.rand(shape)]
+
+    compiled_model = forge.compile(model, sample_inputs=[torch.rand(shape), torch.rand(shape)])
+
+    file_path = "generated_export_add.cpp"
+    compiled_model.export_to_cpp(file_path)
+
+    assert os.path.exists(file_path)
+    with open(file_path, "r") as f:
+        print(f.read())
+
+    os.remove(file_path)


### PR DESCRIPTION
Adding support for exporting compiled model as c++ source, via the MLIR `emitc` pipeline.

To export the model, the user would call `export_to_cpp()` on the already compiled model (`CompiledModel` instance). This means that there are no changes in the compile flow.

The `CompiledModel` will hold the `ForgeGraphModule` generated during the compile, so that it can execute the needed `tt-mlir` pipeline for generating c++ code on demand. The other option would be to hold the generated `ttir` text (during compile) in memory, so that the pipeline can be ran from that point onwards. I've chosen the first option, since it's simpler to fit in the existing flow, and I don't see a big improvement in the other approach.

Existing code for running the MLIR compiler is refactored a bit to allow generating different outputs (flatbuffer or cpp) without duplicating the logic.

Simple test is added to confirm the C++ generation completes successfully.

Example usage:
```python
compiled_model.export_to_cpp(file_name)
```

Closes #1340
Closes https://github.com/tenstorrent/tt-mlir/issues/1944
