### PR TITLE
 Fix the execution phase and stage recording issue and replace compare_with_golden with verify function

### DIFF
--- a/forge/forge/compiled_graph_state.py
+++ b/forge/forge/compiled_graph_state.py
@@ -17,7 +17,6 @@ from forge._C.runtime import run_binary, Binary
 from forge._C import run_mlir_compiler_to_cpp
 from forge.tensor import Tensor, get_post_const_eval_tensors, to_pt_tensors, cast_unsupported_torch_dtype, AnyTensor
 from forge.module import Module, PyTorchModule, AnyModule
-from forge.execution_tracker import ExecutionPhase, record_execution_phase_and_stage
 
 
 class CompileResults:
@@ -284,8 +283,6 @@ class CompiledModel:
                 # NOTE: the default idx parameter for the lambda is used to capture the idx by value. Otherwise, the lambda
                 # would capture the idx by reference, and all the lambdas would have the same idx value.
                 output.register_hook(lambda grad, idx=idx: self.tie_grad_fn(idx, grad))
-
-        record_execution_phase_and_stage(ExecutionPhase.EXECUTED_TTNN)
 
         return model_outputs
 

--- a/forge/forge/execution_tracker.py
+++ b/forge/forge/execution_tracker.py
@@ -108,13 +108,7 @@ class ExecutionStage(Enum):
 
     # Stage under PASSED
 
-    # 1. Compared the golden and framework output (compare_with_golden in forge/forge/verify/compare.py).
-    COMPARE_WITH_GOLDEN = (
-        ExecutionPhase.PASSED,
-        "COMPARE_WITH_GOLDEN",
-    )
-
-    # 2. Performed verification (verify function in forge/forge/verify/verify.py).
+    # 1. Performed verification (verify function in forge/forge/verify/verify.py).
     VERIFICATON = (ExecutionPhase.PASSED, "VERIFICATON")
 
     def __init__(self, phase, stage_name):

--- a/forge/forge/python_codegen.py
+++ b/forge/forge/python_codegen.py
@@ -159,7 +159,6 @@ class ForgeWriter(PythonWriter):
         if include_pytest_imports:
             self.wl("")
             self.wl("from forge import Tensor, compile")
-            self.wl("from forge.verify.compare import compare_with_golden")
             self.wl("from forge.verify.verify import verify")
             self.wl("from forge.verify.value_checkers import AutomaticValueChecker")
             self.wl("from forge.verify.config import VerifyConfig")

--- a/forge/forge/verify/compare.py
+++ b/forge/forge/verify/compare.py
@@ -13,7 +13,6 @@ from loguru import logger
 from scipy.spatial import distance
 
 from forge.tensor import narrow_forge_tensor_to_pytorch
-from forge.execution_tracker import ExecutionPhase, ExecutionStage, record_execution_phase_and_stage
 
 # Compares golden and calculated tensors. Using allclose for scalar values, rogerstanimoto for bool tensors, pcc otherwise
 def compare_with_golden(
@@ -44,13 +43,6 @@ def compare_with_golden(
             logger.error(calculated)
 
         result = all_close
-
-    # The verify function (in forge/forge/verify/verify.py) calls compare_with_golden for each output.
-    # If any call returns False, it signals a tensor mismatch, so we revert to the previous execution phase (EXECUTED_TTNN)
-    if result:
-        record_execution_phase_and_stage(ExecutionStage.COMPARE_WITH_GOLDEN)
-    else:
-        record_execution_phase_and_stage(ExecutionPhase.EXECUTED_TTNN)
 
     return result
 

--- a/forge/forge/verify/verify.py
+++ b/forge/forge/verify/verify.py
@@ -22,7 +22,7 @@ import forge._C.graph as pygraph
 from forge.tools.run_net2pipe import net2pipe
 from forge.compiled_graph_state import CompiledModel
 from forge.verify.compare import compare_tensor_to_golden
-from forge.execution_tracker import ExecutionStage, record_execution_phase_and_stage
+from forge.execution_tracker import ExecutionPhase, ExecutionStage, record_execution_phase_and_stage
 
 
 def _generate_random_losses(outputs, is_forge):
@@ -310,7 +310,9 @@ def verify(
     # 1st step: run forward pass for the networks
     fw_out = framework_model(*inputs)
 
+    record_execution_phase_and_stage(ExecutionPhase.COMPILE_MLIR)
     co_out = compiled_model(*inputs)
+    record_execution_phase_and_stage(ExecutionPhase.EXECUTED_TTNN)
 
     # 2nd step: apply preprocessing (push tensors to cpu, perform any reshape if necessary,
     #  cast from tensorflow tensors to pytorch tensors if needed)

--- a/forge/test/benchmark/benchmark/models/mnist_linear.py
+++ b/forge/test/benchmark/benchmark/models/mnist_linear.py
@@ -10,7 +10,7 @@ import json
 import torch
 from torch import nn
 import forge
-from forge.verify.compare import compare_with_golden_pcc
+from forge.verify.verify import verify
 
 # Common constants
 GIT_REPO_NAME = "tenstorrent/tt-forge-fe"
@@ -108,8 +108,7 @@ def test_mnist_linear(
         co_out = compiled_model(*inputs)
     end = time.time()
 
-    co_out = [co.to("cpu") for co in co_out]
-    assert [compare_with_golden_pcc(golden=fo, calculated=co) for fo, co in zip(fw_out, co_out)]
+    verify(inputs, framework_model, compiled_model)
 
     short_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("ascii").strip()
     date = (

--- a/forge/test/mlir/llama/tests/test_llama_decode.py
+++ b/forge/test/mlir/llama/tests/test_llama_decode.py
@@ -4,12 +4,58 @@
 import pytest
 
 import torch
-from transformers import LlamaConfig, LlamaForCausalLM, LlamaTokenizer
 from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
 
 import forge
-from forge.verify.compare import compare_with_golden
+from forge.verify.verify import verify
 from test.mlir.llama.utils.utils import load_model
+from typing import List, Tuple
+from loguru import logger
+
+
+def flatten_pastkv(past_key_values_list: List[Tuple[torch.Tensor, torch.Tensor]]) -> List[torch.Tensor]:
+    """
+    Flattens a list of past key-value pairs into a single list of tensors.
+
+    Each element in `past_key_values_list` is a tuple containing two torch.Tensors
+    (typically representing a key and its corresponding value). This function
+    concatenates all these tuples into one flat list, preserving their order.
+
+    Args:
+        past_key_values_list (List[Tuple[torch.Tensor, torch.Tensor]]): A list of key-value pairs,
+            where each pair is represented as a tuple of two torch.Tensors.
+
+    Returns:
+        List[torch.Tensor]: A flattened list containing all the torch.Tensors from the input pairs.
+    """
+    new_past_key_values_list: List[torch.Tensor] = []
+    for past_key_values in past_key_values_list:
+        # Extend the flat list with both the key and value from the current pair.
+        new_past_key_values_list.extend(list(past_key_values))
+    return new_past_key_values_list
+
+
+def unflatten_pastkv(past_key_values_list: List[torch.Tensor]) -> List[List[torch.Tensor]]:
+    """
+    Unflattens a flat list of tensors into a list of key-value pairs.
+
+    The function assumes that the input list contains an even number of elements,
+    where every two consecutive tensors form a key-value pair. For example, if the
+    input list is [key1, value1, key2, value2], it returns [(key1, value1), (key2, value2)].
+
+    Args:
+        past_key_values_list (List[torch.Tensor]): A flat list of torch.Tensors.
+
+    Returns:
+        List[List[torch.Tensor]]: A list of List, each containing two torch.Tensors.
+
+    Note:
+        If the length of `past_key_values_list` is not even, assertion error will be thrown.
+    """
+    assert len(past_key_values_list) % 2 == 0, "past_key_values_list length should be a multiple of two"
+
+    # Group every two consecutive tensors into a tuple.
+    return [past_key_values_list[idx : idx + 2] for idx in range(0, len(past_key_values_list), 2)]
 
 
 class LlamaModelWrapper(torch.nn.Module):
@@ -24,7 +70,7 @@ class LlamaModelWrapper(torch.nn.Module):
             input_id (`torch.Tensor`) - shape of (batch_size, 1)
             attention_mask (`torch.Tensor`) -  shape of (batch_size, key_value_seq_len + 1)
             position_ids (`torch.Tensor`) -  shape of (batch_size, 1)
-            past_key_values (`List[List[torch.Tensor, torch.Tensor]]`)
+            past_key_values (`List[torch.Tensor]`)
                         key/values shape: (batch_size, num_of_key_values_heads, key_value_seq_len, head_dim)
 
     Returns:
@@ -32,7 +78,7 @@ class LlamaModelWrapper(torch.nn.Module):
             logits (`torch.Tensor`) - shape (batch_size, seq_length, vocab_size)
         2) use_cache = True
             logits (`torch.Tensor`) - shape (batch_size, 1, vocab_size)
-            past_key_values (`List[List[torch.Tensor, torch.Tensor]]`)
+            past_key_values (`List[torch.Tensor]`)
                         key/values shape: (batch_size, num_of_key_values_heads, key_value_seq_len + 1, head_dim)
     """
 
@@ -41,9 +87,13 @@ class LlamaModelWrapper(torch.nn.Module):
         self.model = model
         self.embed_tokens = model.model.embed_tokens
 
-    def forward(self, input_ids, attention_mask, position_ids=None, past_key_values=None):
+    def forward(self, input_ids, attention_mask, position_ids=None, *past_key_values):
 
         inputs_embeds = self.embed_tokens(input_ids)
+
+        # Formate the past key values from List(Key1, Values1, ... , KeyN, ValuesN) to
+        # List(List(Key1, Values1), ... , List(KeyN, ValuesN))
+        past_key_values = unflatten_pastkv(past_key_values) if len(past_key_values) > 0 else None
 
         # The causal_mask calculated inside _update_causal_mask method in LlamaModel module
         # is not properly traced by torch.jit.trace while converting pytorch to relay ops in TVM PyTorch Frontend Conversion
@@ -53,17 +103,19 @@ class LlamaModelWrapper(torch.nn.Module):
         causal_attention_mask = _prepare_4d_causal_attention_mask(
             attention_mask, input_ids.shape, inputs_embeds, past_key_values_length
         )
-        model_outputs = self.model(
+        outputs = self.model(
             attention_mask=causal_attention_mask,
             position_ids=position_ids,
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
         )
+        model_outputs = [outputs.logits]
+        if outputs.past_key_values is not None:
+            # Formate the past key values from List(List(Key1, Values1), ... , List(KeyN, ValuesN)) to
+            # List(Key1, Values1, ... , KeyN, ValuesN)
+            model_outputs.extend(flatten_pastkv(outputs.past_key_values))
 
-        if model_outputs.past_key_values is not None:
-            return model_outputs.logits, model_outputs.past_key_values
-
-        return model_outputs.logits
+        return model_outputs
 
 
 def calculate_attention_mask_and_postion_ids(
@@ -87,14 +139,40 @@ def calculate_attention_mask_and_postion_ids(
     return attention_mask, position_ids
 
 
-@pytest.mark.parametrize("run_on_tt_device", [False, True])
-def test_llama_prefill_on_cpu_decode_on_tt_no_cache(run_on_tt_device):
-    # Load Llama 3B model and tokenizer
-    model_path = "openlm-research/open_llama_3b"
-    model, tokenizer = load_model(model_path, return_dict=True, use_cache=False, use_fast=False)
+@pytest.mark.parametrize(
+    "model_path, run_on_tt_device",
+    [
+        ("openlm-research/open_llama_3b", False),
+        ("meta-llama/Llama-3.2-1B", False),
+        pytest.param(
+            "openlm-research/open_llama_3b",
+            True,
+            marks=pytest.mark.skip(
+                reason="Insufficient host DRAM to run this model (requires a bit more than 32 GB during compile time)"
+            ),
+        ),
+        pytest.param(
+            "meta-llama/Llama-3.2-1B",
+            True,
+            marks=pytest.mark.xfail(
+                reason="tt_metal/impl/kernels/kernel.cpp:242: tt::exception unique+common runtime args targeting kernel reader_concat_stick_layout_interleaved_start_id on (x=0,y=0) are too large. Max allowable is 256"
+            ),
+        ),
+    ],
+)
+def test_llama_prefill_on_cpu_decode_on_tt_no_cache(model_path, run_on_tt_device):
+
+    use_fast = False if model_path == "openlm-research/open_llama_3b" else True
+
+    # Load Llama model and tokenizer
+    model, tokenizer = load_model(model_path, return_dict=True, use_cache=False, use_fast=use_fast)
     framework_model = LlamaModelWrapper(model)
     framework_model.eval()
-    tokenizer.pad_token_id = model.config.pad_token_id
+
+    if model_path == "openlm-research/open_llama_3b":
+        tokenizer.pad_token_id = model.config.pad_token_id
+    elif model_path == "meta-llama/Llama-3.2-1B":
+        tokenizer.pad_token = tokenizer.eos_token
 
     # Prepare input sentence
     max_sequence_length = 58
@@ -113,7 +191,7 @@ def test_llama_prefill_on_cpu_decode_on_tt_no_cache(run_on_tt_device):
     padding_seq_len = attention_mask.shape[1] - non_padding_seq_len
 
     # Run Prefill on CPU with no cache to get the initial logits
-    logits = framework_model(input_ids=input_ids, attention_mask=attention_mask)
+    logits = framework_model(input_ids=input_ids, attention_mask=attention_mask)[0]
 
     # Take the last non padding token index in logits for the next token
     next_token_logits = logits[:, non_padding_seq_len - 1, :]
@@ -127,46 +205,32 @@ def test_llama_prefill_on_cpu_decode_on_tt_no_cache(run_on_tt_device):
     padding_seq_len = attention_mask.shape[1] - non_padding_seq_len
 
     if run_on_tt_device:
-        compiler_cfg = forge.config.CompilerConfig()
-        compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
-
         # Compile the model on TT
         compiled_model = forge.compile(
-            framework_model, sample_inputs=[input_ids, attention_mask], compiler_cfg=compiler_cfg
+            framework_model,
+            sample_inputs=[input_ids, attention_mask],
         )
-        pytest.xfail("Found Unsupported operations while lowering from TTForge to TTIR in forward graph.")
 
     # Run decode stage on TT device and generate tokens by appending predicted token into sequence of input tokens
     # untill the a specified maximum number of new tokens is reached or an end-of-sequence token is encountered.
     max_new_tokens = padding_seq_len
     for idx in range(max_new_tokens):
 
-        # CPU Inference
-        framework_output = framework_model(input_ids=input_ids, attention_mask=attention_mask)
-
         if run_on_tt_device:
 
-            model_inputs = [input_ids, attention_mask]
+            tt_inputs = [input_ids, attention_mask]
 
-            # Run on TT device
-            tt_output = compiled_model(*model_inputs)
-            tt_output = [tt_out.to("cpu") for tt_out in tt_output]
-
-            framework_output = [framework_output] if isinstance(framework_output, torch.Tensor) else framework_output
-
-            # Validate TT result with Framework
-            assert all(
-                [
-                    compare_with_golden(golden=fw_out, calculated=tt_out)
-                    for fw_out, tt_out in zip(framework_output, tt_output)
-                ]
-            )
+            # Run on TT device and validate TT result with Framework
+            framework_output, tt_output = verify(tt_inputs, framework_model, compiled_model)
 
             logits = tt_output[0]
 
         else:
 
-            logits = framework_output
+            # CPU Inference
+            framework_output = framework_model(input_ids=input_ids, attention_mask=attention_mask)
+
+            logits = framework_output[0]
 
         next_token_index = non_padding_seq_len + idx
         next_token_logits = logits[:, next_token_index - 1, :]
@@ -183,15 +247,38 @@ def test_llama_prefill_on_cpu_decode_on_tt_no_cache(run_on_tt_device):
     print("generated_text=", generated_text)
 
 
-@pytest.mark.parametrize("run_on_tt_device", [False, True])
-def test_llama_prefill_on_cpu_decode_on_tt_cache(run_on_tt_device):
+@pytest.mark.parametrize(
+    "model_path, run_on_tt_device",
+    [
+        ("openlm-research/open_llama_3b", False),
+        ("meta-llama/Llama-3.2-1B", False),
+        pytest.param(
+            "openlm-research/open_llama_3b",
+            True,
+            marks=pytest.mark.skip(
+                reason="Insufficient host DRAM to run this model (requires a bit more than 32 GB during compile time)"
+            ),
+        ),
+        pytest.param(
+            "meta-llama/Llama-3.2-1B",
+            True,
+            marks=pytest.mark.xfail(reason="BinaryOpType cannot be mapped to BcastOpMath"),
+        ),
+    ],
+)
+def test_llama_prefill_on_cpu_decode_on_tt_cache(model_path, run_on_tt_device):
 
-    # Load Llama 3B model and tokenizer
-    model_path = "openlm-research/open_llama_3b"
+    use_fast = False if model_path == "openlm-research/open_llama_3b" else True
+
+    # Load Llama model and tokenizer
     model, tokenizer = load_model(model_path, return_dict=True, use_cache=True, use_fast=False)
     framework_model = LlamaModelWrapper(model)
     framework_model.eval()
-    tokenizer.pad_token_id = model.config.pad_token_id
+
+    if model_path == "openlm-research/open_llama_3b":
+        tokenizer.pad_token_id = model.config.pad_token_id
+    elif model_path == "meta-llama/Llama-3.2-1B":
+        tokenizer.pad_token = tokenizer.eos_token
 
     # Prepare input sentence
     prompt = "Q: What is the largest animal?\nA:"
@@ -205,92 +292,68 @@ def test_llama_prefill_on_cpu_decode_on_tt_cache(run_on_tt_device):
     generated_tokens = inputs.input_ids
     generated_tokens = torch.cat([generated_tokens, next_token.unsqueeze(0)], dim=-1)
 
-    past_key_values_list = [[k, v] for k, v in prefill_output[1]]
-
-    model_inputs = [next_token.unsqueeze(0), past_key_values_list]
+    model_inputs = [next_token.unsqueeze(0)]
+    model_inputs.extend(prefill_output[1:])
 
     # Zero Pad past key values in key_value_seq_len(i.e -2) dimension
     # Before padding past key values tensor shape -> (batch_size, num_of_key_values_heads, key_value_seq_len, head_dim)
     # After Padding Past key value tensor shape -> (batch_size, num_of_key_values_heads, key_value_seq_len + max_new_tokens, head_dim)
     max_new_tokens = 46
-    non_padding_seq_length = past_key_values_list[0][0].shape[-2]
-    for idx, (k, v) in enumerate(model_inputs[1]):
-        model_inputs[1][idx][0] = torch.cat(
+    non_padding_seq_length = prefill_output[1].shape[-2]
+    for idx, past_key_or_values_states in enumerate(model_inputs[1:]):
+        model_inputs[idx + 1] = torch.cat(
             [
-                k,
-                torch.zeros(k.shape[-4], k.shape[-3], max_new_tokens, k.shape[-1]).to(k.dtype),
-            ],
-            dim=-2,
-        )
-        model_inputs[1][idx][1] = torch.cat(
-            [
-                v,
-                torch.zeros(v.shape[-4], v.shape[-3], max_new_tokens, v.shape[-1]).to(k.dtype),
+                past_key_or_values_states,
+                torch.zeros(
+                    past_key_or_values_states.shape[-4],
+                    past_key_or_values_states.shape[-3],
+                    max_new_tokens,
+                    past_key_or_values_states.shape[-1],
+                ).to(past_key_or_values_states.dtype),
             ],
             dim=-2,
         )
 
     if run_on_tt_device:
         # Calculate attention mask and postion_ids
-        padded_past_key_values_seq_length = model_inputs[1][0][0].shape[-2]
+        padded_past_key_values_seq_length = model_inputs[1].shape[-2]
         input_seq_length = model_inputs[0].shape[-1]
         attention_mask, position_ids = calculate_attention_mask_and_postion_ids(
             padded_past_key_values_seq_length, non_padding_seq_length, input_seq_length
         )
 
-        compiler_cfg = forge.config.CompilerConfig()
-        compiler_cfg.compile_depth = forge.CompileDepth.SPLIT_GRAPH
-
         # Compile the model
         compiled_model = forge.compile(
             framework_model,
-            sample_inputs=[model_inputs[0], attention_mask, position_ids, model_inputs[1]],
-            compiler_cfg=compiler_cfg,
+            sample_inputs=[model_inputs[0], attention_mask, position_ids, *model_inputs[1:]],
         )
-        pytest.xfail("Found Unsupported operations while lowering from TTForge to TTIR in forward graph.")
 
     # Run decode stage on TT device and generate tokens by passing the last predicted token and the past key values.
     # untill the a specified maximum number of new tokens is reached or an end-of-sequence token is encountered.
     for max_new_tokens_idx in range(max_new_tokens):
 
         non_padding_past_key_values_seq_length = non_padding_seq_length + max_new_tokens_idx
-        padded_past_key_values_seq_length = model_inputs[1][0][0].shape[-2]
+        padded_past_key_values_seq_length = model_inputs[1].shape[-2]
         input_seq_length = model_inputs[0].shape[-1]
         attention_mask, position_ids = calculate_attention_mask_and_postion_ids(
             padded_past_key_values_seq_length, non_padding_past_key_values_seq_length, input_seq_length
         )
 
-        # CPU Inference
-        model_outputs = framework_model(model_inputs[0], attention_mask, position_ids, model_inputs[1])
-
-        # TT will return the logits and past key values as list of tensor, so flattening
-        # framework output past key values from List(List(Key1, Values1), ... , List(Key26, Values26)) to
-        # List(Key1, Values1, ... , Key26, Values26) for comparing the Framework and TT output in similar fashion.
-        framework_output = [model_outputs[0]]
-        for k, v in model_outputs[1]:
-            framework_output.append(k)
-            framework_output.append(v)
-
         if run_on_tt_device:
-            # Run on TT device
-            tt_inputs = [model_inputs[0], attention_mask, position_ids, model_inputs[1]]
-            tt_output = compiled_model(*tt_inputs)
-            tt_output = [tt_out.to("cpu") for tt_out in tt_output]
+            tt_inputs = [model_inputs[0], attention_mask, position_ids, *model_inputs[1:]]
 
-            # Validate TT result with Framework
-            assert all(
-                [
-                    compare_with_golden(golden=fw_out, calculated=tt_out)
-                    for fw_out, tt_out in zip(framework_output, tt_output)
-                ]
-            )
+            # Run on TT device and validate TT result with Framework
+            framework_output, tt_output = verify(tt_inputs, framework_model, compiled_model)
 
             logits = tt_output[0]
             past_key_values = tt_output[1:]
 
         else:
-            logits = framework_output[0]
-            past_key_values = framework_output[1:]
+            # CPU Inference
+            framework_outputs = framework_model(model_inputs[0], attention_mask, position_ids, *model_inputs[1:])
+
+            logits = framework_outputs[0]
+            past_key_values = framework_outputs[1:]
 
         next_token_logits = logits[:, -1, :]
         next_token = torch.argmax(next_token_logits, dim=-1)
@@ -299,23 +362,14 @@ def test_llama_prefill_on_cpu_decode_on_tt_cache(run_on_tt_device):
             break
 
         model_inputs = [next_token.unsqueeze(0)]
-
-        # Formate the past key values from List(Key1, Values1, ... , Key26, Values26) to
-        # List(List(Key1, Values1), ... , List(Key26, Values26))
-        model_inputs.append([past_key_values[idx : idx + 2] for idx in range(0, len(past_key_values), 2)])
+        model_inputs.extend(past_key_values)
 
         # Generated new token, key and values states are appended to the past key values tensor on key_values_sequence_length dim (i.e -2).
         # For predicting next token, move the generated new token, key and values states from the last past key values tensor index
         # to the first past key values tensor padding index on key_values_sequence_length dim (i.e -2).
-        for idx in range(len(model_inputs[1])):
-            model_inputs[1][idx][0][:, :, non_padding_past_key_values_seq_length, :] = model_inputs[1][idx][0][
-                :, :, -1, :
-            ]
-            model_inputs[1][idx][0] = model_inputs[1][idx][0][:, :, :-1, :]
-            model_inputs[1][idx][1][:, :, non_padding_past_key_values_seq_length, :] = model_inputs[1][idx][1][
-                :, :, -1, :
-            ]
-            model_inputs[1][idx][1] = model_inputs[1][idx][1][:, :, :-1, :]
+        for idx in range(len(model_inputs[1:])):
+            model_inputs[idx + 1][:, :, non_padding_past_key_values_seq_length, :] = model_inputs[idx + 1][:, :, -1, :]
+            model_inputs[idx + 1] = model_inputs[idx + 1][:, :, :-1, :]
 
         generated_tokens = torch.cat([generated_tokens, next_token.unsqueeze(0)], dim=-1)
 

--- a/forge/test/mlir/llama/tests/test_llama_prefil.py
+++ b/forge/test/mlir/llama/tests/test_llama_prefil.py
@@ -8,15 +8,18 @@ from transformers import LlamaTokenizer
 import forge
 from test.mlir.llama.utils.utils import load_model
 from forge.verify.compare import compare_with_golden
+from forge.verify.verify import verify
 
 
-def prefil_on_cpu(model, input_ids):
-    with torch.no_grad():
-        transformer_outputs = model.model(
-            input_ids=input_ids,  # Pass the entire updated sequence
-        )
-        hidden_states = transformer_outputs.last_hidden_state
-    return hidden_states
+class LlamaPrefillModel(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model.get_decoder()
+
+    def forward(self, input_ids):
+        model_outputs = self.model(input_ids)
+        hidden_states = model_outputs.last_hidden_state
+        return hidden_states
 
 
 def decode_on_cpu(model, tokenizer, input_ids, hidden_states, max_new_tokens):
@@ -65,23 +68,19 @@ def test_llama_prefil_on_device_decode_on_cpu(model_path):
     # Prepare input sentence
     prompt = "Q: What is the largest animal?\nA:"
     input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+    inputs = [input_ids]
 
     # This is the part of the model needed for prefill; model without the last Linear layer (lm_head)
-    model_decoder = model.get_decoder()
-    compiled_decoder = forge.compile(model_decoder, sample_inputs=input_ids)
+    framework_model = LlamaPrefillModel(model)
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
     # Prefill Phase - Process the initial prompt on device
-    transformer_outputs = compiled_decoder(input_ids)
-    # Get hidden states for all tokens from the last "transformer layer".
-    hidden_states_compiled = transformer_outputs[0]
-    hidden_states_compiled = hidden_states_compiled.to("cpu")
+    # Validate prefill outputs between TT and CPU
+    framework_output, compiled_output = verify(inputs, framework_model, compiled_model)
 
-    # Get hidden states for all tokens from the last "transformer layer" calculated on CPU.
-    hidden_states_framework = prefil_on_cpu(model, input_ids)
-
-    # Compare result of prefilling on device with the result of prefilling on CPU.
-    # Calculate the pcc for only the last vector in the hidden states tensor.
-    assert compare_with_golden(hidden_states_framework[:, -1, :], hidden_states_compiled[:, -1, :])
+    # Get hidden states for all tokens from the last "transformer layer" on both TT and CPU.
+    hidden_states_compiled = compiled_output[0]
+    hidden_states_framework = framework_output[0]
 
     # Decode Phase - Generate new tokens
     max_new_tokens = 46

--- a/forge/test/mlir/llama/utils/utils.py
+++ b/forge/test/mlir/llama/utils/utils.py
@@ -16,7 +16,8 @@ def load_model(model_path="openlm-research/open_llama_3b", **kwargs):
     config.use_cache = kwargs.get("use_cache", False)
     config.output_attentions = kwargs.get("output_attentions", False)
     config.output_hidden_states = kwargs.get("output_hidden_states", False)
-    config.num_hidden_layers = kwargs.get("num_hidden_layers", 26)
+    if "num_hidden_layers" in kwargs:
+        config.num_hidden_layers = kwargs["num_hidden_layers"]
 
     # Load the model
     framework_model = LlamaForCausalLM.from_pretrained(model_path, device_map="auto", config=config)

--- a/forge/test/mlir/operators/reduce/test_reduce.py
+++ b/forge/test/mlir/operators/reduce/test_reduce.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 from torch import nn
+from forge.verify.verify import verify
 
 import forge
 
@@ -12,8 +13,18 @@ import forge
 @pytest.mark.parametrize(
     "input_shape, dim, keepdim",
     [
-        ((64,), 0, True),
-        ((64,), -1, True),
+        pytest.param(
+            (64,),
+            0,
+            True,
+            marks=pytest.mark.xfail(reason="Tensor mismatch between framework and compiled model output"),
+        ),
+        pytest.param(
+            (64,),
+            -1,
+            True,
+            marks=pytest.mark.xfail(reason="Tensor mismatch between framework and compiled model output"),
+        ),
         ((4, 64), 0, True),
         ((32, 32), -2, True),
         ((2, 32, 32), 0, True),
@@ -70,22 +81,27 @@ def test_reduce_sum(input_shape, dim, keepdim):
     inputs = [torch.rand(input_shape)]
 
     framework_model = ReduceSum()
-    fw_out = framework_model(*inputs)
 
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
-    co_out = compiled_model(*inputs)
 
-    # Skipping PCC check due to inconsistencies between Framework and Compiled model
-    #
-    # co_out = [co.to("cpu") for co in co_out]
-    # assert compare_with_golden_pcc(golden=fw_out, calculated=co_out[0], pcc=0.99)
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
     "input_shape, dim, keepdim",
     [
-        ((64,), 0, True),
-        ((64,), -1, True),
+        pytest.param(
+            (64,),
+            0,
+            True,
+            marks=pytest.mark.xfail(reason="Tensor mismatch between framework and compiled model output"),
+        ),
+        pytest.param(
+            (64,),
+            -1,
+            True,
+            marks=pytest.mark.xfail(reason="Tensor mismatch between framework and compiled model output"),
+        ),
         ((4, 64), 0, True),
         ((32, 32), -2, True),
         ((2, 32, 32), 0, True),
@@ -142,15 +158,10 @@ def test_reduce_mean(input_shape, dim, keepdim):
     inputs = [torch.rand(input_shape)]
 
     framework_model = ReduceMean()
-    fw_out = framework_model(*inputs)
 
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
-    co_out = compiled_model(*inputs)
 
-    # Skipping PCC check due to inconsistencies between Framework and Compiled model
-    #
-    # co_out = [co.to("cpu") for co in co_out]
-    # assert compare_with_golden_pcc(golden=fw_out, calculated=co_out[0], pcc=0.99)
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize("x_shape", [7, 32, 41])
@@ -170,22 +181,27 @@ def test_mean(x_shape, y_shape, dim):
     ]
 
     framework_model = Mean()
-    fw_out = framework_model(*inputs)
 
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
-    co_out = compiled_model(*inputs)
 
-    # Skipping PCC check due to inconsistencies between Framework and Compiled model
-    #
-    # co_out = [co.to("cpu") for co in co_out]
-    # assert compare_with_golden_pcc(golden=fw_out, calculated=co_out[0], pcc=0.99)
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
     "input_shape, dim, keepdim",
     [
-        ((64,), 0, True),
-        ((64,), -1, True),
+        pytest.param(
+            (64,),
+            0,
+            True,
+            marks=pytest.mark.xfail(reason="Tensor mismatch between framework and compiled model output"),
+        ),
+        pytest.param(
+            (64,),
+            -1,
+            True,
+            marks=pytest.mark.xfail(reason="Tensor mismatch between framework and compiled model output"),
+        ),
         ((4, 64), 0, True),
         ((32, 32), -2, True),
         ((2, 32, 32), 0, True),
@@ -224,11 +240,6 @@ def test_reduce_max(input_shape, dim, keepdim):
     if input in [((64,), 0, False), ((64,), -1, False)]:
         pytest.xfail(reason="[mlir::AffineMap collapsedLinearAffineMap] Assertion `end > 0' failed.")
 
-    # TTNN Max issues:
-    #   Unsupported dim - https://github.com/tenstorrent/tt-metal/issues/13186
-    #   Shape mismatch along the H and W dimension - https://github.com/tenstorrent/tt-metal/issues/13189
-    #   Tensor rank is not 4 - https://github.com/tenstorrent/tt-metal/issues/13190
-
     class ReduceMax(nn.Module):
         def __init__(self):
             super().__init__()
@@ -240,14 +251,7 @@ def test_reduce_max(input_shape, dim, keepdim):
 
     framework_model = ReduceMax()
     framework_model.eval()
-    fw_out = framework_model(*inputs)
 
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
-    co_out = compiled_model(*inputs)
 
-    co_out = [co.to("cpu") for co in co_out]
-
-    # Skipping PCC check due to inconsistencies between Framework and Compiled model
-    #
-    # co_out = [co.to("cpu") for co in co_out]
-    # assert compare_with_golden_pcc(golden=fw_out, calculated=co_out[0], pcc=0.99)
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/mlir/operators/tm/test_tm.py
+++ b/forge/test/mlir/operators/tm/test_tm.py
@@ -553,13 +553,10 @@ def test_stack(input_shapes, dim):
     inputs = [torch.rand(shape) for shape in input_shapes]
 
     framework_model = Stack(dim)
-    fw_out = framework_model(*inputs)
 
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name="stack_sanity")
-    co_out = compiled_model(*inputs)
 
-    co_out = [co.to("cpu") for co in co_out]
-    fw_out = [fw_out] if isinstance(fw_out, torch.Tensor) else fw_out
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(

--- a/forge/test/mlir/test_features.py
+++ b/forge/test/mlir/test_features.py
@@ -9,7 +9,6 @@ import torch
 from torch import nn
 
 import forge
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 
 
@@ -131,9 +130,9 @@ def test_batch_size_training(batch_size, in_features, out_features):
 
     optimizer.zero_grad()
 
-    pred = tt_model(in_data)[0]
-    golden_pred = model(in_data)
-    assert compare_with_golden(golden_pred, pred, pcc=0.95)  # 0.95 is the minimum value for which the test passes
+    fw_out, tt_out = verify(inputs=[in_data], framework_model=model, compiled_model=tt_model)
+    golden_pred = fw_out[0]
+    pred = tt_out[0]
 
     loss = loss_fn(pred, target)
     golden_loss = loss_fn(golden_pred, target)

--- a/forge/test/mlir/test_ops_tf.py
+++ b/forge/test/mlir/test_ops_tf.py
@@ -8,7 +8,6 @@ import tensorflow as tf
 import forge
 from forge.config import CompilerConfig
 from forge.tensor import to_pt_tensors
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge._C import DataFormat
 
@@ -90,15 +89,10 @@ def test_conv2d(
     inputs = [tf.random.uniform((batch_size, input_height, input_width, input_channels), dtype=activations_dtype)]
 
     framework_model = Conv2d()
-    fw_out = to_pt_tensors(framework_model(*inputs))
 
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
-    co_out = compiled_model(*inputs)
 
-    co_out = [co.to("cpu").to(fw_out[0].dtype) for co in co_out]
-    co_out[0] = co_out[0].reshape(fw_out[0].shape)
-
-    assert compare_with_golden(fw_out[0], co_out[0])
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.push

--- a/forge/test/models/pytorch/multimodal/deepseek_math/utils/model_utils.py
+++ b/forge/test/models/pytorch/multimodal/deepseek_math/utils/model_utils.py
@@ -54,11 +54,10 @@ class DeepSeekWrapper(torch.nn.Module):
 
 
 class DeepSeekWrapper_decoder(torch.nn.Module):
-    def __init__(self, model, max_new_tokens=200):
+    def __init__(self, model):
         super().__init__()
         self.model = model
-        self.max_new_tokens = max_new_tokens
 
     def forward(self, input_tensor):
-        output = self.model(input_tensor, max_new_tokens=self.max_new_tokens)
+        output = self.model(input_tensor)
         return output.last_hidden_state

--- a/forge/test/models_ops/test_abs.py
+++ b/forge/test/models_ops/test_abs.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_add.py
+++ b/forge/test/models_ops/test_add.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_advindex.py
+++ b/forge/test/models_ops/test_advindex.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_argmax.py
+++ b/forge/test/models_ops/test_argmax.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_avgpool1d.py
+++ b/forge/test/models_ops/test_avgpool1d.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_avgpool2d.py
+++ b/forge/test/models_ops/test_avgpool2d.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_avgpool3d.py
+++ b/forge/test/models_ops/test_avgpool3d.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_broadcast.py
+++ b/forge/test/models_ops/test_broadcast.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_cast.py
+++ b/forge/test/models_ops/test_cast.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_clip.py
+++ b/forge/test/models_ops/test_clip.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_concatenate.py
+++ b/forge/test/models_ops/test_concatenate.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_conv2d.py
+++ b/forge/test/models_ops/test_conv2d.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_conv2dtranspose.py
+++ b/forge/test/models_ops/test_conv2dtranspose.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_cosine.py
+++ b/forge/test/models_ops/test_cosine.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_cumsum.py
+++ b/forge/test/models_ops/test_cumsum.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_embedding.py
+++ b/forge/test/models_ops/test_embedding.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_equal.py
+++ b/forge/test/models_ops/test_equal.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_exp.py
+++ b/forge/test/models_ops/test_exp.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_gelu.py
+++ b/forge/test/models_ops/test_gelu.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_greater.py
+++ b/forge/test/models_ops/test_greater.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_identity.py
+++ b/forge/test/models_ops/test_identity.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_index.py
+++ b/forge/test/models_ops/test_index.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_layernorm.py
+++ b/forge/test/models_ops/test_layernorm.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_leakyrelu.py
+++ b/forge/test/models_ops/test_leakyrelu.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_less.py
+++ b/forge/test/models_ops/test_less.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_matmul.py
+++ b/forge/test/models_ops/test_matmul.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_max.py
+++ b/forge/test/models_ops/test_max.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_maxpool2d.py
+++ b/forge/test/models_ops/test_maxpool2d.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_multiply.py
+++ b/forge/test/models_ops/test_multiply.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_notequal.py
+++ b/forge/test/models_ops/test_notequal.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_pad.py
+++ b/forge/test/models_ops/test_pad.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_reciprocal.py
+++ b/forge/test/models_ops/test_reciprocal.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_reduceavg.py
+++ b/forge/test/models_ops/test_reduceavg.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_relu.py
+++ b/forge/test/models_ops/test_relu.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_remainder.py
+++ b/forge/test/models_ops/test_remainder.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_repeatinterleave.py
+++ b/forge/test/models_ops/test_repeatinterleave.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_reshape.py
+++ b/forge/test/models_ops/test_reshape.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_resize2d.py
+++ b/forge/test/models_ops/test_resize2d.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_sigmoid.py
+++ b/forge/test/models_ops/test_sigmoid.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_sine.py
+++ b/forge/test/models_ops/test_sine.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_softmax.py
+++ b/forge/test/models_ops/test_softmax.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_sqrt.py
+++ b/forge/test/models_ops/test_sqrt.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_squeeze.py
+++ b/forge/test/models_ops/test_squeeze.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_stack.py
+++ b/forge/test/models_ops/test_stack.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_subtract.py
+++ b/forge/test/models_ops/test_subtract.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_tanh.py
+++ b/forge/test/models_ops/test_tanh.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_transpose.py
+++ b/forge/test/models_ops/test_transpose.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_unsqueeze.py
+++ b/forge/test/models_ops/test_unsqueeze.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig

--- a/forge/test/models_ops/test_where.py
+++ b/forge/test/models_ops/test_where.py
@@ -9,7 +9,6 @@ from loguru import logger
 import torch
 
 from forge import Tensor, compile
-from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.config import VerifyConfig


### PR DESCRIPTION
<html><head></head><body><h3>Problem Description</h3>
<p>The execution phase and stage are recorded incorrectly whenever test cases contain post-processing code that reruns the compiled model.</p>
<h4>Example:</h4>

Test Cases | Execution Phase | Execution Stage
-- | -- | --
forge/test/models/pytorch/vision/resnet/test_resnet.py::test_resnet_hf[microsoft/resnet-50] | EXECUTED_TTNN | EXECUTED_TTNN
forge/test/models/pytorch/vision/resnet/test_resnet.py::test_resnet_timm | PASSED | VERIFICATION


<p>In the table above, both test cases passed verification, but the execution phase and stage for the <a href="https://github.com/tenstorrent/tt-forge-fe/blob/dfcd405ab4e429450c1639b57cae2c80d15082fd/forge/test/models/pytorch/vision/resnet/test_resnet.py#L30">forge/test/models/pytorch/vision/resnet/test_resnet.py::test_resnet_hf[microsoft/resnet-50]</a> test case are incorrect. The execution phase should be <strong>PASSED</strong>, and the execution stage should be <strong>VERIFICATION</strong>.</p>
<p>This occurs because the test case contains a post-processing function (<code inline="">run_and_print_results</code>) that reruns the compiled model, which updates the execution phase from PASSED to EXECUTED_TTNN and the execution stage from VERIFICATION to EXECUTED_TTNN.</p>
<p>On the other hand, another ResNet test case, <a href="https://github.com/tenstorrent/tt-forge-fe/blob/dfcd405ab4e429450c1639b57cae2c80d15082fd/forge/test/models/pytorch/vision/resnet/test_resnet.py#L98">forge/test/models/pytorch/vision/resnet/test_resnet.py::test_resnet_timm</a>, does not contain post-processing, so the execution phase and stage remain unchanged.</p>
<h3>Issue Origin</h3>
<p>Execution depth (EXECUTED_TTNN) is recorded inside the <a href="https://github.com/tenstorrent/tt-forge-fe/blob/dfcd405ab4e429450c1639b57cae2c80d15082fd/forge/forge/compiled_graph_state.py#L151C7-L151C20">CompiledModel</a> class in <code inline="">forge/forge/compiled_graph_state.py</code>, specifically in the <a href="https://github.com/tenstorrent/tt-forge-fe/blob/dfcd405ab4e429450c1639b57cae2c80d15082fd/forge/forge/compiled_graph_state.py#L212C1-L212C66">call method</a>, at <a href="https://github.com/tenstorrent/tt-forge-fe/blob/dfcd405ab4e429450c1639b57cae2c80d15082fd/forge/forge/compiled_graph_state.py#L276">this line</a>.</p>
<p>Whenever the compiled model is rerun, it updates the execution depth again.</p>
<h3>Reason for Current Implementation</h3>
<p>Some test cases still use the <code inline="">compare_with_golden</code> function for verification instead of <code inline="">verify</code>. Test cases using <code inline="">compare_with_golden</code> may run the compiled model anywhere inside the test function. To ensure execution depth tracking, EXECUTED_TTNN was recorded inside the <a href="https://github.com/tenstorrent/tt-forge-fe/blob/dfcd405ab4e429450c1639b57cae2c80d15082fd/forge/forge/compiled_graph_state.py#L212C1-L212C66">call method</a> of the <a href="https://github.com/tenstorrent/tt-forge-fe/blob/dfcd405ab4e429450c1639b57cae2c80d15082fd/forge/forge/compiled_graph_state.py#L151C7-L151C20">CompiledModel</a> class.</p>
<h3>Proposed Fix</h3>
<p>To prevent incorrect updates of execution phase and stage due to post-processing:</p>
<ol>
<li>Record execution depth (<code inline="">EXECUTED_TTNN</code>) inside the <code inline="">verify</code> function rather than inside the <a href="https://github.com/tenstorrent/tt-forge-fe/blob/dfcd405ab4e429450c1639b57cae2c80d15082fd/forge/forge/compiled_graph_state.py#L212C1-L212C66">call method</a> in the <a href="https://github.com/tenstorrent/tt-forge-fe/blob/dfcd405ab4e429450c1639b57cae2c80d15082fd/forge/forge/compiled_graph_state.py#L151C7-L151C20">CompiledModel</a> class.</li>
<li>Replace <code inline="">compare_with_golden</code> with <code inline="">verify</code> in test cases.</li>
</ol>
<h3>Benefits of This Change</h3>
<ol>
<li>
<p><strong>Prevents Depth Changes During Post-Processing</strong></p>
<ul>
<li>Currently, execution depth can change from PASSED → EXECUTED_TTNN if post-processing code calls the compiled model.</li>
<li>By recording EXECUTED_TTNN within <code inline="">verify</code>, execution depth remains correct.</li>
</ul>
</li>
<li>
<p><strong>Ensures Proper Depth Handling Across Loops (e.g., Epochs)</strong></p>
<ul>
<li>If <code inline="">compare_with_golden</code> is replaced with <code inline="">verify</code> in <code inline="">forge/test/mlir/mnist/training/test_training.py</code>, consider this scenario:
<ul>
<li><strong>Epoch 1:</strong> Verification passes, setting execution depth to PASSED.</li>
<li><strong>Epoch 2:</strong> Data mismatch occurs. By recording EXECUTED_TTNN inside <code inline="">verify</code>, execution depth is tracked correctly per epoch, allowing proper rollback if mismatches occur later.</li>
</ul>
</li>
</ul>
</li>
</ol>


### Note:
@vkovinicTT  replaced the compare_with_golden with verify function for the  `forge/test/mlir/mnist/training/test_training.py`  in [this PR](https://github.com/tenstorrent/tt-forge-fe/pull/1348/files). So I haven't replaced it for `forge/test/mlir/mnist/training/test_training.py`  file

### Llama Decode with cache:
The [to_pt_tensors](https://github.com/tenstorrent/tt-forge-fe/blob/42065c610569e4f5df4c4f06e7cfa90309ee7dd5/forge/forge/tensor.py#L1169) function was modified to accept the List/tuple of tensor in this [commit](https://github.com/tenstorrent/tt-forge-fe/commit/04d79324af013cf189af8e2b682179353a1f3de1#diff-6e52372fe71a3dfa74012f5b86adcc1c89916aeebee448998fece56686cf6745) but in the llama decode with cache test will pass the `List[input_ids, attention_mask, postion_ids, past_key_values]` as input, here the `past_key_values` is `list of tuple of tensor`, so modified the llama decode with cache test to accept as list of tensor and update the llama decode implementation to process past key values as list of tensor, not as list of tuple of tensors.