### PR TITLE
Update resize2d nightly models ops test

### DIFF
--- a/forge/test/models_ops/test_resize2d.py
+++ b/forge/test/models_ops/test_resize2d.py
@@ -375,47 +375,33 @@ def ids_func(param):
 
 
 forge_modules_and_shapes_dtypes_list = [
-    pytest.param(
-        (
-            Resize2D0,
-            [((1, 256, 8, 8), torch.float32)],
-            {
-                "model_name": ["pt_fpn_base_img_cls_torchvision"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[16, 16]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D0,
+        [((1, 256, 8, 8), torch.float32)],
+        {
+            "model_name": ["pt_fpn_base_img_cls_torchvision"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[16, 16]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D1,
-            [((1, 256, 16, 16), torch.float32)],
-            {
-                "model_name": ["pt_fpn_base_img_cls_torchvision"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[64, 64]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D1,
+        [((1, 256, 16, 16), torch.float32)],
+        {
+            "model_name": ["pt_fpn_base_img_cls_torchvision"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[64, 64]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
     pytest.param(
         (
@@ -437,1065 +423,729 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 18, 28, 28), torch.float32)],
-            {
-                "model_name": [
-                    "pt_hrnet_hrnet_w18_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
-                    "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 18, 28, 28), torch.float32)],
+        {
+            "model_name": [
+                "pt_hrnet_hrnet_w18_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
+                "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 18, 14, 14), torch.float32)],
-            {
-                "model_name": [
-                    "pt_hrnet_hrnet_w18_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
-                    "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 18, 14, 14), torch.float32)],
+        {
+            "model_name": [
+                "pt_hrnet_hrnet_w18_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
+                "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 36, 14, 14), torch.float32)],
-            {
-                "model_name": [
-                    "pt_hrnet_hrnet_w18_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
-                    "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 36, 14, 14), torch.float32)],
+        {
+            "model_name": [
+                "pt_hrnet_hrnet_w18_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
+                "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 18, 7, 7), torch.float32)],
-            {
-                "model_name": [
-                    "pt_hrnet_hrnet_w18_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
-                    "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 18, 7, 7), torch.float32)],
+        {
+            "model_name": [
+                "pt_hrnet_hrnet_w18_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
+                "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 36, 7, 7), torch.float32)],
-            {
-                "model_name": [
-                    "pt_hrnet_hrnet_w18_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
-                    "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 36, 7, 7), torch.float32)],
+        {
+            "model_name": [
+                "pt_hrnet_hrnet_w18_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
+                "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D5,
-            [((1, 72, 7, 7), torch.float32)],
-            {
-                "model_name": [
-                    "pt_hrnet_hrnet_w18_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
-                    "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[14, 14]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D5,
+        [((1, 72, 7, 7), torch.float32)],
+        {
+            "model_name": [
+                "pt_hrnet_hrnet_w18_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
+                "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[14, 14]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 44, 28, 28), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w44_pose_estimation_timm", "pt_hrnet_hrnetv2_w44_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 44, 28, 28), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w44_pose_estimation_timm", "pt_hrnet_hrnetv2_w44_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 44, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w44_pose_estimation_timm", "pt_hrnet_hrnetv2_w44_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 44, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w44_pose_estimation_timm", "pt_hrnet_hrnetv2_w44_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 88, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w44_pose_estimation_timm", "pt_hrnet_hrnetv2_w44_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 88, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w44_pose_estimation_timm", "pt_hrnet_hrnetv2_w44_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 44, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w44_pose_estimation_timm", "pt_hrnet_hrnetv2_w44_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 44, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w44_pose_estimation_timm", "pt_hrnet_hrnetv2_w44_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 88, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w44_pose_estimation_timm", "pt_hrnet_hrnetv2_w44_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 88, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w44_pose_estimation_timm", "pt_hrnet_hrnetv2_w44_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D5,
-            [((1, 176, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w44_pose_estimation_timm", "pt_hrnet_hrnetv2_w44_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[14, 14]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D5,
+        [((1, 176, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w44_pose_estimation_timm", "pt_hrnet_hrnetv2_w44_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[14, 14]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 30, 28, 28), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnetv2_w30_pose_estimation_osmr", "pt_hrnet_hrnet_w30_pose_estimation_timm"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 30, 28, 28), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnetv2_w30_pose_estimation_osmr", "pt_hrnet_hrnet_w30_pose_estimation_timm"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 30, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnetv2_w30_pose_estimation_osmr", "pt_hrnet_hrnet_w30_pose_estimation_timm"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 30, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnetv2_w30_pose_estimation_osmr", "pt_hrnet_hrnet_w30_pose_estimation_timm"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 60, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnetv2_w30_pose_estimation_osmr", "pt_hrnet_hrnet_w30_pose_estimation_timm"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 60, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnetv2_w30_pose_estimation_osmr", "pt_hrnet_hrnet_w30_pose_estimation_timm"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 30, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnetv2_w30_pose_estimation_osmr", "pt_hrnet_hrnet_w30_pose_estimation_timm"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 30, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnetv2_w30_pose_estimation_osmr", "pt_hrnet_hrnet_w30_pose_estimation_timm"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 60, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnetv2_w30_pose_estimation_osmr", "pt_hrnet_hrnet_w30_pose_estimation_timm"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 60, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnetv2_w30_pose_estimation_osmr", "pt_hrnet_hrnet_w30_pose_estimation_timm"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D5,
-            [((1, 120, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnetv2_w30_pose_estimation_osmr", "pt_hrnet_hrnet_w30_pose_estimation_timm"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[14, 14]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D5,
+        [((1, 120, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnetv2_w30_pose_estimation_osmr", "pt_hrnet_hrnet_w30_pose_estimation_timm"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[14, 14]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 32, 28, 28), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 32, 28, 28), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 32, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 32, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 32, 14, 14), torch.float32)],
-            {
-                "model_name": [
-                    "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 32, 14, 14), torch.float32)],
+        {
+            "model_name": [
+                "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 64, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 64, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 64, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w64_pose_estimation_timm", "pt_hrnet_hrnetv2_w64_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 64, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w64_pose_estimation_timm", "pt_hrnet_hrnetv2_w64_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 32, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 32, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 32, 7, 7), torch.float32)],
-            {
-                "model_name": [
-                    "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 32, 7, 7), torch.float32)],
+        {
+            "model_name": [
+                "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 64, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 64, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D5,
-            [((1, 64, 7, 7), torch.float32)],
-            {
-                "model_name": [
-                    "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[14, 14]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D5,
+        [((1, 64, 7, 7), torch.float32)],
+        {
+            "model_name": [
+                "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[14, 14]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 64, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w64_pose_estimation_timm", "pt_hrnet_hrnetv2_w64_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 64, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w64_pose_estimation_timm", "pt_hrnet_hrnetv2_w64_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D5,
-            [((1, 128, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[14, 14]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D5,
+        [((1, 128, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[14, 14]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 128, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w64_pose_estimation_timm", "pt_hrnet_hrnetv2_w64_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 128, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w64_pose_estimation_timm", "pt_hrnet_hrnetv2_w64_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 16, 28, 28), torch.float32)],
-            {
-                "model_name": [
-                    "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 16, 28, 28), torch.float32)],
+        {
+            "model_name": [
+                "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 16, 14, 14), torch.float32)],
-            {
-                "model_name": [
-                    "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 16, 14, 14), torch.float32)],
+        {
+            "model_name": [
+                "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 16, 7, 7), torch.float32)],
-            {
-                "model_name": [
-                    "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
-                    "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 16, 7, 7), torch.float32)],
+        {
+            "model_name": [
+                "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
+                "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 64, 28, 28), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w64_pose_estimation_timm", "pt_hrnet_hrnetv2_w64_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 64, 28, 28), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w64_pose_estimation_timm", "pt_hrnet_hrnetv2_w64_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 128, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w64_pose_estimation_timm", "pt_hrnet_hrnetv2_w64_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 128, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w64_pose_estimation_timm", "pt_hrnet_hrnetv2_w64_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D5,
-            [((1, 256, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w64_pose_estimation_timm", "pt_hrnet_hrnetv2_w64_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[14, 14]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D5,
+        [((1, 256, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w64_pose_estimation_timm", "pt_hrnet_hrnetv2_w64_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[14, 14]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 48, 28, 28), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnetv2_w48_pose_estimation_osmr", "pt_hrnet_hrnet_w48_pose_estimation_timm"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 48, 28, 28), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnetv2_w48_pose_estimation_osmr", "pt_hrnet_hrnet_w48_pose_estimation_timm"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 48, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnetv2_w48_pose_estimation_osmr", "pt_hrnet_hrnet_w48_pose_estimation_timm"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 48, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnetv2_w48_pose_estimation_osmr", "pt_hrnet_hrnet_w48_pose_estimation_timm"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 96, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnetv2_w48_pose_estimation_osmr", "pt_hrnet_hrnet_w48_pose_estimation_timm"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 96, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnetv2_w48_pose_estimation_osmr", "pt_hrnet_hrnet_w48_pose_estimation_timm"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 48, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnetv2_w48_pose_estimation_osmr", "pt_hrnet_hrnet_w48_pose_estimation_timm"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 48, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnetv2_w48_pose_estimation_osmr", "pt_hrnet_hrnet_w48_pose_estimation_timm"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 96, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnetv2_w48_pose_estimation_osmr", "pt_hrnet_hrnet_w48_pose_estimation_timm"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 96, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnetv2_w48_pose_estimation_osmr", "pt_hrnet_hrnet_w48_pose_estimation_timm"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D5,
-            [((1, 192, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnetv2_w48_pose_estimation_osmr", "pt_hrnet_hrnet_w48_pose_estimation_timm"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[14, 14]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D5,
+        [((1, 192, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnetv2_w48_pose_estimation_osmr", "pt_hrnet_hrnet_w48_pose_estimation_timm"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[14, 14]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 40, 28, 28), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w40_pose_estimation_timm", "pt_hrnet_hrnetv2_w40_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 40, 28, 28), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w40_pose_estimation_timm", "pt_hrnet_hrnetv2_w40_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 40, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w40_pose_estimation_timm", "pt_hrnet_hrnetv2_w40_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 40, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w40_pose_estimation_timm", "pt_hrnet_hrnetv2_w40_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 80, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w40_pose_estimation_timm", "pt_hrnet_hrnetv2_w40_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 80, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w40_pose_estimation_timm", "pt_hrnet_hrnetv2_w40_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 40, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w40_pose_estimation_timm", "pt_hrnet_hrnetv2_w40_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 40, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w40_pose_estimation_timm", "pt_hrnet_hrnetv2_w40_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 80, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w40_pose_estimation_timm", "pt_hrnet_hrnetv2_w40_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 80, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w40_pose_estimation_timm", "pt_hrnet_hrnetv2_w40_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D5,
-            [((1, 160, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_hrnet_hrnet_w40_pose_estimation_timm", "pt_hrnet_hrnetv2_w40_pose_estimation_osmr"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[14, 14]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D5,
+        [((1, 160, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_hrnet_hrnet_w40_pose_estimation_timm", "pt_hrnet_hrnetv2_w40_pose_estimation_osmr"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[14, 14]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
     pytest.param(
         (
@@ -1509,328 +1159,244 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
-    pytest.param(
-        (
-            Resize2D7,
-            [((1, 256, 10, 32), torch.float32)],
-            {
-                "model_name": [
-                    "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[20, 64]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D7,
+        [((1, 256, 10, 32), torch.float32)],
+        {
+            "model_name": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[20, 64]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D8,
-            [((1, 128, 20, 64), torch.float32)],
-            {
-                "model_name": [
-                    "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[40, 128]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D8,
+        [((1, 128, 20, 64), torch.float32)],
+        {
+            "model_name": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[40, 128]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D9,
-            [((1, 64, 40, 128), torch.float32)],
-            {
-                "model_name": [
-                    "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[80, 256]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D9,
+        [((1, 64, 40, 128), torch.float32)],
+        {
+            "model_name": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[80, 256]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D10,
-            [((1, 32, 80, 256), torch.float32)],
-            {
-                "model_name": [
-                    "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[160, 512]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D10,
+        [((1, 32, 80, 256), torch.float32)],
+        {
+            "model_name": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[160, 512]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D11,
-            [((1, 16, 160, 512), torch.float32)],
-            {
-                "model_name": [
-                    "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[320, 1024]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D11,
+        [((1, 16, 160, 512), torch.float32)],
+        {
+            "model_name": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[320, 1024]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D12,
-            [((1, 256, 6, 20), torch.float32)],
-            {
-                "model_name": [
-                    "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[12, 40]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D12,
+        [((1, 256, 6, 20), torch.float32)],
+        {
+            "model_name": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[12, 40]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D13,
-            [((1, 128, 12, 40), torch.float32)],
-            {
-                "model_name": [
-                    "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[24, 80]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D13,
+        [((1, 128, 12, 40), torch.float32)],
+        {
+            "model_name": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[24, 80]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D14,
-            [((1, 64, 24, 80), torch.float32)],
-            {
-                "model_name": [
-                    "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[48, 160]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D14,
+        [((1, 64, 24, 80), torch.float32)],
+        {
+            "model_name": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[48, 160]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D15,
-            [((1, 32, 48, 160), torch.float32)],
-            {
-                "model_name": [
-                    "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[96, 320]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D15,
+        [((1, 32, 48, 160), torch.float32)],
+        {
+            "model_name": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[96, 320]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D16,
-            [((1, 16, 96, 320), torch.float32)],
-            {
-                "model_name": [
-                    "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[192, 640]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D16,
+        [((1, 16, 96, 320), torch.float32)],
+        {
+            "model_name": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[192, 640]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D17,
-            [((1, 256, 15, 20), torch.float32)],
-            {
-                "model_name": [
-                    "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
-                    "pt_retinanet_retinanet_rn152fpn_obj_det_hf",
-                    "pt_retinanet_retinanet_rn34fpn_obj_det_hf",
-                    "pt_retinanet_retinanet_rn50fpn_obj_det_hf",
-                    "pt_retinanet_retinanet_rn18fpn_obj_det_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[30, 40]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D17,
+        [((1, 256, 15, 20), torch.float32)],
+        {
+            "model_name": [
+                "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
+                "pt_retinanet_retinanet_rn152fpn_obj_det_hf",
+                "pt_retinanet_retinanet_rn34fpn_obj_det_hf",
+                "pt_retinanet_retinanet_rn50fpn_obj_det_hf",
+                "pt_retinanet_retinanet_rn18fpn_obj_det_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[30, 40]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D18,
-            [((1, 256, 30, 40), torch.float32)],
-            {
-                "model_name": [
-                    "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
-                    "pt_retinanet_retinanet_rn152fpn_obj_det_hf",
-                    "pt_retinanet_retinanet_rn34fpn_obj_det_hf",
-                    "pt_retinanet_retinanet_rn50fpn_obj_det_hf",
-                    "pt_retinanet_retinanet_rn18fpn_obj_det_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[60, 80]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D18,
+        [((1, 256, 30, 40), torch.float32)],
+        {
+            "model_name": [
+                "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
+                "pt_retinanet_retinanet_rn152fpn_obj_det_hf",
+                "pt_retinanet_retinanet_rn34fpn_obj_det_hf",
+                "pt_retinanet_retinanet_rn50fpn_obj_det_hf",
+                "pt_retinanet_retinanet_rn18fpn_obj_det_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[60, 80]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
     pytest.param(
         (
@@ -1853,7 +1419,7 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
@@ -1878,7 +1444,7 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
@@ -1903,7 +1469,7 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
@@ -1928,7 +1494,7 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
@@ -1952,7 +1518,7 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
@@ -1976,7 +1542,7 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
@@ -2000,7 +1566,7 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
@@ -2016,7 +1582,7 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
@@ -2032,7 +1598,7 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
@@ -2053,7 +1619,7 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
@@ -2074,823 +1640,554 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[
             pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception info: Unsupported mode"
             )
         ],
     ),
-    pytest.param(
-        (
-            Resize2D5,
-            [((1, 2048, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_unet_qubvel_img_seg_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[14, 14]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D5,
+        [((1, 2048, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_unet_qubvel_img_seg_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[14, 14]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D4,
-            [((1, 256, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_unet_qubvel_img_seg_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[28, 28]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D4,
+        [((1, 256, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_unet_qubvel_img_seg_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[28, 28]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D3,
-            [((1, 128, 28, 28), torch.float32)],
-            {
-                "model_name": ["pt_unet_qubvel_img_seg_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[56, 56]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D3,
+        [((1, 128, 28, 28), torch.float32)],
+        {
+            "model_name": ["pt_unet_qubvel_img_seg_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[56, 56]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D22,
-            [((1, 64, 56, 56), torch.float32)],
-            {
-                "model_name": ["pt_unet_qubvel_img_seg_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[112, 112]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D22,
+        [((1, 64, 56, 56), torch.float32)],
+        {
+            "model_name": ["pt_unet_qubvel_img_seg_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[112, 112]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D23,
-            [((1, 32, 112, 112), torch.float32)],
-            {
-                "model_name": ["pt_unet_qubvel_img_seg_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[224, 224]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D23,
+        [((1, 32, 112, 112), torch.float32)],
+        {
+            "model_name": ["pt_unet_qubvel_img_seg_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[224, 224]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D24,
-            [((1, 256, 40, 40), torch.float32)],
-            {
-                "model_name": [
-                    "pt_yolo_v5_yolov5s_imgcls_torchhub_1280x1280",
-                    "pt_yolo_v5_yolov5l_imgcls_torchhub_640x640",
-                    "pt_yolox_yolox_l_obj_det_torchhub",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[80, 80]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D24,
+        [((1, 256, 40, 40), torch.float32)],
+        {
+            "model_name": [
+                "pt_yolo_v5_yolov5s_imgcls_torchhub_1280x1280",
+                "pt_yolo_v5_yolov5l_imgcls_torchhub_640x640",
+                "pt_yolox_yolox_l_obj_det_torchhub",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[80, 80]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D25,
-            [((1, 128, 80, 80), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5s_imgcls_torchhub_1280x1280"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[160, 160]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D25,
+        [((1, 128, 80, 80), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5s_imgcls_torchhub_1280x1280"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[160, 160]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D26,
-            [((1, 640, 20, 20), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5x_imgcls_torchhub_640x640", "pt_yolox_yolox_x_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[40, 40]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D26,
+        [((1, 640, 20, 20), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5x_imgcls_torchhub_640x640", "pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[40, 40]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D24,
-            [((1, 320, 40, 40), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5x_imgcls_torchhub_640x640", "pt_yolox_yolox_x_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[80, 80]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D24,
+        [((1, 320, 40, 40), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5x_imgcls_torchhub_640x640", "pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[80, 80]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D27,
-            [((1, 640, 15, 15), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5x_imgcls_torchhub_480x480"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[30, 30]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D27,
+        [((1, 640, 15, 15), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5x_imgcls_torchhub_480x480"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[30, 30]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D28,
-            [((1, 320, 30, 30), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5x_imgcls_torchhub_480x480"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[60, 60]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D28,
+        [((1, 320, 30, 30), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5x_imgcls_torchhub_480x480"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[60, 60]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D27,
-            [((1, 256, 15, 15), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5s_imgcls_torchhub_480x480"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[30, 30]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D27,
+        [((1, 256, 15, 15), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5s_imgcls_torchhub_480x480"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[30, 30]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D28,
-            [((1, 128, 30, 30), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5s_imgcls_torchhub_480x480"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[60, 60]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D28,
+        [((1, 128, 30, 30), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5s_imgcls_torchhub_480x480"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[60, 60]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D29,
-            [((1, 384, 10, 10), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5m_imgcls_torchhub_320x320"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[20, 20]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D29,
+        [((1, 384, 10, 10), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5m_imgcls_torchhub_320x320"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[20, 20]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D26,
-            [((1, 192, 20, 20), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5m_imgcls_torchhub_320x320"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[40, 40]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D26,
+        [((1, 192, 20, 20), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5m_imgcls_torchhub_320x320"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[40, 40]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D29,
-            [((1, 128, 10, 10), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5n_imgcls_torchhub_320x320"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[20, 20]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D29,
+        [((1, 128, 10, 10), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5n_imgcls_torchhub_320x320"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[20, 20]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D26,
-            [((1, 64, 20, 20), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5n_imgcls_torchhub_320x320"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[40, 40]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D26,
+        [((1, 64, 20, 20), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5n_imgcls_torchhub_320x320"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[40, 40]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D26,
-            [((1, 128, 20, 20), torch.float32)],
-            {
-                "model_name": [
-                    "pt_yolo_v5_yolov5n_imgcls_torchhub_640x640",
-                    "pt_yolo_v5_yolov5s_imgcls_torchhub_320x320",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[40, 40]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D26,
+        [((1, 128, 20, 20), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5n_imgcls_torchhub_640x640", "pt_yolo_v5_yolov5s_imgcls_torchhub_320x320"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[40, 40]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D24,
-            [((1, 64, 40, 40), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5n_imgcls_torchhub_640x640"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[80, 80]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D24,
+        [((1, 64, 40, 40), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5n_imgcls_torchhub_640x640"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[80, 80]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D26,
-            [((1, 256, 20, 20), torch.float32)],
-            {
-                "model_name": [
-                    "pt_yolo_v5_yolov5s_imgcls_torchhub_640x640",
-                    "pt_yolo_v5_yolov5l_imgcls_torchhub_320x320",
-                    "pt_yolox_yolox_s_obj_det_torchhub",
-                    "pt_yolox_yolox_darknet_obj_det_torchhub",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[40, 40]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D26,
+        [((1, 256, 20, 20), torch.float32)],
+        {
+            "model_name": [
+                "pt_yolo_v5_yolov5s_imgcls_torchhub_640x640",
+                "pt_yolo_v5_yolov5l_imgcls_torchhub_320x320",
+                "pt_yolox_yolox_s_obj_det_torchhub",
+                "pt_yolox_yolox_darknet_obj_det_torchhub",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[40, 40]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D24,
-            [((1, 128, 40, 40), torch.float32)],
-            {
-                "model_name": [
-                    "pt_yolo_v5_yolov5s_imgcls_torchhub_640x640",
-                    "pt_yolox_yolox_s_obj_det_torchhub",
-                    "pt_yolox_yolox_darknet_obj_det_torchhub",
-                ],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[80, 80]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D24,
+        [((1, 128, 40, 40), torch.float32)],
+        {
+            "model_name": [
+                "pt_yolo_v5_yolov5s_imgcls_torchhub_640x640",
+                "pt_yolox_yolox_s_obj_det_torchhub",
+                "pt_yolox_yolox_darknet_obj_det_torchhub",
+            ],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[80, 80]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D27,
-            [((1, 384, 15, 15), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5m_imgcls_torchhub_480x480"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[30, 30]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D27,
+        [((1, 384, 15, 15), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5m_imgcls_torchhub_480x480"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[30, 30]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D28,
-            [((1, 192, 30, 30), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5m_imgcls_torchhub_480x480"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[60, 60]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D28,
+        [((1, 192, 30, 30), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5m_imgcls_torchhub_480x480"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[60, 60]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D26,
-            [((1, 512, 20, 20), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5l_imgcls_torchhub_640x640", "pt_yolox_yolox_l_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[40, 40]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D26,
+        [((1, 512, 20, 20), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5l_imgcls_torchhub_640x640", "pt_yolox_yolox_l_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[40, 40]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D29,
-            [((1, 512, 10, 10), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5l_imgcls_torchhub_320x320"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[20, 20]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D29,
+        [((1, 512, 10, 10), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5l_imgcls_torchhub_320x320"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[20, 20]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D29,
-            [((1, 640, 10, 10), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5x_imgcls_torchhub_320x320"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[20, 20]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D29,
+        [((1, 640, 10, 10), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5x_imgcls_torchhub_320x320"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[20, 20]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D26,
-            [((1, 320, 20, 20), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5x_imgcls_torchhub_320x320"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[40, 40]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D26,
+        [((1, 320, 20, 20), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5x_imgcls_torchhub_320x320"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[40, 40]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D27,
-            [((1, 512, 15, 15), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5l_imgcls_torchhub_480x480"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[30, 30]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D27,
+        [((1, 512, 15, 15), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5l_imgcls_torchhub_480x480"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[30, 30]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D28,
-            [((1, 256, 30, 30), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5l_imgcls_torchhub_480x480"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[60, 60]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D28,
+        [((1, 256, 30, 30), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5l_imgcls_torchhub_480x480"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[60, 60]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D27,
-            [((1, 128, 15, 15), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5n_imgcls_torchhub_480x480"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[30, 30]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D27,
+        [((1, 128, 15, 15), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5n_imgcls_torchhub_480x480"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[30, 30]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D28,
-            [((1, 64, 30, 30), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5n_imgcls_torchhub_480x480"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[60, 60]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D28,
+        [((1, 64, 30, 30), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5n_imgcls_torchhub_480x480"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[60, 60]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D29,
-            [((1, 256, 10, 10), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5s_imgcls_torchhub_320x320"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[20, 20]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D29,
+        [((1, 256, 10, 10), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5s_imgcls_torchhub_320x320"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[20, 20]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D26,
-            [((1, 384, 20, 20), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5m_imgcls_torchhub_640x640", "pt_yolox_yolox_m_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[40, 40]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D26,
+        [((1, 384, 20, 20), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5m_imgcls_torchhub_640x640", "pt_yolox_yolox_m_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[40, 40]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D24,
-            [((1, 192, 40, 40), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v5_yolov5m_imgcls_torchhub_640x640", "pt_yolox_yolox_m_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[80, 80]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D24,
+        [((1, 192, 40, 40), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v5_yolov5m_imgcls_torchhub_640x640", "pt_yolox_yolox_m_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[80, 80]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D30,
-            [((1, 192, 13, 13), torch.float32)],
-            {
-                "model_name": ["pt_yolox_yolox_tiny_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[26, 26]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D30,
+        [((1, 192, 13, 13), torch.float32)],
+        {
+            "model_name": ["pt_yolox_yolox_tiny_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[26, 26]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D31,
-            [((1, 96, 26, 26), torch.float32)],
-            {
-                "model_name": ["pt_yolox_yolox_tiny_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[52, 52]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D31,
+        [((1, 96, 26, 26), torch.float32)],
+        {
+            "model_name": ["pt_yolox_yolox_tiny_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[52, 52]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D30,
-            [((1, 128, 13, 13), torch.float32)],
-            {
-                "model_name": ["pt_yolox_yolox_nano_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[26, 26]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D30,
+        [((1, 128, 13, 13), torch.float32)],
+        {
+            "model_name": ["pt_yolox_yolox_nano_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[26, 26]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Resize2D31,
-            [((1, 64, 26, 26), torch.float32)],
-            {
-                "model_name": ["pt_yolox_yolox_nano_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "sizes": "[52, 52]",
-                    "method": '"nearest_neighbor"',
-                    "align_corners": "False",
-                    "channel_last": "0",
-                },
+    (
+        Resize2D31,
+        [((1, 64, 26, 26), torch.float32)],
+        {
+            "model_name": ["pt_yolox_yolox_nano_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "sizes": "[52, 52]",
+                "method": '"nearest_neighbor"',
+                "align_corners": "False",
+                "channel_last": "0",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+        },
     ),
 ]
 


### PR DESCRIPTION
Resize2d(i.e upsample2d) op is supported in tt-forge-fe in [this commit ](https://github.com/tenstorrent/tt-forge-fe/commit/6b68496c3057b1a7eb87eebdbb1515215739dc0d) and in the latest run nightly models ops test (i.e https://github.com/tenstorrent/tt-forge-fe/actions/runs/13580014696) resize2d ops with bilinear mode test are failling with below error due to bilinear mode not supported for upsample op in tt-metal

```
E       RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp:118: tt::exception
E       info:
E       Unsupported mode
```