### PR TITLE
Improve MLIR node locations by referencing original module source path.

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -654,23 +654,13 @@ class MLIRGenerator
         TT_ASSERT(graph != nullptr);
         TT_ASSERT(node != nullptr);
 
-        // Extract source location from "layer" tag if available
-        std::string source_location;
         const graphlib::TaggedNode *tagged_node = node->as<graphlib::TaggedNode>();
 
-        if (tagged_node)
+        // Get source location from layer tag if available, otherwise use node name
+        std::string source_location = node->name();
+        if (tagged_node && tagged_node->has_tag("layer"))
         {
-            const tt::graphlib::TagHints &tags = tagged_node->get_tags();
-            tt::graphlib::TagHints::const_iterator it = tags.find("layer");
-
-            if (it != tags.end() && std::holds_alternative<std::string>(it->second))
-            {
-                source_location = std::get<std::string>(it->second) + "/" + node->name();
-            }
-            else
-            {
-                source_location = node->name();
-            }
+            source_location = std::get<std::string>(tagged_node->tag_value("layer")) + "/" + node->name();
         }
 
         // Create and return FileLineColLoc with the collected information

--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -681,7 +681,7 @@ class MLIRGenerator
     /// location.
     mlir::Location get_tt_forge_operation_location(tt::graphlib::Graph *graph, tt::graphlib::Node *node)
     {
-        return mlir::NameLoc::get(builder_.getStringAttr(node->name()), get_node_location(graph, node));
+        return mlir::NameLoc::get(builder_.getStringAttr(graph->name()), get_node_location(graph, node));
     }
 
     /// Convert an MLIR value to a string.


### PR DESCRIPTION
### Summary
The main benefit of this change is that it enhances how MLIR tools represent models parsed by frontends. E.g. Visualizer, EmitC, etc.

### Details
In sum, instead of storing the FFE node name (e.g. `add_5`), we're now storing the source location of the loaded module. E.g.
```py
transformers.models.resnet.modeling_resnet.ResNetForImageClassification::/transformers.models.resnet.modeling_resnet.ResNetModel::resnet/transformers.models.resnet.modeling_resnet.ResNetEncoder::encoder/transformers.models.resnet.modeling_resnet.ResNetStage::stages.3/transformers.models.resnet.modeling_resnet.ResNetBottleNeckLayer::2/torch.nn.modules.activation.ReLU::activation/add_5
```

Newly defined location contains full source path that includes (when applicable) module name (e.g. `ResNetForImageClassification`), underlying components (e.g. `ResNetEncoder`, `ResNetStage::stages.3`, etc.) and main operation (e.g. `ReLU`).

TTIR example of the ResNet:
- [ffe-resnet-loc.ttir.txt](https://github.com/user-attachments/files/19407097/ffe-resnet-loc.ttir.txt)

### Limitations
As a followup to this change, there is a bug that should be further explored and fixed. However, it's not a blocker to merge this change and provide initial results to Explorer and EmitC teams.
- https://github.com/tenstorrent/tt-forge-fe/issues/1443
