### PR TITLE
Re-enable skipped tests into CI

### DIFF
--- a/forge/test/models/pytorch/audio/whisper/test_whisper_large_v3.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper_large_v3.py
@@ -38,9 +38,9 @@ class Wrapper(torch.nn.Module):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["openai/whisper-large-v3-turbo"])
 def test_whisper_large_v3_speech_translation(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
+++ b/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
@@ -115,9 +115,9 @@ variants = ["dandelin/vilt-b32-mlm"]
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_vilt_maskedlm_hf_pytorch(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/text/codegen/test_codegen.py
+++ b/forge/test/models/pytorch/text/codegen/test_codegen.py
@@ -14,20 +14,16 @@ from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
-    pytest.param(
-        "Salesforce/codegen-350M-mono",
-        marks=[pytest.mark.xfail],
-    ),
+    "Salesforce/codegen-350M-mono",
     "Salesforce/codegen-350M-multi",
     "Salesforce/codegen-350M-nl",
 ]
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_codegen(forge_property_recorder, variant):
-    if variant != "Salesforce/codegen-350M-mono":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
+++ b/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
@@ -18,15 +18,8 @@ from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize(
-    "variant",
-    [
-        pytest.param(
-            "seasionality_basis",
-            marks=[pytest.mark.xfail],
-        ),
-    ],
-)
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", ["seasionality_basis"])
 def test_nbeats_with_seasonality_basis(forge_property_recorder, variant):
     # Build Module Name
     module_name = build_module_name(
@@ -61,9 +54,9 @@ def test_nbeats_with_seasonality_basis(forge_property_recorder, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["generic_basis"])
 def test_nbeats_with_generic_basis(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Build Module Name
     module_name = build_module_name(
@@ -91,9 +84,9 @@ def test_nbeats_with_generic_basis(forge_property_recorder, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["trend_basis"])
 def test_nbeats_with_trend_basis(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
@@ -22,7 +22,13 @@ from torchvision.models._api import WeightsEnum
 import forge
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from test.models.utils import (
+    Framework,
+    Source,
+    Task,
+    build_module_name,
+    print_cls_results,
+)
 from test.utils import download_model
 
 ## https://huggingface.co/docs/timm/models/efficientnet
@@ -49,8 +55,6 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_efficientnet_timm(forge_property_recorder, variant):
-    if variant != "efficientnet_b0":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Build Module Name
     module_name = build_module_name(
@@ -97,7 +101,10 @@ def test_efficientnet_timm(forge_property_recorder, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])
 
 
 def get_state_dict(self, *args, **kwargs):
@@ -122,8 +129,6 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_efficientnet_torchvision(forge_property_recorder, variant):
-    if variant != "efficientnet_b0":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Build Module Name
     module_name = build_module_name(
@@ -145,6 +150,7 @@ def test_efficientnet_torchvision(forge_property_recorder, variant):
         framework_model = efficientnet_b4(weights=EfficientNet_B4_Weights.IMAGENET1K_V1)
 
     framework_model.eval()
+
     # Load and pre-process image
     try:
         url, filename = (
@@ -170,4 +176,7 @@ def test_efficientnet_torchvision(forge_property_recorder, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/pytorch/vision/regnet/test_regnet.py
+++ b/forge/test/models/pytorch/vision/regnet/test_regnet.py
@@ -45,9 +45,9 @@ def test_regnet(forge_property_recorder, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["facebook/regnet-y-040"])
 def test_regnet_img_classification(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Build Module Name
     module_name = build_module_name(
@@ -97,10 +97,7 @@ variants_with_weights = {
 }
 
 variants = [
-    pytest.param(
-        "regnet_y_400mf",
-        marks=[pytest.mark.xfail],
-    ),
+    "regnet_y_400mf",
     "regnet_y_800mf",
     "regnet_y_1_6gf",
     "regnet_y_3_2gf",
@@ -119,11 +116,9 @@ variants = [
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_regnet_torchvision(forge_property_recorder, variant):
-
-    if variant != "regnet_y_400mf":
-        pytest.skip("Skipping this variant; only testing the small variant(regnet_y_400mf) for now.")
 
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -179,27 +179,19 @@ variants_with_weights = {
 }
 
 variants = [
-    pytest.param(
-        "swin_t",
-        marks=[pytest.mark.xfail],
-    ),
+    "swin_t",
     "swin_s",
     "swin_b",
-    pytest.param(
-        "swin_v2_t",
-        marks=[pytest.mark.xfail],
-    ),
+    "swin_v2_t",
     "swin_v2_s",
     "swin_v2_b",
 ]
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_swin_torchvision(forge_property_recorder, variant):
-
-    if variant not in ["swin_t", "swin_v2_t"]:
-        pytest.skip("Skipping this variant; only testing the small variants(swin_t,swin_v2_t) for now.")
 
     # Build Module Name
     module_name = build_module_name(

--- a/forge/test/models/utils.py
+++ b/forge/test/models/utils.py
@@ -3,6 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 import re
 from enum import Enum
+import torch
+import requests
+from tabulate import tabulate
+import json
 
 
 class StrEnum(str, Enum):
@@ -75,3 +79,32 @@ def build_module_name(
     module_name = re.sub(r"_+", "_", module_name)
     module_name = module_name.lower()
     return module_name
+
+
+def print_cls_results(fw_out, compiled_model_out):
+    fw_top1_probabilities, fw_top1_class_indices = torch.topk(fw_out.softmax(dim=1) * 100, k=1)
+    compiled_model_top1_probabilities, compiled_model_top1_class_indices = torch.topk(
+        compiled_model_out.softmax(dim=1) * 100, k=1
+    )
+
+    # Directly get the top 1 predicted class and its probability for both models
+    fw_top1_class_idx = fw_top1_class_indices[0, 0].item()
+    compiled_model_top1_class_idx = compiled_model_top1_class_indices[0, 0].item()
+    fw_top1_class_prob = fw_top1_probabilities[0, 0].item()
+    compiled_model_top1_class_prob = compiled_model_top1_probabilities[0, 0].item()
+
+    # Directly load ImageNet class labels inside post-process
+    class_labels_url = "https://storage.googleapis.com/download.tensorflow.org/data/imagenet_class_index.json"
+    response = requests.get(class_labels_url)
+    class_idx = response.json()
+    class_labels = [class_idx[str(i)][1] for i in range(len(class_idx))]
+    fw_top1_class_label = class_labels[fw_top1_class_idx]
+    compiled_model_top1_class_label = class_labels[compiled_model_top1_class_idx]
+
+    # Prepare the results for displaying
+    table = [
+        ["Metric", "Framework Model", "Compiled Model"],
+        ["Top 1 Predicted Class Label", fw_top1_class_label, compiled_model_top1_class_label],
+        ["Top 1 Predicted Class Probability", fw_top1_class_prob, compiled_model_top1_class_prob],
+    ]
+    print(tabulate(table, headers="firstrow", tablefmt="grid"))


### PR DESCRIPTION
This PR enables the following skipped test cases

```
pt_codegen_salesforce_codegen_350m_multi_clm_hf
pt_codegen_salesforce_codegen_350m_nl_clm_hf
pt_efficientnet_efficientnet_b4_img_cls_timm
pt_efficientnet_efficientnet_b4_img_cls_torchvision
pt_nbeats_generic_basis_clm_hf
pt_nbeats_trend_basis_clm_hf
pt_regnet_facebook_regnet_y_040_img_cls_hf
pt_regnet_regnet_x_1_6gf_img_cls_torchvision
pt_regnet_regnet_x_3_2gf_img_cls_torchvision
pt_regnet_regnet_x_400mf_img_cls_torchvision
pt_regnet_regnet_x_800mf_img_cls_torchvision
pt_regnet_regnet_y_1_6gf_img_cls_torchvision
pt_regnet_regnet_y_400mf_img_cls_torchvision
pt_regnet_regnet_y_800mf_img_cls_torchvision
pt_swin_swin_b_img_cls_torchvision
pt_swin_swin_s_img_cls_torchvision
pt_swin_swin_t_img_cls_torchvision
pt_vilt_dandelin_vilt_b32_mlm_mlm_hf
pt_whisper_openai_whisper_large_v3_turbo_speech_translate_hf
```