### PR TITLE
Add ONNX tests for BERT, DETR model

### DIFF
--- a/forge/test/models/model_utils.py
+++ b/forge/test/models/model_utils.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import requests
+from PIL import Image
+from torchvision import transforms
+
+
+# Mean Pooling - Take attention mask into account for correct averaging
+def mean_pooling(model_output, attention_mask):
+    token_embeddings = model_output[0]  # First element of model_output contains all token embeddings
+    input_mask_expanded = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+    return torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(input_mask_expanded.sum(1), min=1e-9)
+
+
+def preprocess_input_data(image_url):
+    input_image = Image.open(requests.get(image_url, stream=True).raw).convert("RGB")
+    input_tensor = transforms.ToTensor()(input_image)
+    input_batch = input_tensor.unsqueeze(0)
+    return input_batch

--- a/forge/test/models/onnx/text/bert/test_bert.py
+++ b/forge/test/models/onnx/text/bert/test_bert.py
@@ -7,6 +7,7 @@ import onnx
 from transformers import (
     BertForMaskedLM,
     BertForQuestionAnswering,
+    BertModel,
     BertTokenizer,
 )
 
@@ -15,6 +16,7 @@ from forge.verify.verify import verify
 
 from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
+from test.models.model_utils import mean_pooling
 
 
 # Opset 9 is the minimum version to support BERT in Torch.
@@ -130,3 +132,52 @@ def test_bert_question_answering_onnx(forge_property_recorder, variant, tmp_path
 
     # Model Verification
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+
+@pytest.mark.nightly
+@pytest.mark.push
+@pytest.mark.parametrize("variant", ["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr"])
+def test_bert_sentence_embedding_generation_onnx(forge_property_recorder, variant, tmp_path):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.ONNX,
+        model="bert",
+        variant=variant,
+        task=Task.SENTENCE_EMBEDDING_GENERATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Record Forge Property
+    forge_property_recorder.record_group("red")
+    forge_property_recorder.record_model_name(module_name)
+
+    # Load model and tokenizer
+    tokenizer = download_model(BertTokenizer.from_pretrained, variant)
+    framework_model = download_model(BertModel.from_pretrained, variant, return_dict=False, use_cache=False)
+    framework_model.eval()
+
+    # prepare input
+    sentences = "Bu örnek bir cümle"
+    encoded_input = tokenizer(sentences, padding=True, truncation=True, return_tensors="pt")
+    inputs = [encoded_input["input_ids"], encoded_input["attention_mask"], encoded_input["token_type_ids"]]
+
+    # Export model to ONNX
+    onnx_path = f"{tmp_path}/bert_sentence_emb_gen.onnx"
+    torch.onnx.export(framework_model, (inputs[0], inputs[1], inputs[2]), onnx_path, opset_version=17)
+
+    # Load ONNX model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Forge compile framework model
+    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)
+
+    # Model Verification
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Post processing
+    sentence_embeddings = mean_pooling(co_out, encoded_input["attention_mask"])
+
+    print("Sentence embeddings:", sentence_embeddings)

--- a/forge/test/models/onnx/vision/detr/test_detr.py
+++ b/forge/test/models/onnx/vision/detr/test_detr.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+# Detr model having both object detection and segmentation model
+# https://huggingface.co/docs/transformers/en/model_doc/detr
+
+import pytest
+from transformers import DetrForObjectDetection, DetrForSegmentation
+
+import forge
+import torch
+import onnx
+from forge.verify.verify import verify
+from test.utils import download_model
+from test.models.model_utils import preprocess_input_data
+from test.models.utils import Framework, Source, Task, build_module_name
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", ["facebook/detr-resnet-50"])
+def test_detr_detection_onnx(forge_property_recorder, variant, tmp_path):
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.ONNX,
+        model="detr",
+        variant=variant,
+        task=Task.OBJECT_DETECTION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Record Forge Property
+    forge_property_recorder.record_group("red")
+    forge_property_recorder.record_model_name(module_name)
+
+    # Load the model
+    framework_model = download_model(DetrForObjectDetection.from_pretrained, variant, return_dict=False)
+    framework_model.eval()
+
+    # Prepare input
+    image_url = "http://images.cocodataset.org/val2017/000000397133.jpg"
+    input_batch = preprocess_input_data(image_url)
+    inputs = [input_batch]
+
+    # Export model to ONNX
+    onnx_path = f"{tmp_path}/detr_obj_det.onnx"
+    torch.onnx.export(framework_model, (inputs[0]), onnx_path, opset_version=17)
+
+    # Load ONNX model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Forge compile framework model
+    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)
+
+    # Model Verification
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", ["facebook/detr-resnet-50-panoptic"])
+def test_detr_segmentation_onnx(forge_property_recorder, variant, tmp_path):
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.ONNX,
+        model="detr",
+        variant=variant,
+        task=Task.SEMANTIC_SEGMENTATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Record Forge Property
+    forge_property_recorder.record_group("red")
+    forge_property_recorder.record_model_name(module_name)
+
+    # Load the model
+    framework_model = download_model(DetrForSegmentation.from_pretrained, variant, return_dict=False)
+    framework_model.eval()
+
+    # Prepare input
+    image_url = "http://images.cocodataset.org/val2017/000000397133.jpg"
+    input_batch = preprocess_input_data(image_url)
+    inputs = [input_batch]
+
+    # Export model to ONNX
+    onnx_path = f"{tmp_path}/detr_semseg.onnx"
+    torch.onnx.export(framework_model, (inputs[0]), onnx_path, opset_version=17)
+
+    # Load ONNX model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Forge compile framework model
+    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)
+
+    # Model Verification
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)


### PR DESCRIPTION
### summary 

This PR adds ONNX tests for BERT, DETR model

## Logs

- [bert_onnx.log](https://github.com/user-attachments/files/19430194/mar23_bert_sen_gen_1.log)
- [detr_onnx.log](https://github.com/user-attachments/files/19430199/mar23_detr_onnx_c1.log)
 
