### PR TITLE
Add tests for High priority bert, phi3.5 & phi3.5 vision variant

### DIFF
--- a/forge/test/models/pytorch/multimodal/phi3/test_phi3_5_vision.py
+++ b/forge/test/models/pytorch/multimodal/phi3/test_phi3_5_vision.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from transformers import AutoModelForCausalLM, AutoProcessor
+
+import forge
+from forge.verify.verify import verify
+
+from test.models.pytorch.multimodal.phi3.utils.utils import load_input
+from test.models.utils import Framework, Source, Task, build_module_name
+from test.utils import download_model
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids, attention_mask, pixel_values, image_sizes):
+        return self.model(input_ids, attention_mask, None, None, None, pixel_values, image_sizes)
+
+
+variants = ["microsoft/Phi-3.5-vision-instruct"]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail(
+    reason="NotImplementedError: The following operators are not implemented: ['aten::resolve_neg', 'aten::resolve_conj']"
+)
+@pytest.mark.parametrize("variant", variants)
+def test_phi3_5_vision(record_forge_property, variant):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.PYTORCH,
+        model="phi3_5_vision",
+        variant=variant,
+        task=Task.MULTIMODAL_TEXT_GENERATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Record Forge Property
+    record_forge_property("group", "priority")
+    record_forge_property("tags.model_name", module_name)
+
+    # Load model and processor
+    model = download_model(
+        AutoModelForCausalLM.from_pretrained,
+        variant,
+        return_dict=False,
+        trust_remote_code=True,
+        use_cache=False,
+        _attn_implementation="eager",
+    )
+    model.eval()
+    framework_model = Wrapper(model)
+    processor = download_model(AutoProcessor.from_pretrained, variant, trust_remote_code=True, num_crops=4)
+
+    # prepare input
+    inputs = load_input(processor)
+
+    # Forge compile framework model
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
+
+    # Model Verification
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/models/pytorch/multimodal/phi3/utils/utils.py
+++ b/forge/test/models/pytorch/multimodal/phi3/utils/utils.py
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import requests
+from PIL import Image
+
+
+def load_input(processor):
+    url = "https://image.slidesharecdn.com/azureintroduction-191206101932/75/Introduction-to-Microsoft-Azure-Cloud-1-2048.jpg"
+    image = Image.open(requests.get(url, stream=True).raw)
+    placeholder = "<|image_1|>\n"
+    messages = [{"role": "user", "content": placeholder + "Summarize the slide."}]
+    prompt = processor.tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    inputs = processor(prompt, image, return_tensors="pt")
+    inputs = [inputs["input_ids"], inputs["attention_mask"], inputs["pixel_values"], inputs["image_sizes"]]
+    return inputs

--- a/forge/test/models/pytorch/text/bert/test_bert.py
+++ b/forge/test/models/pytorch/text/bert/test_bert.py
@@ -7,6 +7,7 @@ from transformers import (
     BertForQuestionAnswering,
     BertForSequenceClassification,
     BertForTokenClassification,
+    BertModel,
     BertTokenizer,
 )
 
@@ -14,6 +15,7 @@ import forge
 from forge.verify.config import VerifyConfig
 from forge.verify.verify import verify
 
+from test.models.pytorch.text.bert.utils.utils import mean_pooling
 from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
@@ -239,3 +241,43 @@ def test_bert_token_classification_pytorch(record_forge_property, variant):
 
     # Model Verification
     verify(inputs, framework_model, compiled_model, verify_cfg=VerifyConfig(verify_values=False))
+
+
+@pytest.mark.nightly
+@pytest.mark.push
+@pytest.mark.parametrize("variant", ["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr"])
+def test_bert_sentence_embedding_generation_pytorch(record_forge_property, variant):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.PYTORCH,
+        model="bert",
+        variant=variant,
+        task=Task.SENTENCE_EMBEDDING_GENERATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Record Forge Property
+    record_forge_property("group", "priority")
+    record_forge_property("tags.model_name", module_name)
+
+    # Load model and tokenizer
+    tokenizer = download_model(BertTokenizer.from_pretrained, variant)
+    framework_model = download_model(BertModel.from_pretrained, variant, return_dict=False, use_cache=False)
+    framework_model.eval()
+
+    # prepare input
+    sentences = "Bu örnek bir cümle"
+    encoded_input = tokenizer(sentences, padding=True, truncation=True, return_tensors="pt")
+    inputs = [encoded_input["input_ids"], encoded_input["attention_mask"], encoded_input["token_type_ids"]]
+
+    # Forge compile framework model
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post processing
+    sentence_embeddings = mean_pooling(co_out, encoded_input["attention_mask"])
+
+    print("Sentence embeddings:", sentence_embeddings)

--- a/forge/test/models/pytorch/text/bert/utils/utils.py
+++ b/forge/test/models/pytorch/text/bert/utils/utils.py
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import torch
+
+
+# Mean Pooling - Take attention mask into account for correct averaging
+def mean_pooling(model_output, attention_mask):
+    token_embeddings = model_output[0]  # First element of model_output contains all token embeddings
+    input_mask_expanded = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+    return torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(input_mask_expanded.sum(1), min=1e-9)

--- a/forge/test/models/pytorch/text/phi3/test_phi3_5.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3_5.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+import forge
+from forge.verify.verify import verify
+
+from test.models.utils import Framework, Source, Task, build_module_name
+from test.utils import download_model
+
+variants = ["microsoft/Phi-3.5-mini-instruct"]
+
+
+@pytest.mark.nightly
+@pytest.mark.skip(reason="Test skipped due to segmentation fault issue")
+@pytest.mark.parametrize("variant", variants)
+def test_phi3_5_causal_lm(record_forge_property, variant):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.PYTORCH, model="phi3_5", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
+    )
+
+    # Record Forge Property
+    record_forge_property("group", "priority")
+    record_forge_property("tags.model_name", module_name)
+
+    # Load model and tokenizer
+    tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
+    framework_model = download_model(
+        AutoModelForCausalLM.from_pretrained, variant, return_dict=False, trust_remote_code=True, use_cache=False
+    )
+    framework_model.eval()
+
+    # prepare input
+    input_prompt = "Africa is an emerging economy because"
+    inputs = tokenizer(
+        input_prompt,
+        return_tensors="pt",
+        max_length=256,
+        pad_to_max_length=True,
+        truncation=True,
+    )
+    inputs = [inputs["input_ids"], inputs["attention_mask"]]
+
+    # Forge compile framework model
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
+
+    # Model Verification
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/models/utils.py
+++ b/forge/test/models/utils.py
@@ -39,6 +39,8 @@ class Task(StrEnum):
     DEPTH_ESTIMATION = "depth_estimation"
     SCENE_TEXT_RECOGNITION = "scene_text_recognition"
     TEXT_TO_SPEECH = "text_to_speech"
+    SENTENCE_EMBEDDING_GENERATION = "sentence_embed_gen"
+    MULTIMODAL_TEXT_GENERATION = "multimodal_text_gen"
 
 
 class Source(StrEnum):


### PR DESCRIPTION
## Summary 

- This PR adds test for high priority bert, phi3.5 & phi3.5 vision variants
- compilation status of each variant can be found in attached logs 

## logs 

- [bert_sentence_embedding_generation.log](https://github.com/user-attachments/files/19144082/mar8_bert_sen_embed_gen_pr.log)
- [phi3_5_mini.log](https://github.com/user-attachments/files/19144083/mar8_phi3_5_mini_forge_pr.log)
- [phi3_5_vision.log](https://github.com/user-attachments/files/19144085/mar8_phi3_5_vision_pr.log)

## Note

- `forge/test/models/pytorch/text/bert/test_bert.py::test_bert_sentence_embedding_generation_pytorch[emrecan/bert-base-turkish-cased-mean-nli-stsb-tr]` passing e2e. so push marker & post processing steps has been added
