### PR TITLE
Using Detection Model instead of Yolo

### DIFF
--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v10.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v10.py
@@ -2,36 +2,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-
-import numpy as np
 import pytest
-import torch
-from datasets import load_dataset
-from ultralytics import YOLO
 
 import forge
 from forge.verify.verify import verify
 
+from test.models.pytorch.vision.yolo.utils.yolov10_utils import (
+    YoloV10Wrapper,
+    load_yolov10_model_and_image,
+)
 from test.models.utils import Framework, Source, Task, build_module_name
 
 
-class YoloWrapper(torch.nn.Module):
-    def __init__(self, model):
-        super().__init__()
-        self.model = model
-
-    def forward(self, image: torch.Tensor):
-        results = self.model.predict(image, conf=0.25, verbose=False)[0]
-        boxes = results.boxes.xyxy
-        class_ids = results.boxes.cls
-        confidences = results.boxes.conf
-        return boxes, class_ids, confidences
-
-
-@pytest.mark.xfail(reason="TypeError: type Tensor doesn't define __round__ method")
+@pytest.mark.xfail(reason="AssertionError: Encountered unsupported op types. Check error logs for more details")
 @pytest.mark.nightly
 def test_yolov10(forge_property_recorder):
-
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.PYTORCH,
@@ -40,29 +25,20 @@ def test_yolov10(forge_property_recorder):
         task=Task.OBJECT_DETECTION,
         source=Source.GITHUB,
     )
-
-    # Record Forge Property
     forge_property_recorder.record_group("priority")
     forge_property_recorder.record_model_name(module_name)
 
-    MODEL_URL = "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov10n.pt"
-
-    # Load model
-    framework_model = YOLO(MODEL_URL)
-    framework_model.eval()
-    framework_model = YoloWrapper(framework_model)
-
-    # Load input
-    dataset = load_dataset("huggingface/cats-image", split="test[:1]")
-    image = dataset[0]["image"]
-    image_np = np.array(image)
-    image_tensor = torch.tensor(image_np).permute(2, 0, 1).unsqueeze(0).float()
+    # Load  model and input
+    model, image_tensor = load_yolov10_model_and_image()
+    framework_model = YoloV10Wrapper(model)
 
     # Forge compile framework model
-    inputs = [image_tensor]
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=[image_tensor],
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    verify([image_tensor], framework_model, compiled_model, forge_property_handler=forge_property_recorder)

--- a/forge/test/models/pytorch/vision/yolo/utils/yolov10_utils.py
+++ b/forge/test/models/pytorch/vision/yolo/utils/yolov10_utils.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+from datasets import load_dataset
+from torchvision import transforms
+from ultralytics.nn.tasks import DetectionModel
+
+
+class YoloV10Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, image: torch.Tensor):
+        result = self.model(image)[0]
+        return result[0]
+
+
+def load_yolov10_model_and_image():
+    # Load YOLOv10n model weights
+    weights = torch.hub.load_state_dict_from_url(
+        "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov10n.pt", map_location="cpu"
+    )
+
+    # Initialize and load model
+    model = DetectionModel(cfg=weights["model"].yaml)
+    model.load_state_dict(weights["model"].float().state_dict())
+    model.eval()
+
+    # Load sample image and preprocess
+    dataset = load_dataset("huggingface/cats-image", split="test[:1]")
+    image = dataset[0]["image"]
+    preprocess = transforms.Compose(
+        [
+            transforms.Resize((640, 640)),
+            transforms.ToTensor(),
+        ]
+    )
+    image_tensor = preprocess(image).unsqueeze(0)
+
+    return model, image_tensor


### PR DESCRIPTION
- While using Yolo to load the model, we encountered 
`TypeError: type Tensor doesn't define __round__ method`

- The Yolo uses Detection Model and when Detection Model is called directly, the Error is cleared. We now face unsupported op error
`AssertionError: Encountered unsupported op types. Check error logs for more details`
