### PR TITLE
Add job id to artifact name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -139,7 +139,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: success() || failure()
       with:
-        name: test-reports-${{ matrix.build.runs-on }}-${{ matrix.test_group_id }}
+        name: test-reports-${{ matrix.build.runs-on }}-${{ matrix.test_group_id }}-${{ steps.fetch-job-id.outputs.job_id }}
         path: ${{ steps.strings.outputs.test_report_path }}
 
     - name: Show Test Report


### PR DESCRIPTION
### Ticket
N/A

### Problem description
Github artifacts are not properly uploaded in workflow re-runs. Artifacts are uploaded with same name and it is not possible to retrieve them using GH api, it returns artifacts from first attempt.

### What's changed
Adding job_id to artifact name will make it unique across re-runs and will allow us to download them.

### Checklist
- [x ] New/Existing tests provide coverage for changes
