### PR TITLE
Uplift third_party/tt-mlir to origin/main 2025-03-27 with ClampScalarOp and EmptyOP fix

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -644,7 +644,7 @@ class MLIRGenerator
         lowering_handler_map["abs"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::AbsOp>;
         lowering_handler_map["add"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::AddOp>;
         lowering_handler_map["cast"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::TypecastOp>;
-        lowering_handler_map["clip"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ClampOp>;
+        lowering_handler_map["clip"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ClampScalarOp>;
         lowering_handler_map["concatenate"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ConcatOp>;
         lowering_handler_map["conv2d"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::Conv2dOp>;
         lowering_handler_map["cosine"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::CosOp>;

--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -553,7 +553,7 @@ class MLIRGenerator
             shape_vec.push_back((int64_t)dim);
         }
 
-        return builder_.create<mlir::tensor::EmptyOp>(
+        return builder_.create<mlir::tt::ttir::EmptyOp>(
             get_tt_forge_operation_location(graph, node), shape_vec, get_data_type(node));
     }
 


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir submodule to the origin/main with ClampScalarOp and EmptyOp fix
