### PR TITLE
Set batch to 3 for benchmark resnet

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -89,7 +89,7 @@ jobs:
       run: |
         source env/activate
         python forge/test/benchmark/benchmark.py -m mnist_linear -bs 32 -lp 32 -o benchmark_forge_e2e_mnist_32_32_${{ steps.fetch-job-id.outputs.job_id }}.json
-        python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o benchmark_forge_e2e_rasnet50_1_32_${{ steps.fetch-job-id.outputs.job_id }}.json
+        python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 3 -lp 32 -o benchmark_forge_e2e_rasnet50_1_32_${{ steps.fetch-job-id.outputs.job_id }}.json
         python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32 -o benchmark_forge_e2e_llama_1_32_${{ steps.fetch-job-id.outputs.job_id }}.json
 
     - name: Upload Perf Report

--- a/forge/test/benchmark/benchmark/models/resnet_hf.py
+++ b/forge/test/benchmark/benchmark/models/resnet_hf.py
@@ -29,7 +29,7 @@ REPORTS_DIR = "./benchmark_reports/"
 
 # Batch size configurations
 BATCH_SIZE = [
-    1,
+    3,
 ]
 
 # Input size configurations
@@ -66,9 +66,6 @@ def test_resnet_hf(
 
     if training:
         pytest.skip("Training is not supported")
-
-    if batch_size > 1:
-        pytest.skip("Batch size greater than 1 is not supported")
 
     # TODO: This we will need when when we run resnet with real data.
     # Load tiny dataset

--- a/forge/test/benchmark/scripts/run_benchmark_wh.sh
+++ b/forge/test/benchmark/scripts/run_benchmark_wh.sh
@@ -11,7 +11,7 @@
 python forge/test/benchmark/benchmark.py -m mnist_linear -bs 32 -lp 32 -o forge-benchmark-e2e-mnist.json
 
 # Resnet HF
-python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 1 -lp 32 -o forge-benchmark-e2e-resnet50_hf.json
+python forge/test/benchmark/benchmark.py -m resnet50_hf -bs 3 -lp 32 -o forge-benchmark-e2e-resnet50_hf.json
 
 # Llama
 python forge/test/benchmark/benchmark.py -m llama -bs 1 -lp 32 -o forge-benchmark-e2e-llama.json


### PR DESCRIPTION
### Problem description
We want benchmark models to run on largest possible batch.

### What's changed
* Batch for resnet 50 changed form 1 to 3