### PR TITLE
Restructure gliner pytorch test

### DIFF
--- a/forge/test/models/pytorch/text/gliner/utils/model_utils.py
+++ b/forge/test/models/pytorch/text/gliner/utils/model_utils.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+
+
+class GlinerWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids, token_type_ids, attention_mask, words_mask, span_idx, span_mask, text_lengths):
+        model_input_reconstructed = {
+            "input_ids": input_ids,
+            "token_type_ids": token_type_ids,
+            "attention_mask": attention_mask,
+            "words_mask": words_mask,
+            "span_idx": span_idx,
+            "span_mask": span_mask,
+            "text_lengths": text_lengths,
+        }
+        return self.model(**model_input_reconstructed)[0]
+
+
+def pre_processing(model, texts, labels):
+    model_input, raw_batch = model.prepare_model_inputs(texts, labels)
+    input_ids = model_input["input_ids"]
+    token_type_ids = model_input["token_type_ids"]
+    attention_mask = model_input["attention_mask"]
+    words_mask = model_input["words_mask"]
+    span_idx = model_input["span_idx"]
+    span_mask = model_input["span_mask"]
+    text_lengths = model_input["text_lengths"]
+    inputs = [input_ids, token_type_ids, attention_mask, words_mask, span_idx, span_mask, text_lengths]
+
+    return inputs, raw_batch
+
+
+def post_processing(model, model_output, texts, raw_batch):
+    if not isinstance(model_output, torch.Tensor):
+        model_output = torch.from_numpy(model_output)
+
+    outputs = model.decoder.decode(
+        raw_batch["tokens"], raw_batch["id_to_classes"], model_output, flat_ner=True, threshold=0.5, multi_label=False
+    )
+
+    all_entities = []
+    for i, output in enumerate(outputs):
+        start_token_idx_to_text_idx = raw_batch["all_start_token_idx_to_text_idx"][i]
+        end_token_idx_to_text_idx = raw_batch["all_end_token_idx_to_text_idx"][i]
+        entities = []
+        for start_token_idx, end_token_idx, ent_type, ent_score in output:
+            start_text_idx = start_token_idx_to_text_idx[start_token_idx]
+            end_text_idx = end_token_idx_to_text_idx[end_token_idx]
+            entities.append(
+                {
+                    "start": start_token_idx_to_text_idx[start_token_idx],
+                    "end": end_token_idx_to_text_idx[end_token_idx],
+                    "text": texts[i][start_text_idx:end_text_idx],
+                    "label": ent_type,
+                    "score": ent_score,
+                }
+            )
+        all_entities.append(entities)
+
+    return all_entities[0]


### PR DESCRIPTION
Gliner test has now been restructured since it was initially failing with `IndexError: Dimension out of range (expected to be in range of [-2, 1], but got 2)`.

This occurs because in [inference](https://huggingface.co/urchade/gliner_multi-v2.1) of this model , predict_entities function will be called which encapsulates pre-processing, forward function call followed by post-processing.
Now the pre-processing and post-processing has been brought out of the model and this model now currently fails in frontend conversion with below unsupported operators

`"NotImplementedError: The following operators are not implemented: ['aten::floordiv', 'aten::_pad_packed_sequence', 'aten::_pack_padded_sequence']"`