### PR TITLE
Add support for recording pcc and atol

### DIFF
--- a/forge/test/benchmark/benchmark/models/resnet_hf.py
+++ b/forge/test/benchmark/benchmark/models/resnet_hf.py
@@ -20,7 +20,7 @@ from datasets import load_dataset
 
 # Forge modules
 import forge
-from forge.verify.compare import compare_with_golden_pcc
+from forge.verify.compare import compare_with_golden
 from test.utils import download_model
 
 # Common constants
@@ -93,7 +93,7 @@ def test_resnet_hf(
     end = time.time()
 
     co_out = [co.to("cpu") for co in co_out]
-    assert [compare_with_golden_pcc(golden=fo, calculated=co, pcc=0.95) for fo, co in zip(fw_out, co_out)]
+    assert [compare_with_golden(golden=fo, calculated=co, pcc=0.95) for fo, co in zip(fw_out, co_out)]
 
     short_hash = subprocess.check_output(["git", "rev-parse", "--short", "HEAD"]).decode("ascii").strip()
     date = datetime.now().strftime("%d-%m-%Y")

--- a/forge/test/mlir/test_loss.py
+++ b/forge/test/mlir/test_loss.py
@@ -5,6 +5,9 @@
 import pytest
 import torch
 from torch import nn
+from forge.verify.verify import verify
+from forge.verify.config import VerifyConfig
+from forge.verify.value_checkers import AllCloseValueChecker
 
 import forge
 
@@ -34,10 +37,13 @@ def test_l1_loss(forge_property_recorder, prediction_shape, reduction):
     forge_loss = forge.compile(
         forge_loss, sample_inputs=[prediction_forge, target_forge], forge_property_handler=forge_property_recorder
     )
-    forge_loss_out = forge_loss(prediction, target)
-    torch_loss_out = torch_loss(prediction, target)
-
-    assert torch.allclose(torch_loss_out, forge_loss_out[0], rtol=11e-3)
+    verify(
+        inputs=[prediction, target],
+        framework_model=torch_loss,
+        compiled_model=forge_loss,
+        verify_cfg=VerifyConfig(verify_shape=False, value_checker=AllCloseValueChecker(rtol=11e-3)),
+        forge_property_handler=forge_property_recorder,
+    )
 
 
 @pytest.mark.parametrize(
@@ -63,10 +69,14 @@ def test_cross_entropy_loss(forge_property_recorder, prediction_shape):
     forge_loss = forge.compile(
         forge_loss, sample_inputs=[prediction_forge, target_forge], forge_property_handler=forge_property_recorder
     )
-    forge_loss_out = forge_loss(prediction, target)
-    torch_loss_out = torch_loss(prediction, target)
 
-    assert torch.allclose(torch_loss_out, forge_loss_out[0], rtol=11e-3)
+    verify(
+        inputs=[prediction, target],
+        framework_model=torch_loss,
+        compiled_model=forge_loss,
+        verify_cfg=VerifyConfig(verify_shape=False, value_checker=AllCloseValueChecker(rtol=11e-3)),
+        forge_property_handler=forge_property_recorder,
+    )
 
 
 @pytest.mark.parametrize(
@@ -97,9 +107,14 @@ def test_kl_div_loss(forge_property_recorder, prediction_shape, reduction):
     forge_loss = forge.compile(
         forge_loss, sample_inputs=[prediction_forge, target_forge], forge_property_handler=forge_property_recorder
     )
-    forge_loss_out = forge_loss(prediction, target)[0]
-    torch_loss_out = torch_loss(prediction, target)
-    assert torch.allclose(torch_loss_out, forge_loss_out, rtol=5e-2)
+
+    verify(
+        inputs=[prediction, target],
+        framework_model=torch_loss,
+        compiled_model=forge_loss,
+        verify_cfg=VerifyConfig(verify_shape=False, value_checker=AllCloseValueChecker(rtol=5e-2)),
+        forge_property_handler=forge_property_recorder,
+    )
 
 
 @pytest.mark.parametrize(
@@ -128,12 +143,15 @@ def test_mse_loss(forge_property_recorder, prediction_shape, reduction):
     forge_loss = forge.compile(
         forge_loss, sample_inputs=[prediction_forge, target_forge], forge_property_handler=forge_property_recorder
     )
-    forge_loss_out = forge_loss(prediction, target)
-    torch_loss_out = torch_loss(prediction, target)
 
-    assert torch.allclose(
-        torch_loss_out, forge_loss_out[0], rtol=5e-2, atol=5e-3
-    )  # relative tolerance is 5% and absolute tolerance is 0.005
+    # relative tolerance is 5% and absolute tolerance is 0.005
+    verify(
+        inputs=[prediction, target],
+        framework_model=torch_loss,
+        compiled_model=forge_loss,
+        verify_cfg=VerifyConfig(verify_shape=False, value_checker=AllCloseValueChecker(rtol=5e-2, atol=5e-3)),
+        forge_property_handler=forge_property_recorder,
+    )
 
 
 @pytest.mark.parametrize(
@@ -208,10 +226,14 @@ def test_huber_loss(forge_property_recorder, prediction_shape, reduction):
     forge_loss = forge.compile(
         forge_loss, sample_inputs=[prediction_forge, target_forge], forge_property_handler=forge_property_recorder
     )
-    forge_loss_out = forge_loss(prediction, target)
-    torch_loss_out = torch_loss(prediction, target)
 
-    assert torch.allclose(torch_loss_out, forge_loss_out[0], rtol=5e-2)
+    verify(
+        inputs=[prediction, target],
+        framework_model=torch_loss,
+        compiled_model=forge_loss,
+        verify_cfg=VerifyConfig(verify_shape=False, value_checker=AllCloseValueChecker(rtol=5e-2)),
+        forge_property_handler=forge_property_recorder,
+    )
 
 
 @pytest.mark.parametrize(
@@ -241,10 +263,14 @@ def test_bce_loss(forge_property_recorder, prediction_shape, reduction):
     forge_loss = forge.compile(
         forge_loss, sample_inputs=[prediction_forge, target_forge], forge_property_handler=forge_property_recorder
     )
-    forge_loss_out = forge_loss(prediction, target)
-    torch_loss_out = torch_loss(prediction, target)
 
-    assert torch.allclose(torch_loss_out, forge_loss_out[0], rtol=5e-2, atol=5e-3)
+    verify(
+        inputs=[prediction, target],
+        framework_model=torch_loss,
+        compiled_model=forge_loss,
+        verify_cfg=VerifyConfig(verify_shape=False, value_checker=AllCloseValueChecker(rtol=5e-2, atol=5e-3)),
+        forge_property_handler=forge_property_recorder,
+    )
 
 
 @pytest.mark.parametrize(
@@ -274,10 +300,14 @@ def test_bce_with_logits_loss(forge_property_recorder, prediction_shape, reducti
     forge_loss = forge.compile(
         forge_loss, sample_inputs=[prediction_forge, target_forge], forge_property_handler=forge_property_recorder
     )
-    forge_loss_out = forge_loss(prediction, target)
-    torch_loss_out = torch_loss(prediction, target)
 
-    assert torch.allclose(torch_loss_out, forge_loss_out[0], rtol=5e-2, atol=5e-3)
+    verify(
+        inputs=[prediction, target],
+        framework_model=torch_loss,
+        compiled_model=forge_loss,
+        verify_cfg=VerifyConfig(verify_shape=False, value_checker=AllCloseValueChecker(rtol=5e-2, atol=5e-3)),
+        forge_property_handler=forge_property_recorder,
+    )
 
 
 @pytest.mark.parametrize(
@@ -313,7 +343,11 @@ def test_triplet_margin_loss(forge_property_recorder, prediction_shape, reductio
         sample_inputs=[anchor_forge, positive_forge, negative_forge],
         forge_property_handler=forge_property_recorder,
     )
-    forge_loss_out = forge_loss(anchor_forge, positive_forge, negative_forge)
-    torch_loss_out = torch_loss(anchor, positive, negative)
 
-    assert torch.allclose(torch_loss_out, forge_loss_out[0], rtol=5e-2)
+    verify(
+        inputs=[anchor, positive, negative],
+        framework_model=torch_loss,
+        compiled_model=forge_loss,
+        verify_cfg=VerifyConfig(verify_shape=False, value_checker=AllCloseValueChecker(rtol=5e-2)),
+        forge_property_handler=forge_property_recorder,
+    )

--- a/forge/test/mlir/test_training.py
+++ b/forge/test/mlir/test_training.py
@@ -34,13 +34,20 @@ def test_torch_training(forge_property_recorder):
     loss_fn = torch.nn.MSELoss()
     optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
 
-    tt_model = forge.compile(model, sample_inputs=[torch.rand(shape)], optimizer=optimizer)
+    tt_model = forge.compile(
+        model, sample_inputs=[torch.rand(shape)], optimizer=optimizer, forge_property_handler=forge_property_recorder
+    )
 
     num_epochs = 20
 
     model.train()
     for epoch in range(num_epochs):
-        fw_out, tt_out = verify(inputs=[inputs], framework_model=model, compiled_model=tt_model)
+        fw_out, tt_out = verify(
+            inputs=[inputs],
+            framework_model=model,
+            compiled_model=tt_model,
+            forge_property_handler=forge_property_recorder,
+        )
         fw_out, tt_out = fw_out[0], tt_out[0]
 
         optimizer.zero_grad()
@@ -72,4 +79,6 @@ def test_compile_optimizers(forge_property_recorder, optimizer):
     shape = (1, 1024)
 
     optimizer = optimizer(learning_rate=0.1)
-    tt_model = forge.compile(model, sample_inputs=[torch.rand(shape)], optimizer=optimizer)
+    tt_model = forge.compile(
+        model, sample_inputs=[torch.rand(shape)], optimizer=optimizer, forge_property_handler=forge_property_recorder
+    )


### PR DESCRIPTION
Fixes #1394 

1. This PR introduces the `compute_pcc_and_atol` function for calculating **PCC** and **ATOL** values between framework and compiled model outputs. The calculated pcc and atol values will be recorded inside the **tags** property. The function calculates the Pearson correlation coefficient (PCC) for non-scalar outputs and the absolute tolerance (ATOL) for all outputs. For scalar outputs, only ATOL is computed.
In tt-torch, ATOL calculation handles special cases like Inf and NaN values, so replicated the ATOL calculation here.
Reference: https://github.com/tenstorrent/tt-torch/blob/c79248aa29f736e7977e22555d45b47fb2b9d12f/tt_torch/tools/utils.py#L579

2. Modified the forge loss test function present inside the forge/test/mlir/test_loss.py path to use verify function

Note:

1. If the number of framework outputs does not match the number of compiled outputs, the pcc and atol will not be recorded.
2. For non-scalar outputs, if the tensor shapes do not match, the PCC and ATOL calculations for that particular output are skipped.
3. The minimum PCC is computed among  non-scalar outputs, and the maximum ATOL is computed across all outputs.