### PR TITLE
Fix pcc drop in phi2 model

### DIFF
--- a/forge/test/models/pytorch/text/llama/test_llama3.py
+++ b/forge/test/models/pytorch/text/llama/test_llama3.py
@@ -105,7 +105,7 @@ def _update_causal_mask(
             #     padding_mask, min_dtype
             # )
 
-            if causal_mask.shape[-1] < mask_length:
+            if causal_mask.shape[-1] > mask_length:
                 part_1 = causal_mask[:, :, :, :mask_length]
                 part_2 = causal_mask[:, :, :, mask_length:]
                 part_1 = part_1.masked_fill(padding_mask, min_dtype)

--- a/forge/test/models/pytorch/text/phi2/test_phi2.py
+++ b/forge/test/models/pytorch/text/phi2/test_phi2.py
@@ -9,12 +9,61 @@ from transformers import (
     PhiForCausalLM,
     PhiForSequenceClassification,
     PhiForTokenClassification,
+    PhiModel,
 )
 
 import forge
 from forge.verify.verify import verify
 
 from test.models.utils import Framework, Source, Task, build_module_name
+
+
+def _prepare_4d_causal_attention_mask_with_cache_position(
+    self,
+    attention_mask: torch.Tensor,
+    sequence_length: int,
+    target_length: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    cache_position: torch.Tensor,
+    batch_size: int,
+    **kwargs,
+):
+
+    if attention_mask is not None and attention_mask.dim() == 4:
+        # In this case we assume that the mask comes already in inverted form and requires no inversion or slicing.
+        causal_mask = attention_mask
+    else:
+        min_dtype = torch.finfo(dtype).min
+        causal_mask = torch.full((sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device)
+        if sequence_length != 1:
+            causal_mask = torch.triu(causal_mask, diagonal=1)
+        causal_mask *= torch.arange(target_length, device=device) > cache_position.reshape(-1, 1)
+        causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)
+        if attention_mask is not None:
+            causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
+            mask_length = attention_mask.shape[-1]
+            padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :]
+            padding_mask = padding_mask == 0
+
+            # Replace Implace Slice Update
+            # causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
+            #     padding_mask, min_dtype
+            # )
+
+            if causal_mask.shape[-1] > mask_length:
+                part_1 = causal_mask[:, :, :, :mask_length]
+                part_2 = causal_mask[:, :, :, mask_length:]
+                part_1 = part_1.masked_fill(padding_mask, min_dtype)
+                causal_mask = torch.cat([part_1, part_2], dim=-1)
+            else:
+                causal_mask = causal_mask.masked_fill(padding_mask, min_dtype)
+
+    return causal_mask
+
+
+PhiModel._prepare_4d_causal_attention_mask_with_cache_position = _prepare_4d_causal_attention_mask_with_cache_position
+
 
 variants = [
     pytest.param(
@@ -68,7 +117,7 @@ def test_phi2_clm(forge_property_recorder, variant):
     )
 
     input_ids = inputs["input_ids"]
-    attn_mask = inputs["attention_mask"].to(torch.float32)
+    attn_mask = inputs["attention_mask"]
 
     inputs = [input_ids, attn_mask]
 


### PR DESCRIPTION
### Ticket
- N/A

### Problem description

- A **0.33900362229737885** PCC drop was observed in the phi2 model's causal LM task due to this [inplace update operation ](https://github.com/huggingface/transformers/blob/5d7739f15a6e50de416977fe2cc9cb516d67edda/src/transformers/models/phi/modeling_phi.py#L1135C17-L1137C18) 

- In the Llama3 model, the monkey-patched _update_causal_mask function applies splitting and concatenation when `causal_mask.shape[-1] < mask_length`. However, this condition is unnecessary because when the entire tensor is smaller than the desired slice, a direct masked_fill should suffice.

### What's changed

**Monkey Patched Problematic Function:**
- The problematic in-place update in the attention mask update logic has been patched to avoid in-place modifications.

**Fixed Condition in Llama3 Model:**
- The condition has been revised so that splitting and concatenation is only performed when `causal_mask.shape[-1] > mask_length`. If the causal mask's last dimension is smaller than or equal to mask_length, the entire tensor is updated directly with masked_fill, eliminating unnecessary operations.

## Logs 

- [phi2_clm_before_fix.log](https://github.com/user-attachments/files/19466567/mar26_phi2_clm_before_fix.log)
- [phi2_clm_after_fix.log](https://github.com/user-attachments/files/19466564/mar26_phi2_clm_after_fix.log)
