### PR TITLE
Add ONNX tests for Gemma 1&2, Llama3, phi3_5, Qwen_v2 Models

### DIFF
--- a/forge/test/models/onnx/text/gemma/test_gemma_v1.py
+++ b/forge/test/models/onnx/text/gemma/test_gemma_v1.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+import forge
+from forge.verify.verify import verify
+from test.utils import download_model
+
+from test.models.utils import Framework, Source, Task, build_module_name
+import onnx
+import torch
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "google/gemma-1.1-2b-it",
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            "google/gemma-1.1-7b-it",
+            marks=pytest.mark.skip(reason="Skipping due to the current CI/CD pipeline limitations"),
+        ),
+    ],
+)
+def test_gemma_v1_onnx(forge_property_recorder, variant, tmp_path):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.ONNX, model="gemma", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
+    )
+
+    # Record Forge Property
+    forge_property_recorder.record_group("red")
+    forge_property_recorder.record_model_name(module_name)
+
+    # Load model and tokenizer from HuggingFace
+    tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
+    framework_model = download_model(AutoModelForCausalLM.from_pretrained, variant, return_dict=False, use_cache=False)
+    framework_model.eval()
+    prompt = "Write me a poem about Machine Learning."
+    input = tokenizer(prompt, return_tensors="pt")
+    inputs = [input["input_ids"]]
+
+    # Export model to ONNX
+    onnx_path = f"{tmp_path}/gemma_v1.onnx"
+    torch.onnx.export(framework_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+
+    # passing model file instead of model proto due to size of the model(>2GB) - #https://github.com/onnx/onnx/issues/3775#issuecomment-943416925
+    onnx.checker.check_model(onnx_path)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(
+        onnx_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
+    )
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        forge_property_handler=forge_property_recorder,
+    )

--- a/forge/test/models/onnx/text/gemma/test_gemma_v2.py
+++ b/forge/test/models/onnx/text/gemma/test_gemma_v2.py
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+)
+import forge
+from forge.verify.verify import verify
+from test.models.utils import Framework, Source, Task, build_module_name
+from test.utils import download_model
+import onnx
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "google/gemma-2-2b-it",
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            "google/gemma-2-9b-it",
+            marks=pytest.mark.skip(reason="Skipping due to the current CI/CD pipeline limitations"),
+        ),
+    ],
+)
+def test_gemma_v2_onnx(forge_property_recorder, variant, tmp_path):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.ONNX, model="gemma", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
+    )
+
+    # Record Forge Property
+    forge_property_recorder.record_group("red")
+    forge_property_recorder.record_model_name(module_name)
+
+    # Load tokenizer and model
+    tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
+    framework_model = download_model(AutoModelForCausalLM.from_pretrained, variant, return_dict=False, use_cache=False)
+    framework_model.eval()
+    prompt = "Write me a poem about Machine Learning."
+    input = tokenizer(prompt, return_tensors="pt")
+    inputs = [input["input_ids"]]
+
+    # Export model to ONNX
+    onnx_path = f"{tmp_path}/gemma_v2.onnx"
+    torch.onnx.export(framework_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+
+    # passing model file instead of model proto due to size of the model(>2GB) - #https://github.com/onnx/onnx/issues/3775#issuecomment-943416925
+    onnx.checker.check_model(onnx_path)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(
+        onnx_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
+    )
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        forge_property_handler=forge_property_recorder,
+    )

--- a/forge/test/models/onnx/text/llama/test_llama3.py
+++ b/forge/test/models/onnx/text/llama/test_llama3.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+)
+from transformers.models.llama.modeling_llama import (
+    AttentionMaskConverter,
+    Cache,
+    LlamaModel,
+    StaticCache,
+)
+
+import forge
+from forge.verify.verify import verify
+
+from test.models.utils import Framework, Source, Task, build_module_name
+from test.models.models_utils import build_optimum_cli_command
+from test.utils import download_model
+import subprocess
+import onnx
+
+# Monkey Patching Casual Mask Update
+def _update_causal_mask(
+    self,
+    attention_mask: torch.Tensor,
+    input_tensor: torch.Tensor,
+    cache_position: torch.Tensor,
+    past_key_values: Cache,
+    output_attentions: bool,
+):
+    # TODO: As of torch==2.2.0, the `attention_mask` passed to the model in `generate` is 2D and of dynamic length even when the static
+    # KV cache is used. This is an issue for torch.compile which then recaptures cudagraphs at each decode steps due to the dynamic shapes.
+    # (`recording cudagraph tree for symint key 13`, etc.), which is VERY slow. A workaround is `@torch.compiler.disable`, but this prevents using
+    # `fullgraph=True`. See more context in https://github.com/huggingface/transformers/pull/29114
+
+    if self.config._attn_implementation == "flash_attention_2":
+        if attention_mask is not None and 0.0 in attention_mask:
+            return attention_mask
+        return None
+
+    # For SDPA, when possible, we will rely on its `is_causal` argument instead of its `attn_mask` argument, in
+    # order to dispatch on Flash Attention 2. This feature is not compatible with static cache, as SDPA will fail
+    # to infer the attention mask.
+    past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+    using_static_cache = isinstance(past_key_values, StaticCache)
+
+    # When output attentions is True, sdpa implementation's forward method calls the eager implementation's forward
+    if self.config._attn_implementation == "sdpa" and not using_static_cache and not output_attentions:
+        if AttentionMaskConverter._ignore_causal_mask_sdpa(
+            attention_mask,
+            inputs_embeds=input_tensor,
+            past_key_values_length=past_seen_tokens,
+            is_training=self.training,
+        ):
+            return None
+
+    dtype, device = input_tensor.dtype, input_tensor.device
+    min_dtype = torch.finfo(dtype).min
+    sequence_length = input_tensor.shape[1]
+    if using_static_cache:
+        target_length = past_key_values.get_max_length()
+    else:
+        target_length = (
+            attention_mask.shape[-1]
+            if isinstance(attention_mask, torch.Tensor)
+            else past_seen_tokens + sequence_length + 1
+        )
+
+    if attention_mask is not None and attention_mask.dim() == 4:
+        # in this case we assume that the mask comes already in inverted form and requires no inversion or slicing
+        if attention_mask.max() != 0:
+            raise ValueError("Custom 4D attention mask should be passed in inverted form with max==0`")
+        causal_mask = attention_mask
+    else:
+        causal_mask = torch.full((sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device)
+        # return causal_mask
+        if sequence_length != 1:
+            causal_mask = torch.triu(causal_mask, diagonal=1)
+        causal_mask *= torch.arange(target_length, device=device) > cache_position.reshape(-1, 1)
+        causal_mask = causal_mask[None, None, :, :].expand(input_tensor.shape[0], 1, -1, -1)
+        if attention_mask is not None:
+            causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
+            mask_length = attention_mask.shape[-1]
+            padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :]
+            padding_mask = padding_mask == 0
+
+            # Replace Implace Slice Update
+            # causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
+            #     padding_mask, min_dtype
+            # )
+
+            if causal_mask.shape[-1] < mask_length:
+                part_1 = causal_mask[:, :, :, :mask_length]
+                part_2 = causal_mask[:, :, :, mask_length:]
+                part_1 = part_1.masked_fill(padding_mask, min_dtype)
+                causal_mask = torch.cat([part_1, part_2], dim=-1)
+            else:
+                causal_mask = causal_mask.masked_fill(padding_mask, min_dtype)
+
+    if (
+        self.config._attn_implementation == "sdpa"
+        and attention_mask is not None
+        and attention_mask.device.type == "cuda"
+        and not output_attentions
+    ):
+        # Attend to all tokens in fully masked rows in the causal_mask, for example the relevant first rows when
+        # using left padding. This is required by F.scaled_dot_product_attention memory-efficient attention path.
+        # Details: https://github.com/pytorch/pytorch/issues/110213
+        causal_mask = AttentionMaskConverter._unmask_unattended(causal_mask, min_dtype)
+
+    return causal_mask
+
+
+LlamaModel._update_causal_mask = _update_causal_mask
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "meta-llama/Llama-3.1-8B",
+            marks=pytest.mark.skip(reason="Skipping due to the current CI/CD pipeline limitations"),
+        ),
+        pytest.param(
+            "meta-llama/Llama-3.2-1B",
+            marks=pytest.mark.skip(reason="Skipping due to the current CI/CD pipeline limitations"),
+        ),
+        pytest.param(
+            "meta-llama/Llama-3.2-3B",
+            marks=pytest.mark.skip(reason="Skipping due to the current CI/CD pipeline limitations"),
+        ),
+        pytest.param(
+            "meta-llama/Llama-3.1-8B-Instruct",
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            "meta-llama/Llama-3.2-1B-Instruct",
+            marks=pytest.mark.skip(reason="Skipping due to the current CI/CD pipeline limitations"),
+        ),
+        pytest.param(
+            "meta-llama/Llama-3.2-3B-Instruct",
+            marks=pytest.mark.skip(reason="Skipping due to the current CI/CD pipeline limitations"),
+        ),
+    ],
+)
+def test_llama3_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.ONNX, model="llama3", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
+    )
+
+    # Record Forge Property
+    if variant in [
+        "meta-llama/Llama-3.1-8B-Instruct",
+        "meta-llama/Llama-3.2-1B-Instruct",
+        "meta-llama/Llama-3.2-3B-Instruct",
+    ]:
+        forge_property_recorder.record_group("red")
+    else:
+        forge_property_recorder.record_group("generality")
+    forge_property_recorder.record_model_name(module_name)
+
+    # Load model and tokenizer
+    framework_model = download_model(AutoModelForCausalLM.from_pretrained, variant, use_cache=False, return_dict=False)
+    framework_model.eval()
+    tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
+    tokenizer.pad_token = tokenizer.eos_token
+
+    # Prepare input
+    input_prompt = "Hey how are you doing today?"
+    if variant == "meta-llama/Llama-3.2-3B":
+        inputs = tokenizer.encode_plus(
+            input_prompt,
+            return_tensors="pt",
+            max_length=32,
+            padding="max_length",
+            truncation=True,
+        )
+    else:
+        inputs = tokenizer(
+            input_prompt,
+            return_tensors="pt",
+            max_length=256,
+            pad_to_max_length=True,
+            truncation=True,
+        )
+    input_ids = inputs["input_ids"]
+    attn_mask = inputs["attention_mask"]
+    inputs = [input_ids, attn_mask]
+
+    # Export model to ONNX
+    onnx_path = f"{tmp_path}/model.onnx"
+    command = build_optimum_cli_command(variant, tmp_path)
+    subprocess.run(command, check=True)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+
+    # passing model file instead of model proto due to size of the model(>2GB) - #https://github.com/onnx/onnx/issues/3775#issuecomment-943416925
+    onnx.checker.check_model(onnx_path)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(
+        onnx_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
+    )
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        forge_property_handler=forge_property_recorder,
+    )

--- a/forge/test/models/onnx/text/mistral/test_mistral.py
+++ b/forge/test/models/onnx/text/mistral/test_mistral.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+import forge
+from forge.verify.verify import verify
+
+from test.models.pytorch.text.mistral.utils.utils import get_current_weather
+from test.models.utils import Framework, Source, Task, build_module_name
+from test.utils import download_model
+import torch
+import onnx
+
+variants = ["mistralai/Mistral-7B-Instruct-v0.3"]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants)
+@pytest.mark.xfail
+def test_mistral_v0_3_onnx(forge_property_recorder, variant, tmp_path):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.ONNX,
+        model="mistral",
+        variant=variant,
+        task=Task.CAUSAL_LM,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Record Forge Property
+    forge_property_recorder.record_group("red")
+    forge_property_recorder.record_model_name(module_name)
+
+    # Load tokenizer and model
+    tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
+    framework_model = download_model(AutoModelForCausalLM.from_pretrained, variant, return_dict=False, use_cache=False)
+    framework_model.eval()
+
+    # prepare input
+    conversation = [{"role": "user", "content": "What's the weather like in Paris?"}]
+    input = tokenizer.apply_chat_template(
+        conversation,
+        tools=[get_current_weather],
+        add_generation_prompt=True,
+        return_dict=True,
+        return_tensors="pt",
+    )
+    inputs = [input["input_ids"]]
+
+    # Export model to ONNX
+    onnx_path = f"{tmp_path}/mistral_7b_v0_3.onnx"
+    torch.onnx.export(framework_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+
+    # passing model file instead of model proto due to size of the model(>2GB) - #https://github.com/onnx/onnx/issues/3775#issuecomment-943416925
+    onnx.checker.check_model(onnx_path)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(
+        onnx_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
+    )
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        forge_property_handler=forge_property_recorder,
+    )

--- a/forge/test/models/onnx/text/phi3/test_phi3_5.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3_5.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+import forge
+from forge.verify.verify import verify
+
+from test.models.utils import Framework, Source, Task, build_module_name
+from test.models.models_utils import build_optimum_cli_command
+from test.utils import download_model
+import subprocess
+import onnx
+
+variants = ["microsoft/Phi-3.5-mini-instruct"]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", variants)
+def test_phi3_5_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.ONNX, model="phi3_5", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
+    )
+
+    # Record Forge Property
+    forge_property_recorder.record_group("red")
+    forge_property_recorder.record_model_name(module_name)
+
+    # Load model and tokenizer
+    tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
+    framework_model = download_model(
+        AutoModelForCausalLM.from_pretrained, variant, return_dict=False, trust_remote_code=True, use_cache=False
+    )
+    framework_model.eval()
+
+    # prepare input
+    input_prompt = "Africa is an emerging economy because"
+    inputs = tokenizer(
+        input_prompt,
+        return_tensors="pt",
+        max_length=256,
+        pad_to_max_length=True,
+        truncation=True,
+    )
+    inputs = [inputs["input_ids"], inputs["attention_mask"]]
+
+    # Export model to ONNX
+    onnx_path = f"{tmp_path}/model.onnx"
+    command = build_optimum_cli_command(variant, tmp_path)
+    subprocess.run(command, check=True)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+
+    # passing model file instead of model proto due to size of the model(>2GB) - #https://github.com/onnx/onnx/issues/3775#issuecomment-943416925
+    onnx.checker.check_model(onnx_path)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(
+        onnx_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
+    )
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        forge_property_handler=forge_property_recorder,
+    )

--- a/forge/test/models/onnx/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/onnx/text/qwen/test_qwen_v2.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+import forge
+from forge.verify.verify import verify
+
+from test.models.utils import Framework, Source, Task, build_module_name
+from test.models.models_utils import build_optimum_cli_command
+import subprocess
+import onnx
+import torch
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "Qwen/Qwen2.5-0.5B",
+            marks=pytest.mark.xfail,
+        ),
+        pytest.param(
+            "Qwen/Qwen2.5-1.5B",
+            marks=pytest.mark.skip(reason="Skipping due to the current CI/CD pipeline limitations"),
+        ),
+        pytest.param(
+            "Qwen/Qwen2.5-3B",
+            marks=pytest.mark.skip(reason="Skipping due to the current CI/CD pipeline limitations"),
+        ),
+    ],
+)
+def test_qwen_clm_onnx(forge_property_recorder, variant, tmp_path):
+
+    # Build Module Name
+    module_name = build_module_name(
+        framework=Framework.ONNX, model="qwen_v2", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
+    )
+
+    # Record Forge Property
+    forge_property_recorder.record_group("red")
+    forge_property_recorder.record_model_name(module_name)
+
+    # Load model and tokenizer
+    framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu", return_dict=False)
+    framework_model.eval()
+    tokenizer = AutoTokenizer.from_pretrained(variant)
+
+    # Prepare input
+    prompt = "Give me a short introduction to large language models."
+    messages = [{"role": "user", "content": prompt}]
+    text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    model_inputs = tokenizer([text], return_tensors="pt")
+    input_ids = model_inputs["input_ids"]
+    attention_mask = model_inputs["attention_mask"]
+    inputs = [input_ids, attention_mask]
+
+    # Export model to ONNX
+    onnx_path = f"{tmp_path}/model.onnx"
+    if variant != "Qwen/Qwen2.5-0.5B":
+        command = build_optimum_cli_command(variant, tmp_path)
+        subprocess.run(command, check=True)
+    else:
+        torch.onnx.export(framework_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+
+    # passing model file instead of model proto due to size of the model(>2GB) - #https://github.com/onnx/onnx/issues/3775#issuecomment-943416925
+    onnx.checker.check_model(onnx_path)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(
+        onnx_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
+    )
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        forge_property_handler=forge_property_recorder,
+    )


### PR DESCRIPTION
## Summary

- This PR adds ONNX tests for Gemma 1&2, Llama3, phi3_5, Qwen_v2 Models

## Logs

- [gemma_onnx.log](https://github.com/user-attachments/files/19524958/mar30_gemma_onnx_pr_1.log)
- [llama3_onnx.log](https://github.com/user-attachments/files/19524959/mar30_llama3_onnx.log)
- [mistral_onnx.log](https://github.com/user-attachments/files/19524960/mar30_mistral_onnx.log)
- [qwen_onnx.log](https://github.com/user-attachments/files/19524961/mar30_qwen_onnx.log)
- [phi3_5_onnx.log](https://github.com/user-attachments/files/19524957/mar29_phi3_5_onnx.log)
- [llama3_onnx_instruct_variants.log](https://github.com/user-attachments/files/19530711/mar31_llama3_instruct_variants.log)

