### PR TITLE
[ci] fix docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,7 +60,7 @@ jobs:
       run: |
         source env/activate
         apt install cargo -y
-        cargo install --version ${MDBOOK_VERSION} mdbook
+        cargo install --version ${MDBOOK_VERSION} mdbook --locked
 
     - name: Setup Pages
       id: pages


### PR DESCRIPTION
Docs build is failing when installing `mdbook`. Because the latest version of some dependency needs newer `rustc`.

Adding `--locked` to the cargo install command, so that cargo respects `Cargo.lock` defined in `mdbooks` package.