### PR TITLE
[ci] fix ccache key for debug/release builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build:
-          - runs-on: [runner]
+        build: [
+          { runs-on: runner, build-type: Release },
+        ]
 
     runs-on:
       - in-service
@@ -94,7 +95,7 @@ jobs:
       uses: hendrikmuhs/ccache-action@v1.2
       with:
         create-symlink: true
-        key: ${{ matrix.build.runs-on }}-runtime-${{ matrix.build.enable_runtime }}
+        key: forge-build-${{ matrix.build.build-type }}
 
     - name: Build (creates tvm and tt-forge-fe wheels)
       shell: bash
@@ -118,8 +119,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build:
-          - runs-on: [runner]
+        build: [
+          { runs-on: runner, build-type: Debug },
+        ]
 
     runs-on:
       - in-service
@@ -169,7 +171,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           create-symlink: true
-          key: ${{ matrix.build.runs-on }}-runtime-${{ matrix.build.enable_runtime }}
+          key: forge-build-${{ matrix.build.build-type }}
 
       - name: Debug Build
         shell: bash

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,12 +53,6 @@ jobs:
     - name: Git safe dir
       run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
 
-    - name: ccache
-      uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        create-symlink: true
-        key: ${{ matrix.build.runs-on }}-runtime-${{ matrix.build.enable_runtime }}-${{ env.SDK_VERSION }}
-
     - name: Install mdBook
       shell: bash
       run: |


### PR DESCRIPTION
Adding separate cache keys for debug/release builds, to avoid cache thrashing. Also, removing usage of `ccache` from docs build, since we are not building C++ in that case.