### PR TITLE
Update Llama tests

### DIFF
--- a/forge/test/mlir/llama/test_llama_inference.py
+++ b/forge/test/mlir/llama/test_llama_inference.py
@@ -10,32 +10,6 @@ from forge.verify.verify import verify
 from test.mlir.llama.utils.utils import load_model
 
 
-@pytest.mark.nightly
-@pytest.mark.parametrize(
-    "model_path",
-    [
-        "openlm-research/open_llama_3b",
-        "meta-llama/Llama-3.2-1B",
-    ],
-)
-def test_llama_inference(forge_property_recorder, model_path):
-    if model_path == "openlm-research/open_llama_3b":
-        pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 32 GB during compile time)")
-
-    # Load Model and Tokenizer
-    framework_model, tokenizer = load_model(model_path)
-
-    prompt = "Q: What is the largest animal?\nA:"
-    input_ids = tokenizer(prompt, return_tensors="pt").input_ids
-
-    # Sanity run
-    generation_output = framework_model.generate(input_ids=input_ids, max_new_tokens=32)
-    print(tokenizer.decode(generation_output[0]))
-
-    # Compile the model
-    compiled_model = forge.compile(framework_model, input_ids, forge_property_handler=forge_property_recorder)
-
-
 @pytest.mark.parametrize("model_path", ["openlm-research/open_llama_3b", "meta-llama/Llama-3.2-1B"])
 @pytest.mark.skip(reason="No need to run in CI, this is PoC that should be mapped to work on device.")
 @pytest.mark.push

--- a/forge/test/mlir/llama/tests/test_llama_prefil.py
+++ b/forge/test/mlir/llama/tests/test_llama_prefil.py
@@ -9,6 +9,7 @@ import forge
 from test.mlir.llama.utils.utils import load_model
 from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
+from forge.test.models.utils import Framework, Source, Task, build_module_name
 
 
 class LlamaPrefillModel(torch.nn.Module):
@@ -61,6 +62,28 @@ def test_llama_prefil_on_device_decode_on_cpu(forge_property_recorder, model_pat
     """
     if model_path == "openlm-research/open_llama_3b":
         pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 32 GB during compile time)")
+
+    # Extract model variant from path
+    if "open_llama_3b" in model_path:
+        model_name = "Open Llama"
+        variant = "3b"
+    elif "Llama-3.2-1B" in model_path:
+        model_name = "Llama"
+        variant = "3.2_1b"
+    else:
+        model_name = "Llama"
+        variant = "unknown"
+
+    # Record model details
+    module_name = build_module_name(
+        framework=Framework.PYTORCH,
+        model=model_name,
+        variant=variant,
+        source=Source.HUGGINGFACE,
+        task=Task.TEXT_GENERATION,
+    )
+    forge_property_recorder.record_group("generality")
+    forge_property_recorder.record_model_name(module_name)
 
     # Load Llama model and tokenizer
     model, tokenizer = load_model(model_path, return_dict=True)

--- a/forge/test/mlir/llama/tests/test_llama_prefil.py
+++ b/forge/test/mlir/llama/tests/test_llama_prefil.py
@@ -9,7 +9,7 @@ import forge
 from test.mlir.llama.utils.utils import load_model
 from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
-from forge.test.models.utils import Framework, Source, Task, build_module_name
+from test.models.utils import Framework, Source, Task, build_module_name
 
 
 class LlamaPrefillModel(torch.nn.Module):
@@ -67,12 +67,15 @@ def test_llama_prefil_on_device_decode_on_cpu(forge_property_recorder, model_pat
     if "open_llama_3b" in model_path:
         model_name = "Open Llama"
         variant = "3b"
+        group = "generality"
     elif "Llama-3.2-1B" in model_path:
-        model_name = "Llama"
-        variant = "3.2_1b"
+        model_name = "Llama 3.2"
+        variant = "1b"
+        group = "red"
     else:
         model_name = "Llama"
         variant = "unknown"
+        group = "generality"
 
     # Record model details
     module_name = build_module_name(
@@ -82,7 +85,7 @@ def test_llama_prefil_on_device_decode_on_cpu(forge_property_recorder, model_pat
         source=Source.HUGGINGFACE,
         task=Task.TEXT_GENERATION,
     )
-    forge_property_recorder.record_group("generality")
+    forge_property_recorder.record_group(group)
     forge_property_recorder.record_model_name(module_name)
 
     # Load Llama model and tokenizer

--- a/pytest.ini
+++ b/pytest.ini
@@ -47,7 +47,6 @@ testpaths =
     forge/test/mlir/test_optimizers.py
 
     # Llama
-    forge/test/mlir/llama/test_llama_inference.py::test_llama_inference
     forge/test/mlir/llama/tests
 
     # Benchmark


### PR DESCRIPTION
### Ticket
n/a

### Problem description
Missing model name for Llama + removing redundant inference test

### What's changed
- Added build_module_name functionality to test_llama_prefil_on_device_decode_on_cpu
- Used Framework.PYTORCH, proper model name, variant, Source.HUGGINGFACE, and Task.TEXT_GENERATION
- Recorded model details with forge_property_recorder
- Removed redundant test_llama_inference test that is covered by the prefil test

### Checklist
- [ ] New/Existing tests provide coverage for changes
