### PR TITLE
Use nano version of Yolo v5 instead of Small

### DIFF
--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -135,16 +135,11 @@ def generate_model_yoloV5I480_imgcls_torchhub_pytorch(variant, size):
 
 
 size = [
-    pytest.param("n", id="yolov5n"),
     pytest.param(
-        "s",
-        id="yolov5s",
-        marks=[
-            pytest.mark.xfail(
-                reason="Statically allocated circular buffers in program 691 clash with L1 buffers on core range [(x=0,y=0) - (x=7,y=6)]. L1 buffer allocated at 197632 and static circular buffer region ends at 573216"
-            )
-        ],
+        "n",
+        marks=[pytest.mark.xfail],
     ),
+    pytest.param("s", id="yolov5s"),
     pytest.param("m", id="yolov5m"),
     pytest.param("l", id="yolov5l"),
     pytest.param("x", id="yolov5x"),
@@ -154,7 +149,7 @@ size = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size)
 def test_yolov5_480x480(forge_property_recorder, size):
-    if size != "s":
+    if size != "n":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Build Module Name


### PR DESCRIPTION
Run smaller version of this model for faster itteration and e2e push. 