### PR TITLE
Remove xfail markers for the passed models ops tests

### DIFF
--- a/forge/test/models_ops/test_multiply.py
+++ b/forge/test/models_ops/test_multiply.py
@@ -2878,51 +2878,37 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 1, 1, 7), torch.float32)],
         {"model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 256), torch.int64), ((1, 256), torch.int64)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Multiply1,
+        [((1, 256), torch.int64), ((1, 256), torch.int64)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_opt_facebook_opt_350m_clm_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
         [((1, 256, 2048), torch.float32)],
         {"model_name": ["pt_opt_facebook_opt_1_3b_clm_hf", "pt_xglm_facebook_xglm_1_7b_clm_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 32), torch.int64), ((1, 32), torch.int64)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Multiply1,
+        [((1, 32), torch.int64), ((1, 32), torch.int64)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,

--- a/forge/test/models_ops/test_repeatinterleave.py
+++ b/forge/test/models_ops/test_repeatinterleave.py
@@ -121,77 +121,49 @@ def ids_func(param):
 
 
 forge_modules_and_shapes_dtypes_list = [
-    pytest.param(
-        (
-            Repeatinterleave0,
-            [((2, 1, 1, 13), torch.int64)],
-            {
-                "model_name": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"repeats": "1", "dim": "1"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Repeatinterleave0,
+        [((2, 1, 1, 13), torch.int64)],
+        {
+            "model_name": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"repeats": "1", "dim": "1"},
+        },
     ),
-    pytest.param(
-        (
-            Repeatinterleave1,
-            [((2, 1, 1, 13), torch.int64)],
-            {
-                "model_name": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"repeats": "1", "dim": "2"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Repeatinterleave1,
+        [((2, 1, 1, 13), torch.int64)],
+        {
+            "model_name": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"repeats": "1", "dim": "2"},
+        },
     ),
-    pytest.param(
-        (
-            Repeatinterleave0,
-            [((2, 1, 1, 7), torch.int64)],
-            {
-                "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
-                "pcc": 0.99,
-                "op_params": {"repeats": "1", "dim": "1"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Repeatinterleave0,
+        [((2, 1, 1, 7), torch.int64)],
+        {
+            "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
+            "pcc": 0.99,
+            "op_params": {"repeats": "1", "dim": "1"},
+        },
     ),
-    pytest.param(
-        (
-            Repeatinterleave2,
-            [((2, 1, 1, 7), torch.int64)],
-            {
-                "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
-                "pcc": 0.99,
-                "op_params": {"repeats": "7", "dim": "2"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Repeatinterleave2,
+        [((2, 1, 1, 7), torch.int64)],
+        {
+            "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
+            "pcc": 0.99,
+            "op_params": {"repeats": "7", "dim": "2"},
+        },
     ),
     (
         Repeatinterleave3,
@@ -251,91 +223,70 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"repeats": "1", "dim": "2"},
         },
     ),
-    pytest.param(
-        (
-            Repeatinterleave3,
-            [((1, 128), torch.int64)],
-            {
-                "model_name": [
-                    "pt_albert_xxlarge_v1_token_cls_hf",
-                    "pt_albert_base_v2_token_cls_hf",
-                    "pt_albert_xxlarge_v2_token_cls_hf",
-                    "pt_albert_large_v1_token_cls_hf",
-                    "pt_albert_large_v2_token_cls_hf",
-                    "pt_albert_base_v1_token_cls_hf",
-                    "pt_albert_base_v1_mlm_hf",
-                    "pt_albert_xlarge_v2_token_cls_hf",
-                    "pt_albert_xxlarge_v2_mlm_hf",
-                    "pt_albert_large_v2_mlm_hf",
-                    "pt_albert_base_v2_mlm_hf",
-                    "pt_albert_xlarge_v1_token_cls_hf",
-                    "pt_albert_xlarge_v1_mlm_hf",
-                    "pt_albert_large_v1_mlm_hf",
-                    "pt_albert_xxlarge_v1_mlm_hf",
-                    "pt_albert_xlarge_v2_mlm_hf",
-                    "pt_bert_textattack_bert_base_uncased_sst_2_seq_cls_hf",
-                    "pt_bert_dbmdz_bert_large_cased_finetuned_conll03_english_token_cls_hf",
-                    "pt_bert_bert_base_uncased_mlm_hf",
-                    "pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader",
-                    "pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader",
-                    "pt_roberta_xlm_roberta_base_mlm_hf",
-                    "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"repeats": "1", "dim": "0"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Repeatinterleave3,
+        [((1, 128), torch.int64)],
+        {
+            "model_name": [
+                "pt_albert_xxlarge_v1_token_cls_hf",
+                "pt_albert_base_v2_token_cls_hf",
+                "pt_albert_xxlarge_v2_token_cls_hf",
+                "pt_albert_large_v1_token_cls_hf",
+                "pt_albert_large_v2_token_cls_hf",
+                "pt_albert_base_v1_token_cls_hf",
+                "pt_albert_base_v1_mlm_hf",
+                "pt_albert_xlarge_v2_token_cls_hf",
+                "pt_albert_xxlarge_v2_mlm_hf",
+                "pt_albert_large_v2_mlm_hf",
+                "pt_albert_base_v2_mlm_hf",
+                "pt_albert_xlarge_v1_token_cls_hf",
+                "pt_albert_xlarge_v1_mlm_hf",
+                "pt_albert_large_v1_mlm_hf",
+                "pt_albert_xxlarge_v1_mlm_hf",
+                "pt_albert_xlarge_v2_mlm_hf",
+                "pt_bert_textattack_bert_base_uncased_sst_2_seq_cls_hf",
+                "pt_bert_dbmdz_bert_large_cased_finetuned_conll03_english_token_cls_hf",
+                "pt_bert_bert_base_uncased_mlm_hf",
+                "pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader",
+                "pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader",
+                "pt_roberta_xlm_roberta_base_mlm_hf",
+                "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"repeats": "1", "dim": "0"},
+        },
     ),
-    pytest.param(
-        (
-            Repeatinterleave3,
-            [((1, 1, 1, 256), torch.int64)],
-            {
-                "model_name": [
-                    "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_xglm_facebook_xglm_1_7b_clm_hf",
-                    "pt_xglm_facebook_xglm_564m_clm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"repeats": "1", "dim": "0"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Repeatinterleave3,
+        [((1, 1, 1, 256), torch.int64)],
+        {
+            "model_name": [
+                "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_xglm_facebook_xglm_1_7b_clm_hf",
+                "pt_xglm_facebook_xglm_564m_clm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"repeats": "1", "dim": "0"},
+        },
     ),
-    pytest.param(
-        (
-            Repeatinterleave0,
-            [((1, 1, 1, 256), torch.int64)],
-            {
-                "model_name": [
-                    "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_xglm_facebook_xglm_1_7b_clm_hf",
-                    "pt_xglm_facebook_xglm_564m_clm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"repeats": "1", "dim": "1"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Repeatinterleave0,
+        [((1, 1, 1, 256), torch.int64)],
+        {
+            "model_name": [
+                "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_xglm_facebook_xglm_1_7b_clm_hf",
+                "pt_xglm_facebook_xglm_564m_clm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"repeats": "1", "dim": "1"},
+        },
     ),
     pytest.param(
         (
@@ -360,21 +311,14 @@ forge_modules_and_shapes_dtypes_list = [
             )
         ],
     ),
-    pytest.param(
-        (
-            Repeatinterleave3,
-            [((1, 384), torch.int64)],
-            {
-                "model_name": ["pt_bert_bert_large_cased_whole_word_masking_finetuned_squad_qa_hf"],
-                "pcc": 0.99,
-                "op_params": {"repeats": "1", "dim": "0"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Repeatinterleave3,
+        [((1, 384), torch.int64)],
+        {
+            "model_name": ["pt_bert_bert_large_cased_whole_word_masking_finetuned_squad_qa_hf"],
+            "pcc": 0.99,
+            "op_params": {"repeats": "1", "dim": "0"},
+        },
     ),
     (
         Repeatinterleave3,
@@ -630,74 +574,53 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"repeats": "4", "dim": "2"},
         },
     ),
-    pytest.param(
-        (
-            Repeatinterleave3,
-            [((1, 1, 1, 32), torch.int64)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"repeats": "1", "dim": "0"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Repeatinterleave3,
+        [((1, 1, 1, 32), torch.int64)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"repeats": "1", "dim": "0"},
+        },
     ),
-    pytest.param(
-        (
-            Repeatinterleave0,
-            [((1, 1, 1, 32), torch.int64)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"repeats": "1", "dim": "1"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Repeatinterleave0,
+        [((1, 1, 1, 32), torch.int64)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"repeats": "1", "dim": "1"},
+        },
     ),
-    pytest.param(
-        (
-            Repeatinterleave9,
-            [((1, 1, 1, 32), torch.int64)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"repeats": "32", "dim": "2"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Repeatinterleave9,
+        [((1, 1, 1, 32), torch.int64)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"repeats": "32", "dim": "2"},
+        },
     ),
     (
         Repeatinterleave3,

--- a/forge/test/models_ops/test_reshape.py
+++ b/forge/test/models_ops/test_reshape.py
@@ -9537,25 +9537,18 @@ forge_modules_and_shapes_dtypes_list = [
             )
         ],
     ),
-    pytest.param(
-        (
-            Reshape1,
-            [((2, 1, 1), torch.int64)],
-            {
-                "model_name": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"shape": "(2, 1)"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Reshape1,
+        [((2, 1, 1), torch.int64)],
+        {
+            "model_name": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"shape": "(2, 1)"},
+        },
     ),
     (
         Reshape2,
@@ -9638,25 +9631,18 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"shape": "(2, 2048)"},
         },
     ),
-    pytest.param(
-        (
-            Reshape9,
-            [((2, 13), torch.int64)],
-            {
-                "model_name": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"shape": "(2, 13)"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Reshape9,
+        [((2, 13), torch.int64)],
+        {
+            "model_name": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"shape": "(2, 13)"},
+        },
     ),
     (
         Reshape10,
@@ -11752,21 +11738,14 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"shape": "(20, 2, 1500)"},
         },
     ),
-    pytest.param(
-        (
-            Reshape188,
-            [((2, 7), torch.int64)],
-            {
-                "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
-                "pcc": 0.99,
-                "op_params": {"shape": "(2, 7)"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Reshape188,
+        [((2, 7), torch.int64)],
+        {
+            "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
+            "pcc": 0.99,
+            "op_params": {"shape": "(2, 7)"},
+        },
     ),
     (
         Reshape189,
@@ -12927,29 +12906,22 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"shape": "(256, 1024)"},
         },
     ),
-    pytest.param(
-        (
-            Reshape267,
-            [((1, 256), torch.int64)],
-            {
-                "model_name": [
-                    "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
-                    "pt_gpt2_gpt2_text_gen_hf",
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_xglm_facebook_xglm_1_7b_clm_hf",
-                    "pt_xglm_facebook_xglm_564m_clm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"shape": "(1, 256)"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Reshape267,
+        [((1, 256), torch.int64)],
+        {
+            "model_name": [
+                "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
+                "pt_gpt2_gpt2_text_gen_hf",
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_xglm_facebook_xglm_1_7b_clm_hf",
+                "pt_xglm_facebook_xglm_564m_clm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"shape": "(1, 256)"},
+        },
     ),
     (
         Reshape268,
@@ -14885,21 +14857,14 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"shape": "(1, 128, 14336)"},
         },
     ),
-    pytest.param(
-        (
-            Reshape423,
-            [((1, 7), torch.int64)],
-            {
-                "model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"],
-                "pcc": 0.99,
-                "op_params": {"shape": "(1, 7)"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Reshape423,
+        [((1, 7), torch.int64)],
+        {
+            "model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"],
+            "pcc": 0.99,
+            "op_params": {"shape": "(1, 7)"},
+        },
     ),
     (
         Reshape424,
@@ -15009,28 +14974,21 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"shape": "(7, 3072)"},
         },
     ),
-    pytest.param(
-        (
-            Reshape434,
-            [((1, 32), torch.int64)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"shape": "(1, 32)"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Reshape434,
+        [((1, 32), torch.int64)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"shape": "(1, 32)"},
+        },
     ),
     (
         Reshape435,
@@ -17166,28 +17124,21 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"shape": "(1, 768, 128)"},
         },
     ),
-    pytest.param(
-        (
-            Reshape634,
-            [((1, 61), torch.int64)],
-            {
-                "model_name": [
-                    "pt_t5_google_flan_t5_large_text_gen_hf",
-                    "pt_t5_t5_large_text_gen_hf",
-                    "pt_t5_t5_small_text_gen_hf",
-                    "pt_t5_google_flan_t5_small_text_gen_hf",
-                    "pt_t5_t5_base_text_gen_hf",
-                    "pt_t5_google_flan_t5_base_text_gen_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"shape": "(1, 61)"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Reshape634,
+        [((1, 61), torch.int64)],
+        {
+            "model_name": [
+                "pt_t5_google_flan_t5_large_text_gen_hf",
+                "pt_t5_t5_large_text_gen_hf",
+                "pt_t5_t5_small_text_gen_hf",
+                "pt_t5_google_flan_t5_small_text_gen_hf",
+                "pt_t5_t5_base_text_gen_hf",
+                "pt_t5_google_flan_t5_base_text_gen_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"shape": "(1, 61)"},
+        },
     ),
     (
         Reshape635,

--- a/forge/test/models_ops/test_unsqueeze.py
+++ b/forge/test/models_ops/test_unsqueeze.py
@@ -102,25 +102,18 @@ forge_modules_and_shapes_dtypes_list = [
             )
         ],
     ),
-    pytest.param(
-        (
-            Unsqueeze2,
-            [((2, 1, 13), torch.int64)],
-            {
-                "model_name": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "2"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Unsqueeze2,
+        [((2, 1, 13), torch.int64)],
+        {
+            "model_name": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "2"},
+        },
     ),
     (
         Unsqueeze1,
@@ -289,21 +282,14 @@ forge_modules_and_shapes_dtypes_list = [
             )
         ],
     ),
-    pytest.param(
-        (
-            Unsqueeze2,
-            [((2, 1, 7), torch.int64)],
-            {
-                "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
-                "pcc": 0.99,
-                "op_params": {"dim": "2"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Unsqueeze2,
+        [((2, 1, 7), torch.int64)],
+        {
+            "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
+            "pcc": 0.99,
+            "op_params": {"dim": "2"},
+        },
     ),
     (
         Unsqueeze0,
@@ -419,131 +405,103 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 1, 201), torch.float32)],
         {"model_name": ["pt_vilt_dandelin_vilt_b32_finetuned_vqa_qa_hf"], "pcc": 0.99, "op_params": {"dim": "2"}},
     ),
-    pytest.param(
-        (
-            Unsqueeze1,
-            [((1, 128), torch.int64)],
-            {
-                "model_name": [
-                    "pt_albert_xxlarge_v1_token_cls_hf",
-                    "pt_albert_base_v2_token_cls_hf",
-                    "pt_albert_xxlarge_v2_token_cls_hf",
-                    "pt_albert_large_v1_token_cls_hf",
-                    "pt_albert_large_v2_token_cls_hf",
-                    "pt_albert_base_v1_token_cls_hf",
-                    "pt_albert_base_v1_mlm_hf",
-                    "pt_albert_xlarge_v2_token_cls_hf",
-                    "pt_albert_xxlarge_v2_mlm_hf",
-                    "pt_albert_large_v2_mlm_hf",
-                    "pt_albert_base_v2_mlm_hf",
-                    "pt_albert_xlarge_v1_token_cls_hf",
-                    "pt_albert_xlarge_v1_mlm_hf",
-                    "pt_albert_large_v1_mlm_hf",
-                    "pt_albert_xxlarge_v1_mlm_hf",
-                    "pt_albert_xlarge_v2_mlm_hf",
-                    "pt_dpr_facebook_dpr_ctx_encoder_single_nq_base_qa_hf_context_encoder",
-                    "pt_dpr_facebook_dpr_question_encoder_single_nq_base_qa_hf_question_encoder",
-                    "pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader",
-                    "pt_dpr_facebook_dpr_question_encoder_multiset_base_qa_hf_question_encoder",
-                    "pt_dpr_facebook_dpr_ctx_encoder_multiset_base_qa_hf_context_encoder",
-                    "pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader",
-                    "pt_roberta_xlm_roberta_base_mlm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "1"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Unsqueeze1,
+        [((1, 128), torch.int64)],
+        {
+            "model_name": [
+                "pt_albert_xxlarge_v1_token_cls_hf",
+                "pt_albert_base_v2_token_cls_hf",
+                "pt_albert_xxlarge_v2_token_cls_hf",
+                "pt_albert_large_v1_token_cls_hf",
+                "pt_albert_large_v2_token_cls_hf",
+                "pt_albert_base_v1_token_cls_hf",
+                "pt_albert_base_v1_mlm_hf",
+                "pt_albert_xlarge_v2_token_cls_hf",
+                "pt_albert_xxlarge_v2_mlm_hf",
+                "pt_albert_large_v2_mlm_hf",
+                "pt_albert_base_v2_mlm_hf",
+                "pt_albert_xlarge_v1_token_cls_hf",
+                "pt_albert_xlarge_v1_mlm_hf",
+                "pt_albert_large_v1_mlm_hf",
+                "pt_albert_xxlarge_v1_mlm_hf",
+                "pt_albert_xlarge_v2_mlm_hf",
+                "pt_dpr_facebook_dpr_ctx_encoder_single_nq_base_qa_hf_context_encoder",
+                "pt_dpr_facebook_dpr_question_encoder_single_nq_base_qa_hf_question_encoder",
+                "pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader",
+                "pt_dpr_facebook_dpr_question_encoder_multiset_base_qa_hf_question_encoder",
+                "pt_dpr_facebook_dpr_ctx_encoder_multiset_base_qa_hf_context_encoder",
+                "pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader",
+                "pt_roberta_xlm_roberta_base_mlm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "1"},
+        },
     ),
-    pytest.param(
-        (
-            Unsqueeze2,
-            [((1, 1, 128), torch.int64)],
-            {
-                "model_name": [
-                    "pt_albert_xxlarge_v1_token_cls_hf",
-                    "pt_albert_base_v2_token_cls_hf",
-                    "pt_albert_xxlarge_v2_token_cls_hf",
-                    "pt_albert_large_v1_token_cls_hf",
-                    "pt_albert_large_v2_token_cls_hf",
-                    "pt_albert_base_v1_token_cls_hf",
-                    "pt_albert_base_v1_mlm_hf",
-                    "pt_albert_xlarge_v2_token_cls_hf",
-                    "pt_albert_xxlarge_v2_mlm_hf",
-                    "pt_albert_large_v2_mlm_hf",
-                    "pt_albert_base_v2_mlm_hf",
-                    "pt_albert_xlarge_v1_token_cls_hf",
-                    "pt_albert_xlarge_v1_mlm_hf",
-                    "pt_albert_large_v1_mlm_hf",
-                    "pt_albert_xxlarge_v1_mlm_hf",
-                    "pt_albert_xlarge_v2_mlm_hf",
-                    "pt_dpr_facebook_dpr_ctx_encoder_single_nq_base_qa_hf_context_encoder",
-                    "pt_dpr_facebook_dpr_question_encoder_single_nq_base_qa_hf_question_encoder",
-                    "pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader",
-                    "pt_dpr_facebook_dpr_question_encoder_multiset_base_qa_hf_question_encoder",
-                    "pt_dpr_facebook_dpr_ctx_encoder_multiset_base_qa_hf_context_encoder",
-                    "pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader",
-                    "pt_roberta_xlm_roberta_base_mlm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "2"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Unsqueeze2,
+        [((1, 1, 128), torch.int64)],
+        {
+            "model_name": [
+                "pt_albert_xxlarge_v1_token_cls_hf",
+                "pt_albert_base_v2_token_cls_hf",
+                "pt_albert_xxlarge_v2_token_cls_hf",
+                "pt_albert_large_v1_token_cls_hf",
+                "pt_albert_large_v2_token_cls_hf",
+                "pt_albert_base_v1_token_cls_hf",
+                "pt_albert_base_v1_mlm_hf",
+                "pt_albert_xlarge_v2_token_cls_hf",
+                "pt_albert_xxlarge_v2_mlm_hf",
+                "pt_albert_large_v2_mlm_hf",
+                "pt_albert_base_v2_mlm_hf",
+                "pt_albert_xlarge_v1_token_cls_hf",
+                "pt_albert_xlarge_v1_mlm_hf",
+                "pt_albert_large_v1_mlm_hf",
+                "pt_albert_xxlarge_v1_mlm_hf",
+                "pt_albert_xlarge_v2_mlm_hf",
+                "pt_dpr_facebook_dpr_ctx_encoder_single_nq_base_qa_hf_context_encoder",
+                "pt_dpr_facebook_dpr_question_encoder_single_nq_base_qa_hf_question_encoder",
+                "pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader",
+                "pt_dpr_facebook_dpr_question_encoder_multiset_base_qa_hf_question_encoder",
+                "pt_dpr_facebook_dpr_ctx_encoder_multiset_base_qa_hf_context_encoder",
+                "pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader",
+                "pt_roberta_xlm_roberta_base_mlm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "2"},
+        },
     ),
-    pytest.param(
-        (
-            Unsqueeze1,
-            [((1, 256), torch.int64)],
-            {
-                "model_name": [
-                    "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_xglm_facebook_xglm_1_7b_clm_hf",
-                    "pt_xglm_facebook_xglm_564m_clm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "1"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Unsqueeze1,
+        [((1, 256), torch.int64)],
+        {
+            "model_name": [
+                "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_xglm_facebook_xglm_1_7b_clm_hf",
+                "pt_xglm_facebook_xglm_564m_clm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "1"},
+        },
     ),
-    pytest.param(
-        (
-            Unsqueeze2,
-            [((1, 1, 256), torch.int64)],
-            {
-                "model_name": [
-                    "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_xglm_facebook_xglm_1_7b_clm_hf",
-                    "pt_xglm_facebook_xglm_564m_clm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "2"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Unsqueeze2,
+        [((1, 1, 256), torch.int64)],
+        {
+            "model_name": [
+                "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_xglm_facebook_xglm_1_7b_clm_hf",
+                "pt_xglm_facebook_xglm_564m_clm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "2"},
+        },
     ),
     (
         Unsqueeze0,
@@ -859,75 +817,47 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 8, 128, 128), torch.float32)],
         {"model_name": ["pt_mistral_mistralai_mistral_7b_v0_1_clm_hf"], "pcc": 0.99, "op_params": {"dim": "2"}},
     ),
-    pytest.param(
-        (
-            Unsqueeze1,
-            [((1, 7), torch.int64)],
-            {"model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"], "pcc": 0.99, "op_params": {"dim": "1"}},
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Unsqueeze1,
+        [((1, 7), torch.int64)],
+        {"model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"], "pcc": 0.99, "op_params": {"dim": "1"}},
     ),
-    pytest.param(
-        (
-            Unsqueeze2,
-            [((1, 1, 7), torch.int64)],
-            {"model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"], "pcc": 0.99, "op_params": {"dim": "2"}},
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Unsqueeze2,
+        [((1, 1, 7), torch.int64)],
+        {"model_name": ["pt_nanogpt_financialsupport_nanogpt_text_gen_hf"], "pcc": 0.99, "op_params": {"dim": "2"}},
     ),
-    pytest.param(
-        (
-            Unsqueeze1,
-            [((1, 32), torch.int64)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "1"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Unsqueeze1,
+        [((1, 32), torch.int64)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "1"},
+        },
     ),
-    pytest.param(
-        (
-            Unsqueeze2,
-            [((1, 1, 32), torch.int64)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "2"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32"
-            )
-        ],
+    (
+        Unsqueeze2,
+        [((1, 1, 32), torch.int64)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "2"},
+        },
     ),
     (
         Unsqueeze1,


### PR DESCRIPTION
In the [latest models ops nightly run](https://github.com/tenstorrent/tt-forge-fe/actions/runs/13802331520), below issues was resolved in the multiply, repeat_interleave, unsqueeze and reshape ops test. so remove xfail markers for these test

`TypeError: Dtype mismatch: framework_model.dtype=torch.int64, compiled_model.dtype=torch.int32`

Generated Models Ops Report: 
[model_ops_tests_report.xlsx](https://github.com/user-attachments/files/19208240/model_ops_tests_report.xlsx)


