### PR TITLE
dtypes verification fix

### DIFF
--- a/forge/test/mlir/operators/eltwise_binary/test_eltwise_binary.py
+++ b/forge/test/mlir/operators/eltwise_binary/test_eltwise_binary.py
@@ -287,32 +287,15 @@ def test_equal(shape):
     verify(inputs, framework_model, compiled_model, VerifyConfig(verify_dtype=False))
 
 
-@pytest.mark.push
-def test_add():
-    class Add(nn.Module):
-        def __init__(self):
-            super().__init__()
-
-        def forward(self, a, b):
-            return a + b
-
-    inputs = [torch.rand(2, 32, 32), torch.rand(2, 32, 32)]
-
-    framework_model = Add()
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
-
-    verify(inputs, framework_model, compiled_model)
-
-
 @pytest.mark.parametrize(
     "shape_dtype",
     [
+        ((2, 32, 32), torch.float32),
         ((1, 128), torch.int64),
     ],
 )
 @pytest.mark.push
-def test_add_ints(shape_dtype):
-
+def test_add(shape_dtype):
     shape, dtype = shape_dtype
 
     class Add(nn.Module):
@@ -322,8 +305,10 @@ def test_add_ints(shape_dtype):
         def forward(self, a, b):
             return a + b
 
-    a = torch.randint(high=10, size=shape, dtype=dtype)
-    b = torch.randint(high=10, size=shape, dtype=dtype)
+    # Generate random tensors of the appropriate shape and dtype
+    a = torch.rand(size=shape).to(dtype)
+    b = torch.rand(size=shape).to(dtype)
+
     inputs = [a, b]
 
     framework_model = Add()

--- a/forge/test/mlir/operators/eltwise_binary/test_eltwise_binary.py
+++ b/forge/test/mlir/operators/eltwise_binary/test_eltwise_binary.py
@@ -304,6 +304,34 @@ def test_add():
     verify(inputs, framework_model, compiled_model)
 
 
+@pytest.mark.parametrize(
+    "shape_dtype",
+    [
+        ((1, 128), torch.int64),
+    ],
+)
+@pytest.mark.push
+def test_add_ints(shape_dtype):
+
+    shape, dtype = shape_dtype
+
+    class Add(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, a, b):
+            return a + b
+
+    a = torch.randint(high=10, size=shape, dtype=dtype)
+    b = torch.randint(high=10, size=shape, dtype=dtype)
+    inputs = [a, b]
+
+    framework_model = Add()
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    verify(inputs, framework_model, compiled_model)
+
+
 @pytest.mark.parametrize("dims", [(1, 32, 64), (6, 33), (4, 16, 17)])
 @pytest.mark.push
 def test_greater_equal(dims):


### PR DESCRIPTION
### Problem description
When comparing outputs between PyTorch models and their Forge-compiled counterparts, dtype mismatches were causing false verification failures. This occurred because Forge tensors support only a subset of PyTorch's data types (e.g., mapping torch.int64 to torch.int32), but our verification logic was performing direct dtype equality checks without accounting for these conversions.

### What's changed
Implemented a `verify_dtypes` function that properly handles the dtype conversion between PyTorch and Forge formats. The function:
1. Converts the PyTorch dtype to its Forge representation
2. Converts the Forge representation back to PyTorch
3. Compares this "round-trip" converted dtype with the compiled model's dtype

This allows verification to pass correctly even when dtypes differ due to Forge's internal mappings, ensuring we only fail on genuine dtype incompatibilities rather than expected conversions.