### PR TITLE
[CI] Fix nightly fail message

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "Bad bad nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}>",
+              "text": "Bad bad nightly: <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}>",
               "channel": "C08HFLL9L56"
             }
         env:


### PR DESCRIPTION
Added attempt number into nightly fail link.
If nightly fails and it is rerun with success, link in highly failed message links to the latest attempt which is successful. That might be confusing.