### PR TITLE
[CI] Skipping few models from nightly run due to the insufficient host DRAM during model run.

### DIFF
--- a/forge/test/mlir/llama/test_llama_inference.py
+++ b/forge/test/mlir/llama/test_llama_inference.py
@@ -18,6 +18,9 @@ from test.mlir.llama.utils.utils import load_model
     ],
 )
 def test_llama_inference(model_path):
+    if model_path == "openlm-research/open_llama_3b":
+        pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 32 GB during compile time)")
+
     # Load Model and Tokenizer
     framework_model, tokenizer = load_model(model_path)
 

--- a/forge/test/models/pytorch/multimodal/deepseek_coder/test_deepseek_coder.py
+++ b/forge/test/models/pytorch/multimodal/deepseek_coder/test_deepseek_coder.py
@@ -18,6 +18,7 @@ from test.models.utils import Framework, Source, Task, build_module_name
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["deepseek-coder-1.3b-instruct"])
 def test_deepseek_inference_no_cache(record_forge_property, variant):
+    pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 32 GB during compile time)")
 
     # Build Module Name
     module_name = build_module_name(


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Current nightly CI is broken because of it, so we're skipping these until memory issues during compile time are resolved.

### What's changed
- 2 nightly models are skipped (deepseek & llama)