### PR TITLE
Update nightly test with xfail marker

### DIFF
--- a/forge/test/models/pytorch/audio/stereo/test_stereo.py
+++ b/forge/test/models/pytorch/audio/stereo/test_stereo.py
@@ -12,7 +12,14 @@ from .utils import load_inputs, load_model
 from test.models.utils import Framework, Source, Task, build_module_name
 
 variants = [
-    "facebook/musicgen-small",
+    pytest.param(
+        "facebook/musicgen-small",
+        marks=[
+            pytest.mark.xfail(
+                reason="[Optimization Graph Passes] RuntimeError: (i >= 0) && (i < (int)dims_.size()) Trying to access element outside of dimensions: 3"
+            )
+        ],
+    ),
     "facebook/musicgen-medium",
     "facebook/musicgen-large",
 ]

--- a/forge/test/models/pytorch/audio/whisper/test_whisper.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper.py
@@ -16,7 +16,14 @@ from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
-    "openai/whisper-tiny",
+    pytest.param(
+        "openai/whisper-tiny",
+        marks=[
+            pytest.mark.xfail(
+                reason="Conv2d AssertionError: Setting a tensor value of incorrect shape: (1, 384, 2999, 2) vs torch.Size([1, 384, 3000, 1])"
+            )
+        ],
+    ),
     "openai/whisper-base",
     "openai/whisper-small",
     "openai/whisper-medium",
@@ -25,7 +32,7 @@ variants = [
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_whisper(record_forge_property, variant):
     if variant != "openai/whisper-tiny":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")

--- a/forge/test/models/pytorch/multimodal/clip/test_clip.py
+++ b/forge/test/models/pytorch/multimodal/clip/test_clip.py
@@ -15,7 +15,19 @@ from test.utils import download_model
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["openai/clip-vit-base-patch32"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "openai/clip-vit-base-patch32",
+            marks=[
+                pytest.mark.xfail(
+                    reason="ttir.reshape op Input and output tensors must have the same number of elements"
+                )
+            ],
+        ),
+    ],
+)
 def test_clip_pytorch(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_xl.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_xl.py
@@ -32,7 +32,15 @@ class StableDiffusionXLWrapper(torch.nn.Module):
 
 @pytest.mark.nightly
 @pytest.mark.skip_model_analysis
-@pytest.mark.parametrize("variant", ["stable-diffusion-xl-base-1.0"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "stable-diffusion-xl-base-1.0",
+            marks=[pytest.mark.xfail(reason="NotImplementedError: Unknown output type: <class 'PIL.Image.Image'>")],
+        ),
+    ],
+)
 def test_stable_diffusion_generation(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/text/bart/test_bart.py
+++ b/forge/test/models/pytorch/text/bart/test_bart.py
@@ -25,7 +25,19 @@ class BartWrapper(torch.nn.Module):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["facebook/bart-large-mnli"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "facebook/bart-large-mnli",
+            marks=[
+                pytest.mark.xfail(
+                    reason="unique+common runtime args targeting kernel reader_concat_stick_layout_interleaved_start_id on (x=0,y=0) are too large. Max allowable is 256"
+                )
+            ],
+        ),
+    ],
+)
 def test_pt_bart_classifier(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/text/bloom/test_bloom.py
+++ b/forge/test/models/pytorch/text/bloom/test_bloom.py
@@ -24,7 +24,19 @@ class Wrapper(torch.nn.Module):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["bigscience/bloom-1b1"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "bigscience/bloom-1b1",
+            marks=[
+                pytest.mark.xfail(
+                    reason="AssertionError: Data mismatch on output 0 between framework and Forge codegen"
+                )
+            ],
+        ),
+    ],
+)
 def test_bloom(record_forge_property, variant):
 
     # Build Module Name

--- a/forge/test/models/pytorch/text/codegen/test_codegen.py
+++ b/forge/test/models/pytorch/text/codegen/test_codegen.py
@@ -14,14 +14,19 @@ from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
-    "Salesforce/codegen-350M-mono",
+    pytest.param(
+        "Salesforce/codegen-350M-mono",
+        marks=[
+            pytest.mark.xfail(reason="AssertionError: Data mismatch on output 0 between framework and Forge codegen")
+        ],
+    ),
     "Salesforce/codegen-350M-multi",
     "Salesforce/codegen-350M-nl",
 ]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_codegen(record_forge_property, variant):
     if variant != "Salesforce/codegen-350M-mono":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")

--- a/forge/test/models/pytorch/text/distilbert/test_distilbert.py
+++ b/forge/test/models/pytorch/text/distilbert/test_distilbert.py
@@ -16,11 +16,18 @@ from forge.verify.verify import verify
 from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
-variants = ["distilbert-base-uncased", "distilbert-base-cased", "distilbert-base-multilingual-cased"]
+variants = [
+    pytest.param(
+        "distilbert-base-uncased",
+        marks=[pytest.mark.xfail(reason="ttir.typecast op Result shape must match operand shapes after broadcasting")],
+    ),
+    "distilbert-base-cased",
+    "distilbert-base-multilingual-cased",
+]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_distilbert_masked_lm_pytorch(record_forge_property, variant):
     if variant != "distilbert-base-uncased":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")

--- a/forge/test/models/pytorch/text/fuyu/test_fuyu_8b.py
+++ b/forge/test/models/pytorch/text/fuyu/test_fuyu_8b.py
@@ -25,7 +25,19 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["adept/fuyu-8b"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "adept/fuyu-8b",
+            marks=[
+                pytest.mark.xfail(
+                    reason="[Optimization Graph Passes] RuntimeError: (i >= 0) && (i < (int)dims_.size()) Trying to access element outside of dimensions: 3"
+                )
+            ],
+        ),
+    ],
+)
 def test_fuyu8b(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/text/gpt2/test_gpt2.py
+++ b/forge/test/models/pytorch/text/gpt2/test_gpt2.py
@@ -28,7 +28,17 @@ class Wrapper(torch.nn.Module):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["gpt2"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "gpt2",
+            marks=[
+                pytest.mark.xfail(reason="RuntimeError: Tensor 6 - data type mismatch: expected Float32, got UInt8")
+            ],
+        ),
+    ],
+)
 def test_gpt2_text_gen(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(
@@ -63,7 +73,15 @@ def test_gpt2_text_gen(record_forge_property, variant):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["mnoukhov/gpt2-imdb-sentiment-classifier"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "mnoukhov/gpt2-imdb-sentiment-classifier",
+            marks=[pytest.mark.xfail(reason="ttir.softmax op requires attribute 'dimension'")],
+        ),
+    ],
+)
 def test_gpt2_sequence_classification(record_forge_property, variant):
 
     # Build Module Name

--- a/forge/test/models/pytorch/text/gptneo/test_gptneo.py
+++ b/forge/test/models/pytorch/text/gptneo/test_gptneo.py
@@ -17,14 +17,21 @@ from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
-    "EleutherAI/gpt-neo-125M",
+    pytest.param(
+        "EleutherAI/gpt-neo-125M",
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Data mismatch on output 0 between Framework and Forge codegen(pcc=0.28)"
+            )
+        ],
+    ),
     "EleutherAI/gpt-neo-1.3B",
     "EleutherAI/gpt-neo-2.7B",
 ]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_gptneo_causal_lm(record_forge_property, variant):
     if variant != "EleutherAI/gpt-neo-125M":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")

--- a/forge/test/models/pytorch/text/mamba/test_mamba.py
+++ b/forge/test/models/pytorch/text/mamba/test_mamba.py
@@ -26,7 +26,14 @@ class Wrapper(torch.nn.Module):
 
 
 variants = [
-    "state-spaces/mamba-790m-hf",
+    pytest.param(
+        "state-spaces/mamba-790m-hf",
+        marks=[
+            pytest.mark.xfail(
+                reason="[TVM Relay IRModule Generation] Dimension mismatch: axes has 3 elements, but data.ndim = 6"
+            )
+        ],
+    ),
     "state-spaces/mamba-2.8b-hf",
     "state-spaces/mamba-1.4b-hf",
     "state-spaces/mamba-370m-hf",

--- a/forge/test/models/pytorch/text/nanogpt/test_nanogpt.py
+++ b/forge/test/models/pytorch/text/nanogpt/test_nanogpt.py
@@ -23,7 +23,15 @@ class Wrapper(torch.nn.Module):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["FinancialSupport/NanoGPT"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "FinancialSupport/NanoGPT",
+            marks=pytest.mark.xfail(reason="RuntimeError: Tensor 6 - data type mismatch: expected Float32, got UInt8"),
+        ),
+    ],
+)
 def test_nanogpt_text_generation(record_forge_property, variant):
 
     # Build Module Name

--- a/forge/test/models/pytorch/text/opt/test_opt.py
+++ b/forge/test/models/pytorch/text/opt/test_opt.py
@@ -16,11 +16,22 @@ from forge.verify.verify import verify
 from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
-variants = ["facebook/opt-125m", "facebook/opt-350m", "facebook/opt-1.3b"]
+variants = [
+    pytest.param(
+        "facebook/opt-125m",
+        marks=[
+            pytest.mark.xfail(
+                reason="unique+common runtime args targeting kernel reader_concat_stick_layout_interleaved_start_id on (x=0,y=0) are too large. Max allowable is 256"
+            )
+        ],
+    ),
+    "facebook/opt-350m",
+    "facebook/opt-1.3b",
+]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_opt_causal_lm(record_forge_property, variant):
     if variant != "facebook/opt-125m":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
@@ -72,7 +83,7 @@ def test_opt_causal_lm(record_forge_property, variant):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_opt_qa(record_forge_property, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
@@ -119,7 +130,7 @@ def test_opt_qa(record_forge_property, variant):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_opt_sequence_classification(record_forge_property, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 

--- a/forge/test/models/pytorch/text/phi2/test_phi2.py
+++ b/forge/test/models/pytorch/text/phi2/test_phi2.py
@@ -16,11 +16,19 @@ from forge.verify.verify import verify
 
 from test.models.utils import Framework, Source, Task, build_module_name
 
-variants = ["microsoft/phi-2", "microsoft/phi-2-pytdml"]
+variants = [
+    pytest.param(
+        "microsoft/phi-2",
+        marks=[
+            pytest.mark.xfail(reason="AssertionError: Data mismatch on output 0 between framework and Forge codegen")
+        ],
+    ),
+    "microsoft/phi-2-pytdml",
+]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_phi2_clm(record_forge_property, variant):
     if variant != "microsoft/phi-2":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")

--- a/forge/test/models/pytorch/text/qwen/test_qwen.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen.py
@@ -12,7 +12,15 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["Qwen/Qwen1.5-0.5B"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "Qwen/Qwen1.5-0.5B",
+            marks=[pytest.mark.xfail(reason="RuntimeError: Input count mismatch: expected 533, got 534")],
+        ),
+    ],
+)
 def test_qwen1_5_causal_lm(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
@@ -11,7 +11,10 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 # Variants for testing
 variants = [
-    "Qwen/Qwen2.5-Coder-0.5B",
+    pytest.param(
+        "Qwen/Qwen2.5-Coder-0.5B",
+        marks=[pytest.mark.xfail(reason="RuntimeError: Input count mismatch: expected 533, got 534")],
+    ),
     "Qwen/Qwen2.5-Coder-1.5B",
     "Qwen/Qwen2.5-Coder-1.5B-Instruct",
     "Qwen/Qwen2.5-Coder-3B",
@@ -21,7 +24,7 @@ variants = [
 ]
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_qwen_clm(record_forge_property, variant):
     if variant != "Qwen/Qwen2.5-Coder-0.5B":

--- a/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
@@ -15,7 +15,10 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 # Variants for testing
 variants = [
-    "Qwen/Qwen2.5-0.5B",
+    pytest.param(
+        "Qwen/Qwen2.5-0.5B",
+        marks=[pytest.mark.xfail(reason="RuntimeError: Input count mismatch: expected 533, got 534")],
+    ),
     "Qwen/Qwen2.5-0.5B-Instruct",
     "Qwen/Qwen2.5-1.5B",
     "Qwen/Qwen2.5-1.5B-Instruct",
@@ -26,7 +29,7 @@ variants = [
 ]
 
 
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_qwen_clm(record_forge_property, variant):
     if variant != "Qwen/Qwen2.5-0.5B":

--- a/forge/test/models/pytorch/text/roberta/test_roberta.py
+++ b/forge/test/models/pytorch/text/roberta/test_roberta.py
@@ -17,7 +17,14 @@ from test.utils import download_model
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["xlm-roberta-base"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "xlm-roberta-base", marks=[pytest.mark.xfail(reason="BinaryOpType cannot be mapped to BcastOpMath")]
+        ),
+    ],
+)
 def test_roberta_masked_lm(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/text/speecht5_tts/test_speecht5_tts.py
+++ b/forge/test/models/pytorch/text/speecht5_tts/test_speecht5_tts.py
@@ -22,7 +22,17 @@ class Wrapper(torch.nn.Module):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["microsoft/speecht5_tts"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "microsoft/speecht5_tts",
+            marks=pytest.mark.xfail(
+                reason="[TVM Relay IRModule Generation] aten::bernoulli operator is not implemented"
+            ),
+        ),
+    ],
+)
 def test_speecht5_tts(record_forge_property, variant):
 
     # Build Module Name

--- a/forge/test/models/pytorch/text/squeezebert/test_squeezebert.py
+++ b/forge/test/models/pytorch/text/squeezebert/test_squeezebert.py
@@ -29,7 +29,7 @@ def test_squeezebert_sequence_classification_pytorch(record_forge_property, vari
 
     # Load Bart tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
-    framework_model = download_model(AutoModelForSequenceClassification.from_pretrained, variant)
+    framework_model = download_model(AutoModelForSequenceClassification.from_pretrained, variant, return_dict=False)
 
     # Example from multi-nli validation set
     text = """Hello, my dog is cute"""

--- a/forge/test/models/pytorch/text/t5/test_t5.py
+++ b/forge/test/models/pytorch/text/t5/test_t5.py
@@ -19,11 +19,17 @@ variants = [
     pytest.param(
         "t5-base",
         id="t5-base",
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
-    pytest.param("t5-large", id="t5-large"),
+    pytest.param(
+        "t5-large",
+        id="t5-large",
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
+    ),
     pytest.param(
         "google/flan-t5-small",
         id="google_flan_t5_small",
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
     pytest.param(
         "google/flan-t5-base",

--- a/forge/test/models/pytorch/text/xglm/test_xglm.py
+++ b/forge/test/models/pytorch/text/xglm/test_xglm.py
@@ -10,11 +10,21 @@ from forge.verify.verify import verify
 from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
-variants = ["facebook/xglm-564M", "facebook/xglm-1.7B"]
+variants = [
+    pytest.param(
+        "facebook/xglm-564M",
+        marks=[
+            pytest.mark.xfail(
+                reason="unique+common runtime args targeting kernel reader_concat_stick_layout_interleaved_start_id on (x=0,y=0) are too large. Max allowable is 256"
+            )
+        ],
+    ),
+    "facebook/xglm-1.7B",
+]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_xglm_causal_lm(record_forge_property, variant):
     if variant != "facebook/xglm-564M":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")

--- a/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
+++ b/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
@@ -18,7 +18,15 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["seasionality_basis"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "seasionality_basis",
+            marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 4 - stride mismatch: expected [24, 1], got [1, 12]")],
+        ),
+    ],
+)
 def test_nbeats_with_seasonality_basis(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
+++ b/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
@@ -17,6 +17,9 @@ from test.utils import download_model
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="Statically allocated circular buffers in program 11 clash with L1 buffers on core range [(x=0,y=0) - (x=7,y=5)]. L1 buffer allocated at 947328 and static circular buffer region ends at 1191648"
+)
 def test_alexnet_torchhub(record_forge_property):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
+++ b/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
@@ -18,6 +18,7 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(reason="[Conv2dTranspose][Shape Calculation] TypeError: 'int' object is not subscriptable")
 def test_conv_ae_pytorch(record_forge_property):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/vision/beit/test_beit.py
+++ b/forge/test/models/pytorch/vision/beit/test_beit.py
@@ -9,7 +9,20 @@ from forge.verify.verify import verify
 from test.models.pytorch.vision.beit.utils.utils import load_input, load_model
 from test.models.utils import Framework, Source, Task, build_module_name
 
-variants = ["microsoft/beit-base-patch16-224", "microsoft/beit-large-patch16-224"]
+variants = [
+    pytest.param(
+        "microsoft/beit-base-patch16-224",
+        marks=[
+            pytest.mark.xfail(reason="AssertionError: Data mismatch on output 0 between framework and Forge codegen")
+        ],
+    ),
+    pytest.param(
+        "microsoft/beit-large-patch16-224",
+        marks=[
+            pytest.mark.xfail(reason="AssertionError: Data mismatch on output 0 between framework and Forge codegen")
+        ],
+    ),
+]
 
 
 @pytest.mark.nightly

--- a/forge/test/models/pytorch/vision/deit/test_deit.py
+++ b/forge/test/models/pytorch/vision/deit/test_deit.py
@@ -27,7 +27,14 @@ def generate_model_deit_imgcls_hf_pytorch(variant):
 
 
 variants = [
-    "facebook/deit-base-patch16-224",
+    pytest.param(
+        "facebook/deit-base-patch16-224",
+        marks=[
+            pytest.mark.xfail(
+                reason="Out of Memory: Not enough space to allocate 12500992 B L1 buffer across 7 banks, where each bank needs to store 1785856 B"
+            )
+        ],
+    ),
     "facebook/deit-base-distilled-patch16-224",
     "facebook/deit-small-patch16-224",
     "facebook/deit-tiny-patch16-224",
@@ -35,7 +42,7 @@ variants = [
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_deit_imgcls_hf_pytorch(record_forge_property, variant):
     if variant != "facebook/deit-base-patch16-224":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")

--- a/forge/test/models/pytorch/vision/densenet/test_densenet.py
+++ b/forge/test/models/pytorch/vision/densenet/test_densenet.py
@@ -82,7 +82,19 @@ def test_densenet_121_pytorch(record_forge_property, variant):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["densenet161"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "densenet161",
+            marks=[
+                pytest.mark.xfail(
+                    reason="RuntimeError: Tensor 0 - stride mismatch: expected [150528, 50176, 224, 1], got [3, 1, 672, 3]"
+                )
+            ],
+        ),
+    ],
+)
 def test_densenet_161_pytorch(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(
@@ -112,7 +124,19 @@ def test_densenet_161_pytorch(record_forge_property, variant):
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["densenet169"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "densenet169",
+            marks=[
+                pytest.mark.xfail(
+                    reason="RuntimeError: Tensor 0 - stride mismatch: expected [150528, 50176, 224, 1], got [3, 1, 672, 3]"
+                )
+            ],
+        ),
+    ],
+)
 def test_densenet_169_pytorch(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/vision/detr/test_detr.py
+++ b/forge/test/models/pytorch/vision/detr/test_detr.py
@@ -15,7 +15,15 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["facebook/detr-resnet-50"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "facebook/detr-resnet-50",
+            marks=[pytest.mark.xfail(reason="AttributeError: <class 'tvm.ir.op.Op'> has no attribute name_hint")],
+        )
+    ],
+)
 def test_detr_detection(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/vision/dla/test_dla.py
+++ b/forge/test/models/pytorch/vision/dla/test_dla.py
@@ -59,6 +59,7 @@ variants = ["dla34.in1k"]
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(reason="RuntimeError: Boolean value of Tensor with more than one value is ambiguous")
 @pytest.mark.parametrize("variant", variants)
 def test_dla_timm(record_forge_property, variant):
 

--- a/forge/test/models/pytorch/vision/fpn/utils/model.py
+++ b/forge/test/models/pytorch/vision/fpn/utils/model.py
@@ -23,4 +23,6 @@ class FPNWrapper(nn.Module):
         x["feat0"] = feat0
         x["feat1"] = feat1
         x["feat2"] = feat2
-        return self.fpn(x)
+        outputs = self.fpn(x)
+        outputs = tuple(outputs.values())
+        return outputs

--- a/forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py
+++ b/forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py
@@ -16,7 +16,14 @@ from test.models.utils import Framework, Source, Task, build_module_name
 params = [
     pytest.param("ghostnet_100", marks=[pytest.mark.push]),
     pytest.param("ghostnet_100.in1k", marks=[pytest.mark.push]),
-    pytest.param("ghostnetv2_100.in1k"),
+    pytest.param(
+        "ghostnetv2_100.in1k",
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Setting a tensor value of incorrect shape: (1, 72, 30, 26) vs torch.Size([1, 72, 28, 28])"
+            )
+        ],
+    ),
 ]
 
 

--- a/forge/test/models/pytorch/vision/glpn_kitti/test_glpn_kitti.py
+++ b/forge/test/models/pytorch/vision/glpn_kitti/test_glpn_kitti.py
@@ -11,7 +11,15 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["vinvino02/glpn-kitti"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "vinvino02/glpn-kitti",
+            marks=[pytest.mark.skip(reason="Only tilized tensors are supported for device typecast")],
+        ),
+    ],
+)
 def test_glpn_kitti(record_forge_property, variant):
 
     # Build Module Name

--- a/forge/test/models/pytorch/vision/googlenet/test_googlenet.py
+++ b/forge/test/models/pytorch/vision/googlenet/test_googlenet.py
@@ -15,6 +15,9 @@ from test.utils import download_model
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="RuntimeError: tt-metal/ttnn/cpp/ttnn/tensor/tensor_utils.cpp:50: new_volume == old_volume Invalid arguments to reshape"
+)
 def test_googlenet_pytorch(record_forge_property):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/vision/hrnet/test_hrnet.py
+++ b/forge/test/models/pytorch/vision/hrnet/test_hrnet.py
@@ -76,7 +76,7 @@ variants = [
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_hrnet_osmr_pytorch(record_forge_property, variant):
     if variant != "hrnet_w18_small_v1":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
@@ -154,7 +154,7 @@ variants = [
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_hrnet_timm_pytorch(record_forge_property, variant):
     if variant not in ["hrnet_w18_small", "hrnet_w18.ms_aug_in1k"]:
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")

--- a/forge/test/models/pytorch/vision/inception/test_inception_v4.py
+++ b/forge/test/models/pytorch/vision/inception/test_inception_v4.py
@@ -27,6 +27,9 @@ def generate_model_inceptionV4_imgcls_osmr_pytorch(variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="AssertionError: Setting a tensor value of incorrect shape: (1, 64, 76, 70) vs torch.Size([1, 64, 73, 73])"
+)
 def test_inception_v4_osmr_pytorch(record_forge_property):
     # Build Module Name
     module_name = build_module_name(
@@ -52,7 +55,13 @@ def generate_model_inceptionV4_imgcls_timm_pytorch(variant):
     return framework_model, [img_tensor]
 
 
-variants = ["inception_v4", "inception_v4.tf_in1k"]
+variants = [
+    "inception_v4",
+    pytest.param(
+        "inception_v4.tf_in1k",
+        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 47 - stride mismatch: expected [1225, 1], got [0, 0]")],
+    ),
+]
 
 
 @pytest.mark.nightly

--- a/forge/test/models/pytorch/vision/mgp_str_base/test_mgp_str_base.py
+++ b/forge/test/models/pytorch/vision/mgp_str_base/test_mgp_str_base.py
@@ -13,7 +13,14 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["alibaba-damo/mgp-str-base"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "alibaba-damo/mgp-str-base", marks=[pytest.mark.xfail(reason="RuntimeError: Couldn't lower all tuples")]
+        ),
+    ],
+)
 def test_mgp_scene_text_recognition(record_forge_property, variant):
 
     # Build Module Name

--- a/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
+++ b/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
@@ -18,7 +18,14 @@ from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 varaints = [
-    "mixer_b16_224",
+    pytest.param(
+        "mixer_b16_224",
+        marks=[
+            pytest.mark.xfail(
+                reason="Out of Memory: Not enough space to allocate 12500992 B L1 buffer across 7 banks, where each bank needs to store 1785856 B"
+            )
+        ],
+    ),
     "mixer_b16_224_in21k",
     "mixer_b16_224_miil",
     "mixer_b16_224_miil_in21k",
@@ -28,12 +35,19 @@ varaints = [
     "mixer_l32_224",
     "mixer_s16_224",
     "mixer_s32_224",
-    "mixer_b16_224.goog_in21k",
+    pytest.param(
+        "mixer_b16_224.goog_in21k",
+        marks=[
+            pytest.mark.xfail(
+                reason="Out of Memory: Not enough space to allocate 12500992 B L1 buffer across 7 banks, where each bank needs to store 1785856 B"
+            )
+        ],
+    ),
 ]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", varaints, ids=varaints)
+@pytest.mark.parametrize("variant", varaints)
 def test_mlp_mixer_timm_pytorch(record_forge_property, variant):
     if variant not in ["mixer_b16_224", "mixer_b16_224.goog_in21k"]:
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
@@ -75,6 +89,9 @@ def test_mlp_mixer_timm_pytorch(record_forge_property, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="[Optimzation Graph Passes][Shape Calculation] AssertionError: Eltwise binary ops must have the same shape in both inputs, or one operand must be 1 wide to broadcast: [1, 512, 1, 1024] vs [1, 1024, 512, 1]"
+)
 def test_mlp_mixer_pytorch(record_forge_property):
 
     # Build Module Name

--- a/forge/test/models/pytorch/vision/mnist/test_mnist.py
+++ b/forge/test/models/pytorch/vision/mnist/test_mnist.py
@@ -11,6 +11,7 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(reason="ttir.softmax op requires attribute 'dimension'")
 def test_mnist(record_forge_property):
 
     # Build Module Name

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
@@ -139,6 +139,7 @@ variants = ["mobilenetv1_100.ra4_e3600_r224_in1k"]
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(reason="RuntimeError: Boolean value of Tensor with more than one value is ambiguous")
 @pytest.mark.parametrize("variant", variants)
 def test_mobilenet_v1_timm(record_forge_property, variant):
 

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -298,6 +298,9 @@ variants_with_weights = {
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="RuntimeError: Tensor 0 - stride mismatch: expected [150528, 50176, 224, 1], got [3, 1, 672, 3]"
+)
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_mobilenetv2_torchvision(record_forge_property, variant):
 

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3_ssd.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3_ssd.py
@@ -41,7 +41,7 @@ def test_mobilenetv3_ssd(record_forge_property, variant):
     # Load model and input
     weight_name = variants_with_weights[variant]
     framework_model = load_model(variant, weight_name)
-    inputs = load_input(variant)
+    inputs = load_input()
 
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)

--- a/forge/test/models/pytorch/vision/mobilenet/utils/mobilenet_v3_ssd_utils.py
+++ b/forge/test/models/pytorch/vision/mobilenet/utils/mobilenet_v3_ssd_utils.py
@@ -11,7 +11,8 @@ from torchvision import models, transforms
 
 
 def load_model(variant, weights):
-    model = getattr(models.detection, variant)(weights=weights)
+    weights = getattr(models, weights).DEFAULT
+    model = getattr(models, variant)(weights=weights)
     model.eval()
     return model
 

--- a/forge/test/models/pytorch/vision/monodle/test_monodle.py
+++ b/forge/test/models/pytorch/vision/monodle/test_monodle.py
@@ -14,6 +14,7 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(reason="[Conv2dTranspose][Shape Calculation] TypeError: 'int' object is not subscriptable")
 def test_monodle_pytorch(record_forge_property):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
+++ b/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
@@ -69,13 +69,13 @@ def test_perceiverio_for_image_classification_pytorch(record_forge_property, var
 
     # Load the model from HuggingFace
     if variant == "deepmind/vision-perceiver-learned":
-        framework_model = PerceiverForImageClassificationLearned.from_pretrained(variant)
+        framework_model = PerceiverForImageClassificationLearned.from_pretrained(variant, return_dict=False)
 
     elif variant == "deepmind/vision-perceiver-conv":
-        framework_model = PerceiverForImageClassificationConvProcessing.from_pretrained(variant)
+        framework_model = PerceiverForImageClassificationConvProcessing.from_pretrained(variant, return_dict=False)
 
     elif variant == "deepmind/vision-perceiver-fourier":
-        framework_model = PerceiverForImageClassificationFourier.from_pretrained(variant)
+        framework_model = PerceiverForImageClassificationFourier.from_pretrained(variant, return_dict=False)
 
     else:
         logger.info(f"The model {variant} is not supported")

--- a/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
+++ b/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
@@ -17,6 +17,9 @@ from test.models.utils import Framework, Source, Task, build_module_name
 # Paper - https://arxiv.org/abs/1311.2524
 # Repo - https://github.com/object-detection-algorithm/R-CNN
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="Statically allocated circular buffers in program 13 clash with L1 buffers on core range [(x=0,y=0) - (x=7,y=6)]. L1 buffer allocated at 1031040 and static circular buffer region ends at 1191648"
+)
 def test_rcnn_pytorch(record_forge_property):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/vision/regnet/test_regnet.py
+++ b/forge/test/models/pytorch/vision/regnet/test_regnet.py
@@ -29,7 +29,7 @@ def test_regnet(record_forge_property, variant):
     record_forge_property("tags.model_name", module_name)
 
     # Load RegNet model
-    framework_model = RegNetModel.from_pretrained("facebook/regnet-y-040")
+    framework_model = RegNetModel.from_pretrained("facebook/regnet-y-040", return_dict=False)
 
     # Preprocess the image
     image_url = "http://images.cocodataset.org/val2017/000000039769.jpg"
@@ -92,9 +92,32 @@ variants_with_weights = {
     "regnet_x_32gf": "RegNet_X_32GF_Weights",
 }
 
+variants = [
+    pytest.param(
+        "regnet_y_400mf",
+        marks=pytest.mark.xfail(
+            reason="RuntimeError: Tensor 0 - stride mismatch: expected [150528, 50176, 224, 1], got [3, 1, 672, 3]"
+        ),
+    ),
+    "regnet_y_800mf",
+    "regnet_y_1_6gf",
+    "regnet_y_3_2gf",
+    "regnet_y_8gf",
+    "regnet_y_16gf",
+    "regnet_y_32gf",
+    "regnet_y_128gf",
+    "regnet_x_400mf",
+    "regnet_x_800mf",
+    "regnet_x_1_6gf",
+    "regnet_x_3_2gf",
+    "regnet_x_8gf",
+    "regnet_x_16gf",
+    "regnet_x_32gf",
+]
+
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants_with_weights.keys())
+@pytest.mark.parametrize("variant", variants)
 def test_regnet_torchvision(record_forge_property, variant):
 
     if variant != "regnet_y_400mf":

--- a/forge/test/models/pytorch/vision/resnet/test_resnet.py
+++ b/forge/test/models/pytorch/vision/resnet/test_resnet.py
@@ -123,6 +123,9 @@ variants_with_weights = {
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="RuntimeError: Tensor 0 - stride mismatch: expected [150528, 50176, 224, 1], got [3, 1, 672, 3]"
+)
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_resnet_torchvision(record_forge_property, variant):
 

--- a/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
+++ b/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
@@ -87,6 +87,9 @@ variants_with_weights = {
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="RuntimeError: Couldn't load custom C++ ops. This can happen if your PyTorch and torchvision versions are incompatible, or if you had errors while compiling torchvision from source"
+)
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_retinanet_torchvision(record_forge_property, variant):
 

--- a/forge/test/models/pytorch/vision/rmbg/test_rmbg.py
+++ b/forge/test/models/pytorch/vision/rmbg/test_rmbg.py
@@ -12,6 +12,9 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="RuntimeError: Couldn't load custom C++ ops. This can happen if your PyTorch and torchvision versions are incompatible, or if you had errors while compiling torchvision from source"
+)
 @pytest.mark.parametrize("variant", ["briaai/RMBG-2.0"])
 def test_rmbg(record_forge_property, variant):
 

--- a/forge/test/models/pytorch/vision/segformer/test_segformer.py
+++ b/forge/test/models/pytorch/vision/segformer/test_segformer.py
@@ -16,7 +16,14 @@ from test.models.pytorch.vision.segformer.utils.image_utils import get_sample_da
 from test.models.utils import Framework, Source, Task, build_module_name
 
 variants_img_classification = [
-    "nvidia/mit-b0",
+    pytest.param(
+        "nvidia/mit-b0",
+        marks=[
+            pytest.mark.xfail(
+                reason="Statically allocated circular buffers in program 9 clash with L1 buffers on core range [(x=0,y=0) - (x=7,y=7)]. L1 buffer allocated at 213120 and static circular buffer region ends at 626464"
+            )
+        ],
+    ),
     "nvidia/mit-b1",
     "nvidia/mit-b2",
     "nvidia/mit-b3",

--- a/forge/test/models/pytorch/vision/ssd300_resnet50/test_ssd300_resnet50.py
+++ b/forge/test/models/pytorch/vision/ssd300_resnet50/test_ssd300_resnet50.py
@@ -14,6 +14,9 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="RuntimeError: Tensor 0 - stride mismatch: expected [270000, 90000, 300, 1], got [3, 1, 900, 3]"
+)
 def test_pytorch_ssd300_resnet50(record_forge_property):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/vision/ssd300_vgg16/test_ssd300_vgg16.py
+++ b/forge/test/models/pytorch/vision/ssd300_vgg16/test_ssd300_vgg16.py
@@ -15,6 +15,9 @@ variants_with_weights = {
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="RuntimeError: Couldn't load custom C++ ops. This can happen if your PyTorch and torchvision versions are incompatible, or if you had errors while compiling torchvision from source"
+)
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_ssd300_vgg16(record_forge_property, variant):
 

--- a/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3.py
+++ b/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3.py
@@ -15,6 +15,9 @@ variants_with_weights = {
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="RuntimeError: Couldn't load custom C++ ops. This can happen if your PyTorch and torchvision versions are incompatible, or if you had errors while compiling torchvision from source"
+)
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_ssdlite320_mobilenetv3(record_forge_property, variant):
 

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -20,7 +20,15 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["microsoft/swin-tiny-patch4-window7-224"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "microsoft/swin-tiny-patch4-window7-224",
+            marks=[pytest.mark.xfail(reason="Tensor mismatch between Framework and Forge codegen output(pcc=0.98)")],
+        ),
+    ],
+)
 def test_swin_v1_tiny_4_224_hf_pytorch(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(
@@ -53,7 +61,15 @@ def test_swin_v1_tiny_4_224_hf_pytorch(record_forge_property, variant):
 
 @pytest.mark.nightly
 @pytest.mark.skip_model_analysis
-@pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "microsoft/swinv2-tiny-patch4-window8-256",
+            marks=[pytest.mark.xfail(reason="Tensor mismatch between Framework and Forge codegen output(pcc=0.86)")],
+        ),
+    ],
+)
 def test_swin_v2_tiny_4_256_hf_pytorch(record_forge_property, variant):
     # Build Module Name
     module_name = build_module_name(
@@ -154,9 +170,32 @@ variants_with_weights = {
     "swin_v2_b": "Swin_V2_B_Weights",
 }
 
+variants = [
+    pytest.param(
+        "swin_t",
+        marks=[
+            pytest.mark.xfail(
+                reason="RuntimeError: Tensor 0 - stride mismatch: expected [150528, 50176, 224, 1], got [3, 1, 672, 3]"
+            )
+        ],
+    ),
+    "swin_s",
+    "swin_b",
+    pytest.param(
+        "swin_v2_t",
+        marks=[
+            pytest.mark.xfail(
+                reason="[TVM Relay IRModule Generation] relay.op._make.full expects Array[IntImm], but got Array[index 0: tir.Any] in argument 1"
+            )
+        ],
+    ),
+    "swin_v2_s",
+    "swin_v2_b",
+]
+
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants_with_weights.keys())
+@pytest.mark.parametrize("variant", variants)
 def test_swin_torchvision(record_forge_property, variant):
 
     if variant not in ["swin_t", "swin_v2_t"]:

--- a/forge/test/models/pytorch/vision/unet/test_unet.py
+++ b/forge/test/models/pytorch/vision/unet/test_unet.py
@@ -38,6 +38,9 @@ def generate_model_unet_imgseg_osmr_pytorch(variant):
     return model, [img_tensor], {}
 
 
+@pytest.mark.xfail(
+    reason="RuntimeError: TT_THROW tt-metal/ttnn/cpp/ttnn/operations/pool/upsample/device/upsample_op.cpp Unsupported mode"
+)
 @pytest.mark.nightly
 def test_unet_osmr_cityscape_pytorch(record_forge_property):
     # Build Module Name
@@ -232,6 +235,7 @@ def test_unet_torchhub_pytorch(record_forge_property):
 
 # Reference: https://github.com/arief25ramadhan/carvana-unet-segmentation
 @pytest.mark.nightly
+@pytest.mark.xfail(reason="[Conv2dTranspose][Shape Calculation] TypeError: 'int' object is not subscriptable")
 def test_unet_carvana(record_forge_property):
 
     # Build Module Name

--- a/forge/test/models/pytorch/vision/vgg/test_vgg.py
+++ b/forge/test/models/pytorch/vision/vgg/test_vgg.py
@@ -21,7 +21,14 @@ from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
 from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
-variants = ["vgg11", "vgg13", "vgg16", "vgg19", "bn_vgg19", "bn_vgg19b"]
+variants = [
+    "vgg11",
+    "vgg13",
+    "vgg16",
+    "vgg19",
+    "bn_vgg19",
+    "bn_vgg19b",
+]
 
 
 @pytest.mark.nightly
@@ -229,9 +236,26 @@ variants_with_weights = {
     "vgg19": "VGG19_Weights",
 }
 
+variants = [
+    pytest.param(
+        "vgg11",
+        marks=[
+            pytest.mark.xfail(
+                reason="RuntimeError: Tensor 0 - stride mismatch: expected [150528, 50176, 224, 1], got [3, 1, 672, 3]"
+            )
+        ],
+    ),
+    "vgg11_bn",
+    "vgg13",
+    "vgg13_bn",
+    "vgg16",
+    "vgg16_bn",
+    "vgg19",
+]
+
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants_with_weights.keys())
+@pytest.mark.parametrize("variant", variants)
 def test_vgg_torchvision(record_forge_property, variant):
 
     if variant != "vgg11":

--- a/forge/test/models/pytorch/vision/vit/test_vit.py
+++ b/forge/test/models/pytorch/vision/vit/test_vit.py
@@ -27,11 +27,14 @@ def generate_model_vit_imgcls_hf_pytorch(variant):
     return model, [img_tensor], {}
 
 
-variants = ["google/vit-base-patch16-224", "google/vit-large-patch16-224"]
+variants = [
+    pytest.param("google/vit-base-patch16-224", marks=[pytest.mark.xfail(reason="Tracing issue by torch.jit.trace")]),
+    "google/vit-large-patch16-224",
+]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_vit_classify_224_hf_pytorch(record_forge_property, variant):
     if variant != "google/vit-base-patch16-224":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
@@ -69,9 +72,17 @@ variants_with_weights = {
     "vit_h_14": "ViT_H_14_Weights",
 }
 
+variants = [
+    pytest.param("vit_b_16", marks=[pytest.mark.xfail(reason="Tracing issue by torch.jit.trace")]),
+    "vit_b_32",
+    "vit_l_16",
+    "vit_l_32",
+    "vit_h_14",
+]
+
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants_with_weights.keys())
+@pytest.mark.parametrize("variant", variants)
 def test_vit_torchvision(record_forge_property, variant):
 
     if variant != "vit_b_16":

--- a/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
@@ -25,11 +25,15 @@ def generate_model_vovnet_imgcls_osmr_pytorch(variant):
     return model, [image_tensor], {}
 
 
-varaints = ["vovnet27s", "vovnet39", "vovnet57"]
+varaints = [
+    pytest.param("vovnet27s", marks=[pytest.mark.xfail(reason="Invalid arguments to reshape")]),
+    "vovnet39",
+    "vovnet57",
+]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", varaints, ids=varaints)
+@pytest.mark.parametrize("variant", varaints)
 def test_vovnet_osmr_pytorch(record_forge_property, variant):
     if variant != "vovnet27s":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
@@ -130,11 +134,23 @@ def generate_model_vovnet_imgcls_timm_pytorch(variant):
     return model, [image_tensor], {}
 
 
-variants = ["ese_vovnet19b_dw", "ese_vovnet39b", "ese_vovnet99b", "ese_vovnet19b_dw.ra_in1k"]
+variants = [
+    "ese_vovnet19b_dw",
+    "ese_vovnet39b",
+    "ese_vovnet99b",
+    pytest.param(
+        "ese_vovnet19b_dw.ra_in1k",
+        marks=[
+            pytest.mark.xfail(
+                reason="AssertionError: Eltwise binary ops must have the same shape in both inputs, or one operand must be 1 wide to broadcast: [1, 1, 7, 7168] vs [1, 1, 7, 7]"
+            )
+        ],
+    ),
+]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_vovnet_timm_pytorch(record_forge_property, variant):
     if variant != "ese_vovnet19b_dw.ra_in1k":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")

--- a/forge/test/models/pytorch/vision/xception/test_xception.py
+++ b/forge/test/models/pytorch/vision/xception/test_xception.py
@@ -37,7 +37,12 @@ def generate_model_xception_imgcls_timm(variant):
 
 
 params = [
-    pytest.param("xception"),
+    pytest.param(
+        "xception",
+        marks=[
+            pytest.mark.xfail(reason="Input channels (728) should be padded to nearest TILE_WIDTH (32) or should be 16")
+        ],
+    ),
     pytest.param("xception41"),
     pytest.param("xception65"),
     pytest.param("xception71"),

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -21,11 +21,17 @@ def generate_model_yoloV5I320_imgcls_torchhub_pytorch(variant, size):
     return model, [input_tensor], {}
 
 
-size = ["n", "s", "m", "l", "x"]
+size = [
+    pytest.param("n", id="yolov5n"),
+    pytest.param("s", id="yolov5s"),
+    pytest.param("m", id="yolov5m"),
+    pytest.param("l", id="yolov5l"),
+    pytest.param("x", id="yolov5x"),
+]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("size", size, ids=["yolov5" + s for s in size])
+@pytest.mark.parametrize("size", size)
 def test_yolov5_320x320(record_forge_property, size):
     if size != "s":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
@@ -65,11 +71,25 @@ def generate_model_yoloV5I640_imgcls_torchhub_pytorch(variant, size):
     return model, [input_tensor], {}
 
 
-size = ["n", "s", "m", "l", "x"]
+size = [
+    pytest.param("n", id="yolov5n"),
+    pytest.param(
+        "s",
+        id="yolov5s",
+        marks=[
+            pytest.mark.xfail(
+                reason="Out of Memory: Not enough space to allocate 73859072 B L1 buffer across 64 banks, where each bank needs to store 1154048 B"
+            )
+        ],
+    ),
+    pytest.param("m", id="yolov5m"),
+    pytest.param("l", id="yolov5l"),
+    pytest.param("x", id="yolov5x"),
+]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("size", size, ids=["yolov5" + s for s in size])
+@pytest.mark.parametrize("size", size)
 def test_yolov5_640x640(record_forge_property, size):
     if size != "s":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
@@ -108,8 +128,25 @@ def generate_model_yoloV5I480_imgcls_torchhub_pytorch(variant, size):
     return model, [input_tensor], {}
 
 
+size = [
+    pytest.param("n", id="yolov5n"),
+    pytest.param(
+        "s",
+        id="yolov5s",
+        marks=[
+            pytest.mark.xfail(
+                reason="Statically allocated circular buffers in program 691 clash with L1 buffers on core range [(x=0,y=0) - (x=7,y=6)]. L1 buffer allocated at 197632 and static circular buffer region ends at 573216"
+            )
+        ],
+    ),
+    pytest.param("m", id="yolov5m"),
+    pytest.param("l", id="yolov5l"),
+    pytest.param("x", id="yolov5x"),
+]
+
+
 @pytest.mark.nightly
-@pytest.mark.parametrize("size", size, ids=["yolov5" + s for s in size])
+@pytest.mark.parametrize("size", size)
 def test_yolov5_480x480(record_forge_property, size):
     if size != "s":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
@@ -17,7 +17,19 @@ from test.models.pytorch.vision.yolo.utils.yolov6_utils import (
 from test.models.utils import Framework, Source, Task, build_module_name
 
 # Didn't dealt with yolov6n6,yolov6s6,yolov6m6,yolov6l6 variants because of its higher input size(1280)
-variants = ["yolov6n", "yolov6s", "yolov6m", "yolov6l"]
+variants = [
+    pytest.param(
+        "yolov6n",
+        marks=[
+            pytest.mark.xfail(
+                reason="[Conv2dTranspose][Shape Calculation] TypeError: 'int' object is not subscriptable"
+            )
+        ],
+    ),
+    "yolov6s",
+    "yolov6m",
+    "yolov6l",
+]
 
 
 @pytest.mark.nightly

--- a/forge/test/models/pytorch/vision/yolo/test_yolos.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolos.py
@@ -11,7 +11,15 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["hustvl/yolos-tiny"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "hustvl/yolos-tiny",
+            marks=[pytest.mark.xfail(reason="AssertionError: Only support nearest neighbor and linear for now")],
+        ),
+    ],
+)
 def test_yolos(record_forge_property, variant):
 
     # Build Module Name

--- a/forge/test/models/pytorch/vision/yolo/test_yolox.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolox.py
@@ -33,7 +33,15 @@ from forge.verify.verify import verify
 from test.models.pytorch.vision.yolo.utils.yolox_utils import preprocess
 from test.models.utils import Framework, Source, Task, build_module_name
 
-variants = ["yolox_nano", "yolox_tiny", "yolox_s", "yolox_m", "yolox_l", "yolox_darknet", "yolox_x"]
+variants = [
+    "yolox_nano",
+    "yolox_tiny",
+    "yolox_s",
+    "yolox_m",
+    "yolox_l",
+    "yolox_darknet",
+    "yolox_x",
+]
 
 
 @pytest.mark.nightly


### PR DESCRIPTION
The PR will add xfail markers with reason for the nightly test based upon [this nightly pipeline results](https://github.com/tenstorrent/tt-forge-fe/actions/runs/13694042603) and fixed the failed test which has minor bugs 

