### PR TITLE
Add Gliner onnx test

### DIFF
--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -45,7 +45,7 @@ openpyxl==3.1.5
 GitPython==3.1.44
 kornia==0.8.0
 mlp-mixer-pytorch==0.2.0
-gliner==0.2.16
+gliner==0.2.7
 ase==3.24.0
 hippynn==0.0.3
 bi-lstm-crf==0.2.1

--- a/forge/test/models/onnx/multimodal/stable_diffusion/test_stable_diffusion_xl.py
+++ b/forge/test/models/onnx/multimodal/stable_diffusion/test_stable_diffusion_xl.py
@@ -42,7 +42,7 @@ class StableDiffusionXLWrapper(torch.nn.Module):
 def test_stable_diffusion_generation(variant, forge_tmp_path):
     # Build Module Name
     module_name = record_model_properties(
-        framework=Framework.PYTORCH,
+        framework=Framework.ONNX,
         model=ModelArch.STABLEDIFFUSION,
         variant=variant,
         task=Task.CONDITIONAL_GENERATION,

--- a/forge/test/models/onnx/text/gliner/model_utils/model_utils.py
+++ b/forge/test/models/onnx/text/gliner/model_utils/model_utils.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+
+
+def export_onnx(inputs, framework_model, onnx_path):
+    input_names = ["input_ids", "attention_mask", "words_mask", "text_lengths", "span_idx", "span_mask"]
+    torch.onnx.export(
+        framework_model.model,
+        inputs,
+        f=onnx_path,
+        input_names=input_names,
+        output_names=["logits"],
+        opset_version=17,
+    )
+
+
+def prepare_inputs(framework_model, text, labels):
+    inputs, _ = framework_model.prepare_model_inputs(text, labels)
+    input_ids = inputs["input_ids"]
+    attention_mask = inputs["attention_mask"]
+    words_mask = inputs["words_mask"]
+    text_lengths = inputs["text_lengths"]
+    span_idx = inputs["span_idx"]
+    span_mask = inputs["span_mask"]
+    inputs = [input_ids, attention_mask, words_mask, text_lengths, span_idx, span_mask]
+
+    return inputs

--- a/forge/test/models/onnx/text/gliner/test_gliner_onnx.py
+++ b/forge/test/models/onnx/text/gliner/test_gliner_onnx.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from gliner import GLiNER
+
+import forge
+from forge.verify.verify import verify
+import onnx
+
+from test.models.onnx.text.gliner.model_utils.model_utils import export_onnx, prepare_inputs
+from forge.forge_property_utils import Framework, ModelArch, Source, Task, record_model_properties
+
+variants = ["urchade/gliner_multi-v2.1"]
+
+
+@pytest.mark.nightly
+@pytest.mark.skip(reason="Segmentation Fault")
+@pytest.mark.parametrize("variant", variants)
+def test_gliner_onnx(variant, forge_tmp_path):
+
+    # Build Module Name
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.GLINER,
+        variant=variant,
+        task=Task.TOKEN_CLASSIFICATION,
+        source=Source.GITHUB,
+    )
+
+    # Load model
+    framework_model = GLiNER.from_pretrained(variant)
+    framework_model.eval()
+
+    # prepare input
+    text = """
+    Cristiano Ronaldo dos Santos Aveiro was born 5 February 1985 is a Portuguese professional footballer.
+    """
+    labels = ["person", "award", "date", "competitions", "teams"]
+    inputs = prepare_inputs(framework_model, [text], labels)
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/gliner.onnx"
+    export_onnx(tuple(inputs), framework_model, onnx_path)
+
+    # Load ONNX model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Forge compile framework model
+    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
+
+    # Model Verification
+    verify(inputs, framework_model, compiled_model)


### PR DESCRIPTION
Gliner version has been downgraded from latest version to 0.2.7 since onnx export is supported only in downgraded version, corresponding pytorch test has also been tested with downgraded version and it gives the same results. The exported onnx is leading to segmentation fault which will be debugged later, for now test is skipped.