### PR TITLE
Added support for intermediate golden verification in forward pass only

### DIFF
--- a/forge/forge/config.py
+++ b/forge/forge/config.py
@@ -81,9 +81,6 @@ class CompilerConfig:
     enable_tvm_dropout: bool = False
     # Create "unsupported" forge ops in python file, allowing user to modify later
     enable_tvm_unsupported_ops: bool = False
-
-    # Should we need to compare every op with framework output at each compilation stage.
-    enable_op_level_comparision: bool = False
     # Should we constant prop in tvm
     enable_tvm_constant_prop: bool = False
     # Convert framework params to relay params

--- a/forge/forge/tvm_calls/forge_compile.py
+++ b/forge/forge/tvm_calls/forge_compile.py
@@ -661,9 +661,7 @@ def compile_tvm_for_forge(
     )
 
     if verify_cfg is not None and verify_cfg.verify_tvm_compile:
-        assert (
-            compiler_cfg.convert_framework_params_to_tvm
-        ), "Cannot verify TVM compile without converting framework params to relay"
+        compiler_cfg.convert_framework_params_to_tvm = True
         # If we have conv2d_transpose ops that are channel-last, tvm cannot execute the module, skip in this case
         skip_verify = has_op(mod["main"], "nn.conv2d_transpose", {"data_layout": "NHWC"})
         if skip_verify:

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1941,7 +1941,7 @@ def verify_framework_vs_forge_codegen(frame_outputs, forge_outputs, verify_cfg):
     test_pass = True
     for i, (golden, output) in enumerate(zip(frame_outputs, forge_outputs)):
         test_pass &= compare_tensor_to_golden(
-            f"Framework vs. Forge codegen output {i}", golden, output.value(), is_forge=False, verify_cfg=verify_cfg
+            f"Framework vs. Forge codegen output {i}", golden, output.value(), verify_cfg=verify_cfg
         )
 
         assert test_pass, f"Data mismatch on output {i} between framework and Forge codegen"
@@ -2623,9 +2623,7 @@ def compile_tvm_to_python(
             current_module_name += f"_{json_graph['device']}_{graph_index}"
 
         if json_graph["device"] == "tt":
-            delete_inputs = not (
-                (verify_cfg is not None and verify_cfg.verify_all) or compiler_cfg.enable_op_level_comparision
-            )
+            delete_inputs = not verify_cfg.enable_op_level_comparision
             if not delete_inputs:
                 logger.warning(
                     "Preserving Intermediate tensor values in ForgeModule forward may causes out-of-memory issues"

--- a/forge/forge/verify/compare.py
+++ b/forge/forge/verify/compare.py
@@ -146,7 +146,6 @@ def compare_tensor_to_golden(
     name: str,
     golden: Union[torch.Tensor, tf.Tensor, tf.Variable],
     calculated: torch.Tensor,
-    is_forge=False,
     rtol=None,
     atol=None,
     pcc=None,
@@ -163,9 +162,6 @@ def compare_tensor_to_golden(
 
     if golden.dtype == torch.bool and calculated.dtype == torch.bool:
         return bool(torch.all(golden == calculated))
-
-    if is_forge:
-        calculated = narrow_forge_tensor_to_pytorch(calculated, golden.shape)
 
     if rtol is None or (isinstance(rtol, dict) and (golden.dtype not in rtol or rtol[golden.dtype] is None)):
         if verify_cfg is not None and golden.dtype in verify_cfg.rtol and verify_cfg.rtol[golden.dtype] is not None:

--- a/forge/forge/verify/config.py
+++ b/forge/forge/verify/config.py
@@ -16,6 +16,7 @@ from forge._C import DataFormat
 from dataclasses_json import dataclass_json
 from forge.utils import as_json
 from forge.verify.value_checkers import ValueChecker, AutomaticValueChecker
+from forge.config import CompileDepth
 
 
 class TestKind(Enum):
@@ -114,17 +115,15 @@ class DepricatedVerifyConfig:
     verify_forge_codegen_vs_framework: bool = (
         True  # Compare Framework output on CPU vs forge codegen from TVM json graphs
     )
+    # Setting this to true will enable intermediate outputs to remain in graph
+    # If false, all unused outputs will be removed. This needs to be true for intermediate golden verification
+    # if we want to compare all intermediate tensors in graph.
+    enable_op_level_comparision: bool = False
 
-    verify_all: bool = (
-        "FORGE_FORCE_VERIFY_ALL" in os.environ and os.environ["FORGE_FORCE_VERIFY_ALL"] == "1"
-    )  # Whether or not to verify after every compile stage
+    _verify_all: bool = False  # Whether or not to verify after every compile stage
     verify_last: bool = True  # Whether or not to verify after the final stage (overriden by disabled())
-    verify_post_autograd_passes: bool = (
-        "FORGE_VERIFY_POST_AUTOGRAD_PASSES" in os.environ and os.environ["FORGE_VERIFY_POST_AUTOGRAD_PASSES"] == "1"
-    )  # Whether or not to force verification at post autograd passes (overridden by disabled())
-    verify_post_placer: bool = (
-        "FORGE_VERIFY_POST_PLACER" in os.environ and os.environ["FORGE_VERIFY_POST_PLACER"] == "1"
-    )  # Whether or not to force verification at post placer (overidden by disabled())
+    # When we want to perform verification after some specific compilation stages.
+    stages_for_intermediate_verification = set()
 
     # names of parameters for which gradient error will not fail the test. Some gradients are so small that
     # atol/rtol/pcc will never be good enough to pass
@@ -156,25 +155,6 @@ class DepricatedVerifyConfig:
     enable_parameter_gradient_checking: bool = True
     _input_gradient_queue: Optional[torch.multiprocessing.Queue] = None
     _parameter_gradient_queue: Optional[torch.multiprocessing.Queue] = None
-
-    if "FORGE_VERIFY_RESULTS_OFF_BY_DEFAULT" in os.environ and not (
-        "FORGE_FORCE_VERIFY_ALL" in os.environ and os.environ["FORGE_FORCE_VERIFY_ALL"] == "1"
-    ):
-        intermediates = False
-        run_golden = False
-        verify_all = False
-        verify_last = False
-        verify_post_placer = False
-        verify_post_autograd_passes = False
-        verify_tvm_compile = False
-        verify_pipeline_result_vs_framework = False
-        verify_forge_codegen_vs_framework = False
-
-    if verify_all:
-        verify_pipeline_result_vs_framework = True
-        verify_forge_codegen_vs_framework = True
-        verify_tvm_compile = True
-        verify_each_forge_pass = True
 
     def __post_init__(self):
         # set defaults if not set explicitly by user. Relax under silicon, focus on pcc more.
@@ -216,12 +196,21 @@ class DepricatedVerifyConfig:
         v.intermediates = False
         v.run_golden = False
         v.scale_loss = 1.0
-        v.verify_post_autograd_passes = False
-        v.verify_post_placer = False
         return v
 
     def total_number_of_inputs(self):
         return self.epochs * self.steps * self.accumulation_steps * self.microbatch_count
+
+    @property
+    def verify_all(self):
+        """Getter for verify_all"""
+        return self._verify_all
+
+    @verify_all.setter
+    def verify_all(self, value: bool):
+        """Setter for verify_all"""
+        print(f"Setting verify_all to {value}")
+        self._verify_all = value
 
 
 def should_waive_gradient(param_name, verify_cfg):

--- a/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
+++ b/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
@@ -69,7 +69,13 @@ def test_pixel_shuffle(forge_property_recorder, input_shape, scale_factor):
             torch.float32,
             marks=pytest.mark.xfail(reason="BinaryOpType cannot be mapped to BcastOpMath"),
         ),
-        pytest.param((512,), torch.float16),
+        pytest.param(
+            (512,),
+            torch.float16,
+            marks=pytest.mark.xfail(
+                reason="Stage optimized_graph: Data mismatch detected. Issue: https://github.com/tenstorrent/tt-forge-fe/issues/1423 "
+            ),
+        ),
         pytest.param(
             (224, 224), torch.float32, marks=pytest.mark.xfail(reason="BinaryOpType cannot be mapped to BcastOpMath")
         ),
@@ -78,14 +84,32 @@ def test_pixel_shuffle(forge_property_recorder, input_shape, scale_factor):
             torch.float32,
             marks=pytest.mark.xfail(reason="BinaryOpType cannot be mapped to BcastOpMath"),
         ),
-        pytest.param((2, 128, 8, 8), torch.float16),
+        pytest.param(
+            (2, 128, 8, 8),
+            torch.float16,
+            marks=pytest.mark.xfail(
+                reason="Stage optimized_graph: Data mismatch detected. Issue: https://github.com/tenstorrent/tt-forge-fe/issues/1423 "
+            ),
+        ),
         pytest.param(
             (4, 1, 32, 32),
             torch.float32,
             marks=pytest.mark.xfail(reason="BinaryOpType cannot be mapped to BcastOpMath"),
         ),
-        pytest.param((6, 1, 900, 256), torch.float16),
-        pytest.param((8, 64, 32, 32, 45), torch.float16),
+        pytest.param(
+            (6, 1, 900, 256),
+            torch.float16,
+            marks=pytest.mark.xfail(
+                reason="Stage optimized_graph: Data mismatch detected. Issue: https://github.com/tenstorrent/tt-forge-fe/issues/1423 "
+            ),
+        ),
+        pytest.param(
+            (8, 64, 32, 32, 45),
+            torch.float16,
+            marks=pytest.mark.xfail(
+                reason="Stage optimized_graph: Data mismatch detected. Issue: https://github.com/tenstorrent/tt-forge-fe/issues/1423 "
+            ),
+        ),
     ],
 )
 @pytest.mark.push

--- a/forge/test/mlir/operators/nn/test_nn.py
+++ b/forge/test/mlir/operators/nn/test_nn.py
@@ -58,6 +58,9 @@ def test_conv2d_reflect_padding_mode(
         ((1, 16, 32, 16, 16), (8, 1, 1), (3, 3, 3)),
     ],
 )
+@pytest.mark.xfail(
+    reason="permute(sparse_coo): number of dimensions in the tensor input does not match the length of the desired ordering of dimensions i.e. input.dim() = 5 is not equal to len(dims) = 4. Tracking Issue: https://github.com/tenstorrent/tt-forge-fe/issues/1422"
+)
 @pytest.mark.push
 def test_avgpool3d(forge_property_recorder, shape, kernel_size, stride):
     class AvgPool3D(nn.Module):

--- a/forge/test/mlir/test_golden_verification.py
+++ b/forge/test/mlir/test_golden_verification.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+from torch import nn
+
+import forge
+from forge.verify.verify import verify
+
+
+@pytest.mark.parametrize(
+    "batch_size",
+    [
+        1,
+    ],
+)
+@pytest.mark.parametrize("outer_dim_x", [7])
+@pytest.mark.parametrize("outer_dim_y", [7])
+@pytest.mark.parametrize("inner_dim", [64])
+@pytest.mark.push
+def test_matmul_and_add(batch_size, outer_dim_x, outer_dim_y, inner_dim):
+    class MatmulAdd(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x, y, z, t):
+            mm = torch.matmul(x, y)
+            add_1 = mm + z
+            return add_1 + t
+
+    inputs = [
+        torch.rand(batch_size, outer_dim_x, inner_dim),
+        torch.rand(batch_size, inner_dim, outer_dim_y),
+        torch.rand(batch_size, outer_dim_x, outer_dim_y),
+        torch.rand(batch_size, outer_dim_x, outer_dim_y),
+    ]
+
+    framework_model = MatmulAdd()
+    verify_cfg = DepricatedVerifyConfig()
+    verify_cfg.verify_all = True
+    verify_cfg.enable_op_level_comparision = True
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, verify_cfg=verify_cfg)
+
+    verify(inputs, framework_model, compiled_model)
+
+
+@pytest.mark.parametrize(
+    "batch_size",
+    [
+        1,
+    ],
+)
+@pytest.mark.parametrize("lhs", [7])
+@pytest.mark.parametrize("rhs", [7])
+@pytest.mark.push
+def test_constant_add(batch_size, lhs, rhs):
+    class ConstAdd(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.const_1 = torch.rand(batch_size, lhs, rhs)
+
+        def forward(self, x):
+            out = x + self.const_1
+            return out
+
+    inputs = [torch.rand(batch_size, lhs, rhs)]
+
+    framework_model = ConstAdd()
+
+    verify_cfg = DepricatedVerifyConfig()
+    verify_cfg.verify_all = True
+    verify_cfg.enable_op_level_comparision = True
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, verify_cfg=verify_cfg)
+
+    verify(inputs, framework_model, compiled_model)

--- a/scripts/bisect.sh
+++ b/scripts/bisect.sh
@@ -28,9 +28,6 @@ set_evn_flags() {
     local arch=$1
     local runtype=$2
     local device_config=$3
-    export FORGE_VERIFY_POST_AUTOGRAD_PASSES=1
-    export FORGE_VERIFY_POST_PLACER=1
-    export FORGE_VERIFY_NET2PIPE=3
     export PYTEST_ADDOPTS=" -svv"
 
     if [ "$arch" = "wormhole_b0" ] ; then


### PR DESCRIPTION
Closes #1405 
- Added support for intermediate golden verification in forward pass only
- Added few simple tests in forge/test/mlir/test_golden_verification.py, more to come with backward support.

### Ticket
[Link to Github Issue
](https://github.com/tenstorrent/tt-forge-fe/issues/1405)

There are two scopes of graph verification:

1. First scope is verifying graph between compile stages. This enables us to detect in which stage of compile data mismatch occurs.
We can now set which compile stages to verify using:
`STAGES_TO_PERFORM_INTERMEDIATE_VERIFICATION` env variable. Specify the compile stages to perform verification in comma separated manner:
`STAGES_TO_PERFORM_INTERMEDIATE_VERIFICATION=OPTIMIZED_GRAPH, PRE_LOWERING_PASS`
Also, setting `FORGE_FORCE_VERIFY_ALL=1` will do verification for all compile stages.

2. Second scope is verifying each intermediate tensor as opposed to verifying only outputs. This will enable us to locate where exactly data mismatch occurs in the graph.
By setting `FORGE_OP_LEVEL_COMPARISON=1` intermediate golden outputs will be compared with intermediate graph outputs. Without setting this variable, verification will be done only on outputs (for compile stages chosen like explained above)

