### PR TITLE
[CI] Changed default execution depth from "" -> CI_FAILURE

### DIFF
--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -173,6 +173,7 @@ PYBIND11_MODULE(_C, m)
             });
 
     py::enum_<tt::property::ExecutionDepth>(m, "ExecutionDepth")
+        .value("CI_FAILURE", tt::property::ExecutionDepth::CI_FAILURE)
         .value("FAILED_FE_COMPILATION", tt::property::ExecutionDepth::FAILED_FE_COMPILATION)
         .value("FAILED_TTMLIR_COMPILATION", tt::property::ExecutionDepth::FAILED_TTMLIR_COMPILATION)
         .value("FAILED_RUNTIME", tt::property::ExecutionDepth::FAILED_RUNTIME)
@@ -192,6 +193,7 @@ PYBIND11_MODULE(_C, m)
             [](std::string const &encoded)
             {
                 static std::unordered_map<std::string, tt::property::ExecutionDepth> decode = {
+                    {"CI_FAILURE", tt::property::ExecutionDepth::CI_FAILURE},
                     {"FAILED_FE_COMPILATION", tt::property::ExecutionDepth::FAILED_FE_COMPILATION},
                     {"FAILED_TTMLIR_COMPILATION", tt::property::ExecutionDepth::FAILED_TTMLIR_COMPILATION},
                     {"FAILED_RUNTIME", tt::property::ExecutionDepth::FAILED_RUNTIME},

--- a/forge/csrc/shared_utils/forge_property_utils.cpp
+++ b/forge/csrc/shared_utils/forge_property_utils.cpp
@@ -14,6 +14,7 @@ std::string to_string(const ExecutionDepth depth)
 {
     switch (depth)
     {
+        case ExecutionDepth::CI_FAILURE: return "CI_FAILURE";
         case ExecutionDepth::FAILED_FE_COMPILATION: return "FAILED_FE_COMPILATION";
         case ExecutionDepth::FAILED_TTMLIR_COMPILATION: return "FAILED_TTMLIR_COMPILATION";
         case ExecutionDepth::FAILED_RUNTIME: return "FAILED_RUNTIME";

--- a/forge/csrc/shared_utils/forge_property_utils.hpp
+++ b/forge/csrc/shared_utils/forge_property_utils.hpp
@@ -19,6 +19,7 @@ namespace tt::property
 
 enum class ExecutionDepth
 {
+    CI_FAILURE,                 // CI failure
     FAILED_FE_COMPILATION,      // Front end compilation fails (tvm->ttir)
     FAILED_TTMLIR_COMPILATION,  // TT-MLIR compilation fails, can't produce flatbuffer
     FAILED_RUNTIME,             // Runtime execution fails

--- a/forge/csrc/shared_utils/forge_property_utils.hpp
+++ b/forge/csrc/shared_utils/forge_property_utils.hpp
@@ -19,7 +19,7 @@ namespace tt::property
 
 enum class ExecutionDepth
 {
-    CI_FAILURE,                 // CI failure
+    CI_FAILURE,                 // CI failure (e.g. download of model weights fails)
     FAILED_FE_COMPILATION,      // Front end compilation fails (tvm->ttir)
     FAILED_TTMLIR_COMPILATION,  // TT-MLIR compilation fails, can't produce flatbuffer
     FAILED_RUNTIME,             // Runtime execution fails

--- a/forge/test/conftest.py
+++ b/forge/test/conftest.py
@@ -83,8 +83,8 @@ def forge_property_recorder(record_property):
 
     forge_property_handler = ForgePropertyHandler(forge_property_store)
 
-    # Set FAILED_FE_COMPILATION as default execution depth (even if we fail before FE compilation)
-    forge_property_handler.record_execution_depth(ExecutionDepth.FAILED_FE_COMPILATION)
+    # Set CI_FAILURE as default execution depth
+    forge_property_handler.record_execution_depth(ExecutionDepth.CI_FAILURE)
 
     yield forge_property_handler
 

--- a/forge/test/conftest.py
+++ b/forge/test/conftest.py
@@ -15,6 +15,8 @@ import torch.multiprocessing as mp
 import torch
 import tensorflow as tf
 
+from forge._C import ExecutionDepth
+
 # This is a workaround to set RTLD_GLOBAL flag to load emulation ZeBu library.
 # Essentially symbol names have to be unique in global scope to work with ZeBu,
 # hence need to be set as GLOBAL. This is a requirement for ZeBu.
@@ -80,6 +82,9 @@ def forge_property_recorder(record_property):
     forge_property_store = ForgePropertyStore()
 
     forge_property_handler = ForgePropertyHandler(forge_property_store)
+
+    # Set FAILED_FE_COMPILATION as default execution depth (even if we fail before FE compilation)
+    forge_property_handler.record_execution_depth(ExecutionDepth.FAILED_FE_COMPILATION)
 
     yield forge_property_handler
 


### PR DESCRIPTION
### Problem description
Previously execution depth wasn't set on beginning so if we were to fail test before compile stage (e.g. while downloading model), in our database `bringup_status` would be `N/A` and now we changed it to `CI_FAILURE` per @tt-mpantic request, so now if it fails during preprocessing it will show `CI_FAILURE`.

### What's changed
Changed default execution depth from "" -> `CI_FAILURE`.