### PR TITLE
Update the model analysis job execution timeout and machine type

### DIFF
--- a/.github/workflows/model-analysis.yml
+++ b/.github/workflows/model-analysis.yml
@@ -24,8 +24,8 @@ jobs:
 
   model-analysis:
     needs: docker-build
-    runs-on: runner
-    timeout-minutes: 4320 # Set job execution time to 3 days(default: 6 hours)
+    runs-on: performance
+    timeout-minutes: 5760 # Set job execution time to 4 days(default: 6 hours)
 
     container:
       image: ${{ needs.docker-build.outputs.docker-image }}


### PR DESCRIPTION
The PR will update the job execution timeout for model analysis pipeline from 3 days(i.e 4320 minutes) to 4 days(i.e 5760 minutes) because the last model analysis weekly pipeline(i.e https://github.com/tenstorrent/tt-forge-fe/actions/runs/13760362793/job/38474992666) has exceeded the maximum execution time of 4320 minutes(i.e 3 days).

Updated the `runs-on` from `runner` to `performance` machine type because the model analysis pipeline needs high memory.