### PR TITLE
Refactor Paddle tensor conversion

### DIFF
--- a/forge/forge/module.py
+++ b/forge/forge/module.py
@@ -969,5 +969,7 @@ def wrap_module(module, name: str) -> Module:
         raise RuntimeError("Unsupported module type: " + str(type(module)))
 
 
-FrameworkModule: TypeAlias = torch.nn.Module | tf.keras.Model | paddle.nn.Layer | onnx.onnx_ml_pb2.ModelProto
+FrameworkModule: TypeAlias = (
+    torch.nn.Module | tf.keras.Model | paddle.nn.Layer | onnx.onnx_ml_pb2.ModelProto | OnnxModule
+)
 AnyModule: TypeAlias = FrameworkModule | ForgeModule

--- a/forge/forge/module.py
+++ b/forge/forge/module.py
@@ -20,7 +20,7 @@ from .tensor import (
     to_pt_tensors,
     to_tf_tensors,
     to_tf_variables,
-    pt_to_paddle_tensors,
+    to_pd_tensors,
     pytorch_dtype_to_forge_dataformat,
     forge_dataformat_to_pytorch_dtype,
 )
@@ -224,7 +224,7 @@ class PaddleModule(Module):
         self.module = module
 
     def forward(self, *args, **kwargs):
-        paddle_args = pt_to_paddle_tensors(args)
+        paddle_args = to_pd_tensors(args)
         outputs = self.module(*paddle_args, **kwargs)
         return to_pt_tensors(outputs)
 

--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -517,7 +517,7 @@ class TensorFromTrace(Tensor):
         return super().to_framework(framework)
 
 
-FrameworkTensor: TypeAlias = torch.Tensor | tf.Tensor | tf.Variable | paddle.Tensor 
+FrameworkTensor: TypeAlias = torch.Tensor | tf.Tensor | tf.Variable | paddle.Tensor
 AnyTensor: TypeAlias = FrameworkTensor | Tensor
 
 
@@ -1202,7 +1202,8 @@ def to_pt_tensor(t: AnyTensor) -> torch.Tensor:
     else:
         raise RuntimeError(f"Unknown type of tensor: {type(t)}")
 
-def to_pd_tensors(tensors: Union[AnyTensor, Tuple[AnyTensor, ...], List[AnyTensor]]) -> Tuple[paddle.Tensor, ...]: 
+
+def to_pd_tensors(tensors: Union[AnyTensor, Tuple[AnyTensor, ...], List[AnyTensor]]) -> Tuple[paddle.Tensor, ...]:
     paddle_tensors = []
 
     if not isinstance(tensors, (list, tuple)):
@@ -1213,6 +1214,7 @@ def to_pd_tensors(tensors: Union[AnyTensor, Tuple[AnyTensor, ...], List[AnyTenso
 
     return tuple(paddle_tensors)
 
+
 def to_pd_tensor(pt: torch.Tensor) -> paddle.Tensor:
     if isinstance(pt, paddle.Tensor):
         return pt
@@ -1222,6 +1224,7 @@ def to_pd_tensor(pt: torch.Tensor) -> paddle.Tensor:
         return pd
     else:
         raise RuntimeError(f"Unsupported type of tensor: {type(pt)}")
+
 
 def to_jax_tensors(
     tensors: Union[

--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Union, Tuple, List, Optional, Dict, TypeAlias
-from forge.tvm_utils import map_tf_dtype_to_pt
+from forge.tvm_utils import map_pt_dtype_to_pd, map_tf_dtype_to_pt, map_pd_dtype_to_pt
 
 import paddle
 import torch
@@ -517,7 +517,7 @@ class TensorFromTrace(Tensor):
         return super().to_framework(framework)
 
 
-FrameworkTensor: TypeAlias = torch.Tensor | tf.Tensor
+FrameworkTensor: TypeAlias = torch.Tensor | tf.Tensor | paddle.Tensor
 AnyTensor: TypeAlias = FrameworkTensor | Tensor
 
 
@@ -1194,7 +1194,7 @@ def to_pt_tensor(t: AnyTensor) -> torch.Tensor:
         assert t.has_value(), "Expected Forge tensor to have a value"
         return t.value()
     elif isinstance(t, paddle.Tensor):
-        pt = torch.Tensor(t.numpy())
+        pt = torch.Tensor(t.numpy()).type(map_pd_dtype_to_pt(t.dtype))
         pt.requires_grad = t.stop_gradient == False
         return pt
     elif isinstance(t, np.ndarray):
@@ -1202,28 +1202,26 @@ def to_pt_tensor(t: AnyTensor) -> torch.Tensor:
     else:
         raise RuntimeError(f"Unknown type of tensor: {type(t)}")
 
-
-def pt_to_paddle_tensor(pt: torch.Tensor):
-    if isinstance(pt, paddle.Tensor):
-        return pt
-    elif isinstance(pt, torch.Tensor):
-        return paddle.to_tensor(pt.detach().numpy())
-
-    else:
-        raise RuntimeError(f"Unknown type of tensor: {type(pt)}")
-
-
-def pt_to_paddle_tensors(tensors: Union[AnyTensor, Tuple[AnyTensor, ...], List[AnyTensor]]):
+def to_pd_tensors(tensors: Union[AnyTensor, Tuple[AnyTensor, ...], List[AnyTensor]]) -> Tuple[paddle.Tensor, ...]: 
     paddle_tensors = []
 
     if not isinstance(tensors, (list, tuple)):
         tensors = (tensors,)
 
     for t in tensors:
-        paddle_tensors.append(pt_to_paddle_tensor(t))
+        paddle_tensors.append(to_pd_tensor(t))
 
     return tuple(paddle_tensors)
 
+def to_pd_tensor(pt: torch.Tensor) -> paddle.Tensor:
+    if isinstance(pt, paddle.Tensor):
+        return pt
+    elif isinstance(pt, torch.Tensor):
+        pd = paddle.to_tensor(pt.detach().numpy(), dtype=map_pt_dtype_to_pd(pt.dtype))
+        pd.stop_gradient = not pt.requires_grad
+        return pd
+    else:
+        raise RuntimeError(f"Unsupported type of tensor: {type(pt)}")
 
 def to_jax_tensors(
     tensors: Union[

--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -517,7 +517,7 @@ class TensorFromTrace(Tensor):
         return super().to_framework(framework)
 
 
-FrameworkTensor: TypeAlias = torch.Tensor | tf.Tensor | paddle.Tensor
+FrameworkTensor: TypeAlias = torch.Tensor | tf.Tensor | tf.Variable | paddle.Tensor 
 AnyTensor: TypeAlias = FrameworkTensor | Tensor
 
 

--- a/forge/forge/tvm_calls/forge_compile.py
+++ b/forge/forge/tvm_calls/forge_compile.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-from forge.tensor import to_tf_tensors, to_pt_tensor, to_pt_tensors, pt_to_paddle_tensors
+from forge.tensor import to_tf_tensors, to_pt_tensor, to_pt_tensors, to_pd_tensors
 from forge.tvm_utils import flatten_inputs, flatten_structured_output
 from forge.forge_property_utils import ExecutionStage
 import torch
@@ -558,7 +558,7 @@ def compile_paddle_for_forge(
     paddlemod, *inputs, graph_name, compiler_cfg, verify_cfg=None, input_names=[], forge_property_handler=None
 ):
 
-    paddle_inputs = pt_to_paddle_tensors(inputs)
+    paddle_inputs = to_pd_tensors(inputs)
 
     with ConvertEmulatedDtypes(paddlemod, inputs):
         framework_outputs = extract_framework_model_outputs(

--- a/forge/forge/tvm_calls/forge_utils.py
+++ b/forge/forge/tvm_calls/forge_utils.py
@@ -18,7 +18,7 @@ import tvm
 from tvm.relay import ExprVisitor
 from forge.config import CompilerConfig
 from forge.tvm_utils import flatten_inputs, flatten_structured_output
-from forge.tensor import to_pt_tensors, pt_to_paddle_tensors
+from forge.tensor import to_pt_tensors, to_pd_tensors
 from forge.tvm_calls.relay.op.forge import extract_function_callnodes, trace_to_origin
 
 
@@ -169,7 +169,7 @@ def extract_flatten_inputs(framework: str, model, inputs, input_names=[]):
         flattened_inputs, flattened_input_names, flattened_name_map = flatten_inputs(inputs, input_names)
 
     elif framework == "paddle":
-        paddle_inputs = pt_to_paddle_tensors(inputs)
+        paddle_inputs = to_pd_tensors(inputs)
         input_structure = [paddle.static.InputSpec(shape=inp.shape, dtype=inp.dtype) for inp in paddle_inputs]
 
         if hasattr(model, "_input_args_names"):

--- a/forge/forge/tvm_utils.py
+++ b/forge/forge/tvm_utils.py
@@ -59,15 +59,18 @@ def map_pt_dtype_to_tf(pt_dtype):
     assert pt_dtype in pt_types, f"{pt_dtype} Tensorflow equivelant not defined"
     return list(tf_to_pt_type_map.keys())[pt_types.index(pt_dtype)]
 
+
 def map_pd_dtype_to_pt(pd_dtype):
     pt_type = pd_to_pt_type_map[pd_dtype]
     assert pt_type is not None, f"Paddle DType {pd_dtype} has no PyTorch equivalent"
     return pt_type
 
+
 def map_pt_dtype_to_pd(pt_dtype):
     pt_types = list(pd_to_pt_type_map.values())
     assert pt_dtype in pt_types, f"{pt_dtype} Paddle equivelant not defined"
     return list(pd_to_pt_type_map.keys())[pt_types.index(pt_dtype)]
+
 
 def flatten_inputs(inputs, names=None, force_float32=False):
     from forge.tensor import AnyTensor

--- a/forge/forge/tvm_utils.py
+++ b/forge/forge/tvm_utils.py
@@ -70,13 +70,13 @@ def map_pt_dtype_to_pd(pt_dtype):
     return list(pd_to_pt_type_map.keys())[pt_types.index(pt_dtype)]
 
 def flatten_inputs(inputs, names=None, force_float32=False):
-    from forge.tensor import Tensor
+    from forge.tensor import AnyTensor
 
     new_inputs = []
     new_names = []
     flattened_name_map = {}
 
-    if isinstance(inputs, (torch.Tensor, tf.Tensor, Tensor)):
+    if isinstance(inputs, AnyTensor):
         inputs = (inputs,)
 
     if names is None:
@@ -108,7 +108,7 @@ def flatten_inputs(inputs, names=None, force_float32=False):
             new_names += sub_names
             flattened_name_map[name] = sub_names
 
-        elif isinstance(inp, (torch.Tensor, tf.Tensor, Tensor)):
+        elif isinstance(inp, AnyTensor):
             new_inputs.append(inp)
             new_names.append(name)
             flattened_name_map[name] = [name]
@@ -123,7 +123,7 @@ def flatten_inputs(inputs, names=None, force_float32=False):
 
 
 def flatten_structured_output(outputs):
-    from forge.tensor import Tensor
+    from forge.tensor import AnyTensor
 
     new_outputs = []
 
@@ -146,7 +146,7 @@ def flatten_structured_output(outputs):
             )
             new_outputs += sub_output
 
-        elif isinstance(out, (torch.Tensor, tf.Tensor, Tensor, np.ndarray, paddle.Tensor)):
+        elif isinstance(out, (np.ndarray, AnyTensor)):
             new_outputs.append(out)
 
         elif out is None:

--- a/forge/forge/tvm_utils.py
+++ b/forge/forge/tvm_utils.py
@@ -34,6 +34,19 @@ tf_to_pt_type_map = {
     tf.variant: None,  # No torch.uint16
 }
 
+pd_to_pt_type_map = {
+    paddle.bfloat16: torch.bfloat16,
+    paddle.bool: torch.bool,
+    paddle.float16: torch.float16,
+    paddle.float32: torch.float32,
+    paddle.float64: torch.float64,
+    paddle.int8: torch.int8,
+    paddle.int16: torch.int16,
+    paddle.int32: torch.int32,
+    paddle.int64: torch.int64,
+    paddle.uint8: torch.uint8,
+}
+
 
 def map_tf_dtype_to_pt(tf_dtype):
     pt_type = tf_to_pt_type_map[tf_dtype]
@@ -44,9 +57,17 @@ def map_tf_dtype_to_pt(tf_dtype):
 def map_pt_dtype_to_tf(pt_dtype):
     pt_types = list(tf_to_pt_type_map.values())
     assert pt_dtype in pt_types, f"{pt_dtype} Tensorflow equivelant not defined"
-
     return list(tf_to_pt_type_map.keys())[pt_types.index(pt_dtype)]
 
+def map_pd_dtype_to_pt(pd_dtype):
+    pt_type = pd_to_pt_type_map[pd_dtype]
+    assert pt_type is not None, f"Paddle DType {pd_dtype} has no PyTorch equivalent"
+    return pt_type
+
+def map_pt_dtype_to_pd(pt_dtype):
+    pt_types = list(pd_to_pt_type_map.values())
+    assert pt_dtype in pt_types, f"{pt_dtype} Paddle equivelant not defined"
+    return list(pd_to_pt_type_map.keys())[pt_types.index(pt_dtype)]
 
 def flatten_inputs(inputs, names=None, force_float32=False):
     from forge.tensor import Tensor

--- a/forge/forge/verify/config.py
+++ b/forge/forge/verify/config.py
@@ -266,16 +266,15 @@ class VerifyConfig:
     # --- Supported Types --- #
     @property
     def supported_tensor_types(self) -> Tuple:
-        from forge import Tensor  # Local import to avoid circular dependency
-
-        return (tf.Tensor, tf.Variable, torch.Tensor, Tensor, paddle.Tensor)
+        from forge.tensor import AnyTensor  # Local import to avoid circular dependency
+        return (AnyTensor,)
 
     @property
     def compiled_model_types(self) -> Tuple:
-        from forge.compiled_graph_state import CompiledModel  # Local import to avoid circular dependency
-
+        from forge.compiled_graph_state import CompiledModel  # Local import to avoid circular dependency 
         return (CompiledModel,)
 
     @property
-    def framework_model_types(self) -> Tuple:
-        return (torch.nn.Module, tf.Module, tf.keras.Model, forge.ForgeModule, paddle.nn.Layer, forge.OnnxModule)
+    def framework_model_types(self) -> Tuple: 
+        from forge.module import AnyModule # Local import to avoid circular dependency
+        return (AnyModule,)

--- a/forge/forge/verify/config.py
+++ b/forge/forge/verify/config.py
@@ -267,14 +267,17 @@ class VerifyConfig:
     @property
     def supported_tensor_types(self) -> Tuple:
         from forge.tensor import AnyTensor  # Local import to avoid circular dependency
+
         return (AnyTensor,)
 
     @property
     def compiled_model_types(self) -> Tuple:
-        from forge.compiled_graph_state import CompiledModel  # Local import to avoid circular dependency 
+        from forge.compiled_graph_state import CompiledModel  # Local import to avoid circular dependency
+
         return (CompiledModel,)
 
     @property
-    def framework_model_types(self) -> Tuple: 
-        from forge.module import AnyModule # Local import to avoid circular dependency
+    def framework_model_types(self) -> Tuple:
+        from forge.module import AnyModule  # Local import to avoid circular dependency
+
         return (AnyModule,)

--- a/forge/forge/verify/verify.py
+++ b/forge/forge/verify/verify.py
@@ -284,7 +284,7 @@ def check_dtypes(fw_dtype: torch.dtype, co_dtype: torch.dtype):
 
 
 def verify(
-    inputs: List[Union[FrameworkTensor, tf.Variable]],
+    inputs: List[FrameworkTensor],
     framework_model: FrameworkModule,
     compiled_model: CompiledModel,
     verify_cfg: VerifyConfig = VerifyConfig(),

--- a/forge/forge/verify/verify.py
+++ b/forge/forge/verify/verify.py
@@ -9,6 +9,7 @@ Verify by evaluating the forge graph
 import os
 from typing import Tuple, Dict, List, Any, Union, Optional
 
+from forge.module import FrameworkModule
 from loguru import logger
 from forge.forgeglobal import align_up_tile
 import paddle
@@ -18,6 +19,7 @@ import tensorflow as tf
 from forge.tensor import to_pt_tensors
 
 from ..tensor import (
+    FrameworkTensor,
     Tensor,
     TensorShape,
     pad_pytorch_tensor_to_forge,
@@ -282,8 +284,8 @@ def check_dtypes(fw_dtype: torch.dtype, co_dtype: torch.dtype):
 
 
 def verify(
-    inputs: List[Union[torch.Tensor, tf.Tensor, tf.Variable, paddle.Tensor]],
-    framework_model: Union[torch.nn.Module, tf.Module, tf.keras.Model, paddle.nn.Layer, onnx.onnx_ml_pb2.ModelProto],
+    inputs: List[Union[FrameworkTensor, tf.Variable]],
+    framework_model: FrameworkModule,
     compiled_model: CompiledModel,
     verify_cfg: VerifyConfig = VerifyConfig(),
     forge_property_handler: Optional[ForgePropertyHandler] = None,

--- a/forge/test/mlir/test_ops_paddle.py
+++ b/forge/test/mlir/test_ops_paddle.py
@@ -325,26 +325,3 @@ def test_embedding_pp(forge_property_recorder, vocab_size, token_num, embedding_
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-
-@pytest.mark.parametrize("vocab_size", [32000])
-@pytest.mark.parametrize("token_num", [12])
-@pytest.mark.parametrize("embedding_dim", [3200])
-@pytest.mark.push
-def test_embedding_pp(forge_property_recorder, vocab_size, token_num, embedding_dim):
-    class Embedding(paddle.nn.Layer):
-        def __init__(self):
-            super().__init__()
-            self.embedding = paddle.nn.Embedding(vocab_size, embedding_dim)
-
-        def forward(self, x):
-            return self.embedding(x)
-
-    inputs = [
-        paddle.randint(0, vocab_size, (1, token_num)),
-    ]
-
-    framework_model = Embedding()
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
-
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)

--- a/forge/test/mlir/test_ops_paddle.py
+++ b/forge/test/mlir/test_ops_paddle.py
@@ -303,6 +303,7 @@ def test_convbn_pp(forge_property_recorder):
 
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
+
 @pytest.mark.parametrize("vocab_size", [32000])
 @pytest.mark.parametrize("token_num", [12])
 @pytest.mark.parametrize("embedding_dim", [3200])

--- a/forge/test/mlir/test_ops_paddle.py
+++ b/forge/test/mlir/test_ops_paddle.py
@@ -326,6 +326,7 @@ def test_embedding_pp(forge_property_recorder, vocab_size, token_num, embedding_
 
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
+
 @pytest.mark.parametrize("vocab_size", [32000])
 @pytest.mark.parametrize("token_num", [12])
 @pytest.mark.parametrize("embedding_dim", [3200])

--- a/forge/test/mlir/test_ops_paddle.py
+++ b/forge/test/mlir/test_ops_paddle.py
@@ -302,3 +302,47 @@ def test_convbn_pp(forge_property_recorder):
     )
 
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+@pytest.mark.parametrize("vocab_size", [32000])
+@pytest.mark.parametrize("token_num", [12])
+@pytest.mark.parametrize("embedding_dim", [3200])
+@pytest.mark.push
+def test_embedding_pp(forge_property_recorder, vocab_size, token_num, embedding_dim):
+    class Embedding(paddle.nn.Layer):
+        def __init__(self):
+            super().__init__()
+            self.embedding = paddle.nn.Embedding(vocab_size, embedding_dim)
+
+        def forward(self, x):
+            return self.embedding(x)
+
+    inputs = [
+        paddle.randint(0, vocab_size, (1, token_num)),
+    ]
+
+    framework_model = Embedding()
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+@pytest.mark.parametrize("vocab_size", [32000])
+@pytest.mark.parametrize("token_num", [12])
+@pytest.mark.parametrize("embedding_dim", [3200])
+@pytest.mark.push
+def test_embedding_pp(forge_property_recorder, vocab_size, token_num, embedding_dim):
+    class Embedding(paddle.nn.Layer):
+        def __init__(self):
+            super().__init__()
+            self.embedding = paddle.nn.Embedding(vocab_size, embedding_dim)
+
+        def forward(self, x):
+            return self.embedding(x)
+
+    inputs = [
+        paddle.randint(0, vocab_size, (1, token_num)),
+    ]
+
+    framework_model = Embedding()
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)


### PR DESCRIPTION
- Renamed `pt_to_paddle_tensors` to `to_pd_tensors` and fixed type conversion between Torch and Paddle tensors.  
- Added a test in `test_ops_paddle.py` to verify the type conversion, which previously failed.  
- Replaced explicit type listings with `FrameworkModule`, `FrameworkTensor`, and `AnyTensor` where applicable.

solves issues https://github.com/tenstorrent/tt-forge-fe/issues/1504 and https://github.com/tenstorrent/tt-forge-fe/issues/1505 .