### PR TITLE
[ci] skip phi-3.5 test due to large memory usage

### DIFF
--- a/forge/test/models/pytorch/multimodal/phi3/test_phi3_5_vision.py
+++ b/forge/test/models/pytorch/multimodal/phi3/test_phi3_5_vision.py
@@ -30,6 +30,7 @@ variants = ["microsoft/Phi-3.5-vision-instruct"]
 @pytest.mark.xfail(
     reason="NotImplementedError: The following operators are not implemented: ['aten::resolve_neg', 'aten::resolve_conj']"
 )
+@pytest.mark.skip("Test uses large amount of host memory (>30GB).")
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_5_vision(forge_property_recorder, variant):
 


### PR DESCRIPTION
This test is executing as part of the nightly xfail run; skip the test until we reduce memory consumption, since it is causing sporadic failures.