### PR TITLE
Remove xfail marker in models ops

### DIFF
--- a/forge/test/models_ops/test_broadcast.py
+++ b/forge/test/models_ops/test_broadcast.py
@@ -97,23 +97,20 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="RuntimeError: Generated MLIR module failed verification.")],
     ),
-    pytest.param(
-        (
-            Broadcast2,
-            [((1, 1, 1, 128), torch.bool)],
-            {
-                "model_name": [
-                    "pt_distilbert_distilbert_base_uncased_mlm_hf",
-                    "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
-                    "pt_distilbert_distilbert_base_cased_mlm_hf",
-                    "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
-                    "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "-4", "shape": "1"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
+    (
+        Broadcast2,
+        [((1, 1, 1, 128), torch.bool)],
+        {
+            "model_name": [
+                "pt_distilbert_distilbert_base_uncased_mlm_hf",
+                "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
+                "pt_distilbert_distilbert_base_cased_mlm_hf",
+                "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
+                "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "-4", "shape": "1"},
+        },
     ),
     pytest.param(
         (
@@ -145,17 +142,14 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="RuntimeError: Generated MLIR module failed verification.")],
     ),
-    pytest.param(
-        (
-            Broadcast2,
-            [((1, 1, 1, 384), torch.bool)],
-            {
-                "model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
-                "pcc": 0.99,
-                "op_params": {"dim": "-4", "shape": "1"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
+    (
+        Broadcast2,
+        [((1, 1, 1, 384), torch.bool)],
+        {
+            "model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
+            "pcc": 0.99,
+            "op_params": {"dim": "-4", "shape": "1"},
+        },
     ),
     pytest.param(
         (

--- a/forge/test/models_ops/test_cast.py
+++ b/forge/test/models_ops/test_cast.py
@@ -84,20 +84,18 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.float32"},
         },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((2, 1, 1, 13), torch.bool)],
-            {
-                "model_name": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
+    (
+        Cast0,
+        [((2, 1, 1, 13), torch.bool)],
+        {
+            "model_name": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
     (
         Cast0,
@@ -108,27 +106,23 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.float32"},
         },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((2, 1, 7, 7), torch.bool)],
-            {
-                "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
+    (
+        Cast0,
+        [((2, 1, 7, 7), torch.bool)],
+        {
+            "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 596, 4096), torch.bool)],
-            {
-                "model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
+    (
+        Cast0,
+        [((1, 596, 4096), torch.bool)],
+        {
+            "model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
     pytest.param(
         (
@@ -219,64 +213,58 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.float32"},
         },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 1, 256, 256), torch.bool)],
-            {
-                "model_name": [
-                    "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
-                    "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
-                    "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
-                    "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_phi3_5_microsoft_phi_3_5_mini_instruct_clm_hf",
-                    "pt_xglm_facebook_xglm_1_7b_clm_hf",
-                    "pt_xglm_facebook_xglm_564m_clm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
+    (
+        Cast0,
+        [((1, 1, 256, 256), torch.bool)],
+        {
+            "model_name": [
+                "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
+                "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
+                "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
+                "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
+                "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_phi3_5_microsoft_phi_3_5_mini_instruct_clm_hf",
+                "pt_xglm_facebook_xglm_1_7b_clm_hf",
+                "pt_xglm_facebook_xglm_564m_clm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
-    pytest.param(
-        (
-            Cast1,
-            [((1, 1, 256, 256), torch.bool)],
-            {
-                "model_name": [
-                    "pt_gpt2_gpt2_text_gen_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_2_7b_clm_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_125m_clm_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.bool"},
-            },
-        ),
+    (
+        Cast1,
+        [((1, 1, 256, 256), torch.bool)],
+        {
+            "model_name": [
+                "pt_gpt2_gpt2_text_gen_hf",
+                "pt_gptneo_eleutherai_gpt_neo_2_7b_clm_hf",
+                "pt_gptneo_eleutherai_gpt_neo_125m_clm_hf",
+                "pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.bool"},
+        },
     ),
-    pytest.param(
-        (
-            Cast2,
-            [((1, 1, 256, 256), torch.bool)],
-            {
-                "model_name": [
-                    "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
-                    "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
-                    "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.int32"},
-            },
-        ),
+    (
+        Cast2,
+        [((1, 1, 256, 256), torch.bool)],
+        {
+            "model_name": [
+                "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
+                "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
+                "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
+                "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.int32"},
+        },
     ),
     (
         Cast0,
@@ -310,24 +298,22 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
-    pytest.param(
-        (
-            Cast2,
-            [((1, 128), torch.bool)],
-            {
-                "model_name": [
-                    "pt_distilbert_distilbert_base_uncased_mlm_hf",
-                    "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
-                    "pt_distilbert_distilbert_base_cased_mlm_hf",
-                    "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
-                    "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
-                    "pt_roberta_xlm_roberta_base_mlm_hf",
-                    "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.int32"},
-            },
-        ),
+    (
+        Cast2,
+        [((1, 128), torch.bool)],
+        {
+            "model_name": [
+                "pt_distilbert_distilbert_base_uncased_mlm_hf",
+                "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
+                "pt_distilbert_distilbert_base_cased_mlm_hf",
+                "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
+                "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
+                "pt_roberta_xlm_roberta_base_mlm_hf",
+                "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.int32"},
+        },
     ),
     pytest.param(
         (
@@ -359,22 +345,20 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.int64"},
         },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 12, 128, 128), torch.bool)],
-            {
-                "model_name": [
-                    "pt_distilbert_distilbert_base_uncased_mlm_hf",
-                    "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
-                    "pt_distilbert_distilbert_base_cased_mlm_hf",
-                    "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
-                    "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
+    (
+        Cast0,
+        [((1, 12, 128, 128), torch.bool)],
+        {
+            "model_name": [
+                "pt_distilbert_distilbert_base_uncased_mlm_hf",
+                "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
+                "pt_distilbert_distilbert_base_cased_mlm_hf",
+                "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
+                "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
     pytest.param(
         (
@@ -388,16 +372,14 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
-    pytest.param(
-        (
-            Cast2,
-            [((1, 384), torch.bool)],
-            {
-                "model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.int32"},
-            },
-        ),
+    (
+        Cast2,
+        [((1, 384), torch.bool)],
+        {
+            "model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.int32"},
+        },
     ),
     pytest.param(
         (
@@ -411,30 +393,26 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 12, 384, 384), torch.bool)],
-            {
-                "model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
+    (
+        Cast0,
+        [((1, 12, 384, 384), torch.bool)],
+        {
+            "model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
-    pytest.param(
-        (
-            Cast1,
-            [((1, 1, 7, 7), torch.bool)],
-            {
-                "model_name": [
-                    "pt_gpt2_mnoukhov_gpt2_imdb_sentiment_classifier_seq_cls_hf",
-                    "pt_nanogpt_financialsupport_nanogpt_text_gen_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.bool"},
-            },
-        ),
+    (
+        Cast1,
+        [((1, 1, 7, 7), torch.bool)],
+        {
+            "model_name": [
+                "pt_gpt2_mnoukhov_gpt2_imdb_sentiment_classifier_seq_cls_hf",
+                "pt_nanogpt_financialsupport_nanogpt_text_gen_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.bool"},
+        },
     ),
     (
         Cast0,
@@ -448,16 +426,14 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.float32"},
         },
     ),
-    pytest.param(
-        (
-            Cast2,
-            [((1, 7), torch.bool)],
-            {
-                "model_name": ["pt_gpt2_mnoukhov_gpt2_imdb_sentiment_classifier_seq_cls_hf"],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.int32"},
-            },
-        ),
+    (
+        Cast2,
+        [((1, 7), torch.bool)],
+        {
+            "model_name": ["pt_gpt2_mnoukhov_gpt2_imdb_sentiment_classifier_seq_cls_hf"],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.int32"},
+        },
     ),
     (
         Cast3,
@@ -474,51 +450,45 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.int64"},
         },
     ),
-    pytest.param(
-        (
-            Cast1,
-            [((1, 1, 32, 32), torch.bool)],
-            {
-                "model_name": [
-                    "pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.bool"},
-            },
-        ),
+    (
+        Cast1,
+        [((1, 1, 32, 32), torch.bool)],
+        {
+            "model_name": [
+                "pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf",
+                "pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf",
+                "pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.bool"},
+        },
     ),
-    pytest.param(
-        (
-            Cast2,
-            [((1, 1, 32, 32), torch.bool)],
-            {
-                "model_name": ["pt_llama3_meta_llama_llama_3_2_3b_clm_hf", "pt_llama3_huggyllama_llama_7b_clm_hf"],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.int32"},
-            },
-        ),
+    (
+        Cast2,
+        [((1, 1, 32, 32), torch.bool)],
+        {
+            "model_name": ["pt_llama3_meta_llama_llama_3_2_3b_clm_hf", "pt_llama3_huggyllama_llama_7b_clm_hf"],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.int32"},
+        },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 1, 32, 32), torch.bool)],
-            {
-                "model_name": [
-                    "pt_llama3_meta_llama_llama_3_2_3b_clm_hf",
-                    "pt_llama3_huggyllama_llama_7b_clm_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.float32"},
-            },
-        ),
+    (
+        Cast0,
+        [((1, 1, 32, 32), torch.bool)],
+        {
+            "model_name": [
+                "pt_llama3_meta_llama_llama_3_2_3b_clm_hf",
+                "pt_llama3_huggyllama_llama_7b_clm_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.float32"},
+        },
     ),
     pytest.param(
         (
@@ -532,16 +502,14 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch -> AutomaticValueChecker (compare_with_golden)")],
     ),
-    pytest.param(
-        (
-            Cast2,
-            [((1, 4), torch.bool)],
-            {
-                "model_name": ["pt_llama3_huggyllama_llama_7b_seq_cls_hf"],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.int32"},
-            },
-        ),
+    (
+        Cast2,
+        [((1, 4), torch.bool)],
+        {
+            "model_name": ["pt_llama3_huggyllama_llama_7b_seq_cls_hf"],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.int32"},
+        },
     ),
     pytest.param(
         (
@@ -633,20 +601,18 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.float32"},
         },
     ),
-    pytest.param(
-        (
-            Cast2,
-            [((1, 32), torch.bool)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.int32"},
-            },
-        ),
+    (
+        Cast2,
+        [((1, 32), torch.bool)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.int32"},
+        },
     ),
     (
         Cast0,
@@ -657,38 +623,34 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.float32"},
         },
     ),
-    pytest.param(
-        (
-            Cast1,
-            [((1, 16, 320, 1024), torch.bool)],
-            {
-                "model_name": [
-                    "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.bool"},
-            },
-        ),
+    (
+        Cast1,
+        [((1, 16, 320, 1024), torch.bool)],
+        {
+            "model_name": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.bool"},
+        },
     ),
-    pytest.param(
-        (
-            Cast1,
-            [((1, 16, 192, 640), torch.bool)],
-            {
-                "model_name": [
-                    "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dtype": "torch.bool"},
-            },
-        ),
+    (
+        Cast1,
+        [((1, 16, 192, 640), torch.bool)],
+        {
+            "model_name": [
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dtype": "torch.bool"},
+        },
     ),
 ]
 

--- a/forge/test/models_ops/test_repeatinterleave.py
+++ b/forge/test/models_ops/test_repeatinterleave.py
@@ -351,29 +351,22 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"repeats": "1", "dim": "1"},
         },
     ),
-    pytest.param(
-        (
-            Repeatinterleave4,
-            [((1, 1, 1, 256), torch.int64)],
-            {
-                "model_name": [
-                    "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_phi3_5_microsoft_phi_3_5_mini_instruct_clm_hf",
-                    "pt_xglm_facebook_xglm_1_7b_clm_hf",
-                    "pt_xglm_facebook_xglm_564m_clm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"repeats": "256", "dim": "2"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/kernels/kernel.cpp:265: tt::exception info: 1283 unique+common runtime args targeting kernel reader_concat_stick_layout_interleaved_start_id on (x=0,y=0) are too large. Max allowable is 256"
-            )
-        ],
+    (
+        Repeatinterleave4,
+        [((1, 1, 1, 256), torch.int64)],
+        {
+            "model_name": [
+                "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_phi3_5_microsoft_phi_3_5_mini_instruct_clm_hf",
+                "pt_xglm_facebook_xglm_1_7b_clm_hf",
+                "pt_xglm_facebook_xglm_564m_clm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"repeats": "256", "dim": "2"},
+        },
     ),
     (
         Repeatinterleave3,

--- a/forge/test/models_ops/test_reshape.py
+++ b/forge/test/models_ops/test_reshape.py
@@ -16715,23 +16715,20 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"shape": "(1, 256, 32, 128)"},
         },
     ),
-    pytest.param(
-        (
-            Reshape344,
-            [((1, 128), torch.bool)],
-            {
-                "model_name": [
-                    "pt_distilbert_distilbert_base_uncased_mlm_hf",
-                    "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
-                    "pt_distilbert_distilbert_base_cased_mlm_hf",
-                    "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
-                    "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"shape": "(1, 1, 1, 128)"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
+    (
+        Reshape344,
+        [((1, 128), torch.bool)],
+        {
+            "model_name": [
+                "pt_distilbert_distilbert_base_uncased_mlm_hf",
+                "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
+                "pt_distilbert_distilbert_base_cased_mlm_hf",
+                "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
+                "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"shape": "(1, 1, 1, 128)"},
+        },
     ),
     (
         Reshape345,
@@ -16778,17 +16775,14 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"shape": "(1, 12, 384, 384)"},
         },
     ),
-    pytest.param(
-        (
-            Reshape350,
-            [((1, 384), torch.bool)],
-            {
-                "model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
-                "pcc": 0.99,
-                "op_params": {"shape": "(1, 1, 1, 384)"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
+    (
+        Reshape350,
+        [((1, 384), torch.bool)],
+        {
+            "model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
+            "pcc": 0.99,
+            "op_params": {"shape": "(1, 1, 1, 384)"},
+        },
     ),
     (
         Reshape351,

--- a/forge/test/models_ops/test_where.py
+++ b/forge/test/models_ops/test_where.py
@@ -270,50 +270,41 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
     ),
-    pytest.param(
-        (
-            Where2,
-            [((1, 1, 256, 256), torch.bool)],
-            {
-                "model_name": [
-                    "pt_gpt2_gpt2_text_gen_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_2_7b_clm_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_125m_clm_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
+    (
+        Where2,
+        [((1, 1, 256, 256), torch.bool)],
+        {
+            "model_name": [
+                "pt_gpt2_gpt2_text_gen_hf",
+                "pt_gptneo_eleutherai_gpt_neo_2_7b_clm_hf",
+                "pt_gptneo_eleutherai_gpt_neo_125m_clm_hf",
+                "pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
-    pytest.param(
-        (
-            Where2,
-            [((1, 1, 7, 7), torch.bool)],
-            {
-                "model_name": [
-                    "pt_gpt2_mnoukhov_gpt2_imdb_sentiment_classifier_seq_cls_hf",
-                    "pt_nanogpt_financialsupport_nanogpt_text_gen_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
+    (
+        Where2,
+        [((1, 1, 7, 7), torch.bool)],
+        {
+            "model_name": [
+                "pt_gpt2_mnoukhov_gpt2_imdb_sentiment_classifier_seq_cls_hf",
+                "pt_nanogpt_financialsupport_nanogpt_text_gen_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
-    pytest.param(
-        (
-            Where2,
-            [((1, 1, 32, 32), torch.bool)],
-            {
-                "model_name": [
-                    "pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32")],
+    (
+        Where2,
+        [((1, 1, 32, 32), torch.bool)],
+        {
+            "model_name": [
+                "pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf",
+                "pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf",
+                "pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     pytest.param(
         (


### PR DESCRIPTION
In the [latest nightly models ops pipeline](14120678744), below issues was resolved and remove xfail markers for the respective models ops tests

Issue 1:
`RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/kernels/kernel.cpp:265: tt::exception info: 1283 unique+common runtime args targeting kernel reader_concat_stick_layout_interleaved_start_id on (x=0,y=0) are too large. Max allowable is 256`

Issue 2:
`RuntimeError: Tensor 0 - data type mismatch: expected UInt8, got Float32`

Generated models ops test report: 
[model_ops_tests_report.xlsx](https://github.com/user-attachments/files/19500433/model_ops_tests_report.xlsx)


Triggered the On Nightly Models Ops pipeline and all the test passes - https://github.com/tenstorrent/tt-forge-fe/actions/runs/14126626462
