### PR TITLE
Fix asymmetrical padding issue in conv2d

### DIFF
--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -1109,7 +1109,6 @@ def decompose(type, attr, dc, inputs):
                 )
                 dc.fuse(result)
                 return
-
     if type == "pad":
         if all([x == 0 for x in attr[0:-2]]):
             # Pad size is 0
@@ -1202,53 +1201,6 @@ def decompose(type, attr, dc, inputs):
                             [result],
                             (1, orig_shape[-3], orig_shape[-2] + total_padding_r, orig_shape[-1] + total_padding_c),
                         )
-
-                dc.fuse(result)
-                return
-
-            elif mode_idx == 0:  # 'constant' mode
-                c_dim_axis = -2 if channel_last else -1
-                r_dim_axis = -3 if channel_last else -2
-
-                # On right or bottom, we can concat all the way to TILE boundary
-                result = activations
-                if left > 0:
-                    pad_shape = result.shape.as_list().copy()
-                    pad_shape[c_dim_axis] = left
-                    tensor = torch.zeros(pad_shape)
-                    const_tensor = dc.tensor(tensor)
-                    result = dc.op("concatenate", [const_tensor, result], [c_dim_axis])
-
-                if right > 0:
-                    pad_shape = result.shape.as_list().copy()
-                    pad_shape[c_dim_axis] = (
-                        TILE_DIM if pad_shape[c_dim_axis] % TILE_DIM == 0 and right < TILE_DIM else right
-                    )
-                    tensor = torch.zeros(pad_shape)
-                    const_tensor = dc.tensor(tensor)
-                    result = dc.op("concatenate", [result, const_tensor], [c_dim_axis])
-
-                if top > 0:
-                    pad_shape = result.shape.as_list().copy()
-                    pad_shape[r_dim_axis] = top
-                    tensor = torch.zeros(pad_shape)
-                    const_tensor = dc.tensor(tensor)
-                    result = dc.op("concatenate", [const_tensor, result], [r_dim_axis])
-
-                if bottom > 0:
-                    pad_shape = result.shape.as_list().copy()
-                    pad_shape[r_dim_axis] = (
-                        TILE_DIM if pad_shape[r_dim_axis] % TILE_DIM == 0 and bottom < TILE_DIM else bottom
-                    )
-                    tensor = torch.zeros(pad_shape)
-                    const_tensor = dc.tensor(tensor)
-                    result = dc.op("concatenate", [result, const_tensor], [r_dim_axis])
-
-                result = dc.op("narrow", [result], (c_dim_axis, 0, total_padding_c + c, result.shape[c_dim_axis]))
-                if channel_last:
-                    result = dc.op("select", [result], (r_dim_axis, 0, total_padding_r + r, result.shape[r_dim_axis]))
-                else:
-                    result = dc.op("narrow", [result], (r_dim_axis, 0, total_padding_r + r, result.shape[r_dim_axis]))
 
                 dc.fuse(result)
                 return

--- a/forge/forge/tvm_calls/relay/op/forge_passes.py
+++ b/forge/forge/tvm_calls/relay/op/forge_passes.py
@@ -186,12 +186,11 @@ class FuseConvAndPoolPadding(DFPatternCallback):
 
         pad_mode = pad.attrs.pad_mode
 
-        if pad_mode == "constant":
-            padding = [top_pad, left_pad, bottom_pad, right_pad]
-
-        if pad_mode == "reflect":
-            act = tvm.relay.op.nn.pad(act, pad_width, pad_mode="reflect")
+        if top_pad != bottom_pad or left_pad != right_pad:
+            act = tvm.relay.op.nn.pad(act, pad_width, pad_mode=pad_mode)
             padding = [0, 0, 0, 0]
+        else:
+            padding = [top_pad, left_pad, bottom_pad, right_pad]
 
         op_attrs = {**conv_pool.attrs}
         op_attrs["padding"] = padding

--- a/forge/test/mlir/operators/nn/test_nn.py
+++ b/forge/test/mlir/operators/nn/test_nn.py
@@ -396,8 +396,7 @@ def test_avgpool2d_decompose_to_conv2d(shape, padding):
         pytest.param(
             (1, 2, 1, 2),
             marks=pytest.mark.xfail(
-                reason="TTNN only supports padding height/width attributes. Thus, padding_top "
-                "must equal padding_bottom for the op to execute as expected."
+                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph - Pad"
             ),
         ),
     ],
@@ -413,13 +412,6 @@ def test_conv2d_with_padding(shape, padding):
         def forward(self, x):
             x = nn.functional.pad(x, self.padding, mode="constant", value=0)
             return self.conv(x)
-
-    pad_top, pad_bottom, pad_left, pad_right = padding
-    if pad_top != pad_bottom or pad_left != pad_right:
-        pytest.xfail(
-            "TTNN only supports padding height/width attributes. Thus, padding_top "
-            "must equal padding_bottom for the op to execute as expected."
-        )
 
     inputs = [torch.rand(shape)]
 


### PR DESCRIPTION
### Ticket
#682

### Problem description
Padding_top must equal padding_bottom for the op to execute as expected 

### What's changed
Remove xfail statements related to this error in the test files
Updated the fuse_pad_conv2d pass: Added the condition to check asymmetric padding cases.

