### PR TITLE
Fix the forge property recording in model analysis 

### DIFF
--- a/.github/model-analysis-config.sh
+++ b/.github/model-analysis-config.sh
@@ -29,7 +29,7 @@ env_vars["MODELS_OPS_TEST_PACKAGE_NAME"]="models_ops"
 
 
 # Common Config for markdown generation and model ops test generation
-env_vars["TEST_DIR_OR_FILE_PATH"]="forge/test/models"
+env_vars["TEST_DIR_OR_FILE_PATH"]="forge/test/models/pytorch/"
 env_vars["UNIQUE_OPS_OUTPUT_DIR_PATH"]="./models_unique_ops_output"
 
 

--- a/.github/workflows/model-analysis.yml
+++ b/.github/workflows/model-analysis.yml
@@ -141,17 +141,17 @@ jobs:
           name: unique-ops-logs
           path: ${{ env.UNIQUE_OPS_OUTPUT_DIR_PATH }}
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        with:
-          branch: ${{ env.BRANCH_NAME }}
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
-          base: main
-          commit-message: ${{ env.COMMIT_MESSAGE }}
-          title: ${{ env.TITLE }}
-          body: ${{ env.BODY }}
-          delete-branch: true
-          token: ${{ env.GITHUB_TOKEN }}
-          add-paths: |
-              ${{ env.OUTPUT_PATH }}
+      # - name: Create Pull Request
+      #   uses: peter-evans/create-pull-request@v7
+      #   with:
+      #     branch: ${{ env.BRANCH_NAME }}
+      #     committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+      #     author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+      #     base: main
+      #     commit-message: ${{ env.COMMIT_MESSAGE }}
+      #     title: ${{ env.TITLE }}
+      #     body: ${{ env.BODY }}
+      #     delete-branch: true
+      #     token: ${{ env.GITHUB_TOKEN }}
+      #     add-paths: |
+      #         ${{ env.OUTPUT_PATH }}

--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,8 @@ import psutil
 import threading
 from loguru import logger
 from datetime import datetime
+from forge.forge_property_utils import ForgePropertyHandler, ForgePropertyStore
+from forge._C import ExecutionDepth
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -17,6 +19,20 @@ def record_test_timestamp(record_property):
     yield
     end_timestamp = datetime.strftime(datetime.now(), "%Y-%m-%dT%H:%M:%S%z")
     record_property("end_timestamp", end_timestamp)
+
+
+@pytest.fixture(scope="function")
+def forge_property_recorder(record_property):
+    forge_property_store = ForgePropertyStore()
+
+    forge_property_handler = ForgePropertyHandler(forge_property_store)
+
+    # Set CI_FAILURE as default execution depth
+    forge_property_handler.record_execution_depth(ExecutionDepth.CI_FAILURE)
+
+    yield forge_property_handler
+
+    forge_property_handler.store_property(record_property)
 
 
 @pytest.fixture(autouse=True)

--- a/forge/forge/python_codegen.py
+++ b/forge/forge/python_codegen.py
@@ -939,7 +939,7 @@ class ForgeWriter(PythonWriter):
             pytest_metadata_list (Optional[List[Dict[str, Any]]]): A list of dictionaries containing metadata for each pytest parameter.
             use_ids_function(bool): If set, the forge module name and shapes and dtyes will used as id for the pytest parameter.
             include_random_parameter_constant_gen(bool): If set, it will include the code for generating and assigning of random tensor for forge module parameters and constants
-            exclude_record_property(Optional[List[str]]): A list of pytest metadata property which will be excluded in record_forge_property fixtures(i.e pcc)
+            exclude_record_property(Optional[List[str]]): A list of pytest metadata property which will be excluded in forge_property_recorder fixtures(i.e pcc)
         """
         self.wl("")
         self.wl("")
@@ -979,30 +979,27 @@ class ForgeWriter(PythonWriter):
             )
         else:
             self.wl('@pytest.mark.parametrize("forge_module_and_shapes_dtypes", forge_modules_and_shapes_dtypes_list)')
-        if module_metadata is not None or not is_pytest_metadata_list_empty:
-            self.wl("def test_module(forge_module_and_shapes_dtypes, record_forge_property):")
-        else:
-            self.wl("def test_module(forge_module_and_shapes_dtypes):")
+        self.wl("def test_module(forge_module_and_shapes_dtypes, forge_property_recorder):")
         self.indent += 1
         if module_metadata is not None:
             for metadata_name, metadata_value in module_metadata.items():
                 if isinstance(metadata_value, str):
-                    self.wl(f'record_forge_property("tags.{metadata_name}", "{metadata_value}")')
+                    self.wl(f'forge_property_recorder("tags.{metadata_name}", "{metadata_value}")')
                 else:
-                    self.wl(f'record_forge_property("tags.{metadata_name}", {metadata_value})')
+                    self.wl(f'forge_property_recorder("tags.{metadata_name}", {metadata_value})')
         self.wl("")
         if is_pytest_metadata_list_empty:
             self.wl("forge_module, operand_shapes_dtypes = forge_module_and_shapes_dtypes")
         else:
             self.wl("forge_module, operand_shapes_dtypes, metadata = forge_module_and_shapes_dtypes")
-            if exclude_record_property is not None or len(exclude_record_property) != 0:
+            if exclude_record_property is not None and len(exclude_record_property) != 0:
                 self.wl("")
                 for exclude_metadata in exclude_record_property:
                     self.wl(f'{exclude_metadata} = metadata.pop("{exclude_metadata}")')
             self.wl("")
             self.wl("for metadata_name, metadata_value in metadata.items():")
             self.indent += 1
-            self.wl(f'record_forge_property("tags." + str(metadata_name), metadata_value)')
+            self.wl(f'forge_property_recorder("tags." + str(metadata_name), metadata_value)')
             self.indent -= 1
         self.wl("")
         if is_pytest_metadata_list_empty or (
@@ -1053,10 +1050,12 @@ class ForgeWriter(PythonWriter):
             self.wl("framework_model.set_constant(name, constant_tensor)")
             self.indent -= 1
         self.wl("")
-        self.wl("compiled_model = compile(framework_model, sample_inputs=inputs)")
+        self.wl(
+            "compiled_model = compile(framework_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)"
+        )
         self.wl("")
         self.wl(
-            "verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)))"
+            "verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)), forge_property_handler=forge_property_recorder)"
         )
         self.wl("")
         self.wl("")

--- a/forge/test/conftest.py
+++ b/forge/test/conftest.py
@@ -34,7 +34,7 @@ import forge
 from forge.config import CompilerConfig
 from forge.verify.config import TestKind
 from forge.torch_compile import reset_state
-from forge.forge_property_utils import ForgePropertyHandler, ForgePropertyStore
+# from forge.forge_property_utils import ForgePropertyHandler, ForgePropertyStore
 
 import test.utils
 
@@ -77,18 +77,18 @@ def pytest_sessionstart(session):
             print(f"{key}={value}")
 
 
-@pytest.fixture(scope="function")
-def forge_property_recorder(record_property):
-    forge_property_store = ForgePropertyStore()
+# @pytest.fixture(scope="function")
+# def forge_property_recorder(record_property):
+#     forge_property_store = ForgePropertyStore()
 
-    forge_property_handler = ForgePropertyHandler(forge_property_store)
+#     forge_property_handler = ForgePropertyHandler(forge_property_store)
 
-    # Set CI_FAILURE as default execution depth
-    forge_property_handler.record_execution_depth(ExecutionDepth.CI_FAILURE)
+#     # Set CI_FAILURE as default execution depth
+#     forge_property_handler.record_execution_depth(ExecutionDepth.CI_FAILURE)
 
-    yield forge_property_handler
+#     yield forge_property_handler
 
-    forge_property_handler.store_property(record_property)
+#     forge_property_handler.store_property(record_property)
 
 
 @pytest.fixture(autouse=True)

--- a/forge/test/models/pytorch/text/mistral/test_mistral.py
+++ b/forge/test/models/pytorch/text/mistral/test_mistral.py
@@ -38,8 +38,6 @@ def test_mistral(forge_property_recorder, variant):
     tokenizer = AutoTokenizer.from_pretrained(variant)
 
     framework_model.eval()
-    for param in framework_model.parameters():
-        param.requires_grad = False
 
     # test should work for batch size 1 and seqlen <= 128
     # for larger seqlen, a DRAM allocation problem might occur (this model is already near maximum model size for single chip)

--- a/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
+++ b/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
@@ -46,10 +46,6 @@ def test_rcnn_pytorch(forge_property_recorder):
 
     framework_model.eval()
 
-    # Cancel gradient tracking
-    for param in framework_model.parameters():
-        param.requires_grad = False
-
     # Image
     img = cv2.imread("forge/test/models/files/samples/images/car.jpg")
 

--- a/scripts/model_analysis/run_analysis_and_generate_md_files.py
+++ b/scripts/model_analysis/run_analysis_and_generate_md_files.py
@@ -956,7 +956,7 @@ def create_statistics_report_markdown_file(
 
         markdown_writer.close_file()
 
-
+# python scripts/model_analysis/run_analysis_and_generate_md_files.py --test_directory_or_file_path forge/test/models/pytorch/text/albert/test_albert.py --dump_failure_logs &> run_analysis_and_generate_md_files.log
 def main():
     parser = argparse.ArgumentParser(
         description="""Generate unique ops test for the models present in the test_directory_or_file_path
@@ -967,7 +967,7 @@ def main():
     parser.add_argument(
         "--test_directory_or_file_path",
         type=str,
-        default=os.path.join(os.getcwd(), "forge/test/models"),
+        default=os.path.join(os.getcwd(), "forge/test/models/pytorch/"),
         help="Specify the directory or file path containing models test",
     )
     parser.add_argument(
@@ -995,30 +995,30 @@ def main():
         unique_ops_output_directory_path=args.unique_ops_output_directory_path,
     )
 
-    unique_ops_config_across_all_models_file_path = os.path.join(
-        args.unique_ops_output_directory_path, "extracted_unique_op_config_across_all_models.log"
-    )
-    unique_operations = extract_unique_op_tests_from_models(
-        model_output_dir_paths=model_output_dir_paths,
-        unique_ops_config_file_path=unique_ops_config_across_all_models_file_path,
-    )
+    # unique_ops_config_across_all_models_file_path = os.path.join(
+    #     args.unique_ops_output_directory_path, "extracted_unique_op_config_across_all_models.log"
+    # )
+    # unique_operations = extract_unique_op_tests_from_models(
+    #     model_output_dir_paths=model_output_dir_paths,
+    #     unique_ops_config_file_path=unique_ops_config_across_all_models_file_path,
+    # )
 
-    model_variant_info_list, failed_ops_details, compiler_component_failure_analysis = run_models_unique_op_tests(
-        unique_operations=unique_operations,
-        unique_ops_output_directory_path=args.unique_ops_output_directory_path,
-        dump_failure_logs=args.dump_failure_logs,
-    )
+    # model_variant_info_list, failed_ops_details, compiler_component_failure_analysis = run_models_unique_op_tests(
+    #     unique_operations=unique_operations,
+    #     unique_ops_output_directory_path=args.unique_ops_output_directory_path,
+    #     dump_failure_logs=args.dump_failure_logs,
+    # )
 
-    create_root_and_sub_markdown_file(
-        model_variant_info_list=model_variant_info_list, markdown_directory_path=args.markdown_directory_path
-    )
+    # create_root_and_sub_markdown_file(
+    #     model_variant_info_list=model_variant_info_list, markdown_directory_path=args.markdown_directory_path
+    # )
 
-    create_statistics_report_markdown_file(
-        model_variant_info_list=model_variant_info_list,
-        failed_ops_details=failed_ops_details,
-        compiler_component_failure_analysis=compiler_component_failure_analysis,
-        markdown_directory_path=args.markdown_directory_path,
-    )
+    # create_statistics_report_markdown_file(
+    #     model_variant_info_list=model_variant_info_list,
+    #     failed_ops_details=failed_ops_details,
+    #     compiler_component_failure_analysis=compiler_component_failure_analysis,
+    #     markdown_directory_path=args.markdown_directory_path,
+    # )
 
 
 if __name__ == "__main__":

--- a/scripts/model_analysis/utils.py
+++ b/scripts/model_analysis/utils.py
@@ -257,6 +257,28 @@ def run_command(command: str):
     logger.info(f"Running the {command}\n{command_outputs}")
 
 
+def run_pip_freeze(log_file_path: str):
+    """
+    Runs 'pip freeze' and writes the output to a log file.
+
+    :param log_file: Name of the log file to save the output.
+    """
+    try:
+        # Run 'pip freeze' and capture the output
+        result = subprocess.run(["pip", "freeze"], capture_output=True, text=True, check=True)
+        message = ""
+        if result.stderr:
+            message += "STDERR: \n\n"
+            message += result.stderr
+        if result.stdout:
+            message += "STDOUT: \n\n"
+            message += result.stdout
+        dump_logs(log_file_path, message)
+        
+    except subprocess.CalledProcessError as e:
+        message = f"Error executing 'pip freeze': {e}"
+        dump_logs(log_file_path, message)
+
 def run_precommit(directory_path: str):
     """Checks if pre-commit is installed and runs it on all files in the given directory."""
 


### PR DESCRIPTION
The PR will update `forge_property_recorder` pytest fixture in the model analysis and remove the old `record_forge_property` fixture.

Moved the `forge_property_recorder` pytest fixture function from `tt-forge-fe/forge/test/conftest.py` path to `tt-forge-fe/fconftest.py` because the model analysis markdown generation pipeline will generate unique ops test in the `generated_modules/unique_ops/ `directory by default but the pytest fixture is not visible when it is present inside the `tt-forge-fe/forge/test/conftest.py.`