### PR TITLE
Handle XPASS test in the models ops failure updation script and update nightly models ops test

### DIFF
--- a/forge/test/models_ops/test_advindex.py
+++ b/forge/test/models_ops/test_advindex.py
@@ -119,17 +119,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((448, 768), torch.float32), ((1, 1), torch.int64)],
         {"model_name": ["pt_whisper_openai_whisper_small_speech_recognition_hf"], "pcc": 0.99, "max_int": 447},
     ),
-    pytest.param(
-        (
-            Advindex0,
-            [((448, 1280), torch.float32), ((1, 2), torch.int64)],
-            {
-                "model_name": ["pt_whisper_openai_whisper_large_v3_turbo_speech_translate_hf"],
-                "pcc": 0.99,
-                "max_int": 447,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Advindex0,
+        [((448, 1280), torch.float32), ((1, 2), torch.int64)],
+        {"model_name": ["pt_whisper_openai_whisper_large_v3_turbo_speech_translate_hf"], "pcc": 0.99, "max_int": 447},
     ),
     (
         Advindex1,
@@ -179,37 +172,25 @@ forge_modules_and_shapes_dtypes_list = [
             "max_int": 0,
         },
     ),
-    pytest.param(
-        (
-            Advindex2,
-            [((2401,), torch.int64)],
-            {"model_name": ["pt_swin_microsoft_swin_tiny_patch4_window7_224_img_cls_hf"], "pcc": 0.99, "max_int": 168},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Advindex2,
+        [((2401,), torch.int64)],
+        {"model_name": ["pt_swin_microsoft_swin_tiny_patch4_window7_224_img_cls_hf"], "pcc": 0.99, "max_int": 168},
     ),
-    pytest.param(
-        (
-            Advindex3,
-            [((2401,), torch.int64)],
-            {"model_name": ["pt_swin_microsoft_swin_tiny_patch4_window7_224_img_cls_hf"], "pcc": 0.99, "max_int": 168},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Advindex3,
+        [((2401,), torch.int64)],
+        {"model_name": ["pt_swin_microsoft_swin_tiny_patch4_window7_224_img_cls_hf"], "pcc": 0.99, "max_int": 168},
     ),
-    pytest.param(
-        (
-            Advindex4,
-            [((2401,), torch.int64)],
-            {"model_name": ["pt_swin_microsoft_swin_tiny_patch4_window7_224_img_cls_hf"], "pcc": 0.99, "max_int": 168},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Advindex4,
+        [((2401,), torch.int64)],
+        {"model_name": ["pt_swin_microsoft_swin_tiny_patch4_window7_224_img_cls_hf"], "pcc": 0.99, "max_int": 168},
     ),
-    pytest.param(
-        (
-            Advindex5,
-            [((2401,), torch.int64)],
-            {"model_name": ["pt_swin_microsoft_swin_tiny_patch4_window7_224_img_cls_hf"], "pcc": 0.99, "max_int": 168},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Advindex5,
+        [((2401,), torch.int64)],
+        {"model_name": ["pt_swin_microsoft_swin_tiny_patch4_window7_224_img_cls_hf"], "pcc": 0.99, "max_int": 168},
     ),
 ]
 

--- a/forge/test/models_ops/test_cast.py
+++ b/forge/test/models_ops/test_cast.py
@@ -59,37 +59,31 @@ def ids_func(param):
 
 
 forge_modules_and_shapes_dtypes_list = [
-    pytest.param(
-        (
-            Cast0,
-            [((2, 1, 1, 13), torch.int64)],
-            {
-                "model_name": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((2, 1, 1, 13), torch.int64)],
+        {
+            "model_name": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((2, 13, 1), torch.int64)],
-            {
-                "model_name": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((2, 13, 1), torch.int64)],
+        {
+            "model_name": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
     pytest.param(
         (
@@ -107,17 +101,14 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((2, 1, 7, 7), torch.int64)],
-            {
-                "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((2, 1, 7, 7), torch.int64)],
+        {
+            "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
     pytest.param(
         (
@@ -131,60 +122,54 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 1, 1, 128), torch.int64)],
-            {
-                "model_name": [
-                    "pt_albert_xxlarge_v1_token_cls_hf",
-                    "pt_albert_base_v2_token_cls_hf",
-                    "pt_albert_xxlarge_v2_token_cls_hf",
-                    "pt_albert_large_v1_token_cls_hf",
-                    "pt_albert_large_v2_token_cls_hf",
-                    "pt_albert_base_v1_token_cls_hf",
-                    "pt_albert_base_v1_mlm_hf",
-                    "pt_albert_xlarge_v2_token_cls_hf",
-                    "pt_albert_xxlarge_v2_mlm_hf",
-                    "pt_albert_large_v2_mlm_hf",
-                    "pt_albert_base_v2_mlm_hf",
-                    "pt_albert_xlarge_v1_token_cls_hf",
-                    "pt_albert_xlarge_v1_mlm_hf",
-                    "pt_albert_large_v1_mlm_hf",
-                    "pt_albert_xxlarge_v1_mlm_hf",
-                    "pt_albert_xlarge_v2_mlm_hf",
-                    "pt_dpr_facebook_dpr_ctx_encoder_single_nq_base_qa_hf_context_encoder",
-                    "pt_dpr_facebook_dpr_question_encoder_single_nq_base_qa_hf_question_encoder",
-                    "pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader",
-                    "pt_dpr_facebook_dpr_question_encoder_multiset_base_qa_hf_question_encoder",
-                    "pt_dpr_facebook_dpr_ctx_encoder_multiset_base_qa_hf_context_encoder",
-                    "pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader",
-                    "pt_roberta_xlm_roberta_base_mlm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((1, 1, 1, 128), torch.int64)],
+        {
+            "model_name": [
+                "pt_albert_xxlarge_v1_token_cls_hf",
+                "pt_albert_base_v2_token_cls_hf",
+                "pt_albert_xxlarge_v2_token_cls_hf",
+                "pt_albert_large_v1_token_cls_hf",
+                "pt_albert_large_v2_token_cls_hf",
+                "pt_albert_base_v1_token_cls_hf",
+                "pt_albert_base_v1_mlm_hf",
+                "pt_albert_xlarge_v2_token_cls_hf",
+                "pt_albert_xxlarge_v2_mlm_hf",
+                "pt_albert_large_v2_mlm_hf",
+                "pt_albert_base_v2_mlm_hf",
+                "pt_albert_xlarge_v1_token_cls_hf",
+                "pt_albert_xlarge_v1_mlm_hf",
+                "pt_albert_large_v1_mlm_hf",
+                "pt_albert_xxlarge_v1_mlm_hf",
+                "pt_albert_xlarge_v2_mlm_hf",
+                "pt_dpr_facebook_dpr_ctx_encoder_single_nq_base_qa_hf_context_encoder",
+                "pt_dpr_facebook_dpr_question_encoder_single_nq_base_qa_hf_question_encoder",
+                "pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader",
+                "pt_dpr_facebook_dpr_question_encoder_multiset_base_qa_hf_question_encoder",
+                "pt_dpr_facebook_dpr_ctx_encoder_multiset_base_qa_hf_context_encoder",
+                "pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader",
+                "pt_roberta_xlm_roberta_base_mlm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 1, 256, 256), torch.int64)],
-            {
-                "model_name": [
-                    "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_xglm_facebook_xglm_1_7b_clm_hf",
-                    "pt_xglm_facebook_xglm_564m_clm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((1, 1, 256, 256), torch.int64)],
+        {
+            "model_name": [
+                "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_xglm_facebook_xglm_1_7b_clm_hf",
+                "pt_xglm_facebook_xglm_564m_clm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
     pytest.param(
         (
@@ -474,36 +459,30 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 1, 1, 7), torch.int64)],
-            {
-                "model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((1, 1, 1, 7), torch.int64)],
+        {
+            "model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 1, 32, 32), torch.int64)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((1, 1, 32, 32), torch.int64)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
     pytest.param(
         (

--- a/forge/test/models_ops/test_conv2d.py
+++ b/forge/test/models_ops/test_conv2d.py
@@ -21685,20 +21685,27 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D0,
-        [((1, 80, 3000, 1), torch.float32), ((1280, 80, 3, 1), torch.float32)],
-        {
-            "model_name": ["pt_whisper_openai_whisper_large_speech_recognition_hf"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 1, 1]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D0,
+            [((1, 80, 3000, 1), torch.float32), ((1280, 80, 3, 1), torch.float32)],
+            {
+                "model_name": ["pt_whisper_openai_whisper_large_speech_recognition_hf"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 1, 1]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 1280, 2999, 2) vs torch.Size([1, 1280, 3000, 1])"
+            )
+        ],
     ),
     pytest.param(
         (
@@ -35461,35 +35468,49 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D519,
-        [((1, 64, 73, 73), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[3, 3, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D519,
+            [((1, 64, 73, 73), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[3, 3, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 64, 76, 70) vs torch.Size([1, 64, 73, 73])"
+            )
+        ],
     ),
-    (
-        Conv2D520,
-        [((1, 64, 73, 73), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 3, 3]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D520,
+            [((1, 64, 73, 73), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 3, 3]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 64, 70, 76) vs torch.Size([1, 64, 73, 73])"
+            )
+        ],
     ),
     pytest.param(
         (
@@ -35650,80 +35671,115 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D527,
-        [((1, 192, 17, 17), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[3, 3, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D527,
+            [((1, 192, 17, 17), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[3, 3, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 224, 20, 14) vs torch.Size([1, 224, 17, 17])"
+            )
+        ],
     ),
-    (
-        Conv2D528,
-        [((1, 224, 17, 17), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 3, 3]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D528,
+            [((1, 224, 17, 17), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 3, 3]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 256, 14, 20) vs torch.Size([1, 256, 17, 17])"
+            )
+        ],
     ),
-    (
-        Conv2D529,
-        [((1, 192, 17, 17), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 3, 3]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D529,
+            [((1, 192, 17, 17), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 3, 3]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 192, 14, 20) vs torch.Size([1, 192, 17, 17])"
+            )
+        ],
     ),
-    (
-        Conv2D530,
-        [((1, 224, 17, 17), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 3, 3]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D530,
+            [((1, 224, 17, 17), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 3, 3]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 224, 14, 20) vs torch.Size([1, 224, 17, 17])"
+            )
+        ],
     ),
-    (
-        Conv2D531,
-        [((1, 224, 17, 17), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[3, 3, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D531,
+            [((1, 224, 17, 17), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[3, 3, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 256, 20, 14) vs torch.Size([1, 256, 17, 17])"
+            )
+        ],
     ),
     (
         Conv2D100,
@@ -35788,35 +35844,49 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D534,
-        [((1, 256, 17, 17), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[3, 3, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D534,
+            [((1, 256, 17, 17), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[3, 3, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 256, 20, 14) vs torch.Size([1, 256, 17, 17])"
+            )
+        ],
     ),
-    (
-        Conv2D535,
-        [((1, 256, 17, 17), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 3, 3]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D535,
+            [((1, 256, 17, 17), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 3, 3]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 320, 14, 20) vs torch.Size([1, 320, 17, 17])"
+            )
+        ],
     ),
     pytest.param(
         (
@@ -35851,95 +35921,137 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D537,
-        [((1, 384, 8, 8), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[1, 1, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D537,
+            [((1, 384, 8, 8), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[1, 1, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 256, 9, 7) vs torch.Size([1, 256, 8, 8])"
+            )
+        ],
     ),
-    (
-        Conv2D538,
-        [((1, 384, 8, 8), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 1, 1]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D538,
+            [((1, 384, 8, 8), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 1, 1]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 256, 7, 9) vs torch.Size([1, 256, 8, 8])"
+            )
+        ],
     ),
-    (
-        Conv2D539,
-        [((1, 384, 8, 8), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 1, 1]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D539,
+            [((1, 384, 8, 8), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 1, 1]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 448, 7, 9) vs torch.Size([1, 448, 8, 8])"
+            )
+        ],
     ),
-    (
-        Conv2D540,
-        [((1, 448, 8, 8), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[1, 1, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D540,
+            [((1, 448, 8, 8), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[1, 1, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 512, 9, 7) vs torch.Size([1, 512, 8, 8])"
+            )
+        ],
     ),
-    (
-        Conv2D541,
-        [((1, 512, 8, 8), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[1, 1, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D541,
+            [((1, 512, 8, 8), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[1, 1, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 256, 9, 7) vs torch.Size([1, 256, 8, 8])"
+            )
+        ],
     ),
-    (
-        Conv2D542,
-        [((1, 512, 8, 8), torch.float32)],
-        {
-            "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
-            "pcc": 0.99,
-            "op_params": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 1, 1]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D542,
+            [((1, 512, 8, 8), torch.float32)],
+            {
+                "model_name": ["pt_inception_v4_img_cls_timm", "pt_inception_v4_img_cls_osmr"],
+                "pcc": 0.99,
+                "op_params": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 1, 1]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 256, 7, 9) vs torch.Size([1, 256, 8, 8])"
+            )
+        ],
     ),
     (
         Conv2D543,

--- a/forge/test/models_ops/test_embedding.py
+++ b/forge/test/models_ops/test_embedding.py
@@ -783,29 +783,23 @@ def ids_func(param):
 
 
 forge_modules_and_shapes_dtypes_list = [
-    pytest.param(
-        (
-            Embedding0,
-            [((2, 1), torch.int64)],
-            {"model_name": ["pt_stereo_facebook_musicgen_large_music_generation_hf"], "pcc": 0.99, "max_int": 2048},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding0,
+        [((2, 1), torch.int64)],
+        {"model_name": ["pt_stereo_facebook_musicgen_large_music_generation_hf"], "pcc": 0.99, "max_int": 2048},
     ),
-    pytest.param(
-        (
-            Embedding1,
-            [((2, 13), torch.int64)],
-            {
-                "model_name": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "max_int": 32127,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding1,
+        [((2, 13), torch.int64)],
+        {
+            "model_name": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "max_int": 32127,
+        },
     ),
     pytest.param(
         (
@@ -823,21 +817,15 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    pytest.param(
-        (
-            Embedding3,
-            [((2, 1), torch.int64)],
-            {"model_name": ["pt_stereo_facebook_musicgen_medium_music_generation_hf"], "pcc": 0.99, "max_int": 2048},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding3,
+        [((2, 1), torch.int64)],
+        {"model_name": ["pt_stereo_facebook_musicgen_medium_music_generation_hf"], "pcc": 0.99, "max_int": 2048},
     ),
-    pytest.param(
-        (
-            Embedding4,
-            [((2, 1), torch.int64)],
-            {"model_name": ["pt_stereo_facebook_musicgen_small_music_generation_hf"], "pcc": 0.99, "max_int": 2048},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding4,
+        [((2, 1), torch.int64)],
+        {"model_name": ["pt_stereo_facebook_musicgen_small_music_generation_hf"], "pcc": 0.99, "max_int": 2048},
     ),
     (
         Embedding5,
@@ -869,63 +857,51 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 2), torch.int32)],
         {"model_name": ["pt_whisper_openai_whisper_large_v3_turbo_speech_translate_hf"], "pcc": 0.99, "max_int": 51865},
     ),
-    pytest.param(
-        (
-            Embedding11,
-            [((2, 7), torch.int64)],
-            {"model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"], "pcc": 0.99, "max_int": 49407},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding11,
+        [((2, 7), torch.int64)],
+        {"model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"], "pcc": 0.99, "max_int": 49407},
     ),
-    pytest.param(
-        (
-            Embedding12,
-            [((1, 7), torch.int64)],
-            {"model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"], "pcc": 0.99, "max_int": 76},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding12,
+        [((1, 7), torch.int64)],
+        {"model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"], "pcc": 0.99, "max_int": 76},
     ),
-    pytest.param(
-        (
-            Embedding13,
-            [((1, 39), torch.int64)],
-            {"model_name": ["pt_deepseek_deepseek_math_7b_instruct_qa_hf"], "pcc": 0.99, "max_int": 102399},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding13,
+        [((1, 39), torch.int64)],
+        {"model_name": ["pt_deepseek_deepseek_math_7b_instruct_qa_hf"], "pcc": 0.99, "max_int": 102399},
     ),
     (
         Embedding13,
         [((1, 39), torch.int32)],
         {"model_name": ["DeepSeekWrapper_decoder"], "pcc": 0.99, "max_int": 102399},
     ),
-    pytest.param(
-        (
-            Embedding14,
-            [((1, 128), torch.int64)],
-            {
-                "model_name": [
-                    "pt_albert_xxlarge_v1_token_cls_hf",
-                    "pt_albert_base_v2_token_cls_hf",
-                    "pt_albert_xxlarge_v2_token_cls_hf",
-                    "pt_albert_large_v1_token_cls_hf",
-                    "pt_albert_large_v2_token_cls_hf",
-                    "pt_albert_base_v1_token_cls_hf",
-                    "pt_albert_base_v1_mlm_hf",
-                    "pt_albert_xlarge_v2_token_cls_hf",
-                    "pt_albert_xxlarge_v2_mlm_hf",
-                    "pt_albert_large_v2_mlm_hf",
-                    "pt_albert_base_v2_mlm_hf",
-                    "pt_albert_xlarge_v1_token_cls_hf",
-                    "pt_albert_xlarge_v1_mlm_hf",
-                    "pt_albert_large_v1_mlm_hf",
-                    "pt_albert_xxlarge_v1_mlm_hf",
-                    "pt_albert_xlarge_v2_mlm_hf",
-                ],
-                "pcc": 0.99,
-                "max_int": 29999,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding14,
+        [((1, 128), torch.int64)],
+        {
+            "model_name": [
+                "pt_albert_xxlarge_v1_token_cls_hf",
+                "pt_albert_base_v2_token_cls_hf",
+                "pt_albert_xxlarge_v2_token_cls_hf",
+                "pt_albert_large_v1_token_cls_hf",
+                "pt_albert_large_v2_token_cls_hf",
+                "pt_albert_base_v1_token_cls_hf",
+                "pt_albert_base_v1_mlm_hf",
+                "pt_albert_xlarge_v2_token_cls_hf",
+                "pt_albert_xxlarge_v2_mlm_hf",
+                "pt_albert_large_v2_mlm_hf",
+                "pt_albert_base_v2_mlm_hf",
+                "pt_albert_xlarge_v1_token_cls_hf",
+                "pt_albert_xlarge_v1_mlm_hf",
+                "pt_albert_large_v1_mlm_hf",
+                "pt_albert_xxlarge_v1_mlm_hf",
+                "pt_albert_xlarge_v2_mlm_hf",
+            ],
+            "pcc": 0.99,
+            "max_int": 29999,
+        },
     ),
     (
         Embedding15,
@@ -953,73 +929,61 @@ forge_modules_and_shapes_dtypes_list = [
             "max_int": 1,
         },
     ),
-    pytest.param(
-        (
-            Embedding16,
-            [((1, 128), torch.int64)],
-            {
-                "model_name": [
-                    "pt_albert_xxlarge_v1_token_cls_hf",
-                    "pt_albert_base_v2_token_cls_hf",
-                    "pt_albert_xxlarge_v2_token_cls_hf",
-                    "pt_albert_large_v1_token_cls_hf",
-                    "pt_albert_large_v2_token_cls_hf",
-                    "pt_albert_base_v1_token_cls_hf",
-                    "pt_albert_base_v1_mlm_hf",
-                    "pt_albert_xlarge_v2_token_cls_hf",
-                    "pt_albert_xxlarge_v2_mlm_hf",
-                    "pt_albert_large_v2_mlm_hf",
-                    "pt_albert_base_v2_mlm_hf",
-                    "pt_albert_xlarge_v1_token_cls_hf",
-                    "pt_albert_xlarge_v1_mlm_hf",
-                    "pt_albert_large_v1_mlm_hf",
-                    "pt_albert_xxlarge_v1_mlm_hf",
-                    "pt_albert_xlarge_v2_mlm_hf",
-                ],
-                "pcc": 0.99,
-                "max_int": 511,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding16,
+        [((1, 128), torch.int64)],
+        {
+            "model_name": [
+                "pt_albert_xxlarge_v1_token_cls_hf",
+                "pt_albert_base_v2_token_cls_hf",
+                "pt_albert_xxlarge_v2_token_cls_hf",
+                "pt_albert_large_v1_token_cls_hf",
+                "pt_albert_large_v2_token_cls_hf",
+                "pt_albert_base_v1_token_cls_hf",
+                "pt_albert_base_v1_mlm_hf",
+                "pt_albert_xlarge_v2_token_cls_hf",
+                "pt_albert_xxlarge_v2_mlm_hf",
+                "pt_albert_large_v2_mlm_hf",
+                "pt_albert_base_v2_mlm_hf",
+                "pt_albert_xlarge_v1_token_cls_hf",
+                "pt_albert_xlarge_v1_mlm_hf",
+                "pt_albert_large_v1_mlm_hf",
+                "pt_albert_xxlarge_v1_mlm_hf",
+                "pt_albert_xlarge_v2_mlm_hf",
+            ],
+            "pcc": 0.99,
+            "max_int": 511,
+        },
     ),
-    pytest.param(
-        (
-            Embedding17,
-            [((1, 256), torch.int64)],
-            {"model_name": ["pt_bart_facebook_bart_large_mnli_seq_cls_hf"], "pcc": 0.99, "max_int": 50264},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding17,
+        [((1, 256), torch.int64)],
+        {"model_name": ["pt_bart_facebook_bart_large_mnli_seq_cls_hf"], "pcc": 0.99, "max_int": 50264},
     ),
-    pytest.param(
-        (
-            Embedding2,
-            [((1, 256), torch.int64), ((1026, 1024), torch.float32)],
-            {"model_name": ["pt_bart_facebook_bart_large_mnli_seq_cls_hf"], "pcc": 0.99, "max_int": 1025},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding2,
+        [((1, 256), torch.int64), ((1026, 1024), torch.float32)],
+        {"model_name": ["pt_bart_facebook_bart_large_mnli_seq_cls_hf"], "pcc": 0.99, "max_int": 1025},
     ),
-    pytest.param(
-        (
-            Embedding18,
-            [((1, 128), torch.int64)],
-            {
-                "model_name": [
-                    "pt_bert_textattack_bert_base_uncased_sst_2_seq_cls_hf",
-                    "pt_bert_bert_base_uncased_mlm_hf",
-                    "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
-                    "pt_distilbert_distilbert_base_uncased_mlm_hf",
-                    "pt_dpr_facebook_dpr_ctx_encoder_single_nq_base_qa_hf_context_encoder",
-                    "pt_dpr_facebook_dpr_question_encoder_single_nq_base_qa_hf_question_encoder",
-                    "pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader",
-                    "pt_dpr_facebook_dpr_question_encoder_multiset_base_qa_hf_question_encoder",
-                    "pt_dpr_facebook_dpr_ctx_encoder_multiset_base_qa_hf_context_encoder",
-                    "pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader",
-                ],
-                "pcc": 0.99,
-                "max_int": 30521,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding18,
+        [((1, 128), torch.int64)],
+        {
+            "model_name": [
+                "pt_bert_textattack_bert_base_uncased_sst_2_seq_cls_hf",
+                "pt_bert_bert_base_uncased_mlm_hf",
+                "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
+                "pt_distilbert_distilbert_base_uncased_mlm_hf",
+                "pt_dpr_facebook_dpr_ctx_encoder_single_nq_base_qa_hf_context_encoder",
+                "pt_dpr_facebook_dpr_question_encoder_single_nq_base_qa_hf_question_encoder",
+                "pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader",
+                "pt_dpr_facebook_dpr_question_encoder_multiset_base_qa_hf_question_encoder",
+                "pt_dpr_facebook_dpr_ctx_encoder_multiset_base_qa_hf_context_encoder",
+                "pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader",
+            ],
+            "pcc": 0.99,
+            "max_int": 30521,
+        },
     ),
     (
         Embedding19,
@@ -1039,44 +1003,38 @@ forge_modules_and_shapes_dtypes_list = [
             "max_int": 1,
         },
     ),
-    pytest.param(
-        (
-            Embedding20,
-            [((1, 128), torch.int64)],
-            {
-                "model_name": [
-                    "pt_bert_textattack_bert_base_uncased_sst_2_seq_cls_hf",
-                    "pt_bert_bert_base_uncased_mlm_hf",
-                    "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
-                    "pt_distilbert_distilbert_base_cased_mlm_hf",
-                    "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
-                    "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
-                    "pt_distilbert_distilbert_base_uncased_mlm_hf",
-                    "pt_dpr_facebook_dpr_ctx_encoder_single_nq_base_qa_hf_context_encoder",
-                    "pt_dpr_facebook_dpr_question_encoder_single_nq_base_qa_hf_question_encoder",
-                    "pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader",
-                    "pt_dpr_facebook_dpr_question_encoder_multiset_base_qa_hf_question_encoder",
-                    "pt_dpr_facebook_dpr_ctx_encoder_multiset_base_qa_hf_context_encoder",
-                    "pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader",
-                    "pt_squeezebert_squeezebert_squeezebert_mnli_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "max_int": 511,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding20,
+        [((1, 128), torch.int64)],
+        {
+            "model_name": [
+                "pt_bert_textattack_bert_base_uncased_sst_2_seq_cls_hf",
+                "pt_bert_bert_base_uncased_mlm_hf",
+                "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
+                "pt_distilbert_distilbert_base_cased_mlm_hf",
+                "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
+                "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
+                "pt_distilbert_distilbert_base_uncased_mlm_hf",
+                "pt_dpr_facebook_dpr_ctx_encoder_single_nq_base_qa_hf_context_encoder",
+                "pt_dpr_facebook_dpr_question_encoder_single_nq_base_qa_hf_question_encoder",
+                "pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader",
+                "pt_dpr_facebook_dpr_question_encoder_multiset_base_qa_hf_question_encoder",
+                "pt_dpr_facebook_dpr_ctx_encoder_multiset_base_qa_hf_context_encoder",
+                "pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader",
+                "pt_squeezebert_squeezebert_squeezebert_mnli_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "max_int": 511,
+        },
     ),
-    pytest.param(
-        (
-            Embedding21,
-            [((1, 384), torch.int64)],
-            {
-                "model_name": ["pt_bert_bert_large_cased_whole_word_masking_finetuned_squad_qa_hf"],
-                "pcc": 0.99,
-                "max_int": 28995,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding21,
+        [((1, 384), torch.int64)],
+        {
+            "model_name": ["pt_bert_bert_large_cased_whole_word_masking_finetuned_squad_qa_hf"],
+            "pcc": 0.99,
+            "max_int": 28995,
+        },
     ),
     (
         Embedding22,
@@ -1087,29 +1045,23 @@ forge_modules_and_shapes_dtypes_list = [
             "max_int": 1,
         },
     ),
-    pytest.param(
-        (
-            Embedding23,
-            [((1, 384), torch.int64)],
-            {
-                "model_name": ["pt_bert_bert_large_cased_whole_word_masking_finetuned_squad_qa_hf"],
-                "pcc": 0.99,
-                "max_int": 511,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding23,
+        [((1, 384), torch.int64)],
+        {
+            "model_name": ["pt_bert_bert_large_cased_whole_word_masking_finetuned_squad_qa_hf"],
+            "pcc": 0.99,
+            "max_int": 511,
+        },
     ),
-    pytest.param(
-        (
-            Embedding21,
-            [((1, 128), torch.int64)],
-            {
-                "model_name": ["pt_bert_dbmdz_bert_large_cased_finetuned_conll03_english_token_cls_hf"],
-                "pcc": 0.99,
-                "max_int": 28995,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding21,
+        [((1, 128), torch.int64)],
+        {
+            "model_name": ["pt_bert_dbmdz_bert_large_cased_finetuned_conll03_english_token_cls_hf"],
+            "pcc": 0.99,
+            "max_int": 28995,
+        },
     ),
     (
         Embedding22,
@@ -1120,17 +1072,14 @@ forge_modules_and_shapes_dtypes_list = [
             "max_int": 1,
         },
     ),
-    pytest.param(
-        (
-            Embedding23,
-            [((1, 128), torch.int64)],
-            {
-                "model_name": ["pt_bert_dbmdz_bert_large_cased_finetuned_conll03_english_token_cls_hf"],
-                "pcc": 0.99,
-                "max_int": 511,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding23,
+        [((1, 128), torch.int64)],
+        {
+            "model_name": ["pt_bert_dbmdz_bert_large_cased_finetuned_conll03_english_token_cls_hf"],
+            "pcc": 0.99,
+            "max_int": 511,
+        },
     ),
     (
         Embedding24,
@@ -1145,207 +1094,137 @@ forge_modules_and_shapes_dtypes_list = [
             "max_int": 51199,
         },
     ),
-    pytest.param(
-        (
-            Embedding25,
-            [((1, 128), torch.int64)],
-            {
-                "model_name": [
-                    "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
-                    "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
-                ],
-                "pcc": 0.99,
-                "max_int": 119546,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding25,
+        [((1, 128), torch.int64)],
+        {
+            "model_name": [
+                "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
+                "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
+            ],
+            "pcc": 0.99,
+            "max_int": 119546,
+        },
     ),
-    pytest.param(
-        (
-            Embedding26,
-            [((1, 384), torch.int64)],
-            {
-                "model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
-                "pcc": 0.99,
-                "max_int": 28995,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding26,
+        [((1, 384), torch.int64)],
+        {"model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"], "pcc": 0.99, "max_int": 28995},
     ),
-    pytest.param(
-        (
-            Embedding20,
-            [((1, 384), torch.int64)],
-            {"model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"], "pcc": 0.99, "max_int": 511},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding20,
+        [((1, 384), torch.int64)],
+        {"model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"], "pcc": 0.99, "max_int": 511},
     ),
-    pytest.param(
-        (
-            Embedding26,
-            [((1, 128), torch.int64)],
-            {"model_name": ["pt_distilbert_distilbert_base_cased_mlm_hf"], "pcc": 0.99, "max_int": 28995},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding26,
+        [((1, 128), torch.int64)],
+        {"model_name": ["pt_distilbert_distilbert_base_cased_mlm_hf"], "pcc": 0.99, "max_int": 28995},
     ),
-    pytest.param(
-        (
-            Embedding27,
-            [((1, 6), torch.int64)],
-            {"model_name": ["pt_falcon_tiiuae_falcon_7b_instruct_clm_hf"], "pcc": 0.99, "max_int": 65023},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding27,
+        [((1, 6), torch.int64)],
+        {"model_name": ["pt_falcon_tiiuae_falcon_7b_instruct_clm_hf"], "pcc": 0.99, "max_int": 65023},
     ),
-    pytest.param(
-        (
-            Embedding28,
-            [((1, 10), torch.int64)],
-            {
-                "model_name": ["pt_falcon3_tiiuae_falcon3_3b_base_clm_hf", "pt_falcon3_tiiuae_falcon3_7b_base_clm_hf"],
-                "pcc": 0.99,
-                "max_int": 131071,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding28,
+        [((1, 10), torch.int64)],
+        {
+            "model_name": ["pt_falcon3_tiiuae_falcon3_3b_base_clm_hf", "pt_falcon3_tiiuae_falcon3_7b_base_clm_hf"],
+            "pcc": 0.99,
+            "max_int": 131071,
+        },
     ),
-    pytest.param(
-        (
-            Embedding29,
-            [((1, 10), torch.int64)],
-            {"model_name": ["pt_falcon3_tiiuae_falcon3_1b_base_clm_hf"], "pcc": 0.99, "max_int": 131071},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding29,
+        [((1, 10), torch.int64)],
+        {"model_name": ["pt_falcon3_tiiuae_falcon3_1b_base_clm_hf"], "pcc": 0.99, "max_int": 131071},
     ),
-    pytest.param(
-        (
-            Embedding30,
-            [((1, 7), torch.int64)],
-            {"model_name": ["pt_gemma_google_gemma_2b_text_gen_hf"], "pcc": 0.99, "max_int": 255999},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding30,
+        [((1, 7), torch.int64)],
+        {"model_name": ["pt_gemma_google_gemma_2b_text_gen_hf"], "pcc": 0.99, "max_int": 255999},
     ),
-    pytest.param(
-        (
-            Embedding31,
-            [((1, 256), torch.int64)],
-            {
-                "model_name": ["pt_gpt2_gpt2_text_gen_hf", "pt_gptneo_eleutherai_gpt_neo_125m_clm_hf"],
-                "pcc": 0.99,
-                "max_int": 50256,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding31,
+        [((1, 256), torch.int64)],
+        {
+            "model_name": ["pt_gpt2_gpt2_text_gen_hf", "pt_gptneo_eleutherai_gpt_neo_125m_clm_hf"],
+            "pcc": 0.99,
+            "max_int": 50256,
+        },
     ),
-    pytest.param(
-        (
-            Embedding2,
-            [((1, 256), torch.int64), ((1024, 768), torch.float32)],
-            {"model_name": ["pt_gpt2_gpt2_text_gen_hf"], "pcc": 0.99, "max_int": 1023},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding2,
+        [((1, 256), torch.int64), ((1024, 768), torch.float32)],
+        {"model_name": ["pt_gpt2_gpt2_text_gen_hf"], "pcc": 0.99, "max_int": 1023},
     ),
-    pytest.param(
-        (
-            Embedding32,
-            [((1, 256), torch.int64)],
-            {"model_name": ["pt_gptneo_eleutherai_gpt_neo_2_7b_clm_hf"], "pcc": 0.99, "max_int": 50256},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding32,
+        [((1, 256), torch.int64)],
+        {"model_name": ["pt_gptneo_eleutherai_gpt_neo_2_7b_clm_hf"], "pcc": 0.99, "max_int": 50256},
     ),
-    pytest.param(
-        (
-            Embedding2,
-            [((1, 256), torch.int64), ((2048, 2560), torch.float32)],
-            {"model_name": ["pt_gptneo_eleutherai_gpt_neo_2_7b_clm_hf"], "pcc": 0.99, "max_int": 2047},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding2,
+        [((1, 256), torch.int64), ((2048, 2560), torch.float32)],
+        {"model_name": ["pt_gptneo_eleutherai_gpt_neo_2_7b_clm_hf"], "pcc": 0.99, "max_int": 2047},
     ),
-    pytest.param(
-        (
-            Embedding33,
-            [((1, 256), torch.int64)],
-            {"model_name": ["pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf"], "pcc": 0.99, "max_int": 50256},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding33,
+        [((1, 256), torch.int64)],
+        {"model_name": ["pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf"], "pcc": 0.99, "max_int": 50256},
     ),
-    pytest.param(
-        (
-            Embedding2,
-            [((1, 256), torch.int64), ((2048, 2048), torch.float32)],
-            {"model_name": ["pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf"], "pcc": 0.99, "max_int": 2047},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding2,
+        [((1, 256), torch.int64), ((2048, 2048), torch.float32)],
+        {"model_name": ["pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf"], "pcc": 0.99, "max_int": 2047},
     ),
-    pytest.param(
-        (
-            Embedding31,
-            [((1, 32), torch.int64)],
-            {"model_name": ["pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf"], "pcc": 0.99, "max_int": 50256},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding31,
+        [((1, 32), torch.int64)],
+        {"model_name": ["pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf"], "pcc": 0.99, "max_int": 50256},
     ),
-    pytest.param(
-        (
-            Embedding2,
-            [((1, 32), torch.int64), ((2048, 768), torch.float32)],
-            {"model_name": ["pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf"], "pcc": 0.99, "max_int": 2047},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding2,
+        [((1, 32), torch.int64), ((2048, 768), torch.float32)],
+        {"model_name": ["pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf"], "pcc": 0.99, "max_int": 2047},
     ),
-    pytest.param(
-        (
-            Embedding32,
-            [((1, 32), torch.int64)],
-            {"model_name": ["pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf"], "pcc": 0.99, "max_int": 50256},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding32,
+        [((1, 32), torch.int64)],
+        {"model_name": ["pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf"], "pcc": 0.99, "max_int": 50256},
     ),
-    pytest.param(
-        (
-            Embedding2,
-            [((1, 32), torch.int64), ((2048, 2560), torch.float32)],
-            {"model_name": ["pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf"], "pcc": 0.99, "max_int": 2047},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding2,
+        [((1, 32), torch.int64), ((2048, 2560), torch.float32)],
+        {"model_name": ["pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf"], "pcc": 0.99, "max_int": 2047},
     ),
-    pytest.param(
-        (
-            Embedding2,
-            [((1, 256), torch.int64), ((2048, 768), torch.float32)],
-            {"model_name": ["pt_gptneo_eleutherai_gpt_neo_125m_clm_hf"], "pcc": 0.99, "max_int": 2047},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding2,
+        [((1, 256), torch.int64), ((2048, 768), torch.float32)],
+        {"model_name": ["pt_gptneo_eleutherai_gpt_neo_125m_clm_hf"], "pcc": 0.99, "max_int": 2047},
     ),
-    pytest.param(
-        (
-            Embedding33,
-            [((1, 32), torch.int64)],
-            {"model_name": ["pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf"], "pcc": 0.99, "max_int": 50256},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding33,
+        [((1, 32), torch.int64)],
+        {"model_name": ["pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf"], "pcc": 0.99, "max_int": 50256},
     ),
-    pytest.param(
-        (
-            Embedding2,
-            [((1, 32), torch.int64), ((2048, 2048), torch.float32)],
-            {"model_name": ["pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf"], "pcc": 0.99, "max_int": 2047},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding2,
+        [((1, 32), torch.int64), ((2048, 2048), torch.float32)],
+        {"model_name": ["pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf"], "pcc": 0.99, "max_int": 2047},
     ),
-    pytest.param(
-        (
-            Embedding34,
-            [((1, 4), torch.int64)],
-            {
-                "model_name": [
-                    "pt_llama3_meta_llama_llama_3_2_1b_instruct_seq_cls_hf",
-                    "pt_llama3_meta_llama_llama_3_2_1b_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "max_int": 128255,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding34,
+        [((1, 4), torch.int64)],
+        {
+            "model_name": [
+                "pt_llama3_meta_llama_llama_3_2_1b_instruct_seq_cls_hf",
+                "pt_llama3_meta_llama_llama_3_2_1b_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "max_int": 128255,
+        },
     ),
     (
         Embedding34,
@@ -1359,178 +1238,127 @@ forge_modules_and_shapes_dtypes_list = [
             "max_int": 128255,
         },
     ),
-    pytest.param(
-        (
-            Embedding35,
-            [((1, 4), torch.int64)],
-            {
-                "model_name": [
-                    "pt_llama3_meta_llama_llama_3_1_8b_seq_cls_hf",
-                    "pt_llama3_meta_llama_meta_llama_3_8b_instruct_seq_cls_hf",
-                    "pt_llama3_meta_llama_llama_3_1_8b_instruct_seq_cls_hf",
-                    "pt_llama3_meta_llama_meta_llama_3_8b_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "max_int": 128255,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding35,
+        [((1, 4), torch.int64)],
+        {
+            "model_name": [
+                "pt_llama3_meta_llama_llama_3_1_8b_seq_cls_hf",
+                "pt_llama3_meta_llama_meta_llama_3_8b_instruct_seq_cls_hf",
+                "pt_llama3_meta_llama_llama_3_1_8b_instruct_seq_cls_hf",
+                "pt_llama3_meta_llama_meta_llama_3_8b_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "max_int": 128255,
+        },
     ),
-    pytest.param(
-        (
-            Embedding36,
-            [((1, 128), torch.int64)],
-            {"model_name": ["pt_mistral_mistralai_mistral_7b_v0_1_clm_hf"], "pcc": 0.99, "max_int": 31999},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding36,
+        [((1, 128), torch.int64)],
+        {"model_name": ["pt_mistral_mistralai_mistral_7b_v0_1_clm_hf"], "pcc": 0.99, "max_int": 31999},
     ),
-    pytest.param(
-        (
-            Embedding31,
-            [((1, 7), torch.int64)],
-            {"model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"], "pcc": 0.99, "max_int": 50256},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding31,
+        [((1, 7), torch.int64)],
+        {"model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"], "pcc": 0.99, "max_int": 50256},
     ),
-    pytest.param(
-        (
-            Embedding2,
-            [((1, 7), torch.int64), ((1024, 768), torch.float32)],
-            {"model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"], "pcc": 0.99, "max_int": 1023},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding2,
+        [((1, 7), torch.int64), ((1024, 768), torch.float32)],
+        {"model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"], "pcc": 0.99, "max_int": 1023},
     ),
-    pytest.param(
-        (
-            Embedding37,
-            [((1, 256), torch.int64)],
-            {"model_name": ["pt_opt_facebook_opt_1_3b_clm_hf"], "pcc": 0.99, "max_int": 50271},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding37,
+        [((1, 256), torch.int64)],
+        {"model_name": ["pt_opt_facebook_opt_1_3b_clm_hf"], "pcc": 0.99, "max_int": 50271},
     ),
-    pytest.param(
-        (
-            Embedding38,
-            [((1, 256), torch.int64)],
-            {"model_name": ["pt_opt_facebook_opt_1_3b_clm_hf"], "pcc": 0.99, "max_int": 2049},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding38,
+        [((1, 256), torch.int64)],
+        {"model_name": ["pt_opt_facebook_opt_1_3b_clm_hf"], "pcc": 0.99, "max_int": 2049},
     ),
-    pytest.param(
-        (
-            Embedding37,
-            [((1, 32), torch.int64)],
-            {
-                "model_name": ["pt_opt_facebook_opt_1_3b_seq_cls_hf", "pt_opt_facebook_opt_1_3b_qa_hf"],
-                "pcc": 0.99,
-                "max_int": 50271,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding37,
+        [((1, 32), torch.int64)],
+        {
+            "model_name": ["pt_opt_facebook_opt_1_3b_seq_cls_hf", "pt_opt_facebook_opt_1_3b_qa_hf"],
+            "pcc": 0.99,
+            "max_int": 50271,
+        },
     ),
-    pytest.param(
-        (
-            Embedding38,
-            [((1, 32), torch.int64)],
-            {
-                "model_name": ["pt_opt_facebook_opt_1_3b_seq_cls_hf", "pt_opt_facebook_opt_1_3b_qa_hf"],
-                "pcc": 0.99,
-                "max_int": 2049,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding38,
+        [((1, 32), torch.int64)],
+        {
+            "model_name": ["pt_opt_facebook_opt_1_3b_seq_cls_hf", "pt_opt_facebook_opt_1_3b_qa_hf"],
+            "pcc": 0.99,
+            "max_int": 2049,
+        },
     ),
-    pytest.param(
-        (
-            Embedding39,
-            [((1, 32), torch.int64)],
-            {
-                "model_name": ["pt_opt_facebook_opt_350m_qa_hf", "pt_opt_facebook_opt_350m_seq_cls_hf"],
-                "pcc": 0.99,
-                "max_int": 50271,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding39,
+        [((1, 32), torch.int64)],
+        {
+            "model_name": ["pt_opt_facebook_opt_350m_qa_hf", "pt_opt_facebook_opt_350m_seq_cls_hf"],
+            "pcc": 0.99,
+            "max_int": 50271,
+        },
     ),
-    pytest.param(
-        (
-            Embedding40,
-            [((1, 32), torch.int64)],
-            {
-                "model_name": ["pt_opt_facebook_opt_350m_qa_hf", "pt_opt_facebook_opt_350m_seq_cls_hf"],
-                "pcc": 0.99,
-                "max_int": 2049,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding40,
+        [((1, 32), torch.int64)],
+        {
+            "model_name": ["pt_opt_facebook_opt_350m_qa_hf", "pt_opt_facebook_opt_350m_seq_cls_hf"],
+            "pcc": 0.99,
+            "max_int": 2049,
+        },
     ),
-    pytest.param(
-        (
-            Embedding41,
-            [((1, 32), torch.int64)],
-            {
-                "model_name": ["pt_opt_facebook_opt_125m_seq_cls_hf", "pt_opt_facebook_opt_125m_qa_hf"],
-                "pcc": 0.99,
-                "max_int": 50271,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding41,
+        [((1, 32), torch.int64)],
+        {
+            "model_name": ["pt_opt_facebook_opt_125m_seq_cls_hf", "pt_opt_facebook_opt_125m_qa_hf"],
+            "pcc": 0.99,
+            "max_int": 50271,
+        },
     ),
-    pytest.param(
-        (
-            Embedding42,
-            [((1, 32), torch.int64)],
-            {
-                "model_name": ["pt_opt_facebook_opt_125m_seq_cls_hf", "pt_opt_facebook_opt_125m_qa_hf"],
-                "pcc": 0.99,
-                "max_int": 2049,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding42,
+        [((1, 32), torch.int64)],
+        {
+            "model_name": ["pt_opt_facebook_opt_125m_seq_cls_hf", "pt_opt_facebook_opt_125m_qa_hf"],
+            "pcc": 0.99,
+            "max_int": 2049,
+        },
     ),
-    pytest.param(
-        (
-            Embedding41,
-            [((1, 256), torch.int64)],
-            {"model_name": ["pt_opt_facebook_opt_125m_clm_hf"], "pcc": 0.99, "max_int": 50271},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding41,
+        [((1, 256), torch.int64)],
+        {"model_name": ["pt_opt_facebook_opt_125m_clm_hf"], "pcc": 0.99, "max_int": 50271},
     ),
-    pytest.param(
-        (
-            Embedding42,
-            [((1, 256), torch.int64)],
-            {"model_name": ["pt_opt_facebook_opt_125m_clm_hf"], "pcc": 0.99, "max_int": 2049},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding42,
+        [((1, 256), torch.int64)],
+        {"model_name": ["pt_opt_facebook_opt_125m_clm_hf"], "pcc": 0.99, "max_int": 2049},
     ),
-    pytest.param(
-        (
-            Embedding39,
-            [((1, 256), torch.int64)],
-            {"model_name": ["pt_opt_facebook_opt_350m_clm_hf"], "pcc": 0.99, "max_int": 50271},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding39,
+        [((1, 256), torch.int64)],
+        {"model_name": ["pt_opt_facebook_opt_350m_clm_hf"], "pcc": 0.99, "max_int": 50271},
     ),
-    pytest.param(
-        (
-            Embedding40,
-            [((1, 256), torch.int64)],
-            {"model_name": ["pt_opt_facebook_opt_350m_clm_hf"], "pcc": 0.99, "max_int": 2049},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding40,
+        [((1, 256), torch.int64)],
+        {"model_name": ["pt_opt_facebook_opt_350m_clm_hf"], "pcc": 0.99, "max_int": 2049},
     ),
-    pytest.param(
-        (
-            Embedding43,
-            [((1, 12), torch.int64)],
-            {
-                "model_name": ["pt_phi2_microsoft_phi_2_pytdml_token_cls_hf", "pt_phi2_microsoft_phi_2_token_cls_hf"],
-                "pcc": 0.99,
-                "max_int": 51199,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding43,
+        [((1, 12), torch.int64)],
+        {
+            "model_name": ["pt_phi2_microsoft_phi_2_pytdml_token_cls_hf", "pt_phi2_microsoft_phi_2_token_cls_hf"],
+            "pcc": 0.99,
+            "max_int": 51199,
+        },
     ),
     (
         Embedding43,
@@ -1541,182 +1369,125 @@ forge_modules_and_shapes_dtypes_list = [
             "max_int": 51199,
         },
     ),
-    pytest.param(
-        (
-            Embedding43,
-            [((1, 11), torch.int64)],
-            {
-                "model_name": ["pt_phi2_microsoft_phi_2_seq_cls_hf", "pt_phi2_microsoft_phi_2_pytdml_seq_cls_hf"],
-                "pcc": 0.99,
-                "max_int": 51199,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding43,
+        [((1, 11), torch.int64)],
+        {
+            "model_name": ["pt_phi2_microsoft_phi_2_seq_cls_hf", "pt_phi2_microsoft_phi_2_pytdml_seq_cls_hf"],
+            "pcc": 0.99,
+            "max_int": 51199,
+        },
     ),
-    pytest.param(
-        (
-            Embedding44,
-            [((1, 256), torch.int64)],
-            {"model_name": ["pt_phi3_microsoft_phi_3_mini_4k_instruct_clm_hf"], "pcc": 0.99, "max_int": 32063},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding44,
+        [((1, 256), torch.int64)],
+        {"model_name": ["pt_phi3_microsoft_phi_3_mini_4k_instruct_clm_hf"], "pcc": 0.99, "max_int": 32063},
     ),
-    pytest.param(
-        (
-            Embedding44,
-            [((1, 13), torch.int64)],
-            {"model_name": ["pt_phi3_microsoft_phi_3_mini_4k_instruct_token_cls_hf"], "pcc": 0.99, "max_int": 32063},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding44,
+        [((1, 13), torch.int64)],
+        {"model_name": ["pt_phi3_microsoft_phi_3_mini_4k_instruct_token_cls_hf"], "pcc": 0.99, "max_int": 32063},
     ),
-    pytest.param(
-        (
-            Embedding44,
-            [((1, 5), torch.int64)],
-            {"model_name": ["pt_phi3_microsoft_phi_3_mini_4k_instruct_seq_cls_hf"], "pcc": 0.99, "max_int": 32063},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding44,
+        [((1, 5), torch.int64)],
+        {"model_name": ["pt_phi3_microsoft_phi_3_mini_4k_instruct_seq_cls_hf"], "pcc": 0.99, "max_int": 32063},
     ),
-    pytest.param(
-        (
-            Embedding45,
-            [((1, 6), torch.int64)],
-            {"model_name": ["pt_qwen1_5_qwen_qwen1_5_0_5b_clm_hf"], "pcc": 0.99, "max_int": 151935},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding45,
+        [((1, 6), torch.int64)],
+        {"model_name": ["pt_qwen1_5_qwen_qwen1_5_0_5b_clm_hf"], "pcc": 0.99, "max_int": 151935},
     ),
-    pytest.param(
-        (
-            Embedding45,
-            [((1, 29), torch.int64)],
-            {"model_name": ["pt_qwen1_5_qwen_qwen1_5_0_5b_chat_clm_hf"], "pcc": 0.99, "max_int": 151935},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding45,
+        [((1, 29), torch.int64)],
+        {"model_name": ["pt_qwen1_5_qwen_qwen1_5_0_5b_chat_clm_hf"], "pcc": 0.99, "max_int": 151935},
     ),
-    pytest.param(
-        (
-            Embedding46,
-            [((1, 35), torch.int64)],
-            {
-                "model_name": [
-                    "pt_qwen_coder_qwen_qwen2_5_coder_7b_clm_hf",
-                    "pt_qwen_coder_qwen_qwen2_5_coder_7b_instruct_clm_hf",
-                ],
-                "pcc": 0.99,
-                "max_int": 152063,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding46,
+        [((1, 35), torch.int64)],
+        {
+            "model_name": [
+                "pt_qwen_coder_qwen_qwen2_5_coder_7b_clm_hf",
+                "pt_qwen_coder_qwen_qwen2_5_coder_7b_instruct_clm_hf",
+            ],
+            "pcc": 0.99,
+            "max_int": 152063,
+        },
     ),
-    pytest.param(
-        (
-            Embedding47,
-            [((1, 35), torch.int64)],
-            {
-                "model_name": [
-                    "pt_qwen_coder_qwen_qwen2_5_coder_1_5b_clm_hf",
-                    "pt_qwen_coder_qwen_qwen2_5_coder_1_5b_instruct_clm_hf",
-                ],
-                "pcc": 0.99,
-                "max_int": 151935,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding47,
+        [((1, 35), torch.int64)],
+        {
+            "model_name": [
+                "pt_qwen_coder_qwen_qwen2_5_coder_1_5b_clm_hf",
+                "pt_qwen_coder_qwen_qwen2_5_coder_1_5b_instruct_clm_hf",
+            ],
+            "pcc": 0.99,
+            "max_int": 151935,
+        },
     ),
-    pytest.param(
-        (
-            Embedding48,
-            [((1, 35), torch.int64)],
-            {
-                "model_name": [
-                    "pt_qwen_coder_qwen_qwen2_5_coder_3b_clm_hf",
-                    "pt_qwen_coder_qwen_qwen2_5_coder_3b_instruct_clm_hf",
-                ],
-                "pcc": 0.99,
-                "max_int": 151935,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding48,
+        [((1, 35), torch.int64)],
+        {
+            "model_name": [
+                "pt_qwen_coder_qwen_qwen2_5_coder_3b_clm_hf",
+                "pt_qwen_coder_qwen_qwen2_5_coder_3b_instruct_clm_hf",
+            ],
+            "pcc": 0.99,
+            "max_int": 151935,
+        },
     ),
-    pytest.param(
-        (
-            Embedding49,
-            [((1, 35), torch.int64)],
-            {"model_name": ["pt_qwen_coder_qwen_qwen2_5_coder_0_5b_clm_hf"], "pcc": 0.99, "max_int": 151935},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding49,
+        [((1, 35), torch.int64)],
+        {"model_name": ["pt_qwen_coder_qwen_qwen2_5_coder_0_5b_clm_hf"], "pcc": 0.99, "max_int": 151935},
     ),
-    pytest.param(
-        (
-            Embedding47,
-            [((1, 29), torch.int64)],
-            {"model_name": ["pt_qwen_v2_qwen_qwen2_5_1_5b_clm_hf"], "pcc": 0.99, "max_int": 151935},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding47,
+        [((1, 29), torch.int64)],
+        {"model_name": ["pt_qwen_v2_qwen_qwen2_5_1_5b_clm_hf"], "pcc": 0.99, "max_int": 151935},
     ),
-    pytest.param(
-        (
-            Embedding47,
-            [((1, 39), torch.int64)],
-            {"model_name": ["pt_qwen_v2_qwen_qwen2_5_1_5b_instruct_clm_hf"], "pcc": 0.99, "max_int": 151935},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding47,
+        [((1, 39), torch.int64)],
+        {"model_name": ["pt_qwen_v2_qwen_qwen2_5_1_5b_instruct_clm_hf"], "pcc": 0.99, "max_int": 151935},
     ),
-    pytest.param(
-        (
-            Embedding46,
-            [((1, 39), torch.int64)],
-            {"model_name": ["pt_qwen_v2_qwen_qwen2_5_7b_instruct_clm_hf"], "pcc": 0.99, "max_int": 152063},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding46,
+        [((1, 39), torch.int64)],
+        {"model_name": ["pt_qwen_v2_qwen_qwen2_5_7b_instruct_clm_hf"], "pcc": 0.99, "max_int": 152063},
     ),
-    pytest.param(
-        (
-            Embedding46,
-            [((1, 29), torch.int64)],
-            {"model_name": ["pt_qwen_v2_qwen_qwen2_5_7b_clm_hf"], "pcc": 0.99, "max_int": 152063},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding46,
+        [((1, 29), torch.int64)],
+        {"model_name": ["pt_qwen_v2_qwen_qwen2_5_7b_clm_hf"], "pcc": 0.99, "max_int": 152063},
     ),
-    pytest.param(
-        (
-            Embedding48,
-            [((1, 29), torch.int64)],
-            {"model_name": ["pt_qwen_v2_qwen_qwen2_5_3b_clm_hf"], "pcc": 0.99, "max_int": 151935},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding48,
+        [((1, 29), torch.int64)],
+        {"model_name": ["pt_qwen_v2_qwen_qwen2_5_3b_clm_hf"], "pcc": 0.99, "max_int": 151935},
     ),
-    pytest.param(
-        (
-            Embedding48,
-            [((1, 39), torch.int64)],
-            {"model_name": ["pt_qwen_v2_qwen_qwen2_5_3b_instruct_clm_hf"], "pcc": 0.99, "max_int": 151935},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding48,
+        [((1, 39), torch.int64)],
+        {"model_name": ["pt_qwen_v2_qwen_qwen2_5_3b_instruct_clm_hf"], "pcc": 0.99, "max_int": 151935},
     ),
-    pytest.param(
-        (
-            Embedding49,
-            [((1, 29), torch.int64)],
-            {"model_name": ["pt_qwen_v2_qwen_qwen2_5_0_5b_clm_hf"], "pcc": 0.99, "max_int": 151935},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding49,
+        [((1, 29), torch.int64)],
+        {"model_name": ["pt_qwen_v2_qwen_qwen2_5_0_5b_clm_hf"], "pcc": 0.99, "max_int": 151935},
     ),
-    pytest.param(
-        (
-            Embedding49,
-            [((1, 39), torch.int64)],
-            {"model_name": ["pt_qwen_v2_qwen_qwen2_5_0_5b_instruct_clm_hf"], "pcc": 0.99, "max_int": 151935},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding49,
+        [((1, 39), torch.int64)],
+        {"model_name": ["pt_qwen_v2_qwen_qwen2_5_0_5b_instruct_clm_hf"], "pcc": 0.99, "max_int": 151935},
     ),
-    pytest.param(
-        (
-            Embedding50,
-            [((1, 128), torch.int64)],
-            {"model_name": ["pt_roberta_xlm_roberta_base_mlm_hf"], "pcc": 0.99, "max_int": 250001},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding50,
+        [((1, 128), torch.int64)],
+        {"model_name": ["pt_roberta_xlm_roberta_base_mlm_hf"], "pcc": 0.99, "max_int": 250001},
     ),
     (
         Embedding51,
@@ -1730,40 +1501,31 @@ forge_modules_and_shapes_dtypes_list = [
             "max_int": 0,
         },
     ),
-    pytest.param(
-        (
-            Embedding52,
-            [((1, 128), torch.int64)],
-            {
-                "model_name": [
-                    "pt_roberta_xlm_roberta_base_mlm_hf",
-                    "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "max_int": 513,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding52,
+        [((1, 128), torch.int64)],
+        {
+            "model_name": [
+                "pt_roberta_xlm_roberta_base_mlm_hf",
+                "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "max_int": 513,
+        },
     ),
-    pytest.param(
-        (
-            Embedding53,
-            [((1, 128), torch.int64)],
-            {
-                "model_name": ["pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf"],
-                "pcc": 0.99,
-                "max_int": 50264,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding53,
+        [((1, 128), torch.int64)],
+        {
+            "model_name": ["pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf"],
+            "pcc": 0.99,
+            "max_int": 50264,
+        },
     ),
-    pytest.param(
-        (
-            Embedding54,
-            [((1, 128), torch.int64)],
-            {"model_name": ["pt_squeezebert_squeezebert_squeezebert_mnli_seq_cls_hf"], "pcc": 0.99, "max_int": 30527},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding54,
+        [((1, 128), torch.int64)],
+        {"model_name": ["pt_squeezebert_squeezebert_squeezebert_mnli_seq_cls_hf"], "pcc": 0.99, "max_int": 30527},
     ),
     (
         Embedding2,
@@ -1788,17 +1550,14 @@ forge_modules_and_shapes_dtypes_list = [
             "max_int": 31,
         },
     ),
-    pytest.param(
-        (
-            Embedding55,
-            [((1, 61), torch.int64)],
-            {
-                "model_name": ["pt_t5_google_flan_t5_large_text_gen_hf", "pt_t5_t5_large_text_gen_hf"],
-                "pcc": 0.99,
-                "max_int": 32127,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding55,
+        [((1, 61), torch.int64)],
+        {
+            "model_name": ["pt_t5_google_flan_t5_large_text_gen_hf", "pt_t5_t5_large_text_gen_hf"],
+            "pcc": 0.99,
+            "max_int": 32127,
+        },
     ),
     pytest.param(
         (
@@ -1826,17 +1585,14 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 1), torch.int32), ((32, 8), torch.float32)],
         {"model_name": ["pt_t5_t5_small_text_gen_hf"], "pcc": 0.99, "max_int": 31},
     ),
-    pytest.param(
-        (
-            Embedding56,
-            [((1, 61), torch.int64)],
-            {
-                "model_name": ["pt_t5_t5_small_text_gen_hf", "pt_t5_google_flan_t5_small_text_gen_hf"],
-                "pcc": 0.99,
-                "max_int": 32127,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding56,
+        [((1, 61), torch.int64)],
+        {
+            "model_name": ["pt_t5_t5_small_text_gen_hf", "pt_t5_google_flan_t5_small_text_gen_hf"],
+            "pcc": 0.99,
+            "max_int": 32127,
+        },
     ),
     pytest.param(
         (
@@ -1877,17 +1633,14 @@ forge_modules_and_shapes_dtypes_list = [
             "max_int": 31,
         },
     ),
-    pytest.param(
-        (
-            Embedding1,
-            [((1, 61), torch.int64)],
-            {
-                "model_name": ["pt_t5_t5_base_text_gen_hf", "pt_t5_google_flan_t5_base_text_gen_hf"],
-                "pcc": 0.99,
-                "max_int": 32127,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding1,
+        [((1, 61), torch.int64)],
+        {
+            "model_name": ["pt_t5_t5_base_text_gen_hf", "pt_t5_google_flan_t5_base_text_gen_hf"],
+            "pcc": 0.99,
+            "max_int": 32127,
+        },
     ),
     pytest.param(
         (
@@ -1901,21 +1654,15 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    pytest.param(
-        (
-            Embedding57,
-            [((1, 256), torch.int64)],
-            {"model_name": ["pt_xglm_facebook_xglm_1_7b_clm_hf"], "pcc": 0.99, "max_int": 256007},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding57,
+        [((1, 256), torch.int64)],
+        {"model_name": ["pt_xglm_facebook_xglm_1_7b_clm_hf"], "pcc": 0.99, "max_int": 256007},
     ),
-    pytest.param(
-        (
-            Embedding58,
-            [((1, 256), torch.int64)],
-            {"model_name": ["pt_xglm_facebook_xglm_564m_clm_hf"], "pcc": 0.99, "max_int": 256007},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Embedding58,
+        [((1, 256), torch.int64)],
+        {"model_name": ["pt_xglm_facebook_xglm_564m_clm_hf"], "pcc": 0.99, "max_int": 256007},
     ),
 ]
 

--- a/forge/test/models_ops/test_matmul.py
+++ b/forge/test/models_ops/test_matmul.py
@@ -1734,13 +1734,10 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 128, 768), torch.float32), ((768, 119547), torch.float32)],
-            {"model_name": ["pt_distilbert_distilbert_base_multilingual_cased_mlm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 128, 768), torch.float32), ((768, 119547), torch.float32)],
+        {"model_name": ["pt_distilbert_distilbert_base_multilingual_cased_mlm_hf"], "pcc": 0.99},
     ),
     (
         Matmul0,
@@ -2457,19 +2454,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 256, 2048), torch.float32), ((2048, 128256), torch.float32)],
-            {
-                "model_name": [
-                    "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 256, 2048), torch.float32), ((2048, 128256), torch.float32)],
+        {
+            "model_name": [
+                "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Matmul0,
@@ -3196,19 +3190,16 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 35, 3584), torch.float32), ((3584, 152064), torch.float32)],
-            {
-                "model_name": [
-                    "pt_qwen_coder_qwen_qwen2_5_coder_7b_clm_hf",
-                    "pt_qwen_coder_qwen_qwen2_5_coder_7b_instruct_clm_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 35, 3584), torch.float32), ((3584, 152064), torch.float32)],
+        {
+            "model_name": [
+                "pt_qwen_coder_qwen_qwen2_5_coder_7b_clm_hf",
+                "pt_qwen_coder_qwen_qwen2_5_coder_7b_instruct_clm_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Matmul0,
@@ -3279,19 +3270,16 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 35, 1536), torch.float32), ((1536, 151936), torch.float32)],
-            {
-                "model_name": [
-                    "pt_qwen_coder_qwen_qwen2_5_coder_1_5b_clm_hf",
-                    "pt_qwen_coder_qwen_qwen2_5_coder_1_5b_instruct_clm_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 35, 1536), torch.float32), ((1536, 151936), torch.float32)],
+        {
+            "model_name": [
+                "pt_qwen_coder_qwen_qwen2_5_coder_1_5b_clm_hf",
+                "pt_qwen_coder_qwen_qwen2_5_coder_1_5b_instruct_clm_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Matmul0,
@@ -3362,19 +3350,16 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 35, 2048), torch.float32), ((2048, 151936), torch.float32)],
-            {
-                "model_name": [
-                    "pt_qwen_coder_qwen_qwen2_5_coder_3b_clm_hf",
-                    "pt_qwen_coder_qwen_qwen2_5_coder_3b_instruct_clm_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 35, 2048), torch.float32), ((2048, 151936), torch.float32)],
+        {
+            "model_name": [
+                "pt_qwen_coder_qwen_qwen2_5_coder_3b_clm_hf",
+                "pt_qwen_coder_qwen_qwen2_5_coder_3b_instruct_clm_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Matmul0,
@@ -3411,13 +3396,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 35, 4864), torch.float32), ((4864, 896), torch.float32)],
         {"model_name": ["pt_qwen_coder_qwen_qwen2_5_coder_0_5b_clm_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 35, 896), torch.float32), ((896, 151936), torch.float32)],
-            {"model_name": ["pt_qwen_coder_qwen_qwen2_5_coder_0_5b_clm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 35, 896), torch.float32), ((896, 151936), torch.float32)],
+        {"model_name": ["pt_qwen_coder_qwen_qwen2_5_coder_0_5b_clm_hf"], "pcc": 0.99},
     ),
     (
         Matmul0,
@@ -3502,13 +3484,10 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 39, 1536), torch.float32), ((1536, 151936), torch.float32)],
-            {"model_name": ["pt_qwen_v2_qwen_qwen2_5_1_5b_instruct_clm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 39, 1536), torch.float32), ((1536, 151936), torch.float32)],
+        {"model_name": ["pt_qwen_v2_qwen_qwen2_5_1_5b_instruct_clm_hf"], "pcc": 0.99},
     ),
     (
         Matmul0,
@@ -3543,13 +3522,10 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 39, 3584), torch.float32), ((3584, 152064), torch.float32)],
-            {"model_name": ["pt_qwen_v2_qwen_qwen2_5_7b_instruct_clm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 39, 3584), torch.float32), ((3584, 152064), torch.float32)],
+        {"model_name": ["pt_qwen_v2_qwen_qwen2_5_7b_instruct_clm_hf"], "pcc": 0.99},
     ),
     (
         Matmul0,
@@ -3660,13 +3636,10 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 39, 2048), torch.float32), ((2048, 151936), torch.float32)],
-            {"model_name": ["pt_qwen_v2_qwen_qwen2_5_3b_instruct_clm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 39, 2048), torch.float32), ((2048, 151936), torch.float32)],
+        {"model_name": ["pt_qwen_v2_qwen_qwen2_5_3b_instruct_clm_hf"], "pcc": 0.99},
     ),
     (
         Matmul0,
@@ -3738,21 +3711,15 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 39, 4864), torch.float32), ((4864, 896), torch.float32)],
         {"model_name": ["pt_qwen_v2_qwen_qwen2_5_0_5b_instruct_clm_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 39, 896), torch.float32), ((896, 151936), torch.float32)],
-            {"model_name": ["pt_qwen_v2_qwen_qwen2_5_0_5b_instruct_clm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 39, 896), torch.float32), ((896, 151936), torch.float32)],
+        {"model_name": ["pt_qwen_v2_qwen_qwen2_5_0_5b_instruct_clm_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 128, 768), torch.float32), ((768, 250002), torch.float32)],
-            {"model_name": ["pt_roberta_xlm_roberta_base_mlm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 128, 768), torch.float32), ((768, 250002), torch.float32)],
+        {"model_name": ["pt_roberta_xlm_roberta_base_mlm_hf"], "pcc": 0.99},
     ),
     (
         Matmul0,
@@ -3985,21 +3952,15 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 1, 2048), torch.float32), ((2048, 768), torch.float32)],
         {"model_name": ["pt_t5_google_flan_t5_base_text_gen_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 256, 2048), torch.float32), ((2048, 256008), torch.float32)],
-            {"model_name": ["pt_xglm_facebook_xglm_1_7b_clm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 256, 2048), torch.float32), ((2048, 256008), torch.float32)],
+        {"model_name": ["pt_xglm_facebook_xglm_1_7b_clm_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Matmul0,
-            [((1, 256, 1024), torch.float32), ((1024, 256008), torch.float32)],
-            {"model_name": ["pt_xglm_facebook_xglm_564m_clm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Matmul0,
+        [((1, 256, 1024), torch.float32), ((1024, 256008), torch.float32)],
+        {"model_name": ["pt_xglm_facebook_xglm_564m_clm_hf"], "pcc": 0.99},
     ),
     (
         Matmul0,

--- a/forge/test/models_ops/test_multiply.py
+++ b/forge/test/models_ops/test_multiply.py
@@ -3824,19 +3824,16 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 39, 4864), torch.float32), ((1, 39, 4864), torch.float32)],
         {"model_name": ["pt_qwen_v2_qwen_qwen2_5_0_5b_instruct_clm_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 128), torch.int32), ((1, 128), torch.int32)],
-            {
-                "model_name": [
-                    "pt_roberta_xlm_roberta_base_mlm_hf",
-                    "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 128), torch.int32), ((1, 128), torch.int32)],
+        {
+            "model_name": [
+                "pt_roberta_xlm_roberta_base_mlm_hf",
+                "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply1,

--- a/forge/test/models_ops/test_subtract.py
+++ b/forge/test/models_ops/test_subtract.py
@@ -407,16 +407,19 @@ forge_modules_and_shapes_dtypes_list = [
         {"model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"], "pcc": 0.99},
     ),
     (Subtract0, [((1, 1, 1, 256), torch.float32)], {"model_name": ["pt_gpt2_gpt2_text_gen_hf"], "pcc": 0.99}),
-    (
-        Subtract1,
-        [((1, 1, 256, 256), torch.int32)],
-        {
-            "model_name": [
-                "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
-                "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
-            ],
-            "pcc": 0.99,
-        },
+    pytest.param(
+        (
+            Subtract1,
+            [((1, 1, 256, 256), torch.int32)],
+            {
+                "model_name": [
+                    "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
+                    "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
+                ],
+                "pcc": 0.99,
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Subtract0,
@@ -479,20 +482,17 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Subtract3,
-            [((1,), torch.int32)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Subtract3,
+        [((1,), torch.int32)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Subtract4,


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-forge-fe/issues/1368

1. In the models ops test failure script, added support for collecting XPASS test cases (i.e., tests marked as xfail that unexpectedly pass) and updating the report to include these tests with an XPASS marker and the original xfail error message. While updating the test files using the generated report, the xfail marker and its reason are removed for the XPASS tests.

2. Update advindex, cast, conv2d, embedding, subtract, multiply and matmul model ops test based upon the result of the latest nightly models ops pipeline.

Models ops failure updation script generated report:
[model_ops_tests_report.xlsx](https://github.com/user-attachments/files/19089115/model_ops_tests_report.xlsx)


Triggered nightly models ops test and verified all the test cases are passing - https://github.com/tenstorrent/tt-forge-fe/actions/runs/13676255357

