### PR TITLE
Fix: 'ttnn.conv2d' op Bias must only have data on the final dimenstion

### DIFF
--- a/forge/csrc/passes/fuse_conv2d_bias.cpp
+++ b/forge/csrc/passes/fuse_conv2d_bias.cpp
@@ -66,6 +66,11 @@ void fuse_conv2d_bias(graphlib::Graph *graph)
 
         // Create a new bias edge to conv2d
         tt::graphlib::Edge bias_input_edge = graph->operand_data_edges(op)[1];
+
+        // The broadcast dimensions are cleared in the bias edge before copying to the conv2d edge,
+        // as the conv2d bias needs to be converted to the required layout.
+        graph->get_edge_attributes(bias_input_edge)->clear_broadcast_dims();
+
         tt::graphlib::Edge new_bias_input_edge = tt::graphlib::Edge(
             bias_input_edge.producer_node_id,
             bias_input_edge.producer_output_port_id,

--- a/forge/forge/op/convolution.py
+++ b/forge/forge/op/convolution.py
@@ -61,7 +61,7 @@ def Conv2d(
         stride=stride,
         dilation=dilation,
         groups=groups,
-        padding=padding,
+        padding=padding,  # [pT, pL, pB, pR]
         channel_last=channel_last,
     ).get_tensor()
 

--- a/forge/forge/op/eval/forge/convolution.py
+++ b/forge/forge/op/eval/forge/convolution.py
@@ -133,6 +133,11 @@ class Conv2d(PyOp):
             activations = dc.op(TransposeTM.create(dim0=-3, dim1=-2), [activations])
             activations = dc.op(TransposeTM.create(dim0=-2, dim1=-1), [activations])
 
+        # The below condition checks whether the channel is last and the required output channel position (1, 1, 1, C_out) in the bias, as well as the bias type.
+        if (bias is not None) and (bias.shape[-1] != weight.shape[-4]) and (not is_channel_last):
+            bias = dc.op(TransposeTM.create(dim0=-3, dim1=-2), [bias])
+            bias = dc.op(TransposeTM.create(dim0=-2, dim1=-1), [bias])
+
         # Only want to re-create the Conv2d op if something has changed. Otherwise it the compiler will infinitely
         # decompose the same Conv2d over and over.
         if not is_bias_unchanged or not is_channel_last:
@@ -303,6 +308,11 @@ class Conv2dTranspose(PyOp):
         if not is_channel_last:
             activations = dc.op(TransposeTM.create(dim0=-3, dim1=-2), [activations])
             activations = dc.op(TransposeTM.create(dim0=-2, dim1=-1), [activations])
+
+        # The below condition checks whether the channel is last and the required output channel position (1, 1, 1, C_out) in the bias, as well as the bias type.
+        if (bias is not None) and (bias.shape[-1] != weight.shape[-4]) and (not is_channel_last):
+            bias = dc.op(TransposeTM.create(dim0=-3, dim1=-2), [bias])
+            bias = dc.op(TransposeTM.create(dim0=-2, dim1=-1), [bias])
 
         # Only want to re-create the Conv2dTranspose op if something has changed. Otherwise it the compiler will infinitely
         # decompose the same Conv2dTranspose over and over.

--- a/forge/forge/op/eval/forge/convolution.py
+++ b/forge/forge/op/eval/forge/convolution.py
@@ -31,8 +31,7 @@ class Conv2d(PyOp):
         self = cls("conv2d")
         self.stride = stride
         self.groups = groups
-        # Transform padding from [pL, pR, pT, pB] to [pT, pL, pB, pR]
-        self.padding = [padding[2], padding[0], padding[3], padding[1]]
+        self.padding = padding
         self.dilation = dilation
         self.channel_last = int(channel_last)
         return self
@@ -47,7 +46,7 @@ class Conv2d(PyOp):
         bias = t_ops[2] if len(t_ops) == 3 else None
 
         groups = self.groups
-        padding = self.padding
+        padding = [self.padding[1], self.padding[3], self.padding[0], self.padding[2]]
         stride = self.stride
         dilation = self.dilation
 

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -555,18 +555,11 @@ def populate_conv2d_args(graph, nid, compiler_cfg):
     )
 
     padding = [int(padding) for padding in node["attrs"]["padding"][0]]
-    # TVM has padding [top, left, bottom, right]
-    # Convert to [left right top bottom]
-    reordered_padding = [
-        padding[1],
-        padding[3],
-        padding[0],
-        padding[2],
-    ]
+    # Retaining the Padding format for Forge Conv2d Pad Format (Top,Left,Bottom,Right)
     args.append(
         (
             "padding",
-            f"{reordered_padding}",
+            f"{padding}",
         )
     )
 

--- a/forge/test/mlir/operators/nn/test_nn.py
+++ b/forge/test/mlir/operators/nn/test_nn.py
@@ -10,7 +10,6 @@ import forge
 from forge.verify.verify import verify
 
 
-@pytest.mark.xfail(reason="error: 'ttnn.conv2d' op Bias must only have data on the final dimenstion")
 @pytest.mark.parametrize(
     "input_shape, in_channels, out_channels, kernel_size, padding_value",
     [
@@ -396,14 +395,8 @@ def test_avgpool2d_decompose_to_conv2d(shape, padding):
 @pytest.mark.parametrize(
     "padding",
     [
-        pytest.param(
-            (1, 1, 1, 1),
-            marks=pytest.mark.xfail(reason="'ttnn.conv2d' op Bias must only have data on the final dimenstion"),
-        ),
-        pytest.param(
-            (1, 1, 2, 2),
-            marks=pytest.mark.xfail(reason="'ttnn.conv2d' op Bias must only have data on the final dimenstion"),
-        ),
+        pytest.param((1, 1, 1, 1)),
+        pytest.param((1, 1, 2, 2)),
         pytest.param(
             (1, 2, 1, 2),
             marks=pytest.mark.xfail(


### PR DESCRIPTION
### Ticket
Fix https://github.com/tenstorrent/tt-forge-fe/issues/637,
Fix https://github.com/tenstorrent/tt-mlir/issues/1533

### Problem description
'ttnn.conv2d' op Bias must only have data on the final dimenstion

### What's changed
1. Remove xfail statements related to this error in the test files
2. Updated the convolution decomposition to support channel last operation for bias input.
3. Updated the fuse_conv2d_bias pass: The broadcast dimensions are cleared in the bias edge before copying to the conv2d edge,

### Description
The conv2d bias  will be fused during the post_initial_graph stage by the fuse_conv2d_bias pass where the bias edge which is added after the conv2d op will be connected to the conv2d port as part of the fusing the old edge attributes of  type NCHW will be copied to the new edge as the tms introduce to the conv2d bias edge which causes the layout issue.

The approach to solving this issue involves removal of broadcast dims which is not necessary for the conv2d bias edge ,as we require the bias to be in the shape: (1, 1, 1, C_out) we will add the transpose to the decomposition of the conv2d for maintaining the channel last for the ttnn.