### PR TITLE
[Dtypes] Added support for uint8

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -20,6 +20,7 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
+#include "lower_to_forge/common.hpp"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Value.h"
@@ -587,6 +588,7 @@ class MLIRGenerator
             case tt::DataFormat::Float16: return builder_.getF16Type();
             case tt::DataFormat::Int32: return builder_.getI32Type();
             case tt::DataFormat::Int8: return builder_.getI8Type();
+            case tt::DataFormat::RawUInt8: return builder_.getIntegerType(8, false);
             default:
                 log_error("Unsupported data format during lowering from TTForge to TTIR: {}", node->output_df());
                 TT_ASSERT(false);

--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -20,7 +20,6 @@
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
-#include "lower_to_forge/common.hpp"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/Value.h"

--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -670,15 +670,19 @@ def pytorch_dtype_to_forge_dataformat(dtype: torch.dtype, fp32_fallback: Optiona
             return fp32_fallback
         return DataFormat.Float32
 
+    if dtype == torch.uint8:
+        return DataFormat.RawUInt8
+
     if dtype == torch.int8:
-        return DataFormat.Int8
+        logger.warning("Parameter is int8. Setting to Int32, since int8 is not supported .")
+        return DataFormat.Int32
 
     # These are kind of arbitrary..
     # if dtype == torch.uint8 or dtype == torch.int:
     #     return DataFormat.UInt16
 
     if dtype == torch.bool:
-        return DataFormat.Int8
+        return DataFormat.RawUInt8
 
     if dtype == torch.int32:
         return DataFormat.Int32
@@ -708,8 +712,8 @@ def forge_dataformat_to_pytorch_dtype(data_format: DataFormat) -> torch.dtype:
     if data_format in [DataFormat.Bfp8, DataFormat.Bfp4, DataFormat.Bfp2]:
         return torch.float16
 
-    if data_format == DataFormat.Int8:
-        return torch.int8
+    if data_format == DataFormat.RawUInt8:
+        return torch.uint8
 
     if data_format == DataFormat.RawUInt32:
         return torch.int

--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -286,13 +286,17 @@ class Tensor(TensorBase):
 
         if dtype in [torch.float16, torch.bfloat16, torch.float32, torch.float64]:
             torch_tensor = torch.rand(shape, dtype=dtype)
-        elif dtype in [torch.int8, torch.int16, torch.int32, torch.int64]:
+        elif dtype in [torch.int8, torch.uint8, torch.int16, torch.int32, torch.int64]:
             if min_int == max_int:
                 torch_tensor = torch.full(size=shape, fill_value=max_int, dtype=dtype)
             else:
                 torch_tensor = torch.randint(low=min_int, high=max_int, size=shape, dtype=dtype)
-        else:
+        elif dtype == torch.bool:
+            torch_tensor = torch.randint(low=0, high=2, size=shape, dtype=dtype)  # this will create boolean tensor
+        elif dtype is None:
             torch_tensor = torch.rand(shape, dtype=torch.float32)
+        else:
+            raise RuntimeError(f"[create_torch_tensor] - Unsupported dtype {dtype}")
 
         return torch_tensor
 
@@ -309,6 +313,8 @@ class Tensor(TensorBase):
         torch_tensor = Tensor.create_torch_tensor(
             shape=tensor_shape, dtype=torch_dtype, min_int=min_int, max_int=max_int
         )
+
+        print(f"During creation TORCH TENSOR: {torch_tensor.dtype}")
 
         return TensorFromPytorch(
             torch_tensor, dev_data_format=pytorch_dtype_to_forge_dataformat(torch_dtype), constant=constant

--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -314,8 +314,6 @@ class Tensor(TensorBase):
             shape=tensor_shape, dtype=torch_dtype, min_int=min_int, max_int=max_int
         )
 
-        print(f"During creation TORCH TENSOR: {torch_tensor.dtype}")
-
         return TensorFromPytorch(
             torch_tensor, dev_data_format=pytorch_dtype_to_forge_dataformat(torch_dtype), constant=constant
         )
@@ -674,7 +672,7 @@ def pytorch_dtype_to_forge_dataformat(dtype: torch.dtype, fp32_fallback: Optiona
         return DataFormat.RawUInt8
 
     if dtype == torch.int8:
-        logger.warning("Parameter is int8. Setting to Int32, since int8 is not supported .")
+        logger.warning("Parameter is int8. Setting to Int32, since int8 is not supported.")
         return DataFormat.Int32
 
     # These are kind of arbitrary..
@@ -682,13 +680,14 @@ def pytorch_dtype_to_forge_dataformat(dtype: torch.dtype, fp32_fallback: Optiona
     #     return DataFormat.UInt16
 
     if dtype == torch.bool:
+        logger.warning("Parameter is bool. Setting to uint8, since bool is not supported.")
         return DataFormat.RawUInt8
 
     if dtype == torch.int32:
         return DataFormat.Int32
 
     if dtype == torch.int64:
-        logger.warning("Parameter is int64. Setting to int32, since int64 is not supported .")
+        logger.warning("Parameter is int64. Setting to int32, since int64 is not supported.")
         return DataFormat.Int32
 
     raise RuntimeError("Unsupported torch dtype " + str(dtype))

--- a/forge/test/models_ops/test_cast.py
+++ b/forge/test/models_ops/test_cast.py
@@ -118,7 +118,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.float32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -130,7 +129,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.float32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -142,6 +140,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
     (
         Cast2,
@@ -278,7 +277,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.int32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     (
         Cast0,
@@ -423,7 +421,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.float32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -438,7 +435,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     (
         Cast0,
@@ -462,7 +458,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.int32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     (
         Cast3,
@@ -504,7 +499,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.int32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -525,7 +519,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.float32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -537,6 +530,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
     pytest.param(
         (
@@ -548,7 +542,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.int32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -560,6 +553,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
     pytest.param(
         (
@@ -609,6 +603,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
     pytest.param(
         (
@@ -620,6 +615,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
     (
         Cast0,

--- a/forge/test/models_ops/test_cast.py
+++ b/forge/test/models_ops/test_cast.py
@@ -260,7 +260,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -311,6 +310,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
     pytest.param(
         (
@@ -347,6 +347,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
     (
         Cast3,
@@ -387,6 +388,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
     pytest.param(
         (
@@ -409,6 +411,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
     pytest.param(
         (
@@ -490,7 +493,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -576,6 +578,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
     pytest.param(
         (
@@ -594,6 +597,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
+        marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
     pytest.param(
         (
@@ -671,7 +675,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -690,7 +693,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
 ]
 

--- a/forge/test/models_ops/test_cast.py
+++ b/forge/test/models_ops/test_cast.py
@@ -98,7 +98,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.float32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     (
         Cast0,
@@ -143,11 +142,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="ValueError: Dtype mismatch: framework_model.dtype=torch.int8, compiled_model.dtype=torch.uint8"
-            )
-        ],
     ),
     (
         Cast2,
@@ -250,7 +244,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.float32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -318,11 +311,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="ValueError: Dtype mismatch: framework_model.dtype=torch.int8, compiled_model.dtype=torch.uint8"
-            )
-        ],
     ),
     pytest.param(
         (
@@ -342,7 +330,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.int32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -360,11 +347,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="ValueError: Dtype mismatch: framework_model.dtype=torch.int8, compiled_model.dtype=torch.uint8"
-            )
-        ],
     ),
     (
         Cast3,
@@ -394,7 +376,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.float32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -406,11 +387,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="ValueError: Dtype mismatch: framework_model.dtype=torch.int8, compiled_model.dtype=torch.uint8"
-            )
-        ],
     ),
     pytest.param(
         (
@@ -422,7 +398,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.int32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     pytest.param(
         (
@@ -434,11 +409,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="ValueError: Dtype mismatch: framework_model.dtype=torch.int8, compiled_model.dtype=torch.uint8"
-            )
-        ],
     ),
     pytest.param(
         (
@@ -565,11 +535,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="ValueError: Dtype mismatch: framework_model.dtype=torch.int8, compiled_model.dtype=torch.uint8"
-            )
-        ],
     ),
     pytest.param(
         (
@@ -593,11 +558,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="ValueError: Dtype mismatch: framework_model.dtype=torch.int8, compiled_model.dtype=torch.uint8"
-            )
-        ],
     ),
     pytest.param(
         (
@@ -616,11 +576,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="ValueError: Dtype mismatch: framework_model.dtype=torch.int8, compiled_model.dtype=torch.uint8"
-            )
-        ],
     ),
     pytest.param(
         (
@@ -639,11 +594,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="ValueError: Dtype mismatch: framework_model.dtype=torch.int8, compiled_model.dtype=torch.uint8"
-            )
-        ],
     ),
     pytest.param(
         (
@@ -655,11 +605,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="ValueError: Dtype mismatch: framework_model.dtype=torch.int8, compiled_model.dtype=torch.uint8"
-            )
-        ],
     ),
     pytest.param(
         (
@@ -671,11 +616,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.bool"},
             },
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="ValueError: Dtype mismatch: framework_model.dtype=torch.int8, compiled_model.dtype=torch.uint8"
-            )
-        ],
     ),
     (
         Cast0,
@@ -707,7 +647,6 @@ forge_modules_and_shapes_dtypes_list = [
                 "op_params": {"dtype": "torch.int32"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
     (
         Cast0,


### PR DESCRIPTION
This PR mainly addresses issues with `Cast` OP:
- added support for `uint8`
- casting `boolean` to `uint8` (with warning)
- casting `int8` to `int32` since `int8` is not supported in `ttnn` (with warning)
- removed xfail from most of the test since changes above fix the failing reason
- for some tests I updated failing reason since it has changed