### PR TITLE
Add resnet and llama to benchmark models

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -82,9 +82,9 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32
-        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32
-        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32
+        python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32
+        python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32
+        python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32
 
     - name: Upload Perf Report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -82,7 +82,7 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path }}
+        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path }}
         PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path }}
 
     - name: Upload Perf Report

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -84,6 +84,7 @@ jobs:
         source env/activate
         PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path }}
         PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path }}
+        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path }}
 
     - name: Upload Perf Report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -82,7 +82,7 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32
+        python forge/test/benchmark/benchmark.py -m mnist_linear -bs 32 -lp 32
         python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32
         python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32
 

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -44,7 +44,10 @@ jobs:
       run: |
         echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
         echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
-        echo "perf_report_path=./benchmark_reports >> "$GITHUB_OUTPUT"
+        echo "perf_report_path=./benchmark_reports/" >> "$GITHUB_OUTPUT"
+        echo "perf_report_path_mnist=./benchmark_reports/forge-benchmark-e2e-mnist_$JOB_ID.json" >> "$GITHUB_OUTPUT"
+        echo "perf_report_path_resnet_hf=./benchmark_reports/forge-benchmark-e2e-resnet_hf_$JOB_ID.json" >> "$GITHUB_OUTPUT"
+        echo "perf_report_path_llama=./benchmark_reports/forge-benchmark-e2e-llama_$JOB_ID.json" >> "$GITHUB_OUTPUT"
 
     - name: Git safe dir
       run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
@@ -82,9 +85,9 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path }}
-        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path }}
-        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path }}
+        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path_mnist }}
+        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path_resnet_hf }}
+        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path_llama }}
 
     - name: Upload Perf Report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
         echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
-        echo "perf_report_path=forge-benchmark-e2e-mnist_$JOB_ID.json" >> "$GITHUB_OUTPUT"
+        echo "perf_report_path=./benchmark_reports >> "$GITHUB_OUTPUT"
 
     - name: Git safe dir
       run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
@@ -83,6 +83,7 @@ jobs:
       run: |
         source env/activate
         python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path }}
+        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path }}
 
     - name: Upload Perf Report
       uses: actions/upload-artifact@v4

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -45,9 +45,6 @@ jobs:
         echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
         echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
         echo "perf_report_path=./benchmark_reports/" >> "$GITHUB_OUTPUT"
-        echo "perf_report_path_mnist=./benchmark_reports/forge-benchmark-e2e-mnist_$JOB_ID.json" >> "$GITHUB_OUTPUT"
-        echo "perf_report_path_resnet_hf=./benchmark_reports/forge-benchmark-e2e-resnet_hf_$JOB_ID.json" >> "$GITHUB_OUTPUT"
-        echo "perf_report_path_llama=./benchmark_reports/forge-benchmark-e2e-llama_$JOB_ID.json" >> "$GITHUB_OUTPUT"
 
     - name: Git safe dir
       run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
@@ -85,9 +82,9 @@ jobs:
       shell: bash
       run: |
         source env/activate
-        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path_mnist }}
-        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path_resnet_hf }}
-        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32 -o ${{ steps.strings.outputs.perf_report_path_llama }}
+        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32
+        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32
+        PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32
 
     - name: Upload Perf Report
       uses: actions/upload-artifact@v4

--- a/forge/test/benchmark/benchmark.py
+++ b/forge/test/benchmark/benchmark.py
@@ -2,6 +2,15 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
+import os
+
+# Get the absolute path of the project root and add it to the path
+# When we run the tests from benchmark directory it can't find test.utils module,
+# so we add the project root to the path
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, project_root)
+
 import argparse
 
 from benchmark import models

--- a/forge/test/benchmark/benchmark.py
+++ b/forge/test/benchmark/benchmark.py
@@ -6,9 +6,9 @@ import argparse
 
 from benchmark import models
 
-
 MODELS = {
     "mnist_linear": models.mnist_linear.mnist_linear_benchmark,
+    "resnet50_hf": models.resnet_hf.resnet_hf_benchmark,
 }
 
 

--- a/forge/test/benchmark/benchmark.py
+++ b/forge/test/benchmark/benchmark.py
@@ -96,12 +96,6 @@ def read_args():
 
     parsed_args["input_size"] = args.input_size
     parsed_args["hidden_size"] = args.hidden_size
-
-    # if not args.output:
-    #     print("\nOutput file is not specified.\n\n")
-    #     print(parser.print_help())
-    #     exit(1)
-
     parsed_args["output"] = args.output
 
     return parsed_args

--- a/forge/test/benchmark/benchmark.py
+++ b/forge/test/benchmark/benchmark.py
@@ -9,6 +9,7 @@ from benchmark import models
 MODELS = {
     "mnist_linear": models.mnist_linear.mnist_linear_benchmark,
     "resnet50_hf": models.resnet_hf.resnet_hf_benchmark,
+    "llama": models.llama.llama_prefill_benchmark,
 }
 
 

--- a/forge/test/benchmark/benchmark.py
+++ b/forge/test/benchmark/benchmark.py
@@ -55,6 +55,7 @@ def read_args():
     parser.add_argument(
         "-o",
         "--output",
+        default=None,
         help="Output json file to write results to, optionally. If file already exists, results will be appended.",
     )
 
@@ -87,10 +88,10 @@ def read_args():
     parsed_args["input_size"] = args.input_size
     parsed_args["hidden_size"] = args.hidden_size
 
-    if not args.output:
-        print("\nOutput file is not specified.\n\n")
-        print(parser.print_help())
-        exit(1)
+    # if not args.output:
+    #     print("\nOutput file is not specified.\n\n")
+    #     print(parser.print_help())
+    #     exit(1)
 
     parsed_args["output"] = args.output
 

--- a/forge/test/benchmark/benchmark/__init__.py
+++ b/forge/test/benchmark/benchmark/__init__.py
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .models import mnist_linear
+from .models import resnet_hf

--- a/forge/test/benchmark/benchmark/__init__.py
+++ b/forge/test/benchmark/benchmark/__init__.py
@@ -4,3 +4,4 @@
 
 from .models import mnist_linear
 from .models import resnet_hf
+from .models import llama

--- a/forge/test/benchmark/benchmark/models/__init__.py
+++ b/forge/test/benchmark/benchmark/models/__init__.py
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from .mnist_linear import mnist_linear_benchmark
+from .resnet_hf import resnet_hf_benchmark

--- a/forge/test/benchmark/benchmark/models/__init__.py
+++ b/forge/test/benchmark/benchmark/models/__init__.py
@@ -4,3 +4,4 @@
 
 from .mnist_linear import mnist_linear_benchmark
 from .resnet_hf import resnet_hf_benchmark
+from .llama import llama_prefill_benchmark

--- a/forge/test/benchmark/benchmark/models/llama.py
+++ b/forge/test/benchmark/benchmark/models/llama.py
@@ -120,7 +120,7 @@ def test_llama_prefill(
     result = {
         "model": model_name,
         "model_type": model_type,
-        "run_type": f"{'x'.join(model_name)}_{input_size}_{loop_count}",
+        "run_type": f"{'_'.join(model_name.split())}_{input_size}_{loop_count}",
         "config": {"model_size": "small"},
         "num_layers": num_layers,
         "batch_size": batch_size,
@@ -180,7 +180,7 @@ def llama_prefill_benchmark(config: dict):
     if not os.path.exists(REPORTS_DIR):
         os.makedirs(REPORTS_DIR)
     if not output_file:
-        output_file = REPORTS_DIR + f"forge-benchmark-e2e-llama_prefill_{result['run_type']}.json"
+        output_file = f"forge-benchmark-e2e-llama_prefill_{result['run_type']}.json"
     result["output"] = REPORTS_DIR + output_file
 
     # Save the results to a file

--- a/forge/test/benchmark/benchmark/models/llama.py
+++ b/forge/test/benchmark/benchmark/models/llama.py
@@ -1,0 +1,188 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Built-in modules
+import pytest
+import time
+import socket
+import subprocess
+import json
+import random
+import os
+from datetime import datetime
+
+# Third-party modules
+import torch
+from transformers import LlamaTokenizer
+
+# Forge modules
+import forge
+from test.mlir.llama.utils.utils import load_model
+from forge.verify.compare import compare_with_golden
+
+# Common constants
+GIT_REPO_NAME = "tenstorrent/tt-forge-fe"
+REPORTS_DIR = "./benchmark_reports/"
+
+# Model path
+MODEL_PATH = ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"]
+
+# Loop count configurations
+LOOP_COUNT = [1, 2, 4, 8, 16, 32]
+
+
+def prefil_on_cpu(model, input_ids):
+    with torch.no_grad():
+        transformer_outputs = model.model(
+            input_ids=input_ids,  # Pass the entire updated sequence
+        )
+        hidden_states = transformer_outputs.last_hidden_state
+    return hidden_states
+
+
+@pytest.mark.parametrize("loop_count", LOOP_COUNT, ids=[f"loop_count={item}" for item in LOOP_COUNT])
+@pytest.mark.parametrize("model_path", MODEL_PATH, ids=["_".join(item.split("/")) for item in MODEL_PATH])
+def test_llama_prefill(
+    training,
+    batch_size,
+    model_path,
+    loop_count,
+):
+
+    if training:
+        pytest.skip("Training is not supported")
+
+    if batch_size > 1:
+        pytest.skip("Batch size greater than 1 is not supported")
+
+    if model_path == "openlm-research/open_llama_3b":
+        pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 32 GB during compile time)")
+
+    # Load Llama model and tokenizer
+    model, tokenizer = load_model(model_path, return_dict=True)
+
+    # Prepare input sentence
+    prompt = "Q: What is the largest animal?\nA:"
+    input_ids = tokenizer(prompt, return_tensors="pt").input_ids
+
+    # This is the part of the model needed for prefill; model without the last Linear layer (lm_head)
+    model_decoder = model.get_decoder()
+    compiled_decoder = forge.compile(model_decoder, sample_inputs=input_ids)
+
+    # Prefill Phase - Process the initial prompt on device
+    # This what we actually want to benchmark, and measure the time taken.
+    transformer_outputs = compiled_decoder(input_ids)
+    start = time.time()
+    for _ in range(loop_count):
+        transformer_outputs = compiled_decoder(input_ids)
+    end = time.time()
+
+    # Get hidden states for all tokens from the last "transformer layer".
+    hidden_states_compiled = transformer_outputs[0]
+    hidden_states_compiled = hidden_states_compiled.to("cpu")
+
+    # Get hidden states for all tokens from the last "transformer layer" calculated on CPU.
+    hidden_states_framework = prefil_on_cpu(model, input_ids)
+
+    # Compare result of prefilling on device with the result of prefilling on CPU.
+    # Calculate the pcc for only the last vector in the hidden states tensor.
+    assert compare_with_golden(hidden_states_framework[:, -1, :], hidden_states_compiled[:, -1, :])
+
+    short_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("ascii").strip()
+    date = datetime.now().strftime("%d-%m-%Y")
+    machine_name = socket.gethostname()
+    input_size = len(input_ids[0])
+    total_time = end - start
+    total_tokens = input_size * loop_count
+
+    tokens_per_sec = total_tokens / total_time
+    model_name = "Llama Prefill"
+    model_type = "Text Generation, Random Text Data"
+    dataset_name = "Llama, Random Data"
+    num_layers = -1  # Number of layers in the model is not relevant here.
+    batch_size = 1  # Batch size is always 1 for text generation.
+
+    print("====================================================================")
+    print("| Resnet Benchmark Results:                                        |")
+    print("--------------------------------------------------------------------")
+    print(f"| Model: {model_name}")
+    print(f"| Model type: {model_type}")
+    print(f"| Dataset name: {dataset_name}")
+    print(f"| Date: {date}")
+    print(f"| Machine name: {machine_name}")
+    print(f"| Total execution time: : {total_time}")
+    print(f"| Total tokens: {total_tokens}")
+    print(f"| Token per second: {tokens_per_sec}")
+    print(f"| Input size: {input_size}")
+    print("====================================================================")
+
+    result = {
+        "model": model_name,
+        "model_type": model_type,
+        "run_type": f"{'x'.join(model_name)}_{input_size}_{loop_count}",
+        "config": {"model_size": "small"},
+        "num_layers": num_layers,
+        "batch_size": batch_size,
+        "precision": "f32",  # This is we call dataformat, it should be generic, too, but for this test we don't experiment with it
+        # "math_fidelity": math_fidelity, @TODO - For now, we are skipping these parameters, because we are not supporting them
+        "dataset_name": dataset_name,
+        "profile_name": "",
+        "input_sequence_length": -1,  # When this value is negative, it means it is not applicable
+        "output_sequence_length": -1,  # When this value is negative, it means it is not applicable
+        "image_dimension": -1,  # When this value is negative, it means it is not applicable
+        "perf_analysis": False,
+        "training": training,
+        "measurements": [
+            {
+                "iteration": 1,  # This is the number of iterations, we are running only one iteration.
+                "step_name": model_name,
+                "step_warm_up_num_iterations": 0,
+                "measurement_name": "total_tokens",
+                "value": total_tokens,
+                "target": -1,  # This value is negative, because we don't have a target value.
+                "device_power": -1.0,  # This value is negative, because we don't have a device power value.
+                "device_temperature": -1.0,  # This value is negative, because we don't have a device temperature value.
+            },
+            {
+                "iteration": 1,  # This is the number of iterations, we are running only one iteration.
+                "step_name": model_name,
+                "step_warm_up_num_iterations": 0,
+                "measurement_name": "total_time",
+                "value": total_time,
+                "target": -1,  # This value is negative, because we don't have a target value.
+                "device_power": -1.0,  # This value is negative, because we don't have a device power value.
+                "device_temperature": -1.0,  # This value is negative, because we don't have a device temperature value.
+            },
+        ],
+        "device_info": {
+            "device_name": "",
+            "galaxy": False,
+            "arch": "",
+            "chips": 1,
+        },
+        "device_ip": None,
+    }
+
+    return result
+
+
+def llama_prefill_benchmark(config: dict):
+
+    training = config["training"]
+    batch_size = config["batch_size"]
+    model_path = MODEL_PATH[1]
+    output_file = config["output"]
+    loop_count = config["loop_count"]
+
+    result = test_llama_prefill(training=training, batch_size=batch_size, model_path=model_path, loop_count=loop_count)
+
+    if not os.path.exists(REPORTS_DIR):
+        os.makedirs(REPORTS_DIR)
+    if not output_file:
+        output_file = REPORTS_DIR + f"forge-benchmark-e2e-llama_prefill_{result['run_type']}.json"
+    result["output"] = REPORTS_DIR + output_file
+
+    # Save the results to a file
+    with open(result["output"], "w") as f:
+        json.dump(result, f)

--- a/forge/test/benchmark/benchmark/models/mnist_linear.py
+++ b/forge/test/benchmark/benchmark/models/mnist_linear.py
@@ -218,7 +218,7 @@ def mnist_linear_benchmark(config: dict):
     if not os.path.exists(REPORTS_DIR):
         os.makedirs(REPORTS_DIR)
     if not output_file:
-        output_file = REPORTS_DIR + f"forge-benchmark-e2e-mnist_{batch_size}_{input_size}_{hidden_size}.json"
+        output_file = f"forge-benchmark-e2e-mnist_{batch_size}_{input_size}_{hidden_size}.json"
     result["output"] = REPORTS_DIR + output_file
 
     # Save the results to a file

--- a/forge/test/benchmark/benchmark/models/mnist_linear.py
+++ b/forge/test/benchmark/benchmark/models/mnist_linear.py
@@ -2,18 +2,26 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+# Built-in modules
 import pytest
 import time
 import socket
 import subprocess
 import json
+import os
+from datetime import datetime
+
+# Third-party modules
 import torch
 from torch import nn
+
+# Forge modules
 import forge
 from forge.verify.verify import verify
 
 # Common constants
 GIT_REPO_NAME = "tenstorrent/tt-forge-fe"
+REPORTS_DIR = "./benchmark_reports/"
 
 # Batch size configurations
 MNIST_BATCH_SIZE_EXP_RANGE = 7
@@ -111,11 +119,6 @@ def test_mnist_linear(
     verify(inputs, framework_model, compiled_model)
 
     short_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("ascii").strip()
-    # date = (
-    #     subprocess.check_output(["git", "show", "-s", "--format=%cd", "--date=format:%y-%m-%d", "HEAD"])
-    #     .decode("ascii")
-    #     .strip()
-    # )
     date = datetime.now().strftime("%d-%m-%Y")
     machine_name = socket.gethostname()
     total_time = end - start
@@ -212,11 +215,12 @@ def mnist_linear_benchmark(config: dict):
         loop_count=loop_count,
     )
 
+    if not os.path.exists(REPORTS_DIR):
+        os.makedirs(REPORTS_DIR)
     if not output_file:
-        output_file = f"forge-benchmark-e2e-mnist_{batch_size}_{input_size}_{hidden_size}.json"
-
-    result["output"] = output_file
+        output_file = REPORTS_DIR + f"forge-benchmark-e2e-mnist_{batch_size}_{input_size}_{hidden_size}.json"
+    result["output"] = REPORTS_DIR + output_file
 
     # Save the results to a file
-    with open(output_file, "w") as f:
+    with open(result["output"], "w") as f:
         json.dump(result, f)

--- a/forge/test/benchmark/benchmark/models/mnist_linear.py
+++ b/forge/test/benchmark/benchmark/models/mnist_linear.py
@@ -99,9 +99,6 @@ def test_mnist_linear(
     if training:
         pytest.skip("Training is not supported")
 
-    if batch_size > 1:
-        pytest.skip("Batch size greater than 1 is not supported")
-
     inputs = [torch.rand(batch_size, input_size)]
 
     framework_model = MNISTLinear(input_size=input_size, hidden_size=hidden_size)

--- a/forge/test/benchmark/benchmark/models/resnet_hf.py
+++ b/forge/test/benchmark/benchmark/models/resnet_hf.py
@@ -2,90 +2,70 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+# Built-in modules
 import pytest
 import time
 import socket
 import subprocess
 import json
+import random
+
+# import sys
+# import os
+from datetime import datetime
+
+# Third-party modules
 import torch
 from torch import nn
+from transformers import ResNetForImageClassification
+from datasets import load_dataset
+
+# Forge modules
 import forge
-from forge.verify.verify import verify
+from forge.verify.compare import compare_with_golden_pcc
+
+# from ....utils import download_model
+# sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../")))
+from test.utils import download_model
 
 # Common constants
 GIT_REPO_NAME = "tenstorrent/tt-forge-fe"
 
 # Batch size configurations
-MNIST_BATCH_SIZE_EXP_RANGE = 7
+BATCH_SIZE = [
+    1,
+]
 
 # Input size configurations
-MNIIST_INPUT_SIZE_EXP_RANGE = [5, 7]
-MNIIST_INPUT_SIZE_FACTORS = [1, 3, 5, 7]
-
-# Hidden layer size configurations
-MNIST_HIDDEN_SIZE_EXP_RANGE = [5, 7]
-MNIIST_HIDDEN_SIZE_FACTORS = [1, 3]
-
-MNIST_INPUT_FEATURE_SIZE = 784  # 784 = 28 * 28, default size of MNIST image
-MNIST_OUTPUT_FEATURE_SIZE = 10  # 10 classes in MNIST, default output size
-MNIIST_HIDDEN_SIZE = 256  # Hidden layer size, default size
-
-BATCH_SIZE = [
-    2**i for i in range(MNIST_BATCH_SIZE_EXP_RANGE)
-]  # Batch size, sizes will be 1, 2, 4, 8, 16, 32, 64, etc.
-INPUT_SIZE = [  # Input size, sizes will be 1 * 2^5 = 32, 3 * 2^5 = 96, 5 * 2^5 = 160, 7 * 2^5 = 224, etc.
-    factor * hidden
-    for factor in MNIIST_INPUT_SIZE_FACTORS
-    for hidden in [2**i for i in range(MNIIST_INPUT_SIZE_EXP_RANGE[0], MNIIST_INPUT_SIZE_EXP_RANGE[1])]
+INPUT_SIZE = [
+    (224, 224),
 ]
-HIDDEN_SIZE = [  # Hidden layer size, sizes will be 1 * 2^5 = 32, 3 * 2^5 = 96, 1 * 2^6 = 64, 3 * 2^6 = 192, etc.
-    factor * hidden
-    for factor in MNIIST_HIDDEN_SIZE_FACTORS
-    for hidden in [2**i for i in range(MNIST_HIDDEN_SIZE_EXP_RANGE[0], MNIST_HIDDEN_SIZE_EXP_RANGE[1])]
+
+# Channel size configurations
+CHANNEL_SIZE = [
+    3,
 ]
-ARCH = []
-DATAFORMAT = []
-MATH_FIDELITY = []
+
+# Loop count configurations
 LOOP_COUNT = [1, 2, 4, 8, 16, 32]
 
-
-# Model definition
-class MNISTLinear(nn.Module):
-    def __init__(
-        self, input_size=MNIST_INPUT_FEATURE_SIZE, output_size=MNIST_OUTPUT_FEATURE_SIZE, hidden_size=MNIIST_HIDDEN_SIZE
-    ):
-
-        super(MNISTLinear, self).__init__()
-        self.l1 = nn.Linear(input_size, hidden_size)
-        self.relu = nn.ReLU()
-        self.l2 = nn.Linear(hidden_size, output_size)
-
-    def forward(self, x):
-
-        x = self.l1(x)
-        x = self.relu(x)
-        x = self.l2(x)
-
-        return nn.functional.softmax(x)
+variants = [
+    "microsoft/resnet-50",
+]
 
 
-# @TODO - For now, we are skipping these parameters, because we are not supporting them
-# @pytest.mark.parametrize("math_fidelity", MATH_FIDELITY, ids=[f"math_fidelity={item}" for item in MATH_FIDELITY])
-# @pytest.mark.parametrize("dataformat", DATAFORMAT, ids=[f"dataformat={item}" for item in DATAFORMAT])
-# @pytest.mark.parametrize("arch", ARCH, ids=[f"arch={item}" for item in ARCH])
-@pytest.mark.parametrize("hidden_size", HIDDEN_SIZE, ids=[f"hidden_size={item}" for item in HIDDEN_SIZE])
+@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("channel_size", CHANNEL_SIZE, ids=[f"channel_size={item}" for item in CHANNEL_SIZE])
 @pytest.mark.parametrize("input_size", INPUT_SIZE, ids=[f"input_size={item}" for item in INPUT_SIZE])
 @pytest.mark.parametrize("batch_size", BATCH_SIZE, ids=[f"batch_size={item}" for item in BATCH_SIZE])
 @pytest.mark.parametrize("loop_count", LOOP_COUNT, ids=[f"loop_count={item}" for item in LOOP_COUNT])
-def test_mnist_linear(
+def test_resnet_hf(
     training,
     batch_size,
     input_size,
-    hidden_size,
+    channel_size,
     loop_count,
-    # arch,
-    # dataformat,
-    # math_fidelity,
+    variant,
 ):
 
     if training:
@@ -94,21 +74,30 @@ def test_mnist_linear(
     if batch_size > 1:
         pytest.skip("Batch size greater than 1 is not supported")
 
-    inputs = [torch.rand(batch_size, input_size)]
+    # TODO: This we will need when when we run resnet with real data.
+    # Load tiny dataset
+    # dataset = load_dataset("zh-plus/tiny-imagenet")
+    # images = random.sample(dataset["valid"]["image"], 10)
 
-    framework_model = MNISTLinear(input_size=input_size, hidden_size=hidden_size)
-    fw_out = framework_model(*inputs)
+    # Random data
+    input_sample = [torch.rand(batch_size, channel_size, *input_size)]
 
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+    # Load framework model
+    framework_model = download_model(ResNetForImageClassification.from_pretrained, variant, return_dict=False)
+    fw_out = framework_model(*input_sample)
+
+    # Compile model
+    compiled_model = forge.compile(framework_model, *input_sample)
     # Run for the first time to warm up the model.
     # This is required to get accurate performance numbers.
-    co_out = compiled_model(*inputs)
+    co_out = compiled_model(*input_sample)
     start = time.time()
     for _ in range(loop_count):
-        co_out = compiled_model(*inputs)
+        co_out = compiled_model(*input_sample)
     end = time.time()
 
-    verify(inputs, framework_model, compiled_model)
+    co_out = [co.to("cpu") for co in co_out]
+    assert [compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.95) for fo, co in zip(fw_out, co_out)]
 
     short_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("ascii").strip()
     # date = (
@@ -122,13 +111,13 @@ def test_mnist_linear(
     total_samples = batch_size * loop_count
 
     samples_per_sec = total_samples / total_time
-    model_name = "MNIST Linear"
+    model_name = "Resnet 50 HF"
     model_type = "Classification, Random Input Data"
-    num_layers = 2  # Number of layers in the model, in this case 2 Linear hidden layers
-    dataset_name = "MNIST, Random Data"
+    dataset_name = "Resnet, Random Data"
+    num_layers = 50  # Number of layers in the model, in this case 50 layers
 
     print("====================================================================")
-    print("| MNIST Benchmark Results:                                         |")
+    print("| Resnet Benchmark Results:                                         |")
     print("--------------------------------------------------------------------")
     print(f"| Model: {model_name}")
     print(f"| Model type: {model_type}")
@@ -140,14 +129,12 @@ def test_mnist_linear(
     print(f"| Sample per second: {samples_per_sec}")
     print(f"| Batch size: {batch_size}")
     print(f"| Input size: {input_size}")
-    print(f"| Hidden size: {hidden_size}")
-    print(f"| Number of layers: {num_layers}")
     print("====================================================================")
 
     result = {
         "model": model_name,
         "model_type": model_type,
-        "run_type": f"{model_name}_{batch_size}_{input_size}_{hidden_size}",
+        "run_type": f"{'x'.join(model_name)}_{batch_size}_{input_size}_{num_layers}_{loop_count}",
         "config": {"model_size": "small"},
         "num_layers": num_layers,
         "batch_size": batch_size,
@@ -157,7 +144,7 @@ def test_mnist_linear(
         "profile_name": "",
         "input_sequence_length": -1,  # When this value is negative, it means it is not applicable
         "output_sequence_length": -1,  # When this value is negative, it means it is not applicable
-        "image_dimension": f"{MNIST_INPUT_FEATURE_SIZE}",
+        "image_dimension": f"{input_size[0]}x{input_size[1]}",
         "perf_analysis": False,
         "training": training,
         "measurements": [
@@ -194,26 +181,27 @@ def test_mnist_linear(
     return result
 
 
-def mnist_linear_benchmark(config: dict):
+def resnet_hf_benchmark(config: dict):
 
     training = config["training"]
     batch_size = config["batch_size"]
+    input_size = INPUT_SIZE[0]
+    channel_size = CHANNEL_SIZE[0]
     output_file = config["output"]
     loop_count = config["loop_count"]
+    variant = variants[0]
 
-    input_size = MNIST_INPUT_FEATURE_SIZE if config["input_size"] is None else config["input_size"]
-    hidden_size = MNIIST_HIDDEN_SIZE if config["hidden_size"] is None else config["hidden_size"]
-
-    result = test_mnist_linear(
+    result = test_resnet_hf(
         training=training,
         batch_size=batch_size,
         input_size=input_size,
-        hidden_size=hidden_size,
+        channel_size=channel_size,
         loop_count=loop_count,
+        variant=variant,
     )
 
     if not output_file:
-        output_file = f"forge-benchmark-e2e-mnist_{batch_size}_{input_size}_{hidden_size}.json"
+        output_file = f"forge-benchmark-e2e-resnet50_{result['run_type']}.json"
 
     result["output"] = output_file
 

--- a/forge/test/benchmark/benchmark/models/resnet_hf.py
+++ b/forge/test/benchmark/benchmark/models/resnet_hf.py
@@ -9,9 +9,7 @@ import socket
 import subprocess
 import json
 import random
-
-# import sys
-# import os
+import os
 from datetime import datetime
 
 # Third-party modules
@@ -23,13 +21,11 @@ from datasets import load_dataset
 # Forge modules
 import forge
 from forge.verify.compare import compare_with_golden_pcc
-
-# from ....utils import download_model
-# sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../../")))
 from test.utils import download_model
 
 # Common constants
 GIT_REPO_NAME = "tenstorrent/tt-forge-fe"
+REPORTS_DIR = "./benchmark_reports/"
 
 # Batch size configurations
 BATCH_SIZE = [
@@ -100,11 +96,6 @@ def test_resnet_hf(
     assert [compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.95) for fo, co in zip(fw_out, co_out)]
 
     short_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("ascii").strip()
-    # date = (
-    #     subprocess.check_output(["git", "show", "-s", "--format=%cd", "--date=format:%y-%m-%d", "HEAD"])
-    #     .decode("ascii")
-    #     .strip()
-    # )
     date = datetime.now().strftime("%d-%m-%Y")
     machine_name = socket.gethostname()
     total_time = end - start
@@ -200,11 +191,12 @@ def resnet_hf_benchmark(config: dict):
         variant=variant,
     )
 
+    if not os.path.exists(REPORTS_DIR):
+        os.makedirs(REPORTS_DIR)
     if not output_file:
-        output_file = f"forge-benchmark-e2e-resnet50_{result['run_type']}.json"
-
-    result["output"] = output_file
+        output_file = REPORTS_DIR + f"forge-benchmark-e2e-resnet50_{result['run_type']}.json"
+    result["output"] = REPORTS_DIR + output_file
 
     # Save the results to a file
-    with open(output_file, "w") as f:
+    with open(result["output"], "w") as f:
         json.dump(result, f)

--- a/forge/test/benchmark/benchmark/models/resnet_hf.py
+++ b/forge/test/benchmark/benchmark/models/resnet_hf.py
@@ -125,7 +125,7 @@ def test_resnet_hf(
     result = {
         "model": model_name,
         "model_type": model_type,
-        "run_type": f"{'x'.join(model_name)}_{batch_size}_{input_size}_{num_layers}_{loop_count}",
+        "run_type": f"{'_'.join(model_name.split())}_{batch_size}_{'_'.join([str(dim) for dim in input_size])}_{num_layers}_{loop_count}",
         "config": {"model_size": "small"},
         "num_layers": num_layers,
         "batch_size": batch_size,
@@ -194,7 +194,7 @@ def resnet_hf_benchmark(config: dict):
     if not os.path.exists(REPORTS_DIR):
         os.makedirs(REPORTS_DIR)
     if not output_file:
-        output_file = REPORTS_DIR + f"forge-benchmark-e2e-resnet50_{result['run_type']}.json"
+        output_file = f"forge-benchmark-e2e-resnet50_{result['run_type']}.json"
     result["output"] = REPORTS_DIR + output_file
 
     # Save the results to a file

--- a/forge/test/benchmark/scripts/run_benchmark_wh.sh
+++ b/forge/test/benchmark/scripts/run_benchmark_wh.sh
@@ -9,3 +9,6 @@
 
 # MNIST Linear
 python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32 -o forge-benchmark-e2e-mnist.json
+
+# Resnet HF
+PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o forge-benchmark-e2e-resnet50_hf.json

--- a/forge/test/benchmark/scripts/run_benchmark_wh.sh
+++ b/forge/test/benchmark/scripts/run_benchmark_wh.sh
@@ -8,7 +8,7 @@
 
 
 # MNIST Linear
-python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32 -o forge-benchmark-e2e-mnist.json
+PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32 -o forge-benchmark-e2e-mnist.json
 
 # Resnet HF
 PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o forge-benchmark-e2e-resnet50_hf.json

--- a/forge/test/benchmark/scripts/run_benchmark_wh.sh
+++ b/forge/test/benchmark/scripts/run_benchmark_wh.sh
@@ -8,10 +8,10 @@
 
 
 # MNIST Linear
-PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m mnist_linear -bs 1 -lp 32 -o forge-benchmark-e2e-mnist.json
+python forge/test/benchmark/benchmark.py -m mnist_linear -bs 32 -lp 32 -o forge-benchmark-e2e-mnist.json
 
 # Resnet HF
-PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o forge-benchmark-e2e-resnet50_hf.json
+python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o forge-benchmark-e2e-resnet50_hf.json
 
 # Llama
-PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32 -o forge-benchmark-e2e-llama.json
+python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32 -o forge-benchmark-e2e-llama.json

--- a/forge/test/benchmark/scripts/run_benchmark_wh.sh
+++ b/forge/test/benchmark/scripts/run_benchmark_wh.sh
@@ -12,3 +12,6 @@ PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m mnist_linear -bs 
 
 # Resnet HF
 PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o forge-benchmark-e2e-resnet50_hf.json
+
+# Llama
+PYTHONPATH=./forge python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32 -o forge-benchmark-e2e-llama.json


### PR DESCRIPTION
We want to track the end-to-end performance of different models, so we have added ResNet HF and Llama Prefill to the benchmark models. This PR also includes a few changes to existing models, aiming to align all models to be written in the same manner and uploaded successfully.
