### PR TITLE
Record inputs and outputs tensor description from binary

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -98,7 +98,7 @@ jobs:
       shell: bash
       working-directory: install
       run: tar xvf artifact.tar
-  
+
     - name: Download build artifacts
       uses: actions/download-artifact@v4
       with:

--- a/forge/csrc/passes/mlir_compiler.cpp
+++ b/forge/csrc/passes/mlir_compiler.cpp
@@ -105,6 +105,9 @@ auto run_mlir_compiler_generic(tt::ForgeGraphModule& module, const std::optional
 
         tt::property::record_execution_depth(forge_property_handler, tt::property::ExecutionDepth::FAILED_RUNTIME);
 
+        std::string binary_json_str = runtime::Binary(binary).asJson();
+        tt::property::record_flatbuffer_details(forge_property_handler, binary_json_str);
+
         return binary;
     }
     else if constexpr (output == MLIROutputKind::Cpp)

--- a/forge/csrc/shared_utils/forge_property_utils.cpp
+++ b/forge/csrc/shared_utils/forge_property_utils.cpp
@@ -27,23 +27,47 @@ std::string to_string(const ExecutionDepth depth)
 
 std::ostream& operator<<(std::ostream& os, const ExecutionDepth depth) { return os << to_string(depth); }
 
+// Helper function to validate that the handler is provided and contains the required method.
+// Returns true if the handler is valid; false otherwise.
+bool validate_handler_method(const std::optional<py::object>& handler, const std::string& method_name)
+{
+    // If the optional handler is not provided or explicitly set to None in Python, return false
+    if (!handler.has_value() || handler->is_none())
+    {
+        return false;
+    }
+    // Ensure that the provided handler object has a 'method_name' method.
+    if (!py::hasattr(*handler, method_name.c_str()))
+    {
+        return false;
+    }
+    return true;
+}
+
 void record_execution_depth(
     const std::optional<py::object>& forge_property_handler, const ExecutionDepth execution_depth)
 {
-    // If the optional handler is not provided or explicitly set to None in Python, exit early.
-    if (!forge_property_handler.has_value() || forge_property_handler->is_none())
+    // Validate the handler; exit early if it fails.
+    if (!validate_handler_method(forge_property_handler, "record_execution_depth"))
     {
         return;
     }
 
-    // Ensure that the provided handler object has a 'record_execution_depth' method.
-    if (!py::hasattr(*forge_property_handler, "record_execution_depth"))
-    {
-        throw std::runtime_error("The provided forge_property_handler does not have a record_execution_depth method");
-    }
-
     // Invoke the 'record_execution_depth' method of the Python object, passing the execution depth.
     forge_property_handler->attr("record_execution_depth")(execution_depth);
+}
+
+void record_flatbuffer_details(
+    const std::optional<py::object>& forge_property_handler, const std::string& binary_json_str)
+{
+    // Validate the handler; exit early if it fails.
+    if (!validate_handler_method(forge_property_handler, "record_flatbuffer_details"))
+    {
+        return;
+    }
+
+    // Invoke the 'record_flatbuffer_details' method of the Python object, passing the binary json string.
+    forge_property_handler->attr("record_flatbuffer_details")(binary_json_str);
 }
 
 }  // namespace tt::property

--- a/forge/csrc/shared_utils/forge_property_utils.hpp
+++ b/forge/csrc/shared_utils/forge_property_utils.hpp
@@ -34,4 +34,7 @@ std::ostream& operator<<(std::ostream& os, const ExecutionDepth depth);
 void record_execution_depth(
     const std::optional<py::object>& forge_property_handler, const ExecutionDepth execution_depth);
 
+void record_flatbuffer_details(
+    const std::optional<py::object>& forge_property_handler, const std::string& binary_json_str);
+
 }  // namespace tt::property

--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum
+import json
 from dataclasses import dataclass, is_dataclass, field
 from dataclasses_json import dataclass_json
 from typing import Union, List, Optional, Any, get_origin, get_args, Dict
@@ -43,6 +44,112 @@ class ExecutionStage(Enum):
 
 @dataclass_json
 @dataclass
+class TensorDesc:
+    shape: List[int]
+    data_type: str = ""
+    buffer_type: str = ""
+    layout: str = ""
+    grid_shape: Optional[List[int]] = None
+
+
+class FlatbufferDetailsExtractor:
+    """
+    A utility class to parse and extract comprehensive details from a generated flatbuffer binary JSON.
+
+    Args:
+        binary_json (Dict[str, Any]): The flatbuffer binary JSON containing program details.
+    """
+
+    def __init__(self, binary_json):
+        self.binary = binary_json
+
+    def extract_tensor_details(self, inputs_or_outputs):
+        """
+        Extracts tensor descriptions from a list of input/output entries.
+
+        Parameters:
+            inputs_or_outputs (list): A list of dictionaries, each containing a "desc" key
+                                      with tensor description details.
+
+        Returns:
+            list: A list of TensorDesc objects.
+        """
+        tensor_desc_list = []
+        for input_or_output in inputs_or_outputs:
+            desc = input_or_output["desc"]
+            if (
+                "shape" in desc
+                and "layout" in desc
+                and "memory_desc" in desc["layout"]
+                and "data_type" in desc["layout"]["memory_desc"]
+            ):
+                tensor_desc = TensorDesc(shape=desc["shape"], data_type=desc["layout"]["memory_desc"]["data_type"])
+
+                try:
+                    tensor_desc.buffer_type = desc["layout"]["memory_desc"]["memory_space"]
+                except KeyError:
+                    if "memory_config" in desc["layout"]["memory_desc"]:
+                        # If the tensor is on device, the descriptor will have a "memory_config" field.
+                        tensor_desc.buffer_type = desc["layout"]["memory_desc"]["memory_config"]["buffer_type"]
+                    else:
+                        # If the tensor is on host, the descriptor will have a "storage_type" field.
+                        tensor_desc.buffer_type = desc["layout"]["memory_desc"]["storage_type"]
+
+                try:
+                    tensor_desc.layout = desc["layout"]["memory_desc"]["memory_layout"]
+                except KeyError:
+                    if "memory_config" in desc["layout"]["memory_desc"]:
+                        # If the tensor is on device, use the tensor_memory_layout from memory_config.
+                        tensor_desc.layout = desc["layout"]["memory_desc"]["memory_config"]["tensor_memory_layout"]
+                    else:
+                        # If the tensor is on host, no tensor_memory_layout is available.
+                        tensor_desc.layout = ""
+
+                try:
+                    grid_shape = desc["layout"]["core_range_set"][0]["size"]
+                    tensor_desc.grid_shape = [grid_shape["x"], grid_shape["y"]]
+                except KeyError:
+                    pass
+
+                tensor_desc_list.append(tensor_desc)
+        return tensor_desc_list
+
+    def extract_program_io_details(self, program_filter: Optional[List[str]] = None):
+        """
+        Extracts detailed input and output configurations for each program from the flatbuffer binary JSON.
+
+        Args:
+            program_filter (Optional[List[str]]): A list of program names to filter the extraction process.
+                Only programs whose names appear in this list will have their input/output details extracted.
+                If None, details for all programs will be extracted.
+        Returns:
+            tuple: A tuple (program_inputs, program_outputs) where:
+                - program_inputs (Dict[str, List[TensorDesc]]): Maps program names to detailed input configurations.
+                - program_outputs (Dict[str, List[TensorDesc]]): Maps program names to detailed output configurations.
+            Returns (None, None) if the binary JSON does not contain a "programs" key.
+        """
+        if "programs" not in self.binary:
+            return None, None
+
+        program_inputs = {}
+        program_outputs = {}
+
+        for program in self.binary["programs"]:
+            program_name = program["name"]
+            if program_filter is not None and program_name not in program_filter:
+                continue
+            inputs = self.extract_tensor_details(program["inputs"])
+            outputs = self.extract_tensor_details(program["outputs"])
+            if len(inputs) > 0:
+                program_inputs[program_name] = inputs
+            if len(outputs) > 0:
+                program_outputs[program_name] = outputs
+
+        return program_inputs, program_outputs
+
+
+@dataclass_json
+@dataclass
 class Config:
     compiler: Dict[str, Any] = field(default_factory=lambda: dict())
     verify: Dict[str, Any] = field(default_factory=lambda: dict())
@@ -67,6 +174,8 @@ class ForgePropertyStore:
     group: str = ""
     tags: Optional[Tags] = None
     config: Optional[Config] = None
+    inputs: Optional[List[TensorDesc]] = None
+    outputs: Optional[List[TensorDesc]] = None
 
 
 class ForgePropertyHandler:
@@ -292,6 +401,50 @@ class ForgePropertyHandler:
         verify_config = verify_config.to_dict()
         verify_config["value_checker"] = verify_config["value_checker"].__dict__
         self.add("config.verify", verify_config)
+
+    def record_flatbuffer_inputs(self, inputs: List[TensorDesc]):
+        """
+        Records forward program inputs tensor description extracted from a flatbuffer binary.
+
+        Args:
+            inputs (List[TensorDesc]): A list of TensorDesc objects for inputs.
+        """
+        self.add("inputs", inputs)
+
+    def record_flatbuffer_outputs(self, outputs: List[TensorDesc]):
+        """
+        Records forward program outputs tensor description extracted from a flatbuffer binary.
+
+        Args:
+            outputs (List[TensorDesc]): A list of TensorDesc objects for outputs.
+        """
+        self.add("outputs", outputs)
+
+    def record_flatbuffer_details(self, binary_json_str: str):
+        """
+        Records details from a flatbuffer binary JSON string.
+
+        This method convert provided JSON string into a dictionary, and uses the
+        FlatbufferDetailsExtractor to extract details and record it.
+
+        Args:
+            binary_json_str (str): The JSON string representation of the flatbuffer binary.
+        """
+        binary_json = json.loads(binary_json_str)
+
+        flatbuffer_details_extractor = FlatbufferDetailsExtractor(binary_json)
+        inputs, outputs = flatbuffer_details_extractor.extract_program_io_details(program_filter=["forward"])
+        if inputs is not None and outputs is not None:
+            if len(inputs) != len(outputs):
+                logger.error(
+                    f"Mismatch in program count: inputs have {len(inputs)} programs, while outputs have {len(outputs)} programs."
+                )
+            if sorted(inputs.keys()) != sorted(outputs.keys()):
+                logger.error(
+                    f"Mismatch in program names: inputs contain {sorted(inputs.keys())}, while outputs contain {sorted(outputs.keys())}."
+                )
+            self.record_flatbuffer_inputs(inputs["forward"])
+            self.record_flatbuffer_outputs(outputs["forward"])
 
     def to_dict(self):
         """


### PR DESCRIPTION
Fixes #1164 

The PR will add support for recording inputs and outputs tensor description from forward program by extracting the details from the flatbuffer binary json.

Created `FlatbufferDetailsExtractor`, a utility class to extract details from the **flatbuffer binary json** and currently it has method `extract_program_io_details` for extracting inputs and outputs description from all the programs or specific program by passing program name to `program_filter` argument.