### PR TITLE
Add test for stable diffusion 3.5

### DIFF
--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import forge
+
+from test.models.pytorch.multimodal.stable_diffusion.utils.model import (
+    load_pipe_v35,
+    stable_diffusion_preprocessing_v35,
+)
+from test.models.utils import Framework, Source, Task, build_module_name
+
+
+class StableDiffusionWrapper(torch.nn.Module):
+    def __init__(self, model, joint_attention_kwargs=None, return_dict=False):
+        super().__init__()
+        self.model = model
+        self.joint_attention_kwargs = joint_attention_kwargs
+        self.return_dict = return_dict
+
+    def forward(self, latent_model_input, timestep, prompt_embeds, pooled_prompt_embeds):
+        noise_pred = self.model(
+            hidden_states=latent_model_input,
+            timestep=timestep,
+            encoder_hidden_states=prompt_embeds,
+            pooled_projections=pooled_prompt_embeds,
+            joint_attention_kwargs=self.joint_attention_kwargs,
+            return_dict=self.return_dict,
+        )[0]
+        return noise_pred
+
+
+@pytest.mark.nightly
+@pytest.mark.skip(
+    reason="Insufficient host DRAM to run this model (requires a bit more than 40 GB during compile time)"
+)
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "stable-diffusion-3.5-medium",
+            marks=pytest.mark.xfail(reason="Exception: warning unhandled case: <class 'NoneType'>"),
+        ),
+        pytest.param(
+            "stable-diffusion-3.5-large",
+            marks=pytest.mark.xfail(reason="Exception: warning unhandled case: <class 'NoneType'>"),
+        ),
+        pytest.param(
+            "stable-diffusion-3.5-large-turbo",
+            marks=pytest.mark.xfail(reason="Exception: warning unhandled case: <class 'NoneType'>"),
+        ),
+    ],
+)
+def test_stable_diffusion_v35(record_forge_property, variant):
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.PYTORCH,
+        model="stable_diffusion",
+        variant=variant,
+        task=Task.CONDITIONAL_GENERATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Record Forge Property
+    record_forge_property("group", "priority")
+    record_forge_property("tags.model_name", module_name)
+
+    # Load pipeline
+    pipe = load_pipe_v35(variant)
+
+    # Extract only the transformer, as the forward pass occurs here.
+    framework_model = pipe.transformer
+
+    # TODO: Implement post-processing using VAE decode after obtaining the transformer output.
+    framework_model = StableDiffusionWrapper(framework_model, joint_attention_kwargs=None, return_dict=False)
+
+    # Load inputs
+    prompt = "An astronaut riding a green horse"
+    latent_model_input, timestep, prompt_embeds, pooled_prompt_embeds = stable_diffusion_preprocessing_v35(pipe, prompt)
+    inputs = [latent_model_input, timestep, prompt_embeds, pooled_prompt_embeds]
+    # Forge compile framework model
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
+
+    # Model Verification
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/utils/model.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/utils/model.py
@@ -6,10 +6,26 @@
 from typing import List, Optional, Union
 
 import torch
+from diffusers import StableDiffusion3Pipeline
+from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import (
+    retrieve_timesteps,
+)
 
 import forge
 
 from test.models.utils import Framework, build_module_name
+
+
+def load_pipe_v35(variant):
+    pipe = StableDiffusion3Pipeline.from_pretrained(f"stabilityai/{variant}", torch_dtype=torch.float32)
+    pipe.to("cpu")
+    modules = [pipe.text_encoder, pipe.transformer, pipe.text_encoder_2, pipe.text_encoder_3, pipe.vae]
+    for module in modules:
+        module.eval()
+        for param in module.parameters():
+            if param.requires_grad:
+                param.requires_grad = False
+    return pipe
 
 
 def stable_diffusion_preprocessing(
@@ -101,6 +117,107 @@ def stable_diffusion_preprocessing(
         prompt_embeds,
         extra_step_kwargs,
     )
+
+
+def stable_diffusion_preprocessing_v35(
+    pipe,
+    prompt,
+    device="cpu",
+    negative_prompt=None,
+    guidance_scale=7.0,
+    num_inference_steps=1,
+    num_images_per_prompt=1,
+    clip_skip=None,
+    max_sequence_length=256,
+    joint_attention_kwargs=None,
+    skip_guidance_layers=None,
+    skip_layer_guidance_scale=2.8,
+    skip_layer_guidance_start=0.01,
+    skip_layer_guidance_stop=0.2,
+    do_classifier_free_guidance=True,
+    mu=None,
+):
+    height = pipe.default_sample_size * pipe.vae_scale_factor
+    width = pipe.default_sample_size * pipe.vae_scale_factor
+
+    pipe.check_inputs(
+        prompt,
+        None,  # prompt_2
+        None,  # prompt_3
+        height,
+        width,
+        negative_prompt=negative_prompt,
+        negative_prompt_2=None,
+        negative_prompt_3=None,
+        prompt_embeds=None,
+        negative_prompt_embeds=None,
+        pooled_prompt_embeds=None,
+        negative_pooled_prompt_embeds=None,
+        callback_on_step_end_tensor_inputs=["latents"],
+        max_sequence_length=max_sequence_length,
+    )
+
+    prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds = pipe.encode_prompt(
+        prompt=prompt,
+        prompt_2=None,
+        prompt_3=None,
+        negative_prompt=negative_prompt,
+        negative_prompt_2=None,
+        negative_prompt_3=None,
+        do_classifier_free_guidance=do_classifier_free_guidance,
+        prompt_embeds=None,
+        negative_prompt_embeds=None,
+        pooled_prompt_embeds=None,
+        negative_pooled_prompt_embeds=None,
+        device=device,
+        clip_skip=clip_skip,
+        num_images_per_prompt=num_images_per_prompt,
+        max_sequence_length=max_sequence_length,
+        lora_scale=None,
+    )
+
+    if do_classifier_free_guidance:
+        original_prompt_embeds = prompt_embeds
+        original_pooled_prompt_embeds = pooled_prompt_embeds
+
+        prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+        pooled_prompt_embeds = torch.cat([negative_pooled_prompt_embeds, pooled_prompt_embeds], dim=0)
+
+    num_channels_latents = pipe.transformer.config.in_channels
+    shape = (
+        num_images_per_prompt,
+        num_channels_latents,
+        int(height) // pipe.vae_scale_factor,
+        int(width) // pipe.vae_scale_factor,
+    )
+    latents = torch.randn(shape, device=device, dtype=prompt_embeds.dtype)
+
+    scheduler_kwargs = {}
+    if pipe.scheduler.config.get("use_dynamic_shifting", None) and mu is None:
+        image_seq_len = (height // pipe.transformer.config.patch_size) * (width // pipe.transformer.config.patch_size)
+        mu = calculate_shift(
+            image_seq_len,
+            pipe.scheduler.config.base_image_seq_len,
+            pipe.scheduler.config.max_image_seq_len,
+            pipe.scheduler.config.base_shift,
+            pipe.scheduler.config.max_shift,
+        )
+        scheduler_kwargs["mu"] = mu
+    elif mu is not None:
+        scheduler_kwargs["mu"] = mu
+
+    timesteps, num_inference_steps = retrieve_timesteps(
+        pipe.scheduler,
+        num_inference_steps=1,
+        device=device,
+        sigmas=None,
+        **scheduler_kwargs,
+    )
+
+    latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
+    timestep = timesteps[0].expand(latent_model_input.shape[0])
+
+    return latents, timestep, prompt_embeds, pooled_prompt_embeds
 
 
 def denoising_loop(


### PR DESCRIPTION
Stable Diffusion is loaded using a pipeline that includes multiple text encoders (CLIPTextModelWithProjection, T5EncoderModel), tokenizers, a FlowMatchEulerDiscreteScheduler, an SD3Transformer2DModel, and an AutoencoderKL VAE. Since the pipeline lacks a direct forward function call that can be passed to forge.compile, the pipeline structure has been broken down. All preprocessing steps have been manually extracted from StableDiffusion3Pipeline, and only the transformer forward function call is now passed to forge.compile.

Currently, forge.compile fails during TVM frontend conversion with the exception:
Exception: warning unhandled case: <class 'NoneType'> in convert operators