### PR TITLE
Enable ONNX Models

### DIFF
--- a/forge/test/models/onnx/text/bert/test_bert.py
+++ b/forge/test/models/onnx/text/bert/test_bert.py
@@ -25,7 +25,7 @@ opset_versions = [9, 17]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["bert-base-uncased"])
 @pytest.mark.parametrize("opset_version", opset_versions, ids=opset_versions)
-def test_bert_masked_lm(forge_property_recorder, variant, tmp_path, opset_version):
+def test_bert_masked_lm_onnx(forge_property_recorder, variant, tmp_path, opset_version):
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.ONNX,
@@ -75,7 +75,7 @@ def test_bert_masked_lm(forge_property_recorder, variant, tmp_path, opset_versio
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("opset_version", opset_versions, ids=opset_versions)
-def test_bert_question_answering(forge_property_recorder, variant, tmp_path, opset_version):
+def test_bert_question_answering_onnx(forge_property_recorder, variant, tmp_path, opset_version):
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.ONNX,

--- a/forge/test/models/onnx/text/minilm/test_minilm.py
+++ b/forge/test/models/onnx/text/minilm/test_minilm.py
@@ -21,7 +21,7 @@ opset_versions = [9, 17]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["sentence-transformers/all-MiniLM-L6-v2"])
 @pytest.mark.parametrize("opset_version", opset_versions, ids=opset_versions)
-def test_minilm_sequence_classification(forge_property_recorder, variant, tmp_path, opset_version):
+def test_minilm_sequence_classification_onnx(forge_property_recorder, variant, tmp_path, opset_version):
     # Build Module Name
     module_name = build_module_name(
         framework=Framework.ONNX,

--- a/forge/test/models/onnx/vision/ddrnet/test_ddrnet.py
+++ b/forge/test/models/onnx/vision/ddrnet/test_ddrnet.py
@@ -19,7 +19,7 @@ variants = ["ddrnet23s", "ddrnet23", "ddrnet39"]
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_ddrnet(variant, test_device):
@@ -80,7 +80,7 @@ variants = ["ddrnet_23_slim_1024"]
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_ddrnet_semantic_segmentation_onnx(variant, test_device):

--- a/forge/test/models/onnx/vision/ddrnet/test_ddrnet.py
+++ b/forge/test/models/onnx/vision/ddrnet/test_ddrnet.py
@@ -1,22 +1,25 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-import forge, os
+import os
 import pytest
 from torchvision import transforms
 import requests
 from PIL import Image
 import onnx
-from forge.verify.backend import verify_module
-from forge import DepricatedVerifyConfig
-from forge.verify.config import TestKind
-from forge._C.backend_api import BackendDevice
+
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge.verify.backend import verify_module
+# from forge import DepricatedVerifyConfig
+# from forge.verify.config import TestKind
+# from forge._C.backend_api import BackendDevice
 
 variants = ["ddrnet23s", "ddrnet23", "ddrnet39"]
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_ddrnet(variant, test_device):
@@ -77,7 +80,7 @@ variants = ["ddrnet_23_slim_1024"]
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_ddrnet_semantic_segmentation_onnx(variant, test_device):

--- a/forge/test/models/onnx/vision/dla/test_dla.py
+++ b/forge/test/models/onnx/vision/dla/test_dla.py
@@ -1,18 +1,19 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-import forge
 import onnx
 import os
-from forge.verify.backend import verify_module
-from forge import DepricatedVerifyConfig
 import requests
 import pytest
-
-# from forge.verify.config import TestKind
-# from forge._C.backend_api import BackendDevice
 import torchvision.transforms as transforms
 from PIL import Image
+
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge import DepricatedVerifyConfig
+# from forge.verify.backend import verify_module
+# from forge.verify.config import TestKind
+# from forge._C.backend_api import BackendDevice
 
 
 variants = [
@@ -30,7 +31,7 @@ variants = [
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_dla_onnx(test_device, variant):

--- a/forge/test/models/onnx/vision/dla/test_dla.py
+++ b/forge/test/models/onnx/vision/dla/test_dla.py
@@ -31,7 +31,7 @@ variants = [
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_dla_onnx(test_device, variant):

--- a/forge/test/models/onnx/vision/fpn/test_fpn.py
+++ b/forge/test/models/onnx/vision/fpn/test_fpn.py
@@ -13,7 +13,7 @@ import pytest
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.nightly
 def test_fpn_onnx(test_device, test_kind):
     compiler_cfg = forge.config.CompilerConfig()

--- a/forge/test/models/onnx/vision/fpn/test_fpn.py
+++ b/forge/test/models/onnx/vision/fpn/test_fpn.py
@@ -2,16 +2,18 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import torch
-import forge
 import onnx
 import os
 import pytest
-from forge.verify.backend import verify_module
-from forge import DepricatedVerifyConfig
+
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge.verify.backend import verify_module
+# from forge import DepricatedVerifyConfig
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.nightly
 def test_fpn_onnx(test_device, test_kind):
     compiler_cfg = forge.config.CompilerConfig()

--- a/forge/test/models/onnx/vision/hardnet/test_hardnet.py
+++ b/forge/test/models/onnx/vision/hardnet/test_hardnet.py
@@ -18,7 +18,7 @@ variants = ["hardnet68", "hardnet85", "hardnet68ds", "hardnet39ds"]
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_hardnet_onnx(variant, test_device):

--- a/forge/test/models/onnx/vision/hardnet/test_hardnet.py
+++ b/forge/test/models/onnx/vision/hardnet/test_hardnet.py
@@ -1,23 +1,24 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-import forge, os
+import os
 import onnx
+import pytest
 from PIL import Image
 from torchvision import transforms
 import urllib
 
-# from forge.verify.backend import verify_module
-import pytest
-from forge import DepricatedVerifyConfig
-from forge.verify.config import TestKind
-from forge._C.backend_api import BackendDevice
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge import DepricatedVerifyConfig
+# from forge.verify.config import TestKind
+# from forge._C.backend_api import BackendDevice
 
 variants = ["hardnet68", "hardnet85", "hardnet68ds", "hardnet39ds"]
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_hardnet_onnx(variant, test_device):

--- a/forge/test/models/onnx/vision/lstm/test_lstm_genom.py
+++ b/forge/test/models/onnx/vision/lstm/test_lstm_genom.py
@@ -18,7 +18,7 @@ from test.utils import download_model
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.nightly
 def test_lstm_genom_onnx(test_device):
     load_path = "third_party/confidential_customer_models/model_2/onnx/lstm_genom/lstm-genom-model.onnx"

--- a/forge/test/models/onnx/vision/lstm/test_lstm_genom.py
+++ b/forge/test/models/onnx/vision/lstm/test_lstm_genom.py
@@ -6,16 +6,19 @@ import pytest
 import os
 import onnx
 import tensorflow as tf
-import forge
-from forge.verify.backend import verify_module
-from forge import DepricatedVerifyConfig
-from forge._C.backend_api import BackendType, BackendDevice
-from forge.verify.config import TestKind
+
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge.verify.backend import verify_module
+# from forge import DepricatedVerifyConfig
+# from forge._C.backend_api import BackendType, BackendDevice
+# from forge.verify.config import TestKind
+
 from test.utils import download_model
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.nightly
 def test_lstm_genom_onnx(test_device):
     load_path = "third_party/confidential_customer_models/model_2/onnx/lstm_genom/lstm-genom-model.onnx"

--- a/forge/test/models/onnx/vision/lstm/test_lstm_valence.py
+++ b/forge/test/models/onnx/vision/lstm/test_lstm_valence.py
@@ -6,15 +6,17 @@ import pytest
 import os
 import onnx
 import tensorflow as tf
-import forge
-from forge.verify.backend import verify_module
-from forge import DepricatedVerifyConfig
-from forge._C.backend_api import BackendType, BackendDevice
-from forge.verify.config import TestKind
+
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge.verify.backend import verify_module
+# from forge import DepricatedVerifyConfig
+# from forge._C.backend_api import BackendType, BackendDevice
+# from forge.verify.config import TestKind
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.nightly
 def test_lstm_valence_onnx(test_device):
     # Load model checkpoint from HuggingFace

--- a/forge/test/models/onnx/vision/lstm/test_lstm_valence.py
+++ b/forge/test/models/onnx/vision/lstm/test_lstm_valence.py
@@ -16,7 +16,7 @@ import tensorflow as tf
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.nightly
 def test_lstm_valence_onnx(test_device):
     # Load model checkpoint from HuggingFace

--- a/forge/test/models/onnx/vision/perceiverio/test_perceiverio.py
+++ b/forge/test/models/onnx/vision/perceiverio/test_perceiverio.py
@@ -26,56 +26,54 @@ def get_sample_data(model_name):
     return pixel_values
 
 
-# TODO: Temporarily disable this test due to a CI error unrelated to the test itself.
-#   at https://github.com/tenstorrent/tt-forge-fe/pull/1500/checks?check_run_id=39261242125
-# @pytest.mark.skip_model_analysis
-# @pytest.mark.skip(reason="CCM is not public yet.")
-# @pytest.mark.parametrize(
-#    "model_name",
-#    [
-#        "deepmind/vision-perceiver-conv",
-#        "deepmind/vision-perceiver-learned",
-#        "deepmind/vision-perceiver-fourier",
-#    ],
-# )
-# @pytest.mark.nightly
-# def test_perceiver_for_image_classification_onnx(test_device, model_name):
-#
-#    # Set Forge configuration parameters
-#    compiler_cfg = forge.config.CompilerConfig()
-#    compiler_cfg.default_df_override = forge.DataFormat.Float16_b
-#    verify_enabled = True
-#
-#    onnx_model_path = (
-#        "third_party/confidential_customer_models/generated/files/"
-#        + str(model_name).split("/")[-1].replace("-", "_")
-#        + ".onnx"
-#    )
-#
-#    # Sample Image
-#    pixel_values = get_sample_data(model_name)
-#
-#    # Load the onnx model
-#    onnx_model = onnx.load(onnx_model_path)
-#    onnx.checker.check_model(onnx_model)
-#
-#    # Create Forge module from Onnx model
-#    tt_model = forge.OnnxModule(
-#        str(model_name.split("/")[-1].replace("-", "_")) + "_onnx",
-#        onnx_model,
-#    )
-#
-#    # Run inference on Tenstorrent device
-#    verify_module(
-#        tt_model,
-#        input_shapes=(pixel_values.shape,),
-#        inputs=[(pixel_values,)],
-#        verify_cfg=DepricatedVerifyConfig(
-#            arch=test_device.arch,
-#            devtype=test_device.devtype,
-#            devmode=test_device.devmode,
-#            test_kind=TestKind.INFERENCE,
-#            enabled=verify_enabled,  # pcc drops in silicon devicetype
-#            pcc=0.96,
-#        ),
-#    )
+@pytest.mark.skip_model_analysis
+@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "deepmind/vision-perceiver-conv",
+        "deepmind/vision-perceiver-learned",
+        "deepmind/vision-perceiver-fourier",
+    ],
+)
+@pytest.mark.nightly
+def test_perceiver_for_image_classification_onnx(test_device, model_name):
+
+    # Set Forge configuration parameters
+    compiler_cfg = forge.config.CompilerConfig()
+    compiler_cfg.default_df_override = forge.DataFormat.Float16_b
+    verify_enabled = True
+
+    onnx_model_path = (
+        "third_party/confidential_customer_models/generated/files/"
+        + str(model_name).split("/")[-1].replace("-", "_")
+        + ".onnx"
+    )
+
+    # Sample Image
+    pixel_values = get_sample_data(model_name)
+
+    # Load the onnx model
+    onnx_model = onnx.load(onnx_model_path)
+    onnx.checker.check_model(onnx_model)
+
+    # Create Forge module from Onnx model
+    tt_model = forge.OnnxModule(
+        str(model_name.split("/")[-1].replace("-", "_")) + "_onnx",
+        onnx_model,
+    )
+
+    # Run inference on Tenstorrent device
+    verify_module(
+        tt_model,
+        input_shapes=(pixel_values.shape,),
+        inputs=[(pixel_values,)],
+        verify_cfg=DepricatedVerifyConfig(
+            arch=test_device.arch,
+            devtype=test_device.devtype,
+            devmode=test_device.devmode,
+            test_kind=TestKind.INFERENCE,
+            enabled=verify_enabled,  # pcc drops in silicon devicetype
+            pcc=0.96,
+        ),
+    )

--- a/forge/test/models/onnx/vision/perceiverio/test_perceiverio.py
+++ b/forge/test/models/onnx/vision/perceiverio/test_perceiverio.py
@@ -27,7 +27,7 @@ def get_sample_data(model_name):
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.parametrize(
     "model_name",
     [

--- a/forge/test/models/onnx/vision/perceiverio/test_perceiverio.py
+++ b/forge/test/models/onnx/vision/perceiverio/test_perceiverio.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-import forge
 import onnx
 
 import os
@@ -11,9 +10,11 @@ import pytest
 
 from transformers import AutoImageProcessor
 
-from forge.verify.backend import verify_module
-from forge import DepricatedVerifyConfig
-from forge.verify.config import TestKind
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge.verify.backend import verify_module
+# from forge import DepricatedVerifyConfig
+# from forge.verify.config import TestKind
 
 
 def get_sample_data(model_name):
@@ -26,7 +27,7 @@ def get_sample_data(model_name):
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.parametrize(
     "model_name",
     [

--- a/forge/test/models/onnx/vision/perceiverio/test_perceiverio.py
+++ b/forge/test/models/onnx/vision/perceiverio/test_perceiverio.py
@@ -26,54 +26,56 @@ def get_sample_data(model_name):
     return pixel_values
 
 
-@pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
-@pytest.mark.parametrize(
-    "model_name",
-    [
-        "deepmind/vision-perceiver-conv",
-        "deepmind/vision-perceiver-learned",
-        "deepmind/vision-perceiver-fourier",
-    ],
-)
-@pytest.mark.nightly
-def test_perceiver_for_image_classification_onnx(test_device, model_name):
-
-    # Set Forge configuration parameters
-    compiler_cfg = forge.config.CompilerConfig()
-    compiler_cfg.default_df_override = forge.DataFormat.Float16_b
-    verify_enabled = True
-
-    onnx_model_path = (
-        "third_party/confidential_customer_models/generated/files/"
-        + str(model_name).split("/")[-1].replace("-", "_")
-        + ".onnx"
-    )
-
-    # Sample Image
-    pixel_values = get_sample_data(model_name)
-
-    # Load the onnx model
-    onnx_model = onnx.load(onnx_model_path)
-    onnx.checker.check_model(onnx_model)
-
-    # Create Forge module from Onnx model
-    tt_model = forge.OnnxModule(
-        str(model_name.split("/")[-1].replace("-", "_")) + "_onnx",
-        onnx_model,
-    )
-
-    # Run inference on Tenstorrent device
-    verify_module(
-        tt_model,
-        input_shapes=(pixel_values.shape,),
-        inputs=[(pixel_values,)],
-        verify_cfg=DepricatedVerifyConfig(
-            arch=test_device.arch,
-            devtype=test_device.devtype,
-            devmode=test_device.devmode,
-            test_kind=TestKind.INFERENCE,
-            enabled=verify_enabled,  # pcc drops in silicon devicetype
-            pcc=0.96,
-        ),
-    )
+# TODO: Temporarily disable this test due to a CI error unrelated to the test itself.
+#   at https://github.com/tenstorrent/tt-forge-fe/pull/1500/checks?check_run_id=39261242125
+# @pytest.mark.skip_model_analysis
+# @pytest.mark.skip(reason="CCM is not public yet.")
+# @pytest.mark.parametrize(
+#    "model_name",
+#    [
+#        "deepmind/vision-perceiver-conv",
+#        "deepmind/vision-perceiver-learned",
+#        "deepmind/vision-perceiver-fourier",
+#    ],
+# )
+# @pytest.mark.nightly
+# def test_perceiver_for_image_classification_onnx(test_device, model_name):
+#
+#    # Set Forge configuration parameters
+#    compiler_cfg = forge.config.CompilerConfig()
+#    compiler_cfg.default_df_override = forge.DataFormat.Float16_b
+#    verify_enabled = True
+#
+#    onnx_model_path = (
+#        "third_party/confidential_customer_models/generated/files/"
+#        + str(model_name).split("/")[-1].replace("-", "_")
+#        + ".onnx"
+#    )
+#
+#    # Sample Image
+#    pixel_values = get_sample_data(model_name)
+#
+#    # Load the onnx model
+#    onnx_model = onnx.load(onnx_model_path)
+#    onnx.checker.check_model(onnx_model)
+#
+#    # Create Forge module from Onnx model
+#    tt_model = forge.OnnxModule(
+#        str(model_name.split("/")[-1].replace("-", "_")) + "_onnx",
+#        onnx_model,
+#    )
+#
+#    # Run inference on Tenstorrent device
+#    verify_module(
+#        tt_model,
+#        input_shapes=(pixel_values.shape,),
+#        inputs=[(pixel_values,)],
+#        verify_cfg=DepricatedVerifyConfig(
+#            arch=test_device.arch,
+#            devtype=test_device.devtype,
+#            devmode=test_device.devmode,
+#            test_kind=TestKind.INFERENCE,
+#            enabled=verify_enabled,  # pcc drops in silicon devicetype
+#            pcc=0.96,
+#        ),
+#    )

--- a/forge/test/models/onnx/vision/retinanet/test_retinanet.py
+++ b/forge/test/models/onnx/vision/retinanet/test_retinanet.py
@@ -52,7 +52,7 @@ def img_preprocess(scal_val=1):
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.nightly
 def test_retinanet_r101_640x480_onnx(test_device):
     # STEP 1: Set Forge configuration parameters
@@ -109,7 +109,7 @@ variants = [
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_retinanet_onnx(variant, test_device):

--- a/forge/test/models/onnx/vision/retinanet/test_retinanet.py
+++ b/forge/test/models/onnx/vision/retinanet/test_retinanet.py
@@ -4,12 +4,6 @@
 
 # STEP 0: import Forge library
 import pytest
-
-from forge.verify.backend import verify_module
-from forge import DepricatedVerifyConfig, PyTorchModule
-from forge._C.backend_api import BackendType, BackendDevice
-from forge.verify.config import TestKind
-import forge
 import os
 
 import onnx
@@ -21,6 +15,14 @@ import numpy as np
 
 import requests
 from torchvision import transforms
+
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge.verify.backend import verify_module
+# from forge import DepricatedVerifyConfig, PyTorchModule
+# from forge._C.backend_api import BackendType, BackendDevice
+# from forge.verify.config import TestKind
+
 
 ## https://github.com/onnx/models/tree/main/vision/object_detection_segmentation/retinanet
 
@@ -50,7 +52,7 @@ def img_preprocess(scal_val=1):
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.nightly
 def test_retinanet_r101_640x480_onnx(test_device):
     # STEP 1: Set Forge configuration parameters
@@ -107,7 +109,7 @@ variants = [
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_retinanet_onnx(variant, test_device):

--- a/forge/test/models/onnx/vision/segformer/test_segformer_imgcls.py
+++ b/forge/test/models/onnx/vision/segformer/test_segformer_imgcls.py
@@ -35,7 +35,7 @@ variants_img_classification = [
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.parametrize("variant", variants_img_classification)
 @pytest.mark.nightly
 def test_segformer_image_classification_onnx(test_device, variant):

--- a/forge/test/models/onnx/vision/segformer/test_segformer_imgcls.py
+++ b/forge/test/models/onnx/vision/segformer/test_segformer_imgcls.py
@@ -1,17 +1,18 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-
-import forge
-from forge.verify.backend import verify_module
-from forge import DepricatedVerifyConfig
-from forge.verify.config import TestKind
-from transformers import AutoImageProcessor
 import os
 import pytest
 import requests
 from PIL import Image
 import onnx
+from transformers import AutoImageProcessor
+
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge.verify.backend import verify_module
+# from forge import DepricatedVerifyConfig
+# from forge.verify.config import TestKind
 
 
 def get_sample_data(model_name):
@@ -34,7 +35,7 @@ variants_img_classification = [
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.parametrize("variant", variants_img_classification)
 @pytest.mark.nightly
 def test_segformer_image_classification_onnx(test_device, variant):

--- a/forge/test/models/onnx/vision/segformer/test_segformer_semseg.py
+++ b/forge/test/models/onnx/vision/segformer/test_segformer_semseg.py
@@ -35,7 +35,7 @@ variants_semseg = [
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.parametrize("variant", variants_semseg)
 @pytest.mark.nightly
 def test_segformer_semantic_segmentation_onnx(test_device, variant):

--- a/forge/test/models/onnx/vision/segformer/test_segformer_semseg.py
+++ b/forge/test/models/onnx/vision/segformer/test_segformer_semseg.py
@@ -2,16 +2,18 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import forge
-from forge.verify.backend import verify_module
-from forge import DepricatedVerifyConfig
-from forge.verify.config import TestKind
 from transformers import AutoImageProcessor
 import os
 import pytest
 import requests
 from PIL import Image
 import onnx
+
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge.verify.backend import verify_module
+# from forge import DepricatedVerifyConfig
+# from forge.verify.config import TestKind
 
 
 def get_sample_data(model_name):
@@ -33,7 +35,7 @@ variants_semseg = [
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.parametrize("variant", variants_semseg)
 @pytest.mark.nightly
 def test_segformer_semantic_segmentation_onnx(test_device, variant):

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v3.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v3.py
@@ -9,11 +9,13 @@ import numpy as np
 
 import onnx
 import torch
-import forge
-from forge.verify.backend import verify_module
-from forge import DepricatedVerifyConfig
-from forge._C.backend_api import BackendType, BackendDevice
-from forge.verify.config import TestKind
+
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge.verify.backend import verify_module
+# from forge import DepricatedVerifyConfig
+# from forge._C.backend_api import BackendType, BackendDevice
+# from forge.verify.config import TestKind
 
 
 ########
@@ -46,7 +48,7 @@ def preprocess(img):
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="While loop in model, not supported yet")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.nightly
 def test_yolov3_tiny_onnx(test_device):
     # STEP 1: Create Forge module from PyTorch model
@@ -76,7 +78,7 @@ def test_yolov3_tiny_onnx(test_device):
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="While loop in model, not supported yet")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.nightly
 def test_yolov3_onnx(test_device):
     # STEP 1: Create Forge module from PyTorch model

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v3.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v3.py
@@ -48,7 +48,7 @@ def preprocess(img):
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.nightly
 def test_yolov3_tiny_onnx(test_device):
     # STEP 1: Create Forge module from PyTorch model
@@ -78,7 +78,7 @@ def test_yolov3_tiny_onnx(test_device):
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.nightly
 def test_yolov3_onnx(test_device):
     # STEP 1: Create Forge module from PyTorch model

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v5.py
@@ -6,11 +6,9 @@ import requests
 import pytest
 import torch
 from PIL import Image
-from pathlib import Path
 import cv2
 import numpy as np
-from yolov5.utils.dataloaders import exif_transpose, letterbox
-import onnx, pytest
+import onnx
 
 # TODO: These are old forge, we should update them to the currently version.
 # import forge
@@ -20,49 +18,11 @@ import onnx, pytest
 # from forge._C.backend_api import BackendDevice
 
 
-def data_preprocessing(ims: Image.Image, size: tuple) -> tuple:
-    """Data preprocessing function for YOLOv5 object detection.
-
-    Parameters
-    ----------
-    ims : Image.Image
-        Input image
-    size : tuple
-        Desired image size
-
-    Returns
-    -------
-    tuple
-        List of images, number of samples, filenames, image size, inference size, preprocessed images
-    """
-
-    _, ims = (len(ims), list(ims)) if isinstance(ims, (list, tuple)) else (1, [ims])  # number, list of images
-    shape0, shape1, files = [], [], []  # image and inference shapes, filenames
-
-    for i, im in enumerate(ims):
-        f = f"image{i}"  # filename
-        im, f = np.asarray(exif_transpose(im)), getattr(im, "filename", f) or f
-        files.append(Path(f).with_suffix(".jpg").name)
-        if im.shape[0] < 5:  # image in CHW
-            im = im.transpose((1, 2, 0))  # reverse dataloader .transpose(2, 0, 1)
-        im = im[..., :3] if im.ndim == 3 else cv2.cvtColor(im, cv2.COLOR_GRAY2BGR)  # enforce 3ch input
-        s = im.shape[:2]  # HWC
-        shape0.append(s)  # image shape
-        g = max(size) / max(s)  # gain
-        shape1.append([int(y * g) for y in s])
-        ims[i] = im if im.data.contiguous else np.ascontiguousarray(im)  # update
-    shape1 = [size[0] for _ in np.array(shape1).max(0)]  # inf shape
-    x = [letterbox(im, shape1, auto=False)[0] for im in ims]  # pad
-    x = np.ascontiguousarray(np.array(x).transpose((0, 3, 1, 2)))  # stack and BHWC to BCHW
-    x = torch.from_numpy(x) / 255  # uint8 to fp16/32
-    return x
-
-
 variants = ["yolov5n", "yolov5s", "yolov5m", "yolov5l", "yolov5x"]
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_yolo_v5_320x320_onnx(test_device, variant):
@@ -103,7 +63,7 @@ variants = ["yolov5n", "yolov5s", "yolov5m", "yolov5l", "yolov5x"]
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_yolo_v5_480x480_onnx(test_device, variant):
@@ -145,7 +105,7 @@ variants = ["yolov5n", "yolov5s", "yolov5m", "yolov5l", "yolov5x"]
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_yolo_v5_640x640_onnx(test_device, variant):

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v5.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-import forge, os
+import os
 import requests
 import pytest
 import torch
@@ -11,10 +11,13 @@ import cv2
 import numpy as np
 from yolov5.utils.dataloaders import exif_transpose, letterbox
 import onnx, pytest
-from forge.verify.backend import verify_module
-from forge import DepricatedVerifyConfig
-from forge.verify.config import TestKind
-from forge._C.backend_api import BackendDevice
+
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge.verify.backend import verify_module
+# from forge import DepricatedVerifyConfig
+# from forge.verify.config import TestKind
+# from forge._C.backend_api import BackendDevice
 
 
 def data_preprocessing(ims: Image.Image, size: tuple) -> tuple:
@@ -59,7 +62,7 @@ variants = ["yolov5n", "yolov5s", "yolov5m", "yolov5l", "yolov5x"]
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_yolo_v5_320x320_onnx(test_device, variant):
@@ -100,7 +103,7 @@ variants = ["yolov5n", "yolov5s", "yolov5m", "yolov5l", "yolov5x"]
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_yolo_v5_480x480_onnx(test_device, variant):
@@ -142,7 +145,7 @@ variants = ["yolov5n", "yolov5s", "yolov5m", "yolov5l", "yolov5x"]
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_yolo_v5_640x640_onnx(test_device, variant):

--- a/forge/test/models/onnx/vision/yolo/test_yolo_x.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_x.py
@@ -41,7 +41,7 @@ variants = ["yolox_nano", "yolox_tiny", "yolox_s", "yolox_m", "yolox_l", "yolox_
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="CCM is not public yet.")
+@pytest.mark.skip(reason="Requires restructuring")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_yolox_onnx(variant, test_device):

--- a/forge/test/models/onnx/vision/yolo/test_yolo_x.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_x.py
@@ -2,16 +2,18 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import forge, os
+import os
 import pytest
 import cv2, torch
 import numpy as np
 import onnx
-from forge.verify.backend import verify_module
-from forge import DepricatedVerifyConfig
-from forge.verify.config import TestKind
 import requests
 
+# TODO: These are old forge, we should update them to the currently version.
+# import forge
+# from forge.verify.backend import verify_module
+# from forge import DepricatedVerifyConfig
+# from forge.verify.config import TestKind
 # from forge._C.backend_api import BackendDevice
 
 
@@ -39,7 +41,7 @@ variants = ["yolox_nano", "yolox_tiny", "yolox_s", "yolox_m", "yolox_l", "yolox_
 
 
 @pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Not supported")
+@pytest.mark.skip(reason="CCM is not public yet.")
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_yolox_onnx(variant, test_device):

--- a/pytest.ini
+++ b/pytest.ini
@@ -36,8 +36,9 @@ testpaths =
     # API
     forge/test/test_api.py
 
-    # Model Tests (PyTorch)
+    # Model Tests
     forge/test/models/pytorch
+    forge/test/models/onnx
 
     # MNIST Linear
     forge/test/mlir/mnist/test_inference.py


### PR DESCRIPTION
Enable ONNX models to run as part of CI.

Majority of the vision tests (all except ResNet) require further changes before we can enable them (full restructuring). Pushing this change to enable test runs for few text models beside ResNet, as well as enable run for upcoming ONNX models for Red Team.