### PR TITLE
removed xfail from vovnet model

### DIFF
--- a/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
@@ -26,7 +26,7 @@ def generate_model_vovnet_imgcls_osmr_pytorch(variant):
 
 
 varaints = [
-    pytest.param("vovnet27s", marks=[pytest.mark.xfail(reason="Invalid arguments to reshape")]),
+    "vovnet27s",
     "vovnet39",
     "vovnet57",
 ]


### PR DESCRIPTION
### What's changed
Removed xfail notation from `vovnet27s` as it passing now. (important for nightly runs)