### PR TITLE
Add local model caching to fix transient CI failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
       env:
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
         HF_HOME: /mnt/dockercache/huggingface
-        FORGE_MODELS_HUB: /mnt/dockercache/custom_models
+        FORGE_MODELS_HUB: /mnt/dockercache/forge_models_cache
         HF_HUB_DISABLE_PROGRESS_BARS: 1
         FORGE_DISABLE_REPORTIFY_DUMP: 1
         OPERATORS: ${{ inputs.operators }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
       env:
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
         HF_HOME: /mnt/dockercache/huggingface
-        FORGE_MODELS_HUB: /mnt/dockercache/forge_models_cache
+        FORGE_MODELS_CACHE: /mnt/dockercache/forge_models_cache
         HF_HUB_DISABLE_PROGRESS_BARS: 1
         FORGE_DISABLE_REPORTIFY_DUMP: 1
         OPERATORS: ${{ inputs.operators }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,6 +123,7 @@ jobs:
       env:
         HF_TOKEN: ${{ secrets.HF_TOKEN }}
         HF_HOME: /mnt/dockercache/huggingface
+        FORGE_MODELS_HUB: /mnt/dockercache/custom_models
         HF_HUB_DISABLE_PROGRESS_BARS: 1
         FORGE_DISABLE_REPORTIFY_DUMP: 1
         OPERATORS: ${{ inputs.operators }}

--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ pipeline_*.json
 
 coverage.info
 coverage.xml
+
+# Exclude cached models
+.forge_models_cache/

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -8,16 +8,15 @@ import forge
 from forge.verify.verify import verify
 
 from test.models.utils import Framework, build_module_name
-from test.utils import download_model, fetch_model, remove_model
+from test.utils import fetch_model, yolov5_loader
 
 
 def generate_model_yoloV5I320_imgcls_torchhub_pytorch(variant, size):
     name = "yolov5" + size
 
-    if name == "yolov5s":
-        fetch_model(name, "yolov5s.pt", "https://github.com/ultralytics/yolov5/releases/download/v7.0/yolov5s.pt")
-
-    model = download_model(torch.hub.load, variant, name, pretrained=True)
+    model = fetch_model(
+        name, f"https://github.com/ultralytics/yolov5/releases/download/v7.0/{name}.pt", yolov5_loader, variant=variant
+    )
 
     input_shape = (1, 3, 320, 320)
     input_tensor = torch.rand(input_shape)
@@ -66,13 +65,12 @@ def test_yolov5_320x320(forge_property_recorder, size):
     # Model Verification
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
-    # Remove model weights
-    remove_model(f"yolov5{size}.pt")
-
 
 def generate_model_yoloV5I640_imgcls_torchhub_pytorch(variant, size):
     name = "yolov5" + size
-    model = download_model(torch.hub.load, variant, name, pretrained=True)
+    model = fetch_model(
+        name, f"https://github.com/ultralytics/yolov5/releases/download/v7.0/{name}.pt", yolov5_loader, variant=variant
+    )
 
     input_shape = (1, 3, 640, 640)
     input_tensor = torch.rand(input_shape)
@@ -132,7 +130,9 @@ def test_yolov5_640x640(forge_property_recorder, size):
 
 def generate_model_yoloV5I480_imgcls_torchhub_pytorch(variant, size):
     name = "yolov5" + size
-    model = download_model(torch.hub.load, variant, name, pretrained=True)
+    model = fetch_model(
+        name, f"https://github.com/ultralytics/yolov5/releases/download/v7.0/{name}.pt", yolov5_loader, variant=variant
+    )
     input_shape = (1, 3, 480, 480)
     input_tensor = torch.rand(input_shape)
     return model, [input_tensor], {}
@@ -208,7 +208,12 @@ def test_yolov5_1280x1280(forge_property_recorder, variant):
     forge_property_recorder.record_group("generality")
     forge_property_recorder.record_model_name(module_name)
 
-    framework_model = download_model(torch.hub.load, "ultralytics/yolov5", variant, pretrained=True)
+    framework_model = fetch_model(
+        variant,
+        f"https://github.com/ultralytics/yolov5/releases/download/v7.0/{variant}.pt",
+        yolov5_loader,
+        variant="ultralytics/yolov5",
+    )
 
     input_shape = (1, 3, 1280, 1280)
     input_tensor = torch.rand(input_shape)

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -10,13 +10,13 @@ from forge.verify.verify import verify
 from test.models.utils import Framework, build_module_name
 from test.utils import fetch_model, yolov5_loader
 
+base_url = "https://github.com/ultralytics/yolov5/releases/download/v7.0"
+
 
 def generate_model_yoloV5I320_imgcls_torchhub_pytorch(variant, size):
     name = "yolov5" + size
 
-    model = fetch_model(
-        name, f"https://github.com/ultralytics/yolov5/releases/download/v7.0/{name}.pt", yolov5_loader, variant=variant
-    )
+    model = fetch_model(name, f"{base_url}/{name}.pt", yolov5_loader, variant=variant)
 
     input_shape = (1, 3, 320, 320)
     input_tensor = torch.rand(input_shape)
@@ -68,9 +68,7 @@ def test_yolov5_320x320(forge_property_recorder, size):
 
 def generate_model_yoloV5I640_imgcls_torchhub_pytorch(variant, size):
     name = "yolov5" + size
-    model = fetch_model(
-        name, f"https://github.com/ultralytics/yolov5/releases/download/v7.0/{name}.pt", yolov5_loader, variant=variant
-    )
+    model = fetch_model(name, f"{base_url}/{name}.pt", yolov5_loader, variant=variant)
 
     input_shape = (1, 3, 640, 640)
     input_tensor = torch.rand(input_shape)
@@ -130,9 +128,7 @@ def test_yolov5_640x640(forge_property_recorder, size):
 
 def generate_model_yoloV5I480_imgcls_torchhub_pytorch(variant, size):
     name = "yolov5" + size
-    model = fetch_model(
-        name, f"https://github.com/ultralytics/yolov5/releases/download/v7.0/{name}.pt", yolov5_loader, variant=variant
-    )
+    model = fetch_model(name, f"{base_url}/{name}.pt", yolov5_loader, variant=variant)
     input_shape = (1, 3, 480, 480)
     input_tensor = torch.rand(input_shape)
     return model, [input_tensor], {}
@@ -210,7 +206,7 @@ def test_yolov5_1280x1280(forge_property_recorder, variant):
 
     framework_model = fetch_model(
         variant,
-        f"https://github.com/ultralytics/yolov5/releases/download/v7.0/{variant}.pt",
+        f"{base_url}/{variant}.pt",
         yolov5_loader,
         variant="ultralytics/yolov5",
     )

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -8,11 +8,14 @@ import forge
 from forge.verify.verify import verify
 
 from test.models.utils import Framework, build_module_name
-from test.utils import download_model
+from test.utils import download_model, fetch_model, remove_model
 
 
 def generate_model_yoloV5I320_imgcls_torchhub_pytorch(variant, size):
     name = "yolov5" + size
+
+    if name == "yolov5s":
+        fetch_model(name, "yolov5s.pt", "https://github.com/ultralytics/yolov5/releases/download/v7.0/yolov5s.pt")
 
     model = download_model(torch.hub.load, variant, name, pretrained=True)
 
@@ -62,6 +65,9 @@ def test_yolov5_320x320(forge_property_recorder, size):
 
     # Model Verification
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Remove model weights
+    remove_model(f"yolov5{size}.pt")
 
 
 def generate_model_yoloV5I640_imgcls_torchhub_pytorch(variant, size):

--- a/forge/test/utils.py
+++ b/forge/test/utils.py
@@ -35,6 +35,42 @@ def download_model(download_func, *args, num_retries=3, timeout=180, **kwargs):
     assert False, "Failed to download the model after multiple retries."
 
 
+def fetch_model(model_name, model_path, url, max_retries=3, timeout=30):
+    for attempt in range(1, max_retries + 1):
+        try:
+            print(f"Downloading {model_name} model, attempt {attempt}/{max_retries}...")
+            response = requests.get(url, timeout=timeout)
+            response.raise_for_status()
+
+            with open(f"{model_path}", "wb") as f:
+                f.write(response.content)
+
+            return True
+
+        except requests.exceptions.RequestException as e:
+            print(f"Attempt {attempt}/{max_retries} failed: {str(e)}")
+
+            if attempt < max_retries:
+                wait_time = 2**attempt  # Exponential backoff
+                print(f"Retrying in {wait_time} seconds...")
+                time.sleep(wait_time)
+            else:
+                print(f"Failed to download {model_name} after {max_retries} attempts")
+                return False
+
+    return False
+
+
+def remove_model(model_path):
+    try:
+        if os.path.exists(model_path):
+            os.remove(model_path)
+            return True
+    except Exception as e:
+        print(f"Error removing model file {model_path}: {str(e)}")
+        return False
+
+
 def reset_seeds():
     random.seed(0)
     np.random.seed(0)

--- a/forge/test/utils.py
+++ b/forge/test/utils.py
@@ -105,18 +105,6 @@ def fetch_model(
     return model
 
 
-def remove_model(model_name: str) -> bool:
-    """Remove a model from cache."""
-    model_path = os.path.join(get_cache_dir(), model_name)
-    if os.path.exists(model_path):
-        try:
-            os.remove(model_path)
-            return True
-        except OSError as e:
-            print(f"Failed to remove {model_name}: {e}")
-    return False
-
-
 def reset_seeds():
     random.seed(0)
     np.random.seed(0)

--- a/forge/test/utils.py
+++ b/forge/test/utils.py
@@ -40,7 +40,7 @@ def download_model(download_func, *args, num_retries=3, timeout=180, **kwargs):
 
 def get_cache_dir() -> str:
     """Get models cache directory from env var or use local default."""
-    cache_dir = os.environ.get("FORGE_MODELS_HUB")
+    cache_dir = os.environ.get("FORGE_MODELS_CACHE")
     if not cache_dir:
         cache_dir = os.path.join(os.getcwd(), ".forge_models_cache")
         os.makedirs(cache_dir, exist_ok=True)


### PR DESCRIPTION
## Problem
Sometimes on CI some tests fail to download model locally resulting in failing a test and not passing CI checks.

## Solution
This workaround enables us to cache model with method:

- `fetch_model` which downloads model with retry mechanisms from given url to our model cache repository if it's not present already in the model repo.  Cache repo location depends on whether env variable `FORGE_MODELS_CACHE` is set or not (having default location in latter case).

The changes help stabilize our CI pipeline and prevent unnecessary test failures.