### PR TITLE
Use GH runner for docker build

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -36,6 +36,7 @@ RUN apt-get update && apt-get install -y \
     expect \
     lcov
 
+
 # Install clang 17
 RUN wget https://apt.llvm.org/llvm.sh && \
     chmod u+x llvm.sh && \

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -30,10 +30,6 @@ jobs:
       - name: Maximize space
         uses: tenstorrent/tt-github-actions/.github/actions/maximize_space@main
 
-      - name: Fix permissions
-        shell: bash
-        run: sudo chown ubuntu:ubuntu -R $(pwd)
-
       - uses: actions/checkout@v4
         with:
             submodules: recursive

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -22,10 +22,14 @@ on:
 jobs:
 
   build-image:
-    runs-on: builder
+    runs-on: ubuntu-latest
     outputs:
       docker-image: ${{ steps.build.outputs.docker-image }}
     steps:
+
+      - name: Maximize space
+        uses: tenstorrent/tt-github-actions/.github/actions/maximize_space@main
+
       - name: Fix permissions
         shell: bash
         run: sudo chown ubuntu:ubuntu -R $(pwd)


### PR DESCRIPTION
### Ticket
N/A

### Problem description
We have only few builder runners and they can be blocked easy with long running build jobs

### What's changed
Use GH runner for docker build

### Checklist
- [ ] New/Existing tests provide coverage for changes
