### PR TITLE
Fix naming for RUNS_ON_DEFAULT

### DIFF
--- a/.github/workflows/on-nightly-sweeps.yml
+++ b/.github/workflows/on-nightly-sweeps.yml
@@ -19,7 +19,7 @@ on:
     - cron: '0 4 * * *'  # Runs at 04:00 UTC every day
 
 env:
-  runs-on-default: n150
+  RUNS_ON_DEFAULT: n150
 
 jobs:
   docker-build:
@@ -42,5 +42,5 @@ jobs:
       test_group_cnt: 4
       test_group_ids: '[1,2,3,4]'
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      runs-on: '[{"runs-on": "${{ github.event.inputs.runs-on || github.env.runs-on-default }}"}]'
+      runs-on: '[{"runs-on": "${{ github.event.inputs.runs-on || github.env.RUNS_ON_DEFAULT }}"}]'
       operators: ${{ github.event.inputs.operators }}


### PR DESCRIPTION
### Ticket
Attempt 2 to fix #1428

### Problem description
Github action again fails due to resolving runs-on parameter
https://github.com/tenstorrent/tt-forge-fe/actions/runs/13826802634

### What's changed
Rename env variable runs-on-default to RUNS_ON_DEFAULT to comply with linux env namings

### Checklist
- [ ] New/Existing tests provide coverage for changes
