### PR TITLE
Docs build failng for latest

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Docs - Build & Deploy
 
 on:
   push:
-    branches: ["main"]
+    # branches: ["main"]
   workflow_dispatch:
 
 # Sets permissions for:
@@ -16,8 +16,12 @@ permissions:
 
 jobs:
 
-  build:
+  docker-build:
+    uses: ./.github/workflows/build-image.yml
+    secrets: inherit
 
+  build:
+    needs: docker-build
     strategy:
       fail-fast: false
       matrix:
@@ -28,7 +32,7 @@ jobs:
     runs-on: ${{ matrix.build.runs-on }}
 
     container:
-      image: ghcr.io/${{ github.repository }}/tt-forge-fe-ci-ubuntu-22-04:latest
+      image: ${{ needs.docker-build.outputs.docker-image }}
 
     env:
       MDBOOK_VERSION: 0.4.36


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-forge-fe/issues/1413)

### Problem description
Docs build is failing because it uses "latest" tag for CI image instead of specific image.

### What's changed
Us specific tag

### Checklist
- [ ] New/Existing tests provide coverage for changes
