### PR TITLE
Speedup debug build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,7 +174,7 @@ jobs:
           key: forge-build-${{ matrix.build.build-type }}
         env:
           CCACHE_NOHASHDIR: true
-  
+
       - name: Debug Build
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,7 @@ jobs:
         uses: hendrikmuhs/ccache-action@v1.2
         with:
           create-symlink: true
+          max-size: 900M
           key: forge-build-${{ matrix.build.build-type }}
         env:
           CCACHE_NOHASHDIR: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
           create-symlink: true
           key: forge-build-${{ matrix.build.build-type }}
         env:
-          CCACHE_HASHDIR: false
+          CCACHE_NOHASHDIR: true
   
       - name: Debug Build
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -172,7 +172,9 @@ jobs:
         with:
           create-symlink: true
           key: forge-build-${{ matrix.build.build-type }}
-
+        env:
+          CCACHE_HASHDIR: false
+  
       - name: Debug Build
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,6 +175,7 @@ jobs:
           key: forge-build-${{ matrix.build.build-type }}
         env:
           CCACHE_NOHASHDIR: true
+          CCACHE_BASEDIR: ${{ steps.strings.outputs.work-dir }}
 
       - name: Debug Build
         shell: bash


### PR DESCRIPTION
### Ticket
f2f issue report

### Problem description
Low ccache hits on debug build makes it run too long compared to release build

### What's changed
added hash_dir=false
