### PR TITLE
Write down the correct values for certain parameters in the LLAMA benchmark model.

### DIFF
--- a/forge/test/benchmark/benchmark/models/llama.py
+++ b/forge/test/benchmark/benchmark/models/llama.py
@@ -100,8 +100,7 @@ def test_llama_prefill(
     model_name = "Llama Prefill"
     model_type = "Text Generation, Random Text Data"
     dataset_name = "Llama, Random Data"
-    num_layers = ""  # Number of layers in the model is not relevant here.
-    # This parameter can't have a generic value, so we are leaving it empty.
+    num_layers = -1  # Number of layers in the model is not relevant here.
     batch_size = 1  # Batch size is always 1 for text generation.
 
     input_sequence_length = len(input_ids[0])

--- a/forge/test/benchmark/benchmark/models/llama.py
+++ b/forge/test/benchmark/benchmark/models/llama.py
@@ -100,8 +100,13 @@ def test_llama_prefill(
     model_name = "Llama Prefill"
     model_type = "Text Generation, Random Text Data"
     dataset_name = "Llama, Random Data"
-    num_layers = -1  # Number of layers in the model is not relevant here.
+    num_layers = ""  # Number of layers in the model is not relevant here.
+    # This parameter can't have a generic value, so we are leaving it empty.
     batch_size = 1  # Batch size is always 1 for text generation.
+
+    input_sequence_length = len(input_ids[0])
+    output_sequence_length = -1  # We are not generating any output here.
+    # This will be changed when we add the decoding part of the model.
 
     print("====================================================================")
     print("| Llama Benchmark Results:                                         |")
@@ -128,9 +133,10 @@ def test_llama_prefill(
         # "math_fidelity": math_fidelity, @TODO - For now, we are skipping these parameters, because we are not supporting them
         "dataset_name": dataset_name,
         "profile_name": "",
-        "input_sequence_length": -1,  # When this value is negative, it means it is not applicable
-        "output_sequence_length": -1,  # When this value is negative, it means it is not applicable
-        "image_dimension": -1,  # When this value is negative, it means it is not applicable
+        "input_sequence_length": input_sequence_length,
+        "output_sequence_length": output_sequence_length,
+        "image_dimension": "",  # Image dimension is not applicable for this model.
+        # This parameter can't have a generic value, so we are leaving it empty.
         "perf_analysis": False,
         "training": training,
         "measurements": [

--- a/forge/test/benchmark/benchmark/models/llama.py
+++ b/forge/test/benchmark/benchmark/models/llama.py
@@ -134,7 +134,6 @@ def test_llama_prefill(
         "profile_name": "",
         "input_sequence_length": input_sequence_length,
         "output_sequence_length": output_sequence_length,
-        "image_dimension": "",  # Image dimension is not applicable for this model.
         # This parameter can't have a generic value, so we are leaving it empty.
         "perf_analysis": False,
         "training": training,


### PR DESCRIPTION
Some output parameters in the LLAMA benchmark model have inappropriate default values and cannot be written to the database due to schema constraints. In this PR, we update those values. The most important parameters are the number of layers—which is irrelevant in this phase—and image size, which cannot exist as an input in language models.
