### PR TITLE
Add test files for gemma

### DIFF
--- a/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
@@ -4,11 +4,20 @@
 
 import pytest
 import torch
-from transformers import AutoTokenizer, GemmaConfig, GemmaForCausalLM
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    GemmaConfig,
+    GemmaForCausalLM,
+)
 
 import forge
 from forge.verify.verify import verify
 
+from test.models.pytorch.text.gemma.utils.model_utils import (
+    generate_no_cache,
+    pad_inputs,
+)
 from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
@@ -73,3 +82,58 @@ def test_gemma_2b(forge_property_recorder, variant):
 
     # Model Verification
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "google/gemma-2-2b-it",
+            marks=pytest.mark.xfail(reason="RuntimeError: Trying to access element outside of dimensions: 2"),
+        ),
+        pytest.param(
+            "google/gemma-2-9b-it",
+            marks=pytest.mark.skip(
+                reason="Insufficient host DRAM to run this model (requires a bit more than 50 GB during compile time)"
+            ),
+        ),
+    ],
+)
+def test_gemma_pytorch_v2(forge_property_recorder, variant):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.PYTORCH, model="gemma", variant=variant, task=Task.QA, source=Source.HUGGINGFACE
+    )
+
+    # Record Forge Property
+    forge_property_recorder.record_group("priority_2")
+    forge_property_recorder.record_model_name(module_name)
+
+    # Load model and tokenizer from HuggingFace
+    tokenizer = AutoTokenizer.from_pretrained(variant)
+    framework_model = AutoModelForCausalLM.from_pretrained(variant, return_dict=False, use_cache=False)
+    framework_model.eval()
+    prompt = "What is the tallest mountain?"
+    inputs = tokenizer(prompt, return_tensors="pt")
+    input_ids = inputs["input_ids"]
+    max_new_tokens = 200
+    padded_inputs, seq_len = pad_inputs(input_ids, max_new_tokens)
+
+    # Forge compile framework model
+    compiled_model = forge.compile(
+        framework_model,
+        sample_inputs=[padded_inputs],
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+    )
+
+    # Model Verification
+    verify([padded_inputs], framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Runtime and Post-Processing
+    generated_text = generate_no_cache(
+        max_new_tokens=max_new_tokens, model=compiled_model, inputs=padded_inputs, seq_len=seq_len, tokenizer=tokenizer
+    )
+    print(generated_text)

--- a/forge/test/models/pytorch/text/gemma/test_gemma_v1.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_v1.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+import forge
+from forge.verify.verify import verify
+
+from test.models.pytorch.text.gemma.utils.model_utils import (
+    generate_no_cache,
+    pad_inputs,
+)
+from test.models.utils import Framework, Source, Task, build_module_name
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "google/gemma-1.1-2b-it",
+            marks=pytest.mark.push,
+        ),
+        pytest.param(
+            "google/gemma-1.1-7b-it",
+            marks=pytest.mark.skip(
+                reason="Insufficient host DRAM to run this model (requires a bit more than 50 GB during compile time)"
+            ),
+        ),
+    ],
+)
+def test_gemma_pytorch_v1(forge_property_recorder, variant):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.PYTORCH, model="gemma", variant=variant, task=Task.QA, source=Source.HUGGINGFACE
+    )
+
+    # Record Forge Property
+    forge_property_recorder.record_group("priority_2")
+    forge_property_recorder.record_model_name(module_name)
+
+    # Load model and tokenizer from HuggingFace
+    tokenizer = AutoTokenizer.from_pretrained(variant)
+    framework_model = AutoModelForCausalLM.from_pretrained(variant, return_dict=False, use_cache=False)
+    framework_model.eval()
+    prompt = "What is the tallest mountain?"
+    inputs = tokenizer(prompt, return_tensors="pt")
+    input_ids = inputs["input_ids"]
+    max_new_tokens = 200
+    padded_inputs, seq_len = pad_inputs(input_ids, max_new_tokens)
+
+    # Forge compile framework model
+    compiled_model = forge.compile(
+        framework_model,
+        sample_inputs=[padded_inputs],
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+    )
+
+    # Model Verification
+    verify([padded_inputs], framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Runtime and Post-Processing
+    generated_text = generate_no_cache(
+        max_new_tokens=max_new_tokens, model=compiled_model, inputs=padded_inputs, seq_len=seq_len, tokenizer=tokenizer
+    )
+    print(generated_text)

--- a/forge/test/models/pytorch/text/gemma/utils/model_utils.py
+++ b/forge/test/models/pytorch/text/gemma/utils/model_utils.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+
+
+def generate_no_cache(max_new_tokens, model, inputs, seq_len, tokenizer):
+    """
+    Generates text autoregressively without using a KV cache, iteratively predicting one token at a time.
+    The function stops generation if the maximum number of new tokens is reached or an end-of-sequence (EOS) token is encountered.
+
+    Args:
+        max_new_tokens (int): The maximum number of new tokens to generate.
+        model (torch.nn.Module): The language model used for token generation.
+        inputs (torch.Tensor): Input tensor of shape (batch_size, seq_len), representing tokenized text.
+        seq_len (int): The current sequence length before generation starts.
+        tokenizer: The tokenizer used to decode token IDs into text.
+
+    Returns:
+        str: The generated text after decoding the new tokens.
+    """
+    current_pos = seq_len
+
+    for _ in range(max_new_tokens):
+        logits = model(inputs)
+        # Get only the logits corresponding to the last valid token
+        if isinstance(logits, (list, tuple)):
+            logits = logits[0]
+
+        next_token_logits = logits[:, current_pos - 1, :]
+        next_token_id = torch.argmax(next_token_logits, dim=-1)
+        # Stop if EOS token is encountered
+        if next_token_id.item() == tokenizer.eos_token_id:
+            break
+
+        inputs[:, current_pos] = next_token_id
+
+        current_pos += 1  # Move to next position
+
+    # Decode valid tokens
+    valid_tokens = inputs[:, seq_len:current_pos].view(-1).tolist()
+    answer = tokenizer.decode(valid_tokens, skip_special_tokens=True)
+
+    return answer
+
+
+def pad_inputs(inputs, max_new_tokens):
+    batch_size, seq_len = inputs.shape
+    max_seq_len = seq_len + max_new_tokens
+    padded_inputs = torch.zeros((batch_size, max_seq_len), dtype=inputs.dtype, device=inputs.device)
+    padded_inputs[:, :seq_len] = inputs
+    return padded_inputs, seq_len


### PR DESCRIPTION
gemma-1.1-2b-it is passing end-to-end and occupies 19.8 GB, hence it has been added with nightly and push markers.
gemma-1.1-7b-it requires over 50 GB, so it has been skipped.
gemma-2-2b-it fails with RuntimeError: Trying to access element outside of dimensions: 2 which has been added in xfail
google/gemma-2-9b-it requires over 50 GB, so it has been skipped.