### PR TITLE
Add ResNet test for ONNX

### DIFF
--- a/forge/forge/module.py
+++ b/forge/forge/module.py
@@ -26,6 +26,7 @@ from .tensor import (
 )
 from .parameter import Parameter
 import onnx
+from onnx import numpy_helper
 import jax.numpy as jnp
 import numpy as np
 
@@ -440,13 +441,7 @@ class OnnxModule(Module):
     def get_parameters(self) -> List[Parameter]:
         params = []
         for param in self.module.graph.initializer:
-            d_type = onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[param.data_type]
-            if param.raw_data:
-                param_data = np.frombuffer(param.raw_data, dtype=d_type).reshape(param.dims)
-            elif param.float_data:
-                param_data = param.float_data
-            else:
-                raise ValueError(f"Parameter: {param.name} don't have raw_data or float_data")
+            param_data = numpy_helper.to_array(param)
             forge_param = Parameter(torch.tensor(param_data), requires_grad=False, name=param.name)
             params.append(forge_param)
         return params

--- a/forge/forge/module.py
+++ b/forge/forge/module.py
@@ -441,7 +441,12 @@ class OnnxModule(Module):
         params = []
         for param in self.module.graph.initializer:
             d_type = onnx.mapping.TENSOR_TYPE_TO_NP_TYPE[param.data_type]
-            param_data = np.frombuffer(param.raw_data, dtype=d_type).reshape(param.dims)
+            if param.raw_data:
+                param_data = np.frombuffer(param.raw_data, dtype=d_type).reshape(param.dims)
+            elif param.float_data:
+                param_data = param.float_data
+            else:
+                raise ValueError(f"Parameter: {param.name} don't have raw_data or float_data")
             forge_param = Parameter(torch.tensor(param_data), requires_grad=False, name=param.name)
             params.append(forge_param)
         return params

--- a/forge/forge/tvm_calls/forge_compile.py
+++ b/forge/forge/tvm_calls/forge_compile.py
@@ -95,7 +95,7 @@ def load_tvm_graph(inputs, module, compiler_cfg, graph_name, framework, path=Non
         Compiler configurations
 
     path: str
-        Path to onnx file on disk. This is used to verify TVM results vs. framework results.
+        Path to TFLite file on disk. This is used to verify TVM results vs. framework results.
 
     Returns
     -------
@@ -144,7 +144,7 @@ def compile_tvm_graph(
         Compiler configurations
 
     path: str
-        Path to onnx file on disk. This is used to verify TVM results vs. framework results.
+        Path to TFLite file on disk. This is used to verify TVM results vs. framework results.
 
     Returns
     -------
@@ -197,7 +197,7 @@ def compile_tvm_graph(
         assert all([isinstance(x, torch.Tensor) for x in inputs])
         onnx_inputs = [x.detach().numpy() for x in inputs]
         json_graphs, _ = compile_onnx_for_forge(
-            module, path, *onnx_inputs, graph_name=graph_name, compiler_cfg=compiler_cfg, verify_cfg=verify_cfg
+            module, *onnx_inputs, graph_name=graph_name, compiler_cfg=compiler_cfg, verify_cfg=verify_cfg
         )
     elif framework == "jax":
         tf_inputs = to_tf_tensors(inputs, force_float32=True)
@@ -720,7 +720,7 @@ def duplicate_dequantize_nodes_in_onnx_graph(onnx_module):
         graph.node.remove(node)
 
 
-def compile_onnx_for_forge(onnx_mod, path, *inputs, graph_name, compiler_cfg, verify_cfg=None):
+def compile_onnx_for_forge(onnx_mod, *inputs, graph_name, compiler_cfg, verify_cfg=None):
     import onnxruntime as ort
 
     # Set default num threads to 2, hangs on some hosts otherwise https://github.com/microsoft/onnxruntime/issues/10166
@@ -749,7 +749,6 @@ def compile_onnx_for_forge(onnx_mod, path, *inputs, graph_name, compiler_cfg, ve
         model=onnx_mod,
         inputs=inputs,
         verify_tvm_compile=verify_cfg.verify_tvm_compile,
-        path=path,
         input_dict=input_dict,
     )
 
@@ -803,7 +802,6 @@ def compile_tflite_for_forge(module, path, *inputs, graph_name, compiler_cfg, ve
         model=module,
         inputs=inputs,
         verify_tvm_compile=verify_cfg.verify_tvm_compile,
-        path=path,
     )
 
     # Get TFLite model from buffer

--- a/forge/forge/tvm_calls/forge_utils.py
+++ b/forge/forge/tvm_calls/forge_utils.py
@@ -27,7 +27,6 @@ def extract_framework_model_outputs(
     model,
     inputs,
     verify_tvm_compile: bool = False,
-    path=None,
     input_dict={},
 ):
     framework_outputs = []

--- a/forge/test/models/onnx/vision/resnet/test_resnet.py
+++ b/forge/test/models/onnx/vision/resnet/test_resnet.py
@@ -43,9 +43,9 @@ def test_resnet_onnx(variant, tmp_path, record_forge_property, opset_version):
 
     # Export model to ONNX
     torch_model = ResNetForImageClassification.from_pretrained(variant)
-    dummy_input = torch.randn(1, 3, 224, 224)
+    input_sample = torch.randn(1, 3, 224, 224)
     onnx_path = f"{tmp_path}/resnet50.onnx"
-    torch.onnx.export(torch_model, dummy_input, onnx_path, opset_version=opset_version)
+    torch.onnx.export(torch_model, input_sample, onnx_path, opset_version=opset_version)
 
     # Load tiny dataset
     dataset = load_dataset("zh-plus/tiny-imagenet")
@@ -57,7 +57,7 @@ def test_resnet_onnx(variant, tmp_path, record_forge_property, opset_version):
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Compile model
-    input_sample = [dummy_input]
+    input_sample = [input_sample]
     compiled_model = forge.compile(onnx_model, input_sample)
 
     # Verify data on sample input

--- a/forge/test/models/onnx/vision/resnet/test_resnet.py
+++ b/forge/test/models/onnx/vision/resnet/test_resnet.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import random
+import onnx
+import torch
+from datasets import load_dataset
+from transformers import ResNetForImageClassification
+
+import forge
+from forge.verify.verify import verify
+from forge.verify.config import VerifyConfig
+from forge.verify.value_checkers import AutomaticValueChecker
+
+from test.models.utils import Framework, Source, Task, build_module_name
+
+
+variants = [
+    "microsoft/resnet-50",
+]
+
+# Opset 7 is the minimum version in Torch, and 17 is the maximum version in Torchscript.
+opset_versions = [7, 17]
+
+
+@pytest.mark.push
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("opset_version", opset_versions, ids=opset_versions)
+def test_resnet_onnx(variant, tmp_path, record_forge_property, opset_version):
+    random.seed(0)
+
+    # Record model details
+    module_name = build_module_name(
+        framework=Framework.ONNX,
+        model="resnet",
+        variant="50",
+        source=Source.HUGGINGFACE,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+    record_forge_property("tags.model_name", module_name)
+
+    # Export model to ONNX
+    torch_model = ResNetForImageClassification.from_pretrained(variant)
+    dummy_input = torch.randn(1, 3, 224, 224)
+    onnx_path = f"{tmp_path}/resnet50.onnx"
+    torch.onnx.export(torch_model, dummy_input, onnx_path, opset_version=opset_version)
+
+    # Load tiny dataset
+    dataset = load_dataset("zh-plus/tiny-imagenet")
+    images = random.sample(dataset["valid"]["image"], 10)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    input_sample = [dummy_input]
+    compiled_model = forge.compile(onnx_model, input_sample)
+
+    # Verify data on sample input
+    verify(input_sample, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95)))

--- a/forge/test/models/onnx/vision/resnet/test_resnet.py
+++ b/forge/test/models/onnx/vision/resnet/test_resnet.py
@@ -20,7 +20,8 @@ variants = [
     "microsoft/resnet-50",
 ]
 
-# Opset 7 is the minimum version in Torch, and 17 is the maximum version in Torchscript.
+# Opset 7 is the minimum version in Torch.
+# Opset 17 is the maximum version in Torchscript.
 opset_versions = [7, 17]
 
 
@@ -46,10 +47,6 @@ def test_resnet_onnx(variant, tmp_path, record_forge_property, opset_version):
     input_sample = torch.randn(1, 3, 224, 224)
     onnx_path = f"{tmp_path}/resnet50.onnx"
     torch.onnx.export(torch_model, input_sample, onnx_path, opset_version=opset_version)
-
-    # Load tiny dataset
-    dataset = load_dataset("zh-plus/tiny-imagenet")
-    images = random.sample(dataset["valid"]["image"], 10)
 
     # Load framework model
     onnx_model = onnx.load(onnx_path)


### PR DESCRIPTION
Forge can compile ONNX models end-to-end, and this PR adds a test for ResNet50 with minor changes.

In this test, the ONNX file is generated from a PyTorch module using the `onnx.export` API and stored in a temporary path. However, this export process takes approximately 7–8 seconds, which could become a bottleneck if we increase the number of test cases, potentially impacting CI runtime.  

An alternative approach is to store a pre-generated ONNX file in this repository using Git LFS or retrieve it from an external source. Some inactive tests reference an ONNX file from `confidential_customer_models`, but this third-party repository appears to be internal to TT and is not publicly accessible.  

If you have any suggestions regarding handling the ONNX file efficiently, please share your thoughts in the comments.