### PR TITLE
Skip build step for sweeps tests

### DIFF
--- a/.github/workflows/on-nightly-sweeps.yml
+++ b/.github/workflows/on-nightly-sweeps.yml
@@ -1,5 +1,10 @@
 name: On Nightly Sweeps Tests
 
+# This workflow runs after the "on-nightly" workflow.
+# It executes full set of sweep single operator tests.
+# Note: This workflow shouldn't run build, it only
+# does so if no existing run ID is available.
+
 on:
   workflow_dispatch:
     inputs:
@@ -11,21 +16,30 @@ on:
           - n150
           - n300
         default: n150
+      run_id:
+        description: 'Run id (from a previous On nightly workflow)'
+        required: false
+        type: number
       operators:
         description: 'Operators to test (comma separated)'
         type: string
         required: false
+  # workflow_run:
+  #   workflows:
+  #     - "On nightly"
+  #   types: [ completed ]
+  #   branches: [ "main" ]
   schedule:
     - cron: '0 4 * * *'  # Runs at 04:00 UTC every day
 
 jobs:
   docker-build:
-      uses: ./.github/workflows/build-image.yml
-      secrets: inherit
-  build:
+    uses: ./.github/workflows/build-image.yml
+    secrets: inherit
+  build-if-neccessary:
+    if: ${{ !(github.event.workflow_run.id || github.event.inputs.run_id) }}
     needs: docker-build
     uses: ./.github/workflows/build.yml
-    secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
 
@@ -33,7 +47,7 @@ jobs:
     if: inputs.runs-on
     needs:
       - docker-build
-      - build
+      - build-if-neccessary
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
@@ -43,12 +57,14 @@ jobs:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
       runs-on: '[{"runs-on": "${{ github.event.inputs.runs-on }}"}]'
       operators: ${{ github.event.inputs.operators }}
+      # Prioritize workflow trigger, then input run ID, then current run (for new builds)
+      on_nightly_run_id: ${{ github.event.workflow_run.id || github.event.inputs.run_id || github.run_id }}
 
   test_on_schedule:
     if: ${{ ! inputs.runs-on }}
     needs:
       - docker-build
-      - build
+      - build-if-neccessary
     uses: ./.github/workflows/test.yml
     secrets: inherit
     with:
@@ -58,3 +74,5 @@ jobs:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
       runs-on: '[{"runs-on": "n150"}]'
       operators: ${{ github.event.inputs.operators }}
+      # Prioritize workflow trigger, then input run ID, then current run (for new builds)
+      on_nightly_run_id: ${{ github.event.workflow_run.id || github.event.inputs.run_id || github.run_id }}


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Running sweeps tests on main code and rebuilding forge every time is very slow and non effective (30 min overhead).
Reusing approach of nightly xfail fits much better to sweep tests.

### What's changed
Re-use nightly built wheels by providing run_id of a nightly action.

### Checklist
- [ ] New/Existing tests provide coverage for changes
