### PR TITLE
[tvm uplift] Removed DictType from tvm

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -98,7 +98,7 @@ jobs:
       shell: bash
       working-directory: install
       run: tar xvf artifact.tar
-  
+
     - name: Download build artifacts
       uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
### What's changed
TVM uplift where we removed `DictType` from tvm, as it was initially added by us.