### PR TITLE
[CI] Improving stability of nightly runs

### DIFF
--- a/forge/test/models/pytorch/text/albert/test_albert.py
+++ b/forge/test/models/pytorch/text/albert/test_albert.py
@@ -13,6 +13,7 @@ from transformers import (
 )
 
 import forge
+from forge.verify.config import AutomaticValueChecker, VerifyConfig
 from forge.verify.verify import verify
 
 from test.models.utils import Framework, Source, Task, build_module_name
@@ -82,6 +83,7 @@ def test_albert_masked_lm_pytorch(forge_property_recorder, size, variant):
         inputs,
         framework_model,
         compiled_model,
+        verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95)),
         forge_property_handler=forge_property_recorder,
     )
 
@@ -167,6 +169,7 @@ def test_albert_token_classification_pytorch(forge_property_recorder, size, vari
         inputs,
         framework_model,
         compiled_model,
+        verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95)),
         forge_property_handler=forge_property_recorder,
     )
 

--- a/forge/test/models/pytorch/text/albert/test_albert.py
+++ b/forge/test/models/pytorch/text/albert/test_albert.py
@@ -13,7 +13,6 @@ from transformers import (
 )
 
 import forge
-from forge.verify.config import VerifyConfig
 from forge.verify.verify import verify
 
 from test.models.utils import Framework, Source, Task, build_module_name
@@ -83,7 +82,6 @@ def test_albert_masked_lm_pytorch(forge_property_recorder, size, variant):
         inputs,
         framework_model,
         compiled_model,
-        verify_cfg=VerifyConfig(verify_values=False),
         forge_property_handler=forge_property_recorder,
     )
 
@@ -169,7 +167,6 @@ def test_albert_token_classification_pytorch(forge_property_recorder, size, vari
         inputs,
         framework_model,
         compiled_model,
-        verify_cfg=VerifyConfig(verify_values=False),
         forge_property_handler=forge_property_recorder,
     )
 

--- a/forge/test/models/pytorch/text/bert/test_bert.py
+++ b/forge/test/models/pytorch/text/bert/test_bert.py
@@ -12,7 +12,6 @@ from transformers import (
 )
 
 import forge
-from forge.verify.config import VerifyConfig
 from forge.verify.verify import verify
 
 from test.models.pytorch.text.bert.utils.utils import mean_pooling
@@ -61,7 +60,6 @@ def test_bert_masked_lm_pytorch(forge_property_recorder, variant):
         inputs,
         framework_model,
         compiled_model,
-        verify_cfg=VerifyConfig(verify_values=False),
         forge_property_handler=forge_property_recorder,
     )
 
@@ -139,7 +137,6 @@ def test_bert_question_answering_pytorch(forge_property_recorder, variant):
         inputs,
         framework_model,
         compiled_model,
-        verify_cfg=VerifyConfig(verify_values=False),
         forge_property_handler=forge_property_recorder,
     )
 
@@ -264,7 +261,6 @@ def test_bert_token_classification_pytorch(forge_property_recorder, variant):
         inputs,
         framework_model,
         compiled_model,
-        verify_cfg=VerifyConfig(verify_values=False),
         forge_property_handler=forge_property_recorder,
     )
 

--- a/forge/test/models/pytorch/text/dpr/test_dpr.py
+++ b/forge/test/models/pytorch/text/dpr/test_dpr.py
@@ -75,7 +75,6 @@ def test_dpr_context_encoder_pytorch(forge_property_recorder, variant):
         inputs,
         framework_model,
         compiled_model,
-        verify_cfg=VerifyConfig(verify_values=False),
         forge_property_handler=forge_property_recorder,
     )
 
@@ -205,7 +204,6 @@ def test_dpr_reader_pytorch(forge_property_recorder, variant):
         inputs,
         framework_model,
         compiled_model,
-        verify_cfg=VerifyConfig(verify_values=False),
         forge_property_handler=forge_property_recorder,
     )
 

--- a/forge/test/models/pytorch/vision/monodle/test_monodle.py
+++ b/forge/test/models/pytorch/vision/monodle/test_monodle.py
@@ -15,6 +15,7 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 @pytest.mark.nightly
 @pytest.mark.xfail(reason="[Conv2dTranspose][Shape Calculation] TypeError: 'int' object is not subscriptable")
+@pytest.mark.skip(reason="Floating point exception(core dumped)")
 def test_monodle_pytorch(forge_property_recorder):
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/vision/resnet/test_resnet.py
+++ b/forge/test/models/pytorch/vision/resnet/test_resnet.py
@@ -38,6 +38,8 @@ def test_resnet_hf(variant, forge_property_recorder):
         source=Source.HUGGINGFACE,
         task=Task.IMAGE_CLASSIFICATION,
     )
+
+    forge_property_recorder.record_group("generality")
     forge_property_recorder.record_model_name(module_name)
 
     # Load tiny dataset
@@ -106,6 +108,8 @@ def test_resnet_timm(forge_property_recorder):
     module_name = build_module_name(
         framework=Framework.PYTORCH, model="resnet", source=Source.TIMM, variant="50", task=Task.IMAGE_CLASSIFICATION
     )
+
+    forge_property_recorder.record_group("generality")
     forge_property_recorder.record_model_name(module_name)
 
     # Load framework model


### PR DESCRIPTION
### What's changed
- Some tests that were reporting good `pcc` weren't actually checking `pcc` at all, so now that's fixed. While it might degrade our statistics, at least they will be correct :))
- some tests were missing `group` tag which caused `N/A` values in superset, so I added them. Also some values will still be `N/A` but the problem is not on our part, so we opened [ticket](https://tenstorrent.atlassian.net/browse/DATA-640) for database team
- skipped one model which caused our `On nightly xfail` workflow to crash, hopefully now we will have green `On nightly xfail`.