### PR TITLE
verify now returns outputs from forward pass + tests rework

### DIFF
--- a/forge/forge/verify/__init__.py
+++ b/forge/forge/verify/__init__.py
@@ -1,5 +1,14 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-from .config import DepricatedVerifyConfig, TestKind
-from .verify import do_verify, verify_golden, _generate_random_losses, _run_pytorch_backward, get_intermediate_tensors
+from .config import DepricatedVerifyConfig, TestKind, VerifyConfig
+from .verify import (
+    do_verify,
+    verify_golden,
+    _generate_random_losses,
+    _run_pytorch_backward,
+    get_intermediate_tensors,
+    verify,
+)
+from .compare import compare_with_golden
+from .value_checkers import AutomaticValueChecker, AllCloseValueChecker, FullValueChecker


### PR DESCRIPTION
### Ticket
Fix #1331 

### Problem description
`verify()` needed to return outputs from the forward pass, as there are some use cases where we need outputs of forward pass.

### What's changed
Changed `verify()` to return outputs from framework and compiled model and also updated tests.