### PR TITLE
Notify failed nightly builds on slack

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -60,7 +60,7 @@ jobs:
           payload: |
             {
               "text": "Nightly build has failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "channel": "C07R5GYEW8J"
+              "channel": "C08HFLL9L56"
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -35,3 +35,29 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
+
+  fail-notify:
+    if: always()
+    needs:
+      - docker-build
+      - build
+      - test_full_model
+      - perf-benchmark
+    runs-on: Ubuntu-latest
+    steps:
+      - name: Check if the needed jobs succeeded or failed
+        id: check
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}
+      - name: Send Fail Notification
+        if: ${{ steps.check.outputs.failure == 'true' }}
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "Nightly build has failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "channel": "C07R5GYEW8J"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -59,8 +59,8 @@ jobs:
         with:
           payload: |
             {
-              "text": "Nightly build has failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "text": "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>",
               "channel": "C08HFLL9L56"
             }
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NIGHTLY_FAIL }}

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -50,8 +50,11 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+      - name: Check if branch is main
+        id: branch-check
+        run: echo "IS_MAIN=$(if [ '${{ github.ref }}' == 'refs/heads/main' ]; then echo true; else echo false; fi)" >> $GITHUB_OUTPUT
       - name: Send Fail Notification
-        if: ${{ steps.check.outputs.failure == 'true' }}
+        if: ${{ steps.check.outputs.failure == 'true' && steps.branch-check.outputs.IS_MAIN == 'true' }}
         uses: slackapi/slack-github-action@v1.26.0
         with:
           payload: |

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>",
+              "text": "Bad bad nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>",
               "channel": "C08HFLL9L56"
             }
         env:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>",
+              "text": "Bad nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>",
               "channel": "C08HFLL9L56"
             }
         env:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -3,24 +3,9 @@ name: On push
 on:
   workflow_dispatch:
   push:
-#    branches: [ "main" ]
+    branches: [ "main" ]
 
 jobs:
-  fail-notify:
-    if: always()
-    runs-on: Ubuntu-latest
-    steps:
-      - name: Send Fail Notification
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "Bad bad nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>",
-              "channel": "C08HFLL9L56"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NIGHTLY_FAIL }}
-
   docker-build:
     uses: ./.github/workflows/build-image.yml
     secrets: inherit

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -11,15 +11,16 @@ jobs:
     runs-on: Ubuntu-latest
     steps:
       - name: Send Fail Notification
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "Test slac post for nightly build fail commit: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "channel": "C08HFLL9L56"
-            }
+        uses: rtCamp/action-slack-notify@v2
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CHANNEL_WEBHOOK_URL }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_CHANNEL_WEBHOOK_URL }}
+          SLACK_CHANNEL: "C08HFLL9L56"
+          SLACK_TITLE: "Nightly build has failed"
+          SLACK_USERNAME: "CI Bot"
+          SLACK_COLOR: "#FF0000"
+          SLACK_ICON: ":red_circle:"
+          SLACK_FOOTER: "Tenstorrent CI"
+          SLACK_MESSAGE: "TESTING IGNORE Nightly build has failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
   docker-build:
     uses: ./.github/workflows/build-image.yml

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "Bad nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>",
+              "text": "Bad bad nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>",
               "channel": "C08HFLL9L56"
             }
         env:

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -3,9 +3,24 @@ name: On push
 on:
   workflow_dispatch:
   push:
-    branches: [ "main" ]
+#    branches: [ "main" ]
 
 jobs:
+  fail-notify:
+    if: always()
+    runs-on: Ubuntu-latest
+    steps:
+      - name: Send Fail Notification
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "Test slac post for nightly build fail commit: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "channel": "C08HFLL9L56"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CHANNEL_WEBHOOK_URL }}
+
   docker-build:
     uses: ./.github/workflows/build-image.yml
     secrets: inherit

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -11,16 +11,15 @@ jobs:
     runs-on: Ubuntu-latest
     steps:
       - name: Send Fail Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: |
+            {
+              "text": "<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>",
+              "channel": "C08HFLL9L56"
+            }
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_CHANNEL_WEBHOOK_URL }}
-          SLACK_CHANNEL: "C08HFLL9L56"
-          SLACK_TITLE: "Nightly build has failed"
-          SLACK_USERNAME: "CI Bot"
-          SLACK_COLOR: "#FF0000"
-          SLACK_ICON: ":red_circle:"
-          SLACK_FOOTER: "Tenstorrent CI"
-          SLACK_MESSAGE: "TESTING IGNORE Nightly build has failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NIGHTLY_FAIL }}
 
   docker-build:
     uses: ./.github/workflows/build-image.yml


### PR DESCRIPTION
### Ticket
tt-forge-experience request

### Problem description
Notify failed nightly builds run on the main branch on slack

### What's changed
Added fail-check job to on-nightly workflow that is run last to check for failure, check branch, and finally report if it is failed main branch build
