### PR TITLE
Surya_ocr Pytest #1291

### DIFF
--- a/forge/test/models/pytorch/vision/suryaocr/conftest.py
+++ b/forge/test/models/pytorch/vision/suryaocr/conftest.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import sys
+from importlib.abc import MetaPathFinder
+from importlib.util import spec_from_loader
+from typing import Optional
+
+import torch
+
+
+class SuryaLoaderFinder(MetaPathFinder):
+    def find_spec(self, fullname, path, target=None):
+        if fullname == "surya.recognition.loader":
+            return spec_from_loader(fullname, SuryaLoader())
+
+
+class SuryaLoader:
+    def create_module(self, spec):
+        return None
+
+    def exec_module(self, module):
+        from surya.common.load import ModelLoader
+        from surya.recognition.model.config import (
+            DonutSwinConfig,
+            SuryaOCRConfig,
+            SuryaOCRDecoderConfig,
+            SuryaOCRTextEncoderConfig,
+        )
+        from surya.recognition.model.encoderdecoder import OCREncoderDecoderModel
+        from surya.recognition.processor import SuryaProcessor
+        from surya.settings import settings
+
+        class RecognitionModelLoader(ModelLoader):
+            def __init__(self, checkpoint: Optional[str] = None):
+                super().__init__(checkpoint)
+                if self.checkpoint is None:
+                    self.checkpoint = settings.RECOGNITION_MODEL_CHECKPOINT
+
+            def model(self, device="cpu", dtype=torch.float32) -> OCREncoderDecoderModel:
+                config = SuryaOCRConfig.from_pretrained(self.checkpoint)
+                config.decoder = SuryaOCRDecoderConfig(**config.decoder)
+                config.encoder = DonutSwinConfig(**config.encoder)
+                config.text_encoder = SuryaOCRTextEncoderConfig(**config.text_encoder)
+
+                model = OCREncoderDecoderModel.from_pretrained(self.checkpoint, config=config, torch_dtype=dtype)
+                model = model.to(device).eval()
+
+                return model
+
+            def processor(self) -> SuryaProcessor:
+                return SuryaProcessor(self.checkpoint)
+
+        module.RecognitionModelLoader = RecognitionModelLoader
+
+
+sys.meta_path.insert(0, SuryaLoaderFinder())

--- a/forge/test/models/pytorch/vision/suryaocr/test_surya_ocr.py
+++ b/forge/test/models/pytorch/vision/suryaocr/test_surya_ocr.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+
+# Install dependencies to run the surya_ocr model, the surya_ocr PYPI requires torch<3.0.0,>=2.5.1, but the env has torch 2.1.0+cpu.cxx11.abi which is incompatible. Hence we are installing it separately.
+subprocess.run(["pip", "install", "surya-ocr", "--no-deps"])
+subprocess.run(["pip", "install", "pydantic"])
+
+from io import BytesIO
+
+import pytest
+import requests
+import torch
+import torch.nn as nn
+import torchvision.transforms as transforms
+from PIL import Image
+from surya.detection import DetectionPredictor
+from surya.recognition import RecognitionPredictor
+
+import forge
+from forge.verify.verify import verify
+
+from test.models.utils import Framework, Source, Task, build_module_name
+
+IMAGE_URL = "https://raw.githubusercontent.com/VikParuchuri/surya/master/static/images/excerpt_text.png"
+
+LANGUAGE_MAP = {"en": 0, "fr": 1, "de": 2}
+
+
+def preprocess_image(image):
+    transform = transforms.Compose(
+        [
+            transforms.ToTensor(),
+        ]
+    )
+    return transform(image)
+
+
+class SuryaOCRWrapper(nn.Module):
+    def __init__(self):
+        super(SuryaOCRWrapper, self).__init__()
+        self.recognition_predictor = RecognitionPredictor()
+        self.detection_predictor = DetectionPredictor()
+
+    def forward(self, images_tensor, languages_tensor):
+        batch_size = images_tensor.shape[0]
+        images_list = [transforms.ToPILImage()(images_tensor[i]) for i in range(batch_size)]
+        language_indices = languages_tensor.tolist()
+        languages_list = [[list(LANGUAGE_MAP.keys())[i] for i in batch] for batch in language_indices]
+
+        # Get OCR results
+        ocr_results = self.recognition_predictor(images_list, languages_list, self.detection_predictor)
+
+        text_confidence_list = []
+        for batch in ocr_results:
+            for result in batch.text_lines:
+                text_confidence_list.append((result.text, result.confidence))
+
+        return text_confidence_list
+
+
+@pytest.mark.xfail(reason="Unknown output type: <class 'str'>")
+@pytest.mark.nightly
+def test_surya_ocr(record_forge_property):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.PYTORCH,
+        model="surya_ocr",
+        variant="default",
+        task=Task.OPTICAL_CHARACTER_RECOGNITION,
+        source=Source.GITHUB,
+    )
+
+    # Record Forge Property
+    record_forge_property("group", "priority_1")
+    record_forge_property("tags.model_name", module_name)
+
+    response = requests.get(IMAGE_URL)
+    image = Image.open(BytesIO(response.content))
+    image_tensor = preprocess_image(image)
+
+    langs = [["en"]]
+    language_tensor = torch.tensor([[LANGUAGE_MAP[lang] for lang in batch] for batch in langs], dtype=torch.int64)
+
+    images = torch.stack([image_tensor])
+
+    # Load model
+    framework_model = SuryaOCRWrapper()
+
+    # Load input
+    sample_inputs = (images, language_tensor)
+
+    # Forge compile framework model
+    compiled_model = forge.compile(framework_model, sample_inputs=sample_inputs, module_name="surya_ocr")
+
+    # Model Verification
+    verify(sample_inputs, framework_model, compiled_model)

--- a/forge/test/models/utils.py
+++ b/forge/test/models/utils.py
@@ -41,6 +41,7 @@ class Task(StrEnum):
     TEXT_TO_SPEECH = "text_to_speech"
     SENTENCE_EMBEDDING_GENERATION = "sentence_embed_gen"
     MULTIMODAL_TEXT_GENERATION = "multimodal_text_gen"
+    OPTICAL_CHARACTER_RECOGNITION = "optical_char_reg"
 
 
 class Source(StrEnum):


### PR DESCRIPTION
### Ticket
[Link to Github Issue](https://github.com/tenstorrent/tt-forge-fe/issues/1291)

### Problem description
- Added Pytest for Surya-ocr 

### What's changed
- The model consists of two PYPI dependencies.

1. Surya_ocr
2. Pydantic

- The surya-ocr 0.13.0 requires torch<3.0.0,>=2.5.1, but the tt-forge env have torch 2.1.0+cpu.cxx11.abi which is incompatible. Hence it is installed using no deps.
- Due to no-deps installation of Surya_ocr we face below errors.
`ImportError: cannot import name 'field_validator' from 'pydantic
ImportError: cannot import name 'computed_field' from 'pydantic'
`
-Hence pydantic is also installed using subprocess.
- The torch dependency leads to a Loader issue. 
` AttributeError: module 'torch.backends.cuda' has no attribute 'enable_cudnn_sdp'`
Hence the Loader is monkey patched using conftest.py.
