### PR TITLE
[signal handler] don't initialize TTSystem

### DIFF
--- a/forge/csrc/runtime/tt_device.cpp
+++ b/forge/csrc/runtime/tt_device.cpp
@@ -13,6 +13,8 @@
 namespace tt
 {
 
+static bool system_is_initialized = false;
+
 TTSystem detect_available_devices()
 {
     auto [system_desc, chip_ids] = runtime::getCurrentSystemDesc();
@@ -44,6 +46,7 @@ TTSystem detect_available_devices()
         ++logical_device_index;
     }
 
+    system_is_initialized = true;
     return TTSystem{system_desc, chip_ids, devices};
 }
 
@@ -52,6 +55,8 @@ TTSystem& TTSystem::get_system()
     static TTSystem system = detect_available_devices();
     return system;
 }
+
+bool TTSystem::is_initialized() { return system_is_initialized; }
 
 void TTDevice::open_device()
 {

--- a/forge/csrc/runtime/tt_device.hpp
+++ b/forge/csrc/runtime/tt_device.hpp
@@ -18,7 +18,7 @@ struct TTDevice
     bool mmio;
     int index;
 
-    // TODO: These don't seem to belong here
+    // TODO(#1491): These don't seem to belong here
     std::map<int, std::vector<std::string>> input_runtime_transforms;
     std::map<int, std::vector<std::vector<int>>> input_tile_bcast_dims;
     std::map<int, std::vector<std::string>> output_runtime_transforms;
@@ -39,6 +39,8 @@ struct TTDevice
     void close_device();
 };
 
+// Used to store the system description and the list of devices.
+// This is a singleton class that is initialized by calling detect_available_devices().
 struct TTSystem
 {
     runtime::SystemDesc system_desc;
@@ -62,6 +64,9 @@ struct TTSystem
     }
 
     static TTSystem& get_system();
+
+    // Returns wheter the static `TTSystem` singleton instance has been initialized.
+    static bool is_initialized();
 };
 
 TTSystem detect_available_devices();

--- a/utils/signal_handlers.hpp
+++ b/utils/signal_handlers.hpp
@@ -23,9 +23,6 @@ inline void tt_forge_signal_handler(int sig)
     }
 
     std::cerr << "tt_forge_signal_handler - signal: " << sig << " (" << signal_name << ")" << std::endl;
-
-    tt::TTSystem::get_system().close_devices();
-
     std::cerr << "stacktrace: " << std::endl;
 
     std::vector bt = tt::assert::backtrace(100, 0);
@@ -51,6 +48,11 @@ inline void tt_forge_signal_handler(int sig)
 
         in_python_section = false;
         std::cerr << prefix << frame << std::endl;
+    }
+
+    if (tt::TTSystem::is_initialized())
+    {
+        tt::TTSystem::get_system().close_devices();
     }
 
     // Restore the default signal handler and raise the signal again.


### PR DESCRIPTION
During signal handling we want to close the opened device(s), so that we leave the device(s) in a consistent state. However, if the `TTSystem` singleton instance was not initialized before the signal handler is called, the signal handler will end up initializing the system (i.e. open/close the devices) unnecessarily.

Fix this by checking if the system has been initialized before closing the device(s); if not initialized - then we certainly don't have any open devices at that point.

Also, move closing of the devices after the stacktrace has been printed; this is done so that we'll have the stacktrace, even if something goes wrong during the closing of the devices.