### PR TITLE
Fix ONNX module importer

### DIFF
--- a/forge/forge/compile.py
+++ b/forge/forge/compile.py
@@ -191,7 +191,7 @@ def compile_main(
     Parameters
     ----------
     module: AnyModule
-        Torch, TensorFlow, or Forge module to compile
+        Torch, TensorFlow, ONNX or Forge module to compile
 
     sample_inputs: List[torch.Tensor]
         List of sample inputs for the module (used to infer shapes)
@@ -217,7 +217,7 @@ def compile_main(
 
     """
 
-    assert isinstance(module, AnyModule), "Only PyTorch, TensorFlow, and Forge modules are supported."
+    assert isinstance(module, AnyModule), "Only PyTorch, TensorFlow, ONNX and Forge modules are supported."
 
     if module_name is None:
         module_name = module.__class__.__name__

--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -1197,6 +1197,8 @@ def to_pt_tensor(t: AnyTensor) -> torch.Tensor:
         pt = torch.Tensor(t.numpy())
         pt.requires_grad = t.stop_gradient == False
         return pt
+    elif isinstance(t, np.ndarray):
+        return torch.from_numpy(t)
     else:
         raise RuntimeError(f"Unknown type of tensor: {type(t)}")
 

--- a/forge/forge/tvm_calls/forge_compile.py
+++ b/forge/forge/tvm_calls/forge_compile.py
@@ -723,14 +723,13 @@ def duplicate_dequantize_nodes_in_onnx_graph(onnx_module):
 def compile_onnx_for_forge(onnx_mod, path, *inputs, graph_name, compiler_cfg, verify_cfg=None):
     import onnxruntime as ort
 
-    assert path != None, "Onnx compile needs path to onnx file on disk."
-
     # Set default num threads to 2, hangs on some hosts otherwise https://github.com/microsoft/onnxruntime/issues/10166
     so = ort.SessionOptions()
     so.inter_op_num_threads = 2
     so.intra_op_num_threads = 2
 
-    ort_sess = ort.InferenceSession(path, sess_options=so, providers=["CPUExecutionProvider"])
+    onnx_bytes = onnx_mod.SerializeToString()
+    ort_sess = ort.InferenceSession(onnx_bytes, sess_options=so, providers=["CPUExecutionProvider"])
 
     input_names = []
     for inp in ort_sess.get_inputs():

--- a/forge/forge/tvm_calls/forge_utils.py
+++ b/forge/forge/tvm_calls/forge_utils.py
@@ -115,11 +115,11 @@ def extract_framework_model_outputs(
         for out in model.graph.output:
             output_names.append(out.name)
 
-        assert path != None, "Onnx compile needs path to onnx file on disk."
         so = ort.SessionOptions()
         so.inter_op_num_threads = 2
         so.intra_op_num_threads = 2
-        ort_sess = ort.InferenceSession(path, sess_options=so)
+        onnx_model = model.SerializeToString()
+        ort_sess = ort.InferenceSession(onnx_model, sess_options=so)
         framework_outputs = ort_sess.run(output_names, input_dict)
 
     elif framework == "tflite":

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -2114,11 +2114,9 @@ def compile_tvm_to_python(
         else:
             framework_mod.module.eval()
 
-    # Path is needed for Onnx model verification against TVM compile.
+    # Path is needed for TFLite model verification against TVM compile.
     path = None
-    if isinstance(framework_mod, OnnxModule):
-        path = framework_mod.onnx_path
-    elif isinstance(framework_mod, TFLiteModule):
+    if isinstance(framework_mod, TFLiteModule):
         path = framework_mod.tflite_path
 
     # Load here to avoid importing tvm unnecessarily when this file is loaded

--- a/forge/forge/verify/config.py
+++ b/forge/forge/verify/config.py
@@ -289,4 +289,4 @@ class VerifyConfig:
 
     @property
     def framework_model_types(self) -> Tuple:
-        return (torch.nn.Module, tf.Module, tf.keras.Model, forge.ForgeModule, paddle.nn.Layer)
+        return (torch.nn.Module, tf.Module, tf.keras.Model, forge.ForgeModule, paddle.nn.Layer, forge.OnnxModule)

--- a/forge/forge/verify/verify.py
+++ b/forge/forge/verify/verify.py
@@ -12,6 +12,7 @@ from typing import Tuple, Dict, List, Any, Union
 from loguru import logger
 from forge.forgeglobal import align_up_tile
 import paddle
+import onnx
 import torch
 import tensorflow as tf
 from forge.tensor import to_pt_tensors
@@ -266,7 +267,7 @@ def verify_golden(
 
 def verify(
     inputs: List[Union[torch.Tensor, tf.Tensor, tf.Variable, paddle.Tensor]],
-    framework_model: Union[torch.nn.Module, tf.Module, tf.keras.Model, paddle.nn.Layer],
+    framework_model: Union[torch.nn.Module, tf.Module, tf.keras.Model, paddle.nn.Layer, onnx.onnx_ml_pb2.ModelProto],
     compiled_model: CompiledModel,
     verify_cfg: VerifyConfig = VerifyConfig(),
 ):

--- a/forge/test/mlir/test_ops_onnx.py
+++ b/forge/test/mlir/test_ops_onnx.py
@@ -1,0 +1,478 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+import numpy as np
+from onnx import helper, TensorProto, numpy_helper
+
+import forge
+from forge.verify.verify import verify
+
+
+ONNX_OPSET_VERSION = 21
+opset_imports = [helper.make_operatorsetid("", ONNX_OPSET_VERSION)]
+
+
+@pytest.mark.push
+def test_add():
+    input_A = helper.make_tensor_value_info("input_A", TensorProto.FLOAT, [2, 32, 32])
+    input_B = helper.make_tensor_value_info("input_B", TensorProto.FLOAT, [2, 32, 32])
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [2, 32, 32])
+
+    add_node = helper.make_node(
+        "Add",
+        inputs=["input_A", "input_B"],
+        outputs=["output"],
+    )
+
+    graph = helper.make_graph(
+        nodes=[add_node],
+        name="AddGraph",
+        inputs=[input_A, input_B],
+        outputs=[output],
+    )
+    onnx_model = helper.make_model(
+        graph,
+        producer_name="AddModel",
+        opset_imports=opset_imports,
+    )
+
+    inputs = [torch.rand([2, 32, 32]), torch.rand([2, 32, 32])]
+
+    onnx_module = forge.OnnxModule("add", onnx_model)
+    compiled_model = forge.compile(onnx_model, inputs)
+
+    verify(inputs, onnx_module, compiled_model)
+
+
+@pytest.mark.push
+def test_arithmetic():
+    input_A = helper.make_tensor_value_info("input_A", TensorProto.FLOAT, [2, 32, 32])
+    input_B = helper.make_tensor_value_info("input_B", TensorProto.FLOAT, [2, 32, 32])
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [2, 32, 32])
+
+    sqrt_node = helper.make_node(
+        "Sqrt",
+        inputs=["input_A"],
+        outputs=["Sqrt_A"],
+    )
+    exp_node = helper.make_node(
+        "Exp",
+        inputs=["input_B"],
+        outputs=["Exp_B"],
+    )
+    add_node = helper.make_node(
+        "Add",
+        inputs=["Sqrt_A", "Exp_B"],
+        outputs=["output"],
+    )
+
+    graph = helper.make_graph(
+        nodes=[sqrt_node, exp_node, add_node],
+        name="ArithGraph",
+        inputs=[input_A, input_B],
+        outputs=[output],
+    )
+    onnx_model = helper.make_model(
+        graph,
+        producer_name="ArithModel",
+        opset_imports=opset_imports,
+    )
+
+    inputs = [torch.rand([2, 32, 32]), torch.rand([2, 32, 32])]
+
+    onnx_module = forge.OnnxModule("arith", onnx_model)
+    compiled_model = forge.compile(onnx_model, inputs)
+
+    verify(inputs, onnx_module, compiled_model)
+
+
+@pytest.mark.push
+def test_matmul():
+    input_A = helper.make_tensor_value_info("input_A", TensorProto.FLOAT, [32, 64])
+    input_B = helper.make_tensor_value_info("input_B", TensorProto.FLOAT, [64, 32])
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [32, 32])
+
+    matmul_node = helper.make_node(
+        "MatMul",
+        inputs=["input_A", "input_B"],
+        outputs=["output"],
+    )
+
+    graph = helper.make_graph(
+        nodes=[matmul_node],
+        name="MatMulGraph",
+        inputs=[input_A, input_B],
+        outputs=[output],
+    )
+    onnx_model = helper.make_model(
+        graph,
+        producer_name="MatMulModel",
+        opset_imports=opset_imports,
+    )
+
+    inputs = [torch.rand([32, 64]), torch.rand([64, 32])]
+
+    onnx_module = forge.OnnxModule("matmul", onnx_model)
+    compiled_model = forge.compile(onnx_model, inputs)
+
+    verify(inputs, onnx_module, compiled_model)
+
+
+@pytest.mark.push
+def test_squeeze():
+    input_A = helper.make_tensor_value_info("input_A", TensorProto.FLOAT, [1, 32, 32])
+    input_B = helper.make_tensor_value_info("input_B", TensorProto.FLOAT, [1, 32, 32])
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [32, 32])
+
+    squeeze_a_node = helper.make_node(
+        "Squeeze",
+        inputs=["input_A"],
+        outputs=["squeezed_A"],
+    )
+
+    squeeze_b_node = helper.make_node(
+        "Squeeze",
+        inputs=["input_B"],
+        outputs=["squeezed_B"],
+    )
+
+    transpose_a_node = helper.make_node("Transpose", inputs=["squeezed_A"], outputs=["transposed_A"])
+
+    add_node = helper.make_node("Add", inputs=["transposed_A", "squeezed_B"], outputs=["output"])
+
+    graph = helper.make_graph(
+        nodes=[squeeze_a_node, squeeze_b_node, transpose_a_node, add_node],
+        name="SqueezeGraph",
+        inputs=[input_A, input_B],
+        outputs=[output],
+    )
+    onnx_model = helper.make_model(
+        graph,
+        producer_name="SqueezeModel",
+        opset_imports=opset_imports,
+    )
+
+    inputs = [torch.rand([1, 32, 32]), torch.rand([1, 32, 32])]
+
+    onnx_module = forge.OnnxModule("squeeze", onnx_model)
+    compiled_model = forge.compile(onnx_model, inputs)
+
+    verify(inputs, onnx_module, compiled_model)
+
+
+@pytest.mark.push
+def test_flatten():
+    input = helper.make_tensor_value_info("input", TensorProto.FLOAT, [2, 32, 32])
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [2, 1024])
+
+    flatten_node = helper.make_node(
+        "Flatten",
+        inputs=["input"],
+        outputs=["output"],
+    )
+
+    graph = helper.make_graph(
+        nodes=[flatten_node],
+        name="FlattenGraph",
+        inputs=[input],
+        outputs=[output],
+    )
+    onnx_model = helper.make_model(
+        graph,
+        producer_name="FlattenModel",
+        opset_imports=opset_imports,
+    )
+
+    inputs = [torch.rand([2, 32, 32])]
+
+    onnx_module = forge.OnnxModule("flatten", onnx_model)
+    compiled_model = forge.compile(onnx_model, inputs)
+
+    verify(inputs, onnx_module, compiled_model)
+
+
+@pytest.mark.push
+def test_linear_layer():
+    input_features, output_dim = (784, 10)
+
+    input = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, input_features])
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, output_dim])
+
+    weight_data = np.random.rand(input_features, output_dim).astype(np.float32)
+    bias_data = np.random.rand(output_dim).astype(np.float32)
+    weight_initializer = numpy_helper.from_array(weight_data, name="weight")
+    bias_initializer = numpy_helper.from_array(bias_data, name="bias")
+
+    matmul_node = helper.make_node("MatMul", inputs=["input", "weight"], outputs=["matmul_A"])
+
+    add_node = helper.make_node("Add", inputs=["matmul_A", "bias"], outputs=["output"])
+
+    graph = helper.make_graph(
+        nodes=[matmul_node, add_node],
+        name="LinearLayerGraph",
+        inputs=[input],
+        outputs=[output],
+        initializer=[weight_initializer, bias_initializer],
+    )
+
+    onnx_model = helper.make_model(
+        graph,
+        producer_name="LinearLayerModel",
+        opset_imports=opset_imports,
+    )
+
+    inputs = [torch.rand([1, input_features])]
+
+    onnx_module = forge.OnnxModule("linear", onnx_model)
+    compiled_model = forge.compile(onnx_model, inputs)
+
+    verify(inputs, onnx_module, compiled_model)
+
+
+@pytest.mark.push
+def test_multiple_layers():
+    num_classes = 10
+
+    input = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, 3, 32, 32])
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, num_classes])
+
+    conv1_weight = np.random.rand(16, 3, 3, 3).astype(np.float32)
+    conv1_bias = np.random.rand(16).astype(np.float32)
+    conv2_weight = np.random.rand(32, 16, 3, 3).astype(np.float32)
+    conv2_bias = np.random.rand(32).astype(np.float32)
+    fc1_weight = np.random.rand(32 * 8 * 8, 128).astype(np.float32)
+    fc1_bias = np.random.rand(128).astype(np.float32)
+    fc2_weight = np.random.rand(128, num_classes).astype(np.float32)
+    fc2_bias = np.random.rand(num_classes).astype(np.float32)
+
+    initializer = [
+        numpy_helper.from_array(conv1_weight, "conv1_weight"),
+        numpy_helper.from_array(conv1_bias, "conv1_bias"),
+        numpy_helper.from_array(conv2_weight, "conv2_weight"),
+        numpy_helper.from_array(conv2_bias, "conv2_bias"),
+        numpy_helper.from_array(fc1_weight, "fc1_weight"),
+        numpy_helper.from_array(fc1_bias, "fc1_bias"),
+        numpy_helper.from_array(fc2_weight, "fc2_weight"),
+        numpy_helper.from_array(fc2_bias, "fc2_bias"),
+    ]
+
+    nodes = [
+        helper.make_node(
+            "Conv", ["input", "conv1_weight", "conv1_bias"], ["conv1_out"], pads=[1, 1, 1, 1], strides=[1, 1]
+        ),
+        helper.make_node("Relu", ["conv1_out"], ["relu1_out"]),
+        helper.make_node("MaxPool", ["relu1_out"], ["pool1_out"], kernel_shape=[2, 2], strides=[2, 2]),
+        helper.make_node(
+            "Conv", ["pool1_out", "conv2_weight", "conv2_bias"], ["conv2_out"], pads=[1, 1, 1, 1], strides=[1, 1]
+        ),
+        helper.make_node("Relu", ["conv2_out"], ["relu2_out"]),
+        helper.make_node("MaxPool", ["relu2_out"], ["pool2_out"], kernel_shape=[2, 2], strides=[2, 2]),
+        helper.make_node("Flatten", ["pool2_out"], ["flatten_out"], axis=1),
+        helper.make_node("MatMul", ["flatten_out", "fc1_weight"], ["fc1_matmul_out"]),
+        helper.make_node("Add", ["fc1_matmul_out", "fc1_bias"], ["fc1_out"]),
+        helper.make_node("Relu", ["fc1_out"], ["relu_fc1_out"]),
+        helper.make_node("MatMul", ["relu_fc1_out", "fc2_weight"], ["fc2_matmul_out"]),
+        helper.make_node("Add", ["fc2_matmul_out", "fc2_bias"], ["output"]),
+    ]
+
+    graph = helper.make_graph(
+        nodes=nodes,
+        name="CNNClassifierGraph",
+        inputs=[input],
+        outputs=[output],
+        initializer=initializer,
+    )
+
+    onnx_model = helper.make_model(
+        graph,
+        producer_name="CNNClassifierModel",
+        opset_imports=opset_imports,
+    )
+
+    inputs = [torch.rand([1, 3, 32, 32])]
+
+    onnx_module = forge.OnnxModule("multiple_linears", onnx_model)
+    compiled_model = forge.compile(onnx_model, inputs)
+
+    verify(inputs, onnx_module, compiled_model)
+
+
+@pytest.mark.push
+def test_mnist_linear():
+    input_size = 784
+    hidden_size = 512
+    output_size = 10
+
+    input = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, input_size])
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, output_size])
+
+    fc1_weight = np.random.rand(input_size, hidden_size).astype(np.float32)
+    fc1_bias = np.random.rand(hidden_size).astype(np.float32)
+    fc2_weight = np.random.rand(hidden_size, hidden_size).astype(np.float32)
+    fc2_bias = np.random.rand(hidden_size).astype(np.float32)
+    fc3_weight = np.random.rand(hidden_size, output_size).astype(np.float32)
+    fc3_bias = np.random.rand(output_size).astype(np.float32)
+
+    initializer = [
+        numpy_helper.from_array(fc1_weight, "fc1_weight"),
+        numpy_helper.from_array(fc1_bias, "fc1_bias"),
+        numpy_helper.from_array(fc2_weight, "fc2_weight"),
+        numpy_helper.from_array(fc2_bias, "fc2_bias"),
+        numpy_helper.from_array(fc3_weight, "fc3_weight"),
+        numpy_helper.from_array(fc3_bias, "fc3_bias"),
+    ]
+
+    nodes = [
+        helper.make_node("MatMul", ["input", "fc1_weight"], ["fc1_matmul_out"]),
+        helper.make_node("Add", ["fc1_matmul_out", "fc1_bias"], ["fc1_out"]),
+        helper.make_node("Relu", ["fc1_out"], ["relu1_out"]),
+        helper.make_node("MatMul", ["relu1_out", "fc2_weight"], ["fc2_matmul_out"]),
+        helper.make_node("Add", ["fc2_matmul_out", "fc2_bias"], ["fc2_out"]),
+        helper.make_node("Relu", ["fc2_out"], ["relu2_out"]),
+        helper.make_node("MatMul", ["relu2_out", "fc3_weight"], ["fc3_matmul_out"]),
+        helper.make_node("Add", ["fc3_matmul_out", "fc3_bias"], ["output"]),
+    ]
+
+    graph = helper.make_graph(
+        nodes=nodes,
+        name="MNISTLinearGraph",
+        inputs=[input],
+        outputs=[output],
+        initializer=initializer,
+    )
+
+    onnx_model = helper.make_model(
+        graph,
+        producer_name="MNISTLinearModel",
+        opset_imports=opset_imports,
+    )
+
+    inputs = [torch.rand([1, 784])]
+
+    onnx_module = forge.OnnxModule("mnist_linear", onnx_model)
+    compiled_model = forge.compile(onnx_model, inputs)
+
+    verify(inputs, onnx_module, compiled_model)
+
+
+@pytest.mark.push
+def test_batchnorm():
+    num_features = 32
+    input_shape = [1, 32, 56, 56]
+
+    input = helper.make_tensor_value_info("input", TensorProto.FLOAT, input_shape)
+    output = helper.make_tensor_value_info("output", TensorProto.FLOAT, input_shape)
+
+    scale = np.random.rand(num_features).astype(np.float32)
+    bias = np.random.rand(num_features).astype(np.float32)
+    mean = np.random.rand(num_features).astype(np.float32)
+    var = np.random.rand(num_features).astype(np.float32)
+
+    initializer = [
+        numpy_helper.from_array(scale, "scale"),
+        numpy_helper.from_array(bias, "bias"),
+        numpy_helper.from_array(mean, "mean"),
+        numpy_helper.from_array(var, "var"),
+    ]
+
+    batch_norm_node = helper.make_node(
+        "BatchNormalization", inputs=["input", "scale", "bias", "mean", "var"], outputs=["output"], epsilon=1e-5
+    )
+
+    graph = helper.make_graph(
+        nodes=[batch_norm_node],
+        name="BatchNormGraph",
+        inputs=[input],
+        outputs=[output],
+        initializer=initializer,
+    )
+
+    onnx_model = helper.make_model(
+        graph,
+        producer_name="BatchNormModel",
+        opset_imports=opset_imports,
+    )
+
+    inputs = [torch.rand(input_shape)]
+
+    onnx_module = forge.OnnxModule("batchnorm", onnx_model)
+    compiled_model = forge.compile(onnx_model, inputs)
+
+    verify(inputs, onnx_module, compiled_model)
+
+
+@pytest.mark.push
+def test_convbn():
+    in_c = 3
+    out_c = 64
+    filter_size = 3
+    stride = 1
+    padding = 1
+    num_groups = 1
+    input_shape = [1, in_c, 64, 64]
+
+    input_tensor = helper.make_tensor_value_info("input", TensorProto.FLOAT, input_shape)
+    output_tensor = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, out_c, 64, 64])
+
+    conv_weight = np.random.rand(out_c, in_c // num_groups, filter_size, filter_size).astype(np.float32)
+    conv_bias = np.random.rand(out_c).astype(np.float32)
+
+    scale = np.random.rand(out_c).astype(np.float32)
+    bias = np.random.rand(out_c).astype(np.float32)
+    mean = np.random.rand(out_c).astype(np.float32)
+    var = np.random.rand(out_c).astype(np.float32)
+
+    initializer = [
+        numpy_helper.from_array(conv_weight, "conv_weight"),
+        numpy_helper.from_array(conv_bias, "conv_bias"),
+        numpy_helper.from_array(scale, "bn_scale"),
+        numpy_helper.from_array(bias, "bn_bias"),
+        numpy_helper.from_array(mean, "bn_mean"),
+        numpy_helper.from_array(var, "bn_var"),
+    ]
+
+    nodes = [
+        helper.make_node(
+            "Conv",
+            inputs=["input", "conv_weight", "conv_bias"],
+            outputs=["conv_out"],
+            kernel_shape=[filter_size, filter_size],
+            strides=[stride, stride],
+            pads=[padding, padding, padding, padding],
+            group=num_groups,
+        ),
+        helper.make_node(
+            "BatchNormalization",
+            inputs=["conv_out", "bn_scale", "bn_bias", "bn_mean", "bn_var"],
+            outputs=["bn_out"],
+            epsilon=1e-5,
+        ),
+        helper.make_node(
+            "Relu",
+            inputs=["bn_out"],
+            outputs=["output"],
+        ),
+    ]
+
+    graph = helper.make_graph(
+        nodes=nodes,
+        name="ConvBNLayerGraph",
+        inputs=[input_tensor],
+        outputs=[output_tensor],
+        initializer=initializer,
+    )
+
+    onnx_model = helper.make_model(
+        graph,
+        producer_name="ConvBNLayerModel",
+        opset_imports=opset_imports,
+    )
+
+    inputs = [torch.rand(input_shape)]
+
+    onnx_module = forge.OnnxModule("convbn", onnx_model)
+    compiled_model = forge.compile(onnx_model, inputs)
+
+    verify(inputs, onnx_module, compiled_model)

--- a/forge/test/mlir/test_ops_paddle.py
+++ b/forge/test/mlir/test_ops_paddle.py
@@ -94,15 +94,15 @@ def test_matmul_pp():
 
 
 @pytest.mark.push
-def test_sqeeze_pp():
+def test_squeeze_pp():
     class Squeeze_pp(paddle.nn.Layer):
         def __init__(self):
             super().__init__()
 
         def forward(self, a, b):
-            sqeezed_a = paddle.squeeze(a, axis=0)
-            sqeezed_b = paddle.squeeze(b, axis=0)
-            return sqeezed_a.T + sqeezed_b
+            squeezed_a = paddle.squeeze(a, axis=0)
+            squeezed_b = paddle.squeeze(b, axis=0)
+            return squeezed_a.T + squeezed_b
 
     inputs = [paddle.rand([1, 32, 32]), paddle.rand([1, 32, 32])]
 

--- a/forge/test/models/onnx/vision/ddrnet/test_ddrnet.py
+++ b/forge/test/models/onnx/vision/ddrnet/test_ddrnet.py
@@ -42,7 +42,7 @@ def test_ddrnet(variant, test_device):
     load_path = f"third_party/confidential_customer_models/generated/files/{variant}.onnx"
 
     model = onnx.load(load_path)
-    tt_model = forge.OnnxModule(model_name, model, load_path)
+    tt_model = forge.OnnxModule(model_name, model)
 
     # STEP 3: Prepare input
     url = "https://raw.githubusercontent.com/pytorch/hub/master/images/dog.jpg"
@@ -147,7 +147,7 @@ def test_ddrnet_semantic_segmentation_onnx(variant, test_device):
     model = onnx.load(load_path)
     onnx.checker.check_model(model)
     model_name = f"onnx_{variant}"
-    tt_model = forge.OnnxModule(model_name, model, load_path)
+    tt_model = forge.OnnxModule(model_name, model)
 
     # Prepare input
     image_path = "third_party/confidential_customer_models/cv_demos/ddrnet/semantic_segmentation/image/road_scenes.png"

--- a/forge/test/models/onnx/vision/dla/test_dla.py
+++ b/forge/test/models/onnx/vision/dla/test_dla.py
@@ -65,7 +65,7 @@ def test_dla_onnx(test_device, variant):
     # Load DLA model
     model_name = f"dla_{variant}_onnx"
     onnx_model = onnx.load(onnx_model_path)
-    tt_model = forge.OnnxModule(model_name, onnx_model, onnx_model_path)
+    tt_model = forge.OnnxModule(model_name, onnx_model)
 
     pcc = 0.99
     if test_device.arch == BackendDevice.Wormhole_B0:

--- a/forge/test/models/onnx/vision/fpn/test_fpn.py
+++ b/forge/test/models/onnx/vision/fpn/test_fpn.py
@@ -20,7 +20,7 @@ def test_fpn_onnx(test_device, test_kind):
     # Load FPN model
     onnx_model_path = "third_party/confidential_customer_models/generated/files/fpn.onnx"
     model = onnx.load(onnx_model_path)
-    tt_model = forge.OnnxModule("onnx_fpn", model, onnx_model_path)
+    tt_model = forge.OnnxModule("onnx_fpn", model)
 
     feat0 = torch.rand(1, 10, 64, 64)
     feat1 = torch.rand(1, 20, 16, 16)

--- a/forge/test/models/onnx/vision/hardnet/test_hardnet.py
+++ b/forge/test/models/onnx/vision/hardnet/test_hardnet.py
@@ -54,7 +54,7 @@ def test_hardnet_onnx(variant, test_device):
 
     # Create Forge module from onnx weights
     model = onnx.load(load_path)
-    tt_model = forge.OnnxModule(model_name, model, load_path)
+    tt_model = forge.OnnxModule(model_name, model)
 
     # Run inference on Tenstorrent device
     verify_module(

--- a/forge/test/models/onnx/vision/lstm/test_lstm_genom.py
+++ b/forge/test/models/onnx/vision/lstm/test_lstm_genom.py
@@ -24,7 +24,7 @@ def test_lstm_genom_onnx(test_device):
     # Run inference on Tenstorrent device
     inputs = tf.random.uniform(shape=[1, 10, 4])
     verify_module(
-        forge.OnnxModule("onnx_lstm", model, load_path),
+        forge.OnnxModule("onnx_lstm", model),
         input_shapes=(inputs.shape,),
         inputs=[(inputs,)],
         verify_cfg=DepricatedVerifyConfig(

--- a/forge/test/models/onnx/vision/lstm/test_lstm_valence.py
+++ b/forge/test/models/onnx/vision/lstm/test_lstm_valence.py
@@ -33,7 +33,7 @@ def test_lstm_valence_onnx(test_device):
     # Run inference on Tenstorrent device
     inputs = tf.random.uniform(shape=[1, 1, 282])
     verify_module(
-        forge.OnnxModule("onnx_lstm", model, load_path),
+        forge.OnnxModule("onnx_lstm", model),
         input_shapes=(inputs.shape,),
         inputs=[(inputs,)],
         verify_cfg=DepricatedVerifyConfig(

--- a/forge/test/models/onnx/vision/perceiverio/test_perceiverio.py
+++ b/forge/test/models/onnx/vision/perceiverio/test_perceiverio.py
@@ -60,7 +60,6 @@ def test_perceiver_for_image_classification_onnx(test_device, model_name):
     tt_model = forge.OnnxModule(
         str(model_name.split("/")[-1].replace("-", "_")) + "_onnx",
         onnx_model,
-        onnx_model_path,
     )
 
     # Run inference on Tenstorrent device

--- a/forge/test/models/onnx/vision/retinanet/test_retinanet.py
+++ b/forge/test/models/onnx/vision/retinanet/test_retinanet.py
@@ -60,7 +60,7 @@ def test_retinanet_r101_640x480_onnx(test_device):
     # STEP 2: Create Forge module from PyTorch model
     load_path = "third_party/confidential_customer_models/model_2/onnx/retinanet/retinanet-9.onnx"
     model = onnx.load(load_path)
-    tt_model = forge.OnnxModule("onnx_retinanet", model, load_path)
+    tt_model = forge.OnnxModule("onnx_retinanet", model)
 
     # Image preprocessing
     img_tensor = img_preprocess()
@@ -120,7 +120,7 @@ def test_retinanet_onnx(variant, test_device):
     load_path = f"third_party/confidential_customer_models/generated/files/{variant}.onnx"
     model_name = f"onnx_{variant}"
     model = onnx.load(load_path)
-    tt_model = forge.OnnxModule(model_name, model, load_path)
+    tt_model = forge.OnnxModule(model_name, model)
 
     # Prepare input
     input_batch = img_preprocessing()

--- a/forge/test/models/onnx/vision/segformer/test_segformer_imgcls.py
+++ b/forge/test/models/onnx/vision/segformer/test_segformer_imgcls.py
@@ -69,7 +69,7 @@ def test_segformer_image_classification_onnx(test_device, variant):
     model = onnx.load(onnx_model_path)
     onnx.checker.check_model(model)
 
-    tt_model = forge.OnnxModule(str(variant).split("/")[-1].replace("-", "_"), model, onnx_model_path)
+    tt_model = forge.OnnxModule(str(variant).split("/")[-1].replace("-", "_"), model)
 
     # Run inference on Tenstorrent device
     verify_module(

--- a/forge/test/models/onnx/vision/segformer/test_segformer_semseg.py
+++ b/forge/test/models/onnx/vision/segformer/test_segformer_semseg.py
@@ -94,7 +94,7 @@ def test_segformer_semantic_segmentation_onnx(test_device, variant):
     model = onnx.load(onnx_model_path)
     onnx.checker.check_model(model)
 
-    tt_model = forge.OnnxModule(str(variant).split("/")[-1].replace("-", "_"), model, onnx_model_path)
+    tt_model = forge.OnnxModule(str(variant).split("/")[-1].replace("-", "_"), model)
 
     # Run inference on Tenstorrent device
     verify_module(

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v3.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v3.py
@@ -52,7 +52,7 @@ def test_yolov3_tiny_onnx(test_device):
     # STEP 1: Create Forge module from PyTorch model
     load_path = "third_party/confidential_customer_models/model_2/onnx/saved/yolo_v3/tiny-yolov3-11.onnx"
     model = onnx.load(load_path)
-    tt_model = forge.OnnxModule("onnx_yolov3_tiny", model, load_path)
+    tt_model = forge.OnnxModule("onnx_yolov3_tiny", model)
 
     # Image preprocessing
     pil_img = Image.open("third_party/confidential_customer_models/model_2/onnx/saved/yolo_v3/carvana.jpg")
@@ -82,7 +82,7 @@ def test_yolov3_onnx(test_device):
     # STEP 1: Create Forge module from PyTorch model
     load_path = "third_party/confidential_customer_models/model_2/onnx/saved/yolo_v3/yolov3-10.onnx"
     model = onnx.load(load_path)
-    tt_model = forge.OnnxModule("onnx_yolov3_tiny", model, load_path)
+    tt_model = forge.OnnxModule("onnx_yolov3_tiny", model)
 
     # Image preprocessing
     pil_img = Image.open("third_party/confidential_customer_models/model_2/onnx/saved/yolo_v3/carvana.jpg")

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v5.py
@@ -84,7 +84,7 @@ def test_yolo_v5_320x320_onnx(test_device, variant):
 
     # Run inference on Tenstorrent device
     verify_module(
-        forge.OnnxModule(model_name, onnx_model, onnx_model_path),
+        forge.OnnxModule(model_name, onnx_model),
         input_shapes=([pixel_values.shape]),
         inputs=([pixel_values]),
         verify_cfg=DepricatedVerifyConfig(
@@ -126,7 +126,7 @@ def test_yolo_v5_480x480_onnx(test_device, variant):
 
     # Run inference on Tenstorrent device
     verify_module(
-        forge.OnnxModule(model_name, onnx_model, onnx_model_path),
+        forge.OnnxModule(model_name, onnx_model),
         input_shapes=([pixel_values.shape]),
         inputs=([pixel_values]),
         verify_cfg=DepricatedVerifyConfig(
@@ -167,7 +167,7 @@ def test_yolo_v5_640x640_onnx(test_device, variant):
 
     # Run inference on Tenstorrent device
     verify_module(
-        forge.OnnxModule(model_name, onnx_model, onnx_model_path),
+        forge.OnnxModule(model_name, onnx_model),
         input_shapes=([pixel_values.shape]),
         inputs=([pixel_values]),
         verify_cfg=DepricatedVerifyConfig(

--- a/forge/test/models/onnx/vision/yolo/test_yolo_x.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_x.py
@@ -67,7 +67,7 @@ def test_yolox_onnx(variant, test_device):
     onnx_model = onnx.load(onnx_model_path)
     onnx.checker.check_model(onnx_model)
     model_name = f"onnx_{variant}"
-    tt_model = forge.OnnxModule(model_name, onnx_model, onnx_model_path)
+    tt_model = forge.OnnxModule(model_name, onnx_model)
 
     # PCC
     if test_device.arch == BackendDevice.Wormhole_B0:

--- a/pytest.ini
+++ b/pytest.ini
@@ -23,6 +23,7 @@ testpaths =
     forge/test/mlir/operators
     forge/test/mlir/test_ops_tf.py
     forge/test/mlir/test_ops_paddle.py
+    forge/test/mlir/test_ops_onnx.py
     forge/test/mlir/llama/tests/test_specific_ops_llama32.py
 
     # Features


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Currently, compiling the ONNX module is not supported yet.

### What's changed
This commit resolves an issue preventing the ONNX module from being
imported through Forge. And it also adds support for loading the ONNX module
directly as bytes, eliminating the need to import an ONNX file at
verification.

### Checklist
- [ ] New/Existing tests provide coverage for changes
