### PR TITLE
Restructure stable_diffusion_xl test

### DIFF
--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
@@ -8,7 +8,7 @@ import torch
 import forge
 
 from test.models.pytorch.multimodal.stable_diffusion.utils.model import (
-    load_pipe_v35,
+    load_pipe,
     stable_diffusion_preprocessing_v35,
 )
 from test.models.utils import Framework, Source, Task, build_module_name
@@ -69,7 +69,7 @@ def test_stable_diffusion_v35(forge_property_recorder, variant):
     forge_property_recorder.record_model_name(module_name)
 
     # Load pipeline
-    pipe = load_pipe_v35(variant)
+    pipe = load_pipe(variant, variant_type="v35")
 
     # Extract only the transformer, as the forward pass occurs here.
     framework_model = pipe.transformer

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_xl.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_xl.py
@@ -4,30 +4,34 @@
 
 import pytest
 import torch
-from diffusers import DiffusionPipeline
-from torchvision import transforms
 
 import forge
 from forge.verify.verify import verify
 
+from test.models.pytorch.multimodal.stable_diffusion.utils.model import (
+    load_pipe,
+    stable_diffusion_preprocessing_xl,
+)
 from test.models.utils import Framework, Source, Task, build_module_name
 
 
 class StableDiffusionXLWrapper(torch.nn.Module):
-    def __init__(self, pipeline):
+    def __init__(self, model, added_cond_kwargs, cross_attention_kwargs=None):
         super().__init__()
-        self.pipeline = pipeline
-        # Transformation to convert PIL Image to tensor
-        self.transform = transforms.Compose([transforms.ToTensor()])  # Convert PIL Image to PyTorch tensor
+        self.model = model
+        self.cross_attention_kwargs = cross_attention_kwargs
+        self.added_cond_kwargs = added_cond_kwargs
 
-    def forward(self, input_tensor):
-        # Decode the tensor to text prompt
-        tokenizer = self.pipeline.tokenizer
-        prompt = tokenizer.decode(input_tensor[0].tolist())
-        # Generate images using the pipeline
-        images = self.pipeline(prompt=prompt).images
-        # return images
-        return images
+    def forward(self, latent_model_input, timestep, prompt_embeds):
+        noise_pred = self.model(
+            latent_model_input,
+            timestep[0],
+            encoder_hidden_states=prompt_embeds,
+            timestep_cond=None,
+            cross_attention_kwargs=self.cross_attention_kwargs,
+            added_cond_kwargs=self.added_cond_kwargs,
+        )[0]
+        return noise_pred
 
 
 @pytest.mark.nightly
@@ -45,7 +49,7 @@ def test_stable_diffusion_generation(forge_property_recorder, variant):
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH,
-        model="stereo",
+        model="stable_diffusion",
         variant=variant,
         task=Task.MUSIC_GENERATION,
         source=Source.HUGGINGFACE,
@@ -55,19 +59,27 @@ def test_stable_diffusion_generation(forge_property_recorder, variant):
     forge_property_recorder.record_group("red")
     forge_property_recorder.record_model_name(module_name)
 
-    # Load the pipeline and set it to use the CPU
-    pipe = DiffusionPipeline.from_pretrained(f"stabilityai/{variant}", torch_dtype=torch.float32)  # Use float32 for CPU
-    pipe.to("cpu")  # Move the model to CPU
+    # Load the pipeline
+    pipe = load_pipe(variant, variant_type="xl")
 
-    # Wrap the pipeline in the wrapper
-    framework_model = StableDiffusionXLWrapper(pipe)
+    # Extract only the unet, as the forward pass occurs here.
+    framework_model = pipe.unet
 
     # Tokenize the prompt to a tensor
     tokenizer = pipe.tokenizer
     prompt = "An astronaut riding a green horse"
-    input_tensor = tokenizer(prompt, return_tensors="pt").input_ids
+    (
+        latent_model_input,
+        timestep,
+        prompt_embeds,
+        timestep_cond,
+        added_cond_kwargs,
+        add_time_ids,
+    ) = stable_diffusion_preprocessing_xl(pipe, prompt)
+    inputs = [latent_model_input, timestep, prompt_embeds]
 
-    inputs = [input_tensor]
+    # Wrap the pipeline in the wrapper
+    framework_model = StableDiffusionXLWrapper(framework_model, added_cond_kwargs, cross_attention_kwargs=None)
 
     # Forge compile framework model
     compiled_model = forge.compile(

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/utils/model.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/utils/model.py
@@ -3,10 +3,11 @@
 
 # Stable Diffusion Demo Script
 
-from typing import List, Optional, Union
+
+from typing import List, Optional, Tuple, Union
 
 import torch
-from diffusers import StableDiffusion3Pipeline
+from diffusers import DiffusionPipeline, StableDiffusion3Pipeline
 from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import (
     retrieve_timesteps,
 )
@@ -16,15 +17,23 @@ import forge
 from test.models.utils import Framework, build_module_name
 
 
-def load_pipe_v35(variant):
-    pipe = StableDiffusion3Pipeline.from_pretrained(f"stabilityai/{variant}", torch_dtype=torch.float32)
+def load_pipe(variant, variant_type):
+    if variant_type == "v35":
+        pipe = StableDiffusion3Pipeline.from_pretrained(f"stabilityai/{variant}", torch_dtype=torch.float32)
+        modules = [pipe.text_encoder, pipe.transformer, pipe.text_encoder_2, pipe.text_encoder_3, pipe.vae]
+    elif variant_type == "xl":
+        pipe = DiffusionPipeline.from_pretrained(f"stabilityai/{variant}", torch_dtype=torch.float32)
+        modules = [pipe.text_encoder, pipe.unet, pipe.text_encoder_2, pipe.vae]
+
+    # Move the pipeline to CPU
     pipe.to("cpu")
-    modules = [pipe.text_encoder, pipe.transformer, pipe.text_encoder_2, pipe.text_encoder_3, pipe.vae]
+
     for module in modules:
         module.eval()
         for param in module.parameters():
             if param.requires_grad:
                 param.requires_grad = False
+
     return pipe
 
 
@@ -217,7 +226,153 @@ def stable_diffusion_preprocessing_v35(
     latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
     timestep = timesteps[0].expand(latent_model_input.shape[0])
 
-    return latents, timestep, prompt_embeds, pooled_prompt_embeds
+    return latent_model_input, timestep, prompt_embeds, pooled_prompt_embeds
+
+
+def stable_diffusion_preprocessing_xl(
+    pipe,
+    prompt,
+    device="cpu",
+    negative_prompt=None,
+    guidance_scale=5.0,
+    num_inference_steps=50,
+    timesteps=None,
+    sigmas=None,
+    eta=0.0,
+    num_images_per_prompt=1,
+    height=None,
+    width=None,
+    clip_skip=None,
+    original_size=None,
+    target_size=None,
+    cross_attention_kwargs=None,
+    guidance_rescale=0.0,
+    crops_coords_top_left: Tuple[int, int] = (0, 0),
+    negative_original_size: Optional[Tuple[int, int]] = None,
+    negative_target_size: Optional[Tuple[int, int]] = None,
+    negative_crops_coords_top_left: Tuple[int, int] = (0, 0),
+    **kwargs,
+):
+    # Set default height and width
+    height = height or pipe.default_sample_size * pipe.vae_scale_factor
+    width = width or pipe.default_sample_size * pipe.vae_scale_factor
+    original_size = original_size or (height, width)
+    target_size = target_size or (height, width)
+
+    # Check inputs
+    pipe.check_inputs(
+        prompt,
+        None,  # prompt_2 (if applicable)
+        height,
+        width,
+        negative_prompt=negative_prompt,
+        prompt_embeds=None,
+        negative_prompt_embeds=None,
+        pooled_prompt_embeds=None,
+        negative_pooled_prompt_embeds=None,
+        callback_steps=None,
+        callback_on_step_end_tensor_inputs=["latents"],
+    )
+
+    # 1. Encode the prompt
+    do_classifier_free_guidance = True
+    prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, negative_pooled_prompt_embeds = pipe.encode_prompt(
+        prompt=prompt,
+        negative_prompt=negative_prompt,
+        do_classifier_free_guidance=True,  # Assume classifier-free guidance
+        device=device,
+        num_images_per_prompt=num_images_per_prompt,
+        clip_skip=clip_skip,
+    )
+    # 2. Prepare timesteps
+    timesteps, num_inference_steps = retrieve_timesteps(
+        pipe.scheduler,
+        num_inference_steps=num_inference_steps,
+        device=device,
+        timesteps=timesteps,
+        sigmas=sigmas,
+    )
+
+    # 3. Prepare latent variables
+    if isinstance(prompt, str):
+        batch_size = 1
+    elif prompt is not None and isinstance(prompt, list):
+        batch_size = len(prompt)
+    else:
+        batch_size = prompt_embeds.shape[0]
+    num_channels_latents = pipe.unet.config.in_channels
+    shape = (
+        batch_size,
+        num_channels_latents,
+        int(height) // pipe.vae_scale_factor,
+        int(width) // pipe.vae_scale_factor,
+    )
+    torch.manual_seed(42)
+    latents = torch.randn(
+        (
+            batch_size * num_images_per_prompt,
+            num_channels_latents,
+            height // pipe.vae_scale_factor,
+            width // pipe.vae_scale_factor,
+        ),
+        device=device,
+    )
+    latents = latents * pipe.scheduler.init_noise_sigma
+    add_text_embeds = pooled_prompt_embeds
+    if pipe.text_encoder_2 is None:
+        text_encoder_projection_dim = int(pooled_prompt_embeds.shape[-1])
+    else:
+        text_encoder_projection_dim = pipe.text_encoder_2.config.projection_dim
+    add_time_ids = pipe._get_add_time_ids(
+        original_size,
+        crops_coords_top_left,
+        target_size,
+        dtype=prompt_embeds.dtype,
+        text_encoder_projection_dim=text_encoder_projection_dim,
+    )
+    if negative_original_size is not None and negative_target_size is not None:
+        negative_add_time_ids = pipe._get_add_time_ids(
+            negative_original_size,
+            negative_crops_coords_top_left,
+            negative_target_size,
+            dtype=prompt_embeds.dtype,
+            text_encoder_projection_dim=text_encoder_projection_dim,
+        )
+    else:
+        negative_add_time_ids = add_time_ids
+
+    if do_classifier_free_guidance:
+        prompt_embeds = torch.cat([negative_prompt_embeds, prompt_embeds], dim=0)
+        add_text_embeds = torch.cat([negative_pooled_prompt_embeds, add_text_embeds], dim=0)
+        add_time_ids = torch.cat([negative_add_time_ids, add_time_ids], dim=0)
+
+    prompt_embeds = prompt_embeds.to(device)
+    add_text_embeds = add_text_embeds.to(device)
+    add_time_ids = add_time_ids.to(device).repeat(batch_size * num_images_per_prompt, 1)
+    ip_adapter_image = None
+    ip_adapter_image_embeds = None
+    if ip_adapter_image is not None or ip_adapter_image_embeds is not None:
+        image_embeds = pipe.prepare_ip_adapter_image_embeds(
+            ip_adapter_image,
+            ip_adapter_image_embeds,
+            device,
+            batch_size * num_images_per_prompt,
+            do_classifier_free_guidance,
+        )
+    timestep_cond = None
+    if pipe.unet.config.time_cond_proj_dim is not None:
+        guidance_scale_tensor = torch.tensor(guidance_scale - 1).repeat(batch_size * num_images_per_prompt)
+        timestep_cond = pipe.get_guidance_scale_embedding(
+            guidance_scale_tensor, embedding_dim=pipe.unet.config.time_cond_proj_dim
+        ).to(device=device, dtype=latents.dtype)
+    added_cond_kwargs = {"text_embeds": add_text_embeds, "time_ids": add_time_ids}
+    if ip_adapter_image is not None or ip_adapter_image_embeds is not None:
+        added_cond_kwargs["image_embeds"] = image_embeds
+
+    latent_model_input = torch.cat([latents] * 2) if do_classifier_free_guidance else latents
+    latent_model_input = pipe.scheduler.scale_model_input(latent_model_input, timesteps[0])
+
+    return latent_model_input, timesteps, prompt_embeds, timestep_cond, added_cond_kwargs, add_time_ids
 
 
 def denoising_loop(


### PR DESCRIPTION
Original stable_diffusion_xl has been restructured since model is loaded using a pipeline that includes multiple text encoders (CLIPTextModelWithProjection, CLIPTextModel), tokenizers, a EulerDiscreteScheduler, an UNet2DConditionModel, and an AutoencoderKL VAE.Since the pipeline lacks a direct forward function call that can be passed to forge.compile, the pipeline structure has been broken down.
All preprocessing steps have been manually extracted from StableDiffusionXLPipeline, and only the unet forward function call is now passed to forge.compile.
Model currently fails with `"NotImplementedError: The following operators are not implemented: ['aten::concat']"` during frontend conversion which will be debugged later.