### PR TITLE
[runtime] add mechanism to enable program cache

### DIFF
--- a/forge/csrc/runtime/python_bindings.cpp
+++ b/forge/csrc/runtime/python_bindings.cpp
@@ -5,6 +5,7 @@
 #include "runtime/python_bindings.hpp"
 
 #include "runtime/runtime.hpp"
+#include "runtime/tt_device.hpp"
 #include "tt/runtime/types.h"
 
 namespace tt
@@ -12,10 +13,22 @@ namespace tt
 
 void RuntimeModule(py::module &m_runtime)
 {
+    // Main runtime APIs
     py::class_<runtime::Binary>(m_runtime, "Binary")
         .def("get_program_inputs", &runtime::Binary::getProgramInputs)
         .def("get_program_outputs", &runtime::Binary::getProgramOutputs);
     m_runtime.def("run_binary", tt::run_binary);
+
+    // Experimental APIs
+    py::module m_experimental = m_runtime.def_submodule("experimental");
+    py::class_<tt::DeviceSettings>(m_experimental, "DeviceSettings")
+        .def(py::init<>())
+        .def_readwrite("enable_program_cache", &tt::DeviceSettings::enable_program_cache);
+    m_experimental.def(
+        "configure_devices",
+        [](DeviceSettings settings) -> void { tt::TTSystem::get_system().configure_devices(settings); },
+        py::arg("device_settings") = DeviceSettings(),
+        "Configure all devices with the given settings.");
 }
 
 }  // namespace tt

--- a/forge/csrc/runtime/tt_device.cpp
+++ b/forge/csrc/runtime/tt_device.cpp
@@ -58,10 +58,12 @@ TTSystem& TTSystem::get_system()
 
 bool TTSystem::is_initialized() { return system_is_initialized; }
 
-void TTDevice::open_device()
+void TTDevice::open_device(const DeviceSettings& settings)
 {
     TT_ASSERT(!is_open());
-    rt_device = runtime::openDevice({index});
+    static constexpr std::uint32_t num_hw_cqs = 1;
+    rt_device = runtime::openDevice(
+        {index}, num_hw_cqs, std::nullopt, std::nullopt, std::nullopt, settings.enable_program_cache);
 }
 
 void TTDevice::close_device()
@@ -69,6 +71,16 @@ void TTDevice::close_device()
     TT_ASSERT(is_open());
     runtime::closeDevice(rt_device.value());
     rt_device.reset();
+}
+
+void TTDevice::configure_device(const DeviceSettings& settings)
+{
+    if (is_open())
+    {
+        close_device();
+    }
+
+    open_device(settings);
 }
 
 }  // namespace tt

--- a/forge/csrc/runtime/tt_device.hpp
+++ b/forge/csrc/runtime/tt_device.hpp
@@ -11,6 +11,11 @@
 namespace tt
 {
 
+struct DeviceSettings
+{
+    bool enable_program_cache{false};
+};
+
 struct TTDevice
 {
     std::optional<runtime::Device> rt_device;
@@ -35,8 +40,10 @@ struct TTDevice
 
     bool is_open() const { return rt_device.has_value(); }
 
-    void open_device();
+    void open_device(const DeviceSettings& settings = {});
     void close_device();
+
+    void configure_device(const DeviceSettings& settings = {});
 };
 
 // Used to store the system description and the list of devices.
@@ -60,6 +67,14 @@ struct TTSystem
             {
                 device->close_device();
             }
+        }
+    }
+
+    void configure_devices(const DeviceSettings& settings = {})
+    {
+        for (auto& device : devices)
+        {
+            device->configure_device(settings);
         }
     }
 

--- a/forge/test/benchmark/benchmark/models/llama.py
+++ b/forge/test/benchmark/benchmark/models/llama.py
@@ -18,6 +18,7 @@ from transformers import LlamaTokenizer
 
 # Forge modules
 import forge
+from forge._C.runtime.experimental import configure_devices, DeviceSettings
 from test.mlir.llama.utils.utils import load_model
 from forge.verify.compare import compare_with_golden
 
@@ -69,6 +70,11 @@ def test_llama_prefill(
     # This is the part of the model needed for prefill; model without the last Linear layer (lm_head)
     model_decoder = model.get_decoder()
     compiled_decoder = forge.compile(model_decoder, sample_inputs=input_ids)
+
+    # Enable program cache on all devices
+    settings = DeviceSettings()
+    settings.enable_program_cache = True
+    configure_devices(device_settings=settings)
 
     # Prefill Phase - Process the initial prompt on device
     # This what we actually want to benchmark, and measure the time taken.

--- a/forge/test/benchmark/benchmark/models/mnist_linear.py
+++ b/forge/test/benchmark/benchmark/models/mnist_linear.py
@@ -17,6 +17,7 @@ from torch import nn
 
 # Forge modules
 import forge
+from forge._C.runtime.experimental import configure_devices, DeviceSettings
 from forge.verify.verify import verify
 
 # Common constants
@@ -105,6 +106,12 @@ def test_mnist_linear(
     fw_out = framework_model(*inputs)
 
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    # Enable program cache on all devices
+    settings = DeviceSettings()
+    settings.enable_program_cache = True
+    configure_devices(device_settings=settings)
+
     # Run for the first time to warm up the model.
     # This is required to get accurate performance numbers.
     co_out = compiled_model(*inputs)

--- a/forge/test/benchmark/benchmark/models/resnet_hf.py
+++ b/forge/test/benchmark/benchmark/models/resnet_hf.py
@@ -20,6 +20,7 @@ from datasets import load_dataset
 
 # Forge modules
 import forge
+from forge._C.runtime.experimental import configure_devices, DeviceSettings
 from forge.verify.compare import compare_with_golden
 from test.utils import download_model
 
@@ -83,6 +84,12 @@ def test_resnet_hf(
     compiled_model = forge.compile(framework_model, *input_sample)
     # Run for the first time to warm up the model.
     # This is required to get accurate performance numbers.
+
+    # Enable program cache on all devices
+    settings = DeviceSettings()
+    settings.enable_program_cache = True
+    configure_devices(device_settings=settings)
+
     co_out = compiled_model(*input_sample)
     start = time.time()
     for _ in range(loop_count):


### PR DESCRIPTION
There are still some issues that need to be resolved before we enable program cache on by default. For now, adding a mechanism for manually enabling it in runtime.

Perf benchmark models are updated to enable program cache before executing the benchmarks.

The `tt-forge-fe` APIs for configuring/managing the devices are still not properly defined and are work in progress. This is a starting point so that we can enable program cache in benchmarks and catch any regressions coming from `tt-metal`/`tt-mlir`. Hence, adding these APIs to the `experimental` submodule of `runtime` module.

Bumping `tt-mlir` to the commit which exposes this setting in runtime.

Closes #1493