### PR TITLE
[runtime] tensors on device aka runtime stitching

### DIFF
--- a/forge/csrc/runtime/CMakeLists.txt
+++ b/forge/csrc/runtime/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(runtime STATIC runtime.cpp tt_device.cpp python_bindings.cpp)
+add_library(runtime STATIC runtime.cpp tt_device.cpp python_bindings.cpp state.cpp)
 add_dependencies(runtime tt-mlir)
 
 target_link_libraries(runtime PUBLIC coverage_config)

--- a/forge/csrc/runtime/python_bindings.cpp
+++ b/forge/csrc/runtime/python_bindings.cpp
@@ -5,6 +5,7 @@
 #include "runtime/python_bindings.hpp"
 
 #include "runtime/runtime.hpp"
+#include "runtime/state.hpp"
 #include "runtime/tt_device.hpp"
 #include "tt/runtime/types.h"
 
@@ -17,7 +18,50 @@ void RuntimeModule(py::module &m_runtime)
     py::class_<runtime::Binary>(m_runtime, "Binary")
         .def("get_program_inputs", &runtime::Binary::getProgramInputs)
         .def("get_program_outputs", &runtime::Binary::getProgramOutputs);
-    m_runtime.def("run_binary", tt::run_binary);
+    m_runtime.def("run_program", &tt::run_program);
+
+    py::class_<Tensor>(m_runtime, "Tensor")
+        .def(py::init<torch::Tensor &>())
+        .def("to_torch", &Tensor::to_torch)
+        .def("update_host_data", &Tensor::update_host_data)
+        .def("detach_from_device", &Tensor::detach_from_device);
+    py::class_<TensorPool>(m_runtime, "TensorPool")
+        .def(py::init<>())
+        .def("get_tensor", &TensorPool::get_tensor)
+        .def(
+            "insert",
+            [](TensorPool &self, const std::string &name, torch::Tensor &tensor) { self.insert(name, tensor); })
+        .def("update_tensor", &TensorPool::update_tensor);
+
+    py::enum_<ProgramType>(m_runtime, "ProgramType")
+        .value("Forward", ProgramType::Forward)
+        .value("Backward", ProgramType::Backward)
+        .value("Optimizer", ProgramType::Optimizer)
+        .export_values();
+
+    py::class_<ProgramState>(m_runtime, "ProgramState")
+        .def(py::init<ProgramType, std::vector<Tensor>, std::vector<Tensor>>());
+
+    py::class_<ModelState>(m_runtime, "ModelState")
+        .def(py::init<runtime::Binary>())
+        .def_property_readonly("tensor_pool", &ModelState::get_tensor_pool)
+        .def(
+            "init_program_state",
+            [](ModelState &self, ProgramState &program_state) { self.add_program_state(program_state); })
+        .def(
+            "run_program",
+            [](ModelState &self, ProgramType program_type, std::vector<tt::Tensor> &act_inputs)
+            { self.run_program(program_type, act_inputs); })
+        .def(
+            "get_outputs",
+            [](ModelState &self, ProgramType program_type)
+            {
+                std::optional<ProgramState> &opt_program_state = self.program_states[program_idx(program_type)];
+                TT_ASSERT(opt_program_state.has_value(), "Program state for {} not initialized", program_type);
+                return opt_program_state.value().outputs;
+            });
+
+    m_runtime.def("create_program_state", &tt::create_program_state);
 
     // Experimental APIs
     py::module m_experimental = m_runtime.def_submodule("experimental");

--- a/forge/csrc/runtime/runtime.cpp
+++ b/forge/csrc/runtime/runtime.cpp
@@ -6,6 +6,7 @@
 
 #include <optional>
 
+#include "tensor.hpp"
 #include "tt/runtime/runtime.h"
 #include "tt_device.hpp"
 #include "utils/assert.hpp"
@@ -14,132 +15,66 @@
 namespace tt
 {
 
-static target::DataType torch_scalar_type_to_dt(torch::ScalarType st)
-{
-    switch (st)
-    {
-        case torch::ScalarType::Byte: return target::DataType::UInt8;
-        case torch::ScalarType::Char: return target::DataType::UInt8;
-        case torch::ScalarType::Short: return target::DataType::UInt16;
-        case torch::ScalarType::Int: return target::DataType::Int32;
-        case torch::ScalarType::Long: return target::DataType::UInt32;
-        case torch::ScalarType::Half: return target::DataType::Float16;
-        case torch::ScalarType::Float: return target::DataType::Float32;
-        // case torch::ScalarType::Double:
-        // case torch::ScalarType::ComplexHalf:
-        // case torch::ScalarType::ComplexFloat:
-        // case torch::ScalarType::ComplexDouble:
-        // case torch::ScalarType::Bool:
-        case torch::ScalarType::BFloat16: return target::DataType::BFloat16;
-        default: break;
-    }
-
-    log_fatal(LogTTDevice, "Unhandled dtype {}", st);
-}
-
-static torch::ScalarType dt_to_torch_scalar_type(target::DataType df)
-{
-    switch (df)
-    {
-        case target::DataType::UInt8: return torch::ScalarType::Byte;
-        case target::DataType::UInt16: return torch::ScalarType::Short;
-        case target::DataType::UInt32: return torch::ScalarType::Int;
-        case target::DataType::Int32: return torch::ScalarType::Int;
-        case target::DataType::Float16: return torch::ScalarType::Half;
-        case target::DataType::Float32: return torch::ScalarType::Float;
-        case target::DataType::BFloat16: return torch::ScalarType::BFloat16;
-        default: break;
-    }
-
-    log_fatal(LogTTDevice, "Unhandled dtype {}", target::EnumNameDataType(df));
-}
-
-template <typename T>
-std::vector<int64_t> as_vec_int64(std::vector<T> const& vec)
-{
-    std::vector<int64_t> result;
-    result.reserve(vec.size());
-    for (auto const& v : vec)
-    {
-        result.push_back(v);
-    }
-    return result;
-}
-
-static runtime::Tensor create_tensor(const torch::Tensor& tensor)
-{
-    auto data = std::shared_ptr<void>(
-        tensor.data_ptr(),
-        [tensor](void*) { (void)tensor; }  // Capture tensor by value to increase ref count and keep it alive
-    );
-
-    auto shape = std::vector<uint32_t>(tensor.sizes().begin(), tensor.sizes().end());
-    auto stride = std::vector<uint32_t>(tensor.strides().begin(), tensor.strides().end());
-
-    return runtime::createTensor(
-        data, shape, stride, tensor.element_size(), torch_scalar_type_to_dt(tensor.scalar_type()));
-}
-
 runtime::Binary load_binary_from_file(std::string const& filename)
 {
     runtime::Binary binary = tt::runtime::Binary::loadFromPath(filename.c_str()).handle;
     return binary;
 }
 
-std::vector<torch::Tensor> run_binary_from_file(
-    std::string const& filename, int program_idx, std::vector<torch::Tensor> const& inputs)
+std::vector<tt::Tensor> run_program_from_file(
+    std::string const& filename, int program_idx, std::vector<torch::Tensor>& inputs)
 {
     auto binary = load_binary_from_file(filename);
 
-    return run_binary(binary, program_idx, inputs);
+    std::vector<tt::Tensor> tt_inputs;
+    tt_inputs.reserve(inputs.size());
+
+    std::transform(
+        inputs.begin(),
+        inputs.end(),
+        std::back_inserter(tt_inputs),
+        [](torch::Tensor& input) { return tt::Tensor(input); });
+
+    return run_program(binary, program_idx, tt_inputs);
 }
 
-void verify_input_tensors(
-    const std::vector<torch::Tensor>& input_tensors, const std::vector<runtime::TensorDesc>& input_descs)
+void verify_input_descs(
+    const std::vector<runtime::TensorDesc>& descs, const std::vector<runtime::TensorDesc>& expected_descs)
 {
-    if (input_tensors.size() != input_descs.size())
+    if (descs.size() != expected_descs.size())
     {
-        log_fatal(LogTTDevice, "Input count mismatch: expected {}, got {}", input_descs.size(), input_tensors.size());
+        log_fatal(LogTTDevice, "Input count mismatch: expected {}, got {}", descs.size(), expected_descs.size());
     }
 
-    for (size_t i = 0; i < input_descs.size(); ++i)
+    for (size_t i = 0; i < descs.size(); ++i)
     {
-        const auto& input_tensor = input_tensors[i];
-        const auto& desc = input_descs[i];
+        const auto& desc = descs[i];
+        const auto& expected_desc = expected_descs[i];
 
-        auto shape = as_vec_int64(desc.shape);
-        auto stride = as_vec_int64(desc.stride);
-
-        if (input_tensor.sizes().vec() != shape)
+        if (desc.shape != expected_desc.shape)
         {
             log_fatal(
-                LogTTDevice, "Tensor {} - shape mismatch: expected {}, got {}", i, shape, input_tensor.sizes().vec());
+                LogTTDevice, "Tensor {} - shape mismatch: expected {}, got {}", i, expected_desc.shape, desc.shape);
         }
 
-        if (input_tensor.strides().vec() != stride)
+        if (desc.stride != expected_desc.stride)
         {
             log_fatal(
-                LogTTDevice,
-                "Tensor {} - stride mismatch: expected {}, got {}",
-                i,
-                stride,
-                input_tensor.strides().vec());
+                LogTTDevice, "Tensor {} - stride mismatch: expected {}, got {}", i, expected_desc.stride, desc.stride);
         }
 
-        if (torch_scalar_type_to_dt(input_tensor.scalar_type()) != desc.dataType)
+        if (desc.dataType != expected_desc.dataType)
         {
-            auto expected = target::EnumNameDataType(desc.dataType);
-            auto got = target::EnumNameDataType(torch_scalar_type_to_dt(input_tensor.scalar_type()));
+            auto expected = target::EnumNameDataType(expected_desc.dataType);
+            auto got = target::EnumNameDataType(desc.dataType);
             log_fatal(LogTTDevice, "Tensor {} - data type mismatch: expected {}, got {}", i, expected, got);
         }
     }
 }
 
-std::vector<torch::Tensor> run_binary(
-    runtime::Binary& binary, int program_idx, std::vector<torch::Tensor> const& inputs)
+std::vector<tt::Tensor> run_program(runtime::Binary& binary, int program_idx, std::vector<tt::Tensor>& inputs)
 {
     auto& system = TTSystem::get_system();
-
     for (auto& device : system.devices)
     {
         if (!device->is_open())
@@ -149,7 +84,8 @@ std::vector<torch::Tensor> run_binary(
     }
 
     // For now, we only support a single device.
-    auto& tt_device = system.devices[0];
+    constexpr size_t device_id = 0;
+    auto& tt_device = system.devices[device_id];
     if (!tt_device->is_open())
     {
         log_fatal(LogTTDevice, "Failed to open device");
@@ -157,37 +93,45 @@ std::vector<torch::Tensor> run_binary(
 
     auto& device = *tt_device->rt_device;
 
-    auto input_descs = binary.getProgramInputs(program_idx);
-    verify_input_tensors(inputs, input_descs);
+    auto expected_input_descs = binary.getProgramInputs(program_idx);
+
+    std::vector<runtime::TensorDesc> input_descs;
+    input_descs.reserve(inputs.size());
+
+    std::transform(
+        inputs.begin(),
+        inputs.end(),
+        std::back_inserter(input_descs),
+        [](const tt::Tensor& input) { return input.tensor_desc(); });
+
+    verify_input_descs(input_descs, expected_input_descs);
 
     std::vector<runtime::Tensor> rt_inputs;
-    for (auto const& input : inputs)
-    {
-        rt_inputs.emplace_back(create_tensor(input));
-    }
+    rt_inputs.reserve(inputs.size());
 
-    std::vector<torch::Tensor> outputs;
-    std::vector<runtime::Tensor> rt_outputs;
-    std::vector<runtime::TensorDesc> output_descs = binary.getProgramOutputs(program_idx);
-    outputs.reserve(output_descs.size());
-    for (auto const& desc : output_descs)
-    {
-        std::vector<std::int64_t> shape = as_vec_int64(desc.shape);
-        std::vector<std::int64_t> stride = as_vec_int64(desc.stride);
+    std::transform(
+        inputs.begin(),
+        inputs.end(),
+        std::back_inserter(rt_inputs),
+        [](tt::Tensor& input) { return input.get_runtime_tensor(); });
 
-        torch::Tensor output = at::empty_strided(shape, stride, dt_to_torch_scalar_type(desc.dataType));
-        outputs.emplace_back(std::move(output));
-        rt_outputs.emplace_back(create_tensor(outputs.back()));
-    }
+    auto output_descs = binary.getProgramOutputs(program_idx);
+    std::vector<runtime::Tensor> rt_outputs = runtime::submit(device, binary, program_idx, rt_inputs);
+    TT_ASSERT(output_descs.size() == rt_outputs.size(), "Output count mismatch");
 
-    std::vector<runtime::Tensor> submit_outputs = runtime::submit(device, binary, program_idx, rt_inputs);
-    TT_ASSERT(submit_outputs.size() == rt_outputs.size(), "Output count mismatch");
-    for (size_t i = 0; i < submit_outputs.size(); ++i)
-    {
-        auto host = runtime::toHost(submit_outputs[i], true /*untilize*/)[0];
-        runtime::memcpy(rt_outputs[i], host);
-        runtime::deallocateTensor(submit_outputs[i], true);
-    }
+    std::vector<tt::Tensor> outputs;
+    outputs.reserve(rt_outputs.size());
+
+    size_t output_id = 0;
+    std::transform(
+        rt_outputs.begin(),
+        rt_outputs.end(),
+        std::back_inserter(outputs),
+        [&output_id, &output_descs](runtime::Tensor& rt_output)
+        {
+            auto desc = output_descs[output_id++];
+            return tt::Tensor(rt_output, desc);
+        });
 
     return outputs;
 }

--- a/forge/csrc/runtime/runtime.hpp
+++ b/forge/csrc/runtime/runtime.hpp
@@ -6,17 +6,17 @@
 #include <torch/python.h>
 #include <torch/torch.h>
 
+#include "tensor.hpp"
 #include "tt/runtime/types.h"
 
 namespace tt
 {
 
-// Entry point for invoking tt-mlir runtime and running the binary on the device.
-std::vector<torch::Tensor> run_binary(
-    runtime::Binary& binary, int program_idx, std::vector<torch::Tensor> const& inputs);
-
-// Helper function to run the binary from the file - might be useful for testing/debugging.
-std::vector<torch::Tensor> run_binary_from_file(
+// Helper function to load the binary from the file and run a program - might be useful for testing/debugging.
+std::vector<tt::Tensor> run_program_from_file(
     std::string const& filename, int program_idx, std::vector<torch::Tensor> const& inputs);
+
+// Entry point for invoking tt-mlir runtime and running the specific program from the binary on the device.
+std::vector<tt::Tensor> run_program(runtime::Binary& binary, int program_idx, std::vector<tt::Tensor>& inputs);
 
 }  // namespace tt

--- a/forge/csrc/runtime/state.cpp
+++ b/forge/csrc/runtime/state.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "runtime/state.hpp"
+
+#include <utils/logger.hpp>
+
+#include "tt/runtime/runtime.h"
+
+namespace tt
+{
+
+std::ostream& operator<<(std::ostream& os, ProgramType program_type)
+{
+    switch (program_type)
+    {
+        case ProgramType::Forward: os << "Forward"; break;
+        case ProgramType::Backward: os << "Backward"; break;
+        case ProgramType::Optimizer: os << "Optimizer"; break;
+        default: os << "Unknown"; break;
+    }
+    return os;
+}
+
+ProgramState create_program_state(
+    ProgramType program_type, const TensorPool& tensor_pool, std::vector<std::string> persistent_input_names)
+{
+    std::vector<tt::Tensor> persistent_inputs;
+    persistent_inputs.reserve(persistent_input_names.size());
+
+    for (auto& name : persistent_input_names)
+    {
+        auto tensor = tensor_pool.get_tensor(name);
+        persistent_inputs.emplace_back(tensor);
+    }
+    return ProgramState{program_type, persistent_inputs, {}};
+}
+
+void ModelState::run_program(ProgramType program_type, std::vector<tt::Tensor> act_inputs)
+{
+    // ISSUE(#1346): So far, the device_id is hardcoded to 0 - make it user-configurable.
+    constexpr size_t device_id = 0;
+    size_t pg_id = program_idx(program_type);
+    std::optional<ProgramState>& opt_program_state = program_states[pg_id];
+
+    TT_ASSERT(opt_program_state.has_value(), "Program state for {} not initialized", program_type);
+
+    if (!TTSystem::get_system().devices[device_id]->is_open())
+    {
+        TTSystem::get_system().devices[device_id]->open_device();
+    }
+
+    auto& program_state = opt_program_state.value();
+
+    // Clear the outputs from the previous run.
+    program_state.outputs.clear();
+
+    std::vector<tt::Tensor> inputs;
+    inputs.reserve(act_inputs.size() + program_state.persistent_inputs.size());
+
+    // Push activation inputs to the device if they are not already there.
+    // NOTE: there is an ordering requirement for the activation inputs and the persistent inputs, i.e.
+    // in the input list (`inputs` vector here), the activation inputs come first. Unfortunately, there isn't any
+    // mechanism which enforces this, yet. It's an informal contract between the compiler and the runtime.
+    size_t input_idx = 0;
+    for (auto tensor : act_inputs)
+    {
+        if (!tensor.on_device())
+        {
+            auto layout = tt::runtime::getLayout(binary, pg_id, input_idx++);
+            tensor.to_device(device_id, layout);
+        }
+
+        inputs.emplace_back(tensor);
+    }
+
+    // Push persistent inputs to the device if they are not already there.
+    for (auto& persistent_input : program_state.persistent_inputs)
+    {
+        size_t curr_input_id = input_idx++;
+        if (!persistent_input.on_device())
+        {
+            auto layout = tt::runtime::getLayout(binary, pg_id, curr_input_id);
+            persistent_input.to_device(device_id, layout);
+        }
+
+        inputs.emplace_back(persistent_input);
+    }
+
+    program_state.outputs = ::tt::run_program(binary, pg_id, inputs);
+}
+};  // namespace tt

--- a/forge/csrc/runtime/state.hpp
+++ b/forge/csrc/runtime/state.hpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <optional>
+
+#include "runtime/runtime.hpp"
+#include "runtime/tensor.hpp"
+#include "tt/runtime/types.h"
+
+namespace tt
+{
+
+enum class ProgramType : uint32_t
+{
+    Forward = 0,
+    Backward,
+    Optimizer,
+    Count  // Keep this last
+};
+
+std::ostream& operator<<(std::ostream& os, ProgramType program_type);
+
+constexpr size_t PROGRAM_TYPE_COUNT = static_cast<std::underlying_type_t<ProgramType>>(ProgramType::Count);
+
+constexpr auto program_idx(ProgramType program_type)
+{
+    TT_ASSERT(program_type < ProgramType::Count, "Invalid program type");
+    return static_cast<std::underlying_type_t<ProgramType>>(program_type);
+}
+
+// Simple struct to hold the state of a program.
+struct ProgramState
+{
+    ProgramType program_type;
+    std::vector<tt::Tensor> persistent_inputs;
+    std::vector<tt::Tensor> outputs;
+};
+
+// Encapsulates execution context for a model.
+struct ModelState
+{
+    // Handle to the flatbuffer binary which contains the model.
+    runtime::Binary binary;
+
+    // Static array of program states, one for each program type.
+    std::array<std::optional<ProgramState>, PROGRAM_TYPE_COUNT> program_states;
+
+    // Tensor pool containing tensors shared between different programs or program invocations.
+    // E.g. weights, constants, etc.
+    //
+    // These tensors will be pushed to the device the first time they are used in a program (as inputs to the program).
+    // They will be kept on the device until the runtime/user decides to remove them from the device. In that case on
+    // next use they will be pushed to the device again.
+    TensorPool tensor_pool;
+
+    ModelState(runtime::Binary binary) : binary{binary}, program_states{}, tensor_pool{} {}
+
+    // Disallow copy construction and assignment.
+    ModelState(const ModelState&) = delete;
+    ModelState(ModelState&&) = default;
+    ModelState& operator=(const ModelState&) = delete;
+
+    TensorPool& get_tensor_pool() { return tensor_pool; }
+
+    void add_program_state(ProgramState& program_state)
+    {
+        auto program_type = program_state.program_type;
+        auto pidx = program_idx(program_type);
+
+        program_states[pidx] = program_state;
+    }
+
+    void run_program(ProgramType program_type, std::vector<tt::Tensor> act_inputs);
+};
+
+ProgramState create_program_state(
+    ProgramType program_type, const TensorPool& tensor_pool, std::vector<std::string> persistent_input_names);
+
+}  // namespace tt

--- a/forge/csrc/runtime/tensor.hpp
+++ b/forge/csrc/runtime/tensor.hpp
@@ -1,0 +1,343 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstring>
+#include <optional>
+#include <variant>
+
+#include "runtime/tt_device.hpp"
+#include "torch/torch.h"
+#include "tt/runtime/runtime.h"
+#include "tt/runtime/types.h"
+#include "utils/assert.hpp"
+
+namespace tt
+{
+
+target::DataType torch_scalar_type_to_dt(torch::ScalarType st);
+torch::ScalarType dt_to_torch_scalar_type(target::DataType df);
+
+template <typename T>
+std::vector<int64_t> as_vec_int64(std::vector<T> const& vec)
+{
+    std::vector<int64_t> result;
+    result.reserve(vec.size());
+    for (auto const& v : vec)
+    {
+        result.push_back(v);
+    }
+    return result;
+}
+
+// Class which wraps the host storage of a tensor.
+//
+// NOTE: currently this doesn't make much sense, since we only have one type of host storage (torch.Tensor).
+// However, i expect that we will soon introduce at least one additional type of storage, so i've decided to introduce
+// this class. Remove this if i turn out to be an optimist.
+class TensorHostStorage
+{
+   public:
+    explicit TensorHostStorage(torch::Tensor& tensor) : storage(tensor) {}
+
+    // Creates a new shared_ptr to the data of the tensor.
+    // NOTE: the shared_ptr is not owning the data and will not ever release it (see the lambda for the deleter),
+    // it is used only to provide a shared_ptr interface to the data which the device runtime (`tt-mlir` runtime)
+    // expects.
+    std::shared_ptr<void> borrow_data() const
+    {
+        return std::visit(
+            [](auto&& arg) -> std::shared_ptr<void>
+            {
+                using T = std::decay_t<decltype(arg)>;
+                if constexpr (std::is_same_v<T, torch::Tensor>)
+                {
+                    return std::shared_ptr<void>(arg.data_ptr(), [arg](void*) { (void)arg; });
+                }
+            },
+            storage);
+    }
+
+    void* data_ptr() const
+    {
+        return std::visit(
+            [](auto&& arg) -> void*
+            {
+                using T = std::decay_t<decltype(arg)>;
+                if constexpr (std::is_same_v<T, torch::Tensor>)
+                {
+                    return arg.data_ptr();
+                }
+            },
+            storage);
+    }
+
+    template <typename T>
+    static TensorHostStorage from_desc(runtime::TensorDesc desc)
+    {
+        static_assert(std::is_same_v<T, torch::Tensor>, "Currently only torch::Tensor is supported");
+
+        if constexpr (std::is_same_v<T, torch::Tensor>)
+        {
+            auto shape = as_vec_int64(desc.shape);
+            auto stride = as_vec_int64(desc.stride);
+            auto dtype = dt_to_torch_scalar_type(desc.dataType);
+
+            auto tensor = at::empty_strided(shape, stride, dtype);
+            return TensorHostStorage(tensor);
+        }
+    }
+
+    std::variant<torch::Tensor> storage;
+};
+
+// Core implementation behind the `Tensor` class.
+//
+// It holds the tensor description and the actual data.
+//
+// When created from the host tensor, the host tensor is kept alive during the whole lifetime of the `Tensor` object.
+// This way the original host tensor and our `Tensor` are linked, so that it is possible to update the original host
+// tensor with new data that was computed on the device (and vice versa). This might turn out to be a bad idea,
+// but time will tell.
+class TensorImpl : public std::enable_shared_from_this<TensorImpl>
+{
+   public:
+    TensorImpl(torch::Tensor& tensor) : host_storage(tensor), rt_tensor(std::nullopt)
+    {
+        auto shape = std::vector<uint32_t>(tensor.sizes().begin(), tensor.sizes().end());
+        auto stride = std::vector<uint32_t>(tensor.strides().begin(), tensor.strides().end());
+
+        desc.shape = shape;
+        desc.stride = stride;
+        desc.itemsize = tensor.element_size();
+        desc.dataType = torch_scalar_type_to_dt(tensor.scalar_type());
+    }
+
+    TensorImpl(runtime::Tensor& tensor, runtime::TensorDesc tensor_desc) :
+        host_storage(std::nullopt), desc(tensor_desc), rt_tensor(tensor)
+    {
+    }
+
+    std::shared_ptr<void> borrow_host_data() const
+    {
+        TT_ASSERT(host_storage.has_value());
+        return host_storage->borrow_data();
+    }
+
+    runtime::Tensor& get_runtime_tensor()
+    {
+        TT_ASSERT(rt_tensor.has_value());
+        return *rt_tensor;
+    }
+
+    torch::Tensor to_torch()
+    {
+        if (!host_storage.has_value())
+        {
+            // The tensor doesn't have a host storage, so we need to copy it to the host.
+            to_host();
+        }
+
+        TT_ASSERT(
+            std::holds_alternative<torch::Tensor>(host_storage->storage),
+            "For now, we expect the host storage to be a torch tensor");
+
+        auto torch_tensor = std::get<torch::Tensor>(host_storage->storage);
+        return torch_tensor;
+    }
+
+    // Creates a device tensor from the host tensor.
+    // Note: the host tensor is not modified and lives on.
+    void to_device(const size_t device_id, runtime::Layout& layout)
+    {
+        TT_ASSERT(!rt_tensor.has_value());
+        auto device = TTSystem::get_system().devices[device_id];
+
+        TT_ASSERT(host_storage.has_value(), "Since the tensor is on host, we expect the host storage to be set");
+        rt_tensor =
+            runtime::createTensor(host_storage->borrow_data(), desc.shape, desc.stride, desc.itemsize, desc.dataType);
+        rt_tensor = tt::runtime::toLayout(rt_tensor.value(), *device->rt_device, layout);
+    }
+
+    void to_host()
+    {
+        TT_ASSERT(rt_tensor.has_value(), "We expect the tensor to be on device");
+        constexpr bool untilize_tensor = true;
+        auto sharded_tensor = tt::runtime::toHost(rt_tensor.value(), untilize_tensor);
+        TT_ASSERT(sharded_tensor.size() == 1, "We don't expect sharded tensors, i.e. we expect only one shard");
+
+        auto host = sharded_tensor[0];
+
+        if (!host_storage.has_value())
+        {
+            host_storage = TensorHostStorage::from_desc<torch::Tensor>(desc);
+        }
+
+        tt::runtime::memcpy(host_storage->data_ptr(), host);
+    }
+
+    // Updates the host buffer with data from the device tensor.
+    // Used when the original `tt::Tensor` was created from an existing torch (host) tensor, and later moved and
+    // modified on the device.
+    //
+    // Example use case: optimizer step in training scenario (when executed on the device).
+    // The original tensor (weight) was created from a torch tensor and then updated during execution of the optimizer
+    // step on device.
+    void update_host_data()
+    {
+        TT_ASSERT(
+            rt_tensor.has_value() && borrow_host_data().get() != nullptr,
+            "We expect the tensor to have a host buffer as well as a handle to the device tensor");
+
+        constexpr bool untilize_tensor = true;
+        auto sharded_tensor = tt::runtime::toHost(rt_tensor.value(), untilize_tensor);
+        TT_ASSERT(sharded_tensor.size() == 1, "We don't expect sharded tensors, i.e. we expect only one shard");
+
+        auto host = sharded_tensor[0];
+
+        tt::runtime::memcpy(borrow_host_data().get(), host);
+    }
+
+    bool on_device() const { return rt_tensor.has_value(); }
+
+    void detach_from_device() { rt_tensor.reset(); }
+
+    runtime::TensorDesc tensor_desc() const { return desc; }
+
+   private:
+    std::optional<TensorHostStorage> host_storage;
+    runtime::TensorDesc desc;
+    std::optional<runtime::Tensor> rt_tensor;
+};
+
+// Main `Tensor` class that wraps a ref-counted tensor and provides an interface to interact with it.
+//
+// The tensor can be created from a host tensor or from a device runtime handle (runtime::Tensor).
+// For more details look at the `TensorImpl` class.
+class Tensor
+{
+   public:
+    explicit Tensor(torch::Tensor& tensor) : impl(new TensorImpl(tensor)) {}
+    explicit Tensor(runtime::Tensor& tensor, runtime::TensorDesc tensor_desc) :
+        impl(new TensorImpl(tensor, tensor_desc))
+    {
+    }
+
+    Tensor(const Tensor& other) = default;
+    Tensor(Tensor&& other) = default;
+    Tensor& operator=(const Tensor& other) = default;
+
+    runtime::Tensor& get_runtime_tensor() { return impl->get_runtime_tensor(); }
+
+    // Returns a torch tensor representing this tensor's host storage.
+    // If the tensor is on device, it will first be copied to the host.
+    torch::Tensor to_torch() const { return impl->to_torch(); }
+
+    void to_device(const size_t device_id, runtime::Layout& layout) { impl->to_device(device_id, layout); }
+
+    void update_host_data() { impl->update_host_data(); }
+
+    bool on_device() const { return impl->on_device(); }
+
+    runtime::TensorDesc tensor_desc() const { return impl->tensor_desc(); }
+
+    void detach_from_device() { impl->detach_from_device(); }
+
+   private:
+    std::shared_ptr<TensorImpl> impl;
+};
+
+// Container for named tensors.
+class TensorPool
+{
+   public:
+    TensorPool() = default;
+    TensorPool(TensorPool&&) = default;
+    TensorPool(const TensorPool&) = delete;
+
+    void insert(const std::string& name, torch::Tensor& tensor)
+    {
+        auto t = Tensor(tensor);
+        insert(name, std::move(t));
+    }
+
+    Tensor get_tensor(const std::string& name) const
+    {
+        TT_ASSERT(tensor_name_to_value.find(name) != tensor_name_to_value.end(), "Tensor {} not found", name);
+        return tensor_name_to_value.at(name);
+    }
+
+    bool exists(const std::string& name) const { return tensor_name_to_value.find(name) != tensor_name_to_value.end(); }
+
+    void update_tensor(const std::string& name, tt::Tensor& tensor)
+    {
+        TT_ASSERT(tensor_name_to_value.find(name) != tensor_name_to_value.end(), "Tensor {} not found", name);
+        tensor_name_to_value.at(name).get_runtime_tensor() = tensor.get_runtime_tensor();
+    }
+
+   private:
+    std::unordered_map<std::string, Tensor> tensor_name_to_value;
+
+    void insert(std::string name, Tensor& tensor)
+    {
+        if (tensor_name_to_value.find(name) != tensor_name_to_value.end())
+        {
+            return;
+        }
+
+        tensor_name_to_value.emplace(name, tensor);
+    }
+
+    void insert(std::string name, Tensor&& tensor)
+    {
+        if (tensor_name_to_value.find(name) != tensor_name_to_value.end())
+        {
+            return;
+        }
+
+        tensor_name_to_value.emplace(name, tensor);
+    }
+};
+
+inline target::DataType torch_scalar_type_to_dt(torch::ScalarType st)
+{
+    switch (st)
+    {
+        case torch::ScalarType::Byte: return target::DataType::UInt8;
+        case torch::ScalarType::Char: return target::DataType::UInt8;
+        case torch::ScalarType::Short: return target::DataType::UInt16;
+        case torch::ScalarType::Int: return target::DataType::Int32;
+        case torch::ScalarType::Long: return target::DataType::UInt32;
+        case torch::ScalarType::Half: return target::DataType::Float16;
+        case torch::ScalarType::Float: return target::DataType::Float32;
+        case torch::ScalarType::BFloat16: return target::DataType::BFloat16;
+        case torch::ScalarType::Double:
+        case torch::ScalarType::ComplexHalf:
+        case torch::ScalarType::ComplexFloat:
+        case torch::ScalarType::ComplexDouble:
+        case torch::ScalarType::Bool:
+        default: TT_THROW(false, "Unhandled scalar type {}", st);
+    }
+
+    __builtin_unreachable();
+}
+
+inline torch::ScalarType dt_to_torch_scalar_type(target::DataType df)
+{
+    switch (df)
+    {
+        case target::DataType::UInt8: return torch::ScalarType::Byte;
+        case target::DataType::UInt16: return torch::ScalarType::Short;
+        case target::DataType::UInt32: return torch::ScalarType::Int;
+        case target::DataType::Int32: return torch::ScalarType::Int;
+        case target::DataType::Float16: return torch::ScalarType::Half;
+        case target::DataType::Float32: return torch::ScalarType::Float;
+        case target::DataType::BFloat16: return torch::ScalarType::BFloat16;
+        default: TT_THROW(false, "Unhandled dtype {}", target::EnumNameDataType(df));
+    }
+
+    __builtin_unreachable();
+}
+
+}  // namespace tt

--- a/forge/forge/verify/verify.py
+++ b/forge/forge/verify/verify.py
@@ -411,6 +411,7 @@ def verify(
     # 0th step: Check if inputs are of the correct type
     if not inputs:
         raise ValueError("Input tensors must be provided")
+
     for input_tensor in inputs:
         if not isinstance(input_tensor, verify_cfg.supported_tensor_types):
             raise TypeError(

--- a/forge/test/mlir/test_optimizers.py
+++ b/forge/test/mlir/test_optimizers.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 
 import forge
+from forge._C.runtime import Tensor as CTensor
 from test.mlir.utils import get_param_grads, copy_params
 from test.mlir.mnist.utils import MNISTLinear
 from forge.verify.compare import compare_with_golden
@@ -35,10 +36,13 @@ def train_and_compare_optimizers(
         grad_list = []
         for name in ordered_param_names:
             grad_list.append(grads[name])
-        tt_model.gradient_outputs = grad_list[::-1]
+        gradient_outputs = grad_list[::-1]
+        tt_model.gradient_outputs = [CTensor(grad) for grad in gradient_outputs]
 
         # Step
         tt_optimizer.step()
+        tt_model.update_host_weights()
+
         golden_optimizer.step()
 
         # Compare all the parameters

--- a/forge/test/mlir/test_training.py
+++ b/forge/test/mlir/test_training.py
@@ -62,12 +62,7 @@ def test_torch_training(forge_property_recorder):
 
         loss_grad = tt_out.grad
         assert loss_grad is not None
-        grad = tt_model.backward()
-
-        # HACK to run the optimizer step
-        # i'm not sure what's the right way to tie the torch optimizer to our params,
-        # but this can be done automatically after backward() (hidden from user)
-        model.p.grad = grad[0]
+        tt_model.backward()
 
         optimizer.step()
 


### PR DESCRIPTION
This change implements a mechanism to keep certain tensors on device, so that running programs in a loop (or chaining multiple programs) is more efficient. We call this - runtime stitching.

Previously, we were sending each input to device each time we ran a program - which is problematic, since this includes all of the weights, which for example remain the same during multiple invocations of the forward program (in inference) and don't need to be sent to the device each time.

To keep the tensors on the device we only need to hold on to the handles of the tensors provided by the device runtime (`tt-mlir` runtime) so that the tensors don't get deallocated; and pass them on when needed for executing a program. This change introduces several structures for enabling us to that. Tensors which are kept on the device are called `persistent`.

Summary of the new structures:
- `ModelState` which holds info for running the model (module), i.e. multiple programs (e.g. tensor pool, all program states)
- `ProgramState` - holds info needed for running a particular program (e.g. persistent input tensors).
- `TensorPool` simple container for holding named tensors; in the context of the `ModelState` it will contain all `persistent` tensors.
- `Tensor` which represents forge runtime tensor and holds both the handle to the runtime tensor (if exists) and the host storage handle - the torch tensor from which it was created. This tensor object is similar to the torch tensor, in the sense that the object contains (in this case `shared_ptr`) pointer to the actual tensor data. Thus, copying a tensor only creates a new handle to the underlaying data.

The rest of the change is minimal refactor of existing code to incorporate new structures. Additionally, some of the training tests were modified so that they remain functional; additional handling is needed to ensure proper updating of host/device weight tensors, because training tests combine executing some parts of the graphs/modules both on the device and cpu.

There is no additional test coverage added and the correctness relies on the existing e2e tests. More changes are yet to come with the goal of creating a more performant and robust forge runtime. More fine grained functional tests of the runtime component will be added.

Closes #1245, Closes #1329