### PR TITLE
Add support for paddlepaddle and onnx framework in model analysis

### DIFF
--- a/.github/model-analysis-config.sh
+++ b/.github/model-analysis-config.sh
@@ -20,6 +20,7 @@ env_vars["OUTPUT_PATH"]="model_analysis_docs/"
 # 2) Script config
 env_vars["MARDOWN_DIR_PATH"]="./model_analysis_docs"
 env_vars["SCRIPT_OUTPUT_LOG"]="model_analysis.log"
+env_vars["TEST_DIR_OR_FILE_PATH"]="forge/test/models/pytorch"
 
 
 # Model ops test generation
@@ -29,12 +30,12 @@ env_vars["MODELS_OPS_TEST_PACKAGE_NAME"]="models_ops"
 
 
 # Common Config for markdown generation and model ops test generation
-env_vars["TEST_DIR_OR_FILE_PATH"]="forge/test/models"
 env_vars["UNIQUE_OPS_OUTPUT_DIR_PATH"]="./models_unique_ops_output"
 
 
 # If GENERATE_MODELS_OPS_TEST is set to true, Modify the PR config to model ops test generation.
 if [[ "$GENERATE_MODELS_OPS_TEST" == "true" ]]; then
+    env_vars["TEST_DIR_OR_FILE_PATH"]="forge/test/models"
     env_vars["BRANCH_NAME"]="generate_models_ops_test"
     env_vars["COMMIT_MESSAGE"]="Generate and update models ops tests"
     env_vars["TITLE"]="Generate and update models ops tests"

--- a/conftest.py
+++ b/conftest.py
@@ -8,6 +8,8 @@ import psutil
 import threading
 from loguru import logger
 from datetime import datetime
+from forge.forge_property_utils import ForgePropertyHandler, ForgePropertyStore, ExecutionStage
+from forge._C import ExecutionDepth
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -17,6 +19,21 @@ def record_test_timestamp(record_property):
     yield
     end_timestamp = datetime.strftime(datetime.now(), "%Y-%m-%dT%H:%M:%S%z")
     record_property("end_timestamp", end_timestamp)
+
+
+@pytest.fixture(scope="function")
+def forge_property_recorder(record_property):
+    forge_property_store = ForgePropertyStore()
+
+    forge_property_handler = ForgePropertyHandler(forge_property_store)
+
+    # Set CI_FAILURE as default execution depth and FAILED_BEFORE_FORGE_COMPILATION_INITIATION as default execution stage
+    forge_property_handler.record_execution_depth(ExecutionDepth.CI_FAILURE)
+    forge_property_handler.record_execution_stage(ExecutionStage.FAILED_BEFORE_FORGE_COMPILATION_INITIATION)
+
+    yield forge_property_handler
+
+    forge_property_handler.store_property(record_property)
 
 
 @pytest.fixture(autouse=True)

--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from enum import Enum
+from enum import Enum, auto
 import json
 from dataclasses import dataclass, is_dataclass, field
 from dataclasses_json import dataclass_json
@@ -13,25 +13,26 @@ from forge._C import ExecutionDepth
 
 
 class ExecutionStage(Enum):
-    FAILED_TVM_RELAY_IRMODULE_GENERATION = 0
-    FAILED_TVM_RELAY_IO_FLATTENING = 1
-    FAILED_TVM_RELAY_IR_TRANSFORMATION = 2
-    FAILED_TVM_PATTERN_CALLBACKS = 3
-    FAILED_TVM_GRAPH_PARTITIONING = 3
-    FAILED_FORGE_MODULE_GENERATION = 4
-    FAILED_FORGE_INITIAL_GRAPH_PASS = 5
-    FAILED_FORGE_POST_INITIAL_GRAPH_PASS = 6
-    FAILED_FORGE_CONSTEVAL = 7
-    FAILED_FORGE_OPTIMIZATION_GRAPH_PASS = 8
-    FAILED_FORGE_POST_OPTIMIZATION_DECOMP = 9
-    FAILED_FORGE_AUTOGRAD_PASS = 10
-    FAILED_FORGE_POST_AUTOGRAD_DECOMP = 11
-    FAILED_FORGE_PRE_LOWERING = 12
-    FAILED_FORGE_GRAPH_SPLIT = 13
-    FAILED_FORGE_MLIR_COMPILATION = 14
-    FAILED_TTNN_BINARY_EXECUTION = 15
-    FAILED_VERIFICATION = 16
-    PASSED = 17
+    FAILED_BEFORE_FORGE_COMPILATION_INITIATION = auto()
+    FAILED_TVM_RELAY_IRMODULE_GENERATION = auto()
+    FAILED_TVM_RELAY_IO_FLATTENING = auto()
+    FAILED_TVM_RELAY_IR_TRANSFORMATION = auto()
+    FAILED_TVM_PATTERN_CALLBACKS = auto()
+    FAILED_TVM_GRAPH_PARTITIONING = auto()
+    FAILED_FORGE_MODULE_GENERATION = auto()
+    FAILED_FORGE_INITIAL_GRAPH_PASS = auto()
+    FAILED_FORGE_POST_INITIAL_GRAPH_PASS = auto()
+    FAILED_FORGE_CONSTEVAL = auto()
+    FAILED_FORGE_OPTIMIZATION_GRAPH_PASS = auto()
+    FAILED_FORGE_POST_OPTIMIZATION_DECOMP = auto()
+    FAILED_FORGE_AUTOGRAD_PASS = auto()
+    FAILED_FORGE_POST_AUTOGRAD_DECOMP = auto()
+    FAILED_FORGE_PRE_LOWERING = auto()
+    FAILED_FORGE_GRAPH_SPLIT = auto()
+    FAILED_FORGE_MLIR_COMPILATION = auto()
+    FAILED_TTNN_BINARY_EXECUTION = auto()
+    FAILED_VERIFICATION = auto()
+    PASSED = auto()
 
     @classmethod
     def to_str(cls, value):
@@ -165,6 +166,8 @@ class Tags:
     execution_stage: str = ""
     op_name: str = ""
     op_params: Dict[str, Any] = field(default_factory=lambda: dict())
+    inputs: Optional[List[TensorDesc]] = None
+    outputs: Optional[List[TensorDesc]] = None
 
 
 @dataclass_json
@@ -174,8 +177,6 @@ class ForgePropertyStore:
     group: str = ""
     tags: Optional[Tags] = None
     config: Optional[Config] = None
-    inputs: Optional[List[TensorDesc]] = None
-    outputs: Optional[List[TensorDesc]] = None
 
 
 class ForgePropertyHandler:
@@ -409,7 +410,7 @@ class ForgePropertyHandler:
         Args:
             inputs (List[TensorDesc]): A list of TensorDesc objects for inputs.
         """
-        self.add("inputs", inputs)
+        self.add("tags.inputs", inputs)
 
     def record_flatbuffer_outputs(self, outputs: List[TensorDesc]):
         """
@@ -418,7 +419,7 @@ class ForgePropertyHandler:
         Args:
             outputs (List[TensorDesc]): A list of TensorDesc objects for outputs.
         """
-        self.add("outputs", outputs)
+        self.add("tags.outputs", outputs)
 
     def record_flatbuffer_details(self, binary_json_str: str):
         """

--- a/forge/forge/python_codegen.py
+++ b/forge/forge/python_codegen.py
@@ -939,7 +939,7 @@ class ForgeWriter(PythonWriter):
             pytest_metadata_list (Optional[List[Dict[str, Any]]]): A list of dictionaries containing metadata for each pytest parameter.
             use_ids_function(bool): If set, the forge module name and shapes and dtyes will used as id for the pytest parameter.
             include_random_parameter_constant_gen(bool): If set, it will include the code for generating and assigning of random tensor for forge module parameters and constants
-            exclude_record_property(Optional[List[str]]): A list of pytest metadata property which will be excluded in record_forge_property fixtures(i.e pcc)
+            exclude_record_property(Optional[List[str]]): A list of pytest metadata property which will be excluded in forge_property_recorder fixtures(i.e pcc)
         """
         self.wl("")
         self.wl("")
@@ -979,30 +979,27 @@ class ForgeWriter(PythonWriter):
             )
         else:
             self.wl('@pytest.mark.parametrize("forge_module_and_shapes_dtypes", forge_modules_and_shapes_dtypes_list)')
-        if module_metadata is not None or not is_pytest_metadata_list_empty:
-            self.wl("def test_module(forge_module_and_shapes_dtypes, record_forge_property):")
-        else:
-            self.wl("def test_module(forge_module_and_shapes_dtypes):")
+        self.wl("def test_module(forge_module_and_shapes_dtypes, forge_property_recorder):")
         self.indent += 1
         if module_metadata is not None:
             for metadata_name, metadata_value in module_metadata.items():
                 if isinstance(metadata_value, str):
-                    self.wl(f'record_forge_property("tags.{metadata_name}", "{metadata_value}")')
+                    self.wl(f'forge_property_recorder("tags.{metadata_name}", "{metadata_value}")')
                 else:
-                    self.wl(f'record_forge_property("tags.{metadata_name}", {metadata_value})')
+                    self.wl(f'forge_property_recorder("tags.{metadata_name}", {metadata_value})')
         self.wl("")
         if is_pytest_metadata_list_empty:
             self.wl("forge_module, operand_shapes_dtypes = forge_module_and_shapes_dtypes")
         else:
             self.wl("forge_module, operand_shapes_dtypes, metadata = forge_module_and_shapes_dtypes")
-            if exclude_record_property is not None or len(exclude_record_property) != 0:
+            if exclude_record_property is not None and len(exclude_record_property) != 0:
                 self.wl("")
                 for exclude_metadata in exclude_record_property:
                     self.wl(f'{exclude_metadata} = metadata.pop("{exclude_metadata}")')
             self.wl("")
             self.wl("for metadata_name, metadata_value in metadata.items():")
             self.indent += 1
-            self.wl(f'record_forge_property("tags." + str(metadata_name), metadata_value)')
+            self.wl(f'forge_property_recorder("tags." + str(metadata_name), metadata_value)')
             self.indent -= 1
         self.wl("")
         if is_pytest_metadata_list_empty or (
@@ -1053,10 +1050,12 @@ class ForgeWriter(PythonWriter):
             self.wl("framework_model.set_constant(name, constant_tensor)")
             self.indent -= 1
         self.wl("")
-        self.wl("compiled_model = compile(framework_model, sample_inputs=inputs)")
+        self.wl(
+            "compiled_model = compile(framework_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)"
+        )
         self.wl("")
         self.wl(
-            "verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)))"
+            "verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)), forge_property_handler=forge_property_recorder)"
         )
         self.wl("")
         self.wl("")

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -2734,48 +2734,51 @@ def compile_tvm_to_python(
 
         modules.append(writer)
 
-        if framework == "pytorch":
+        if (framework in ["pytorch", "paddle", "onnx"] and compiler_cfg.extract_tvm_unique_ops_config) or (
+            framework == "pytorch" and compiler_cfg.tvm_generate_unique_ops_tests
+        ):
 
-            # Generate unique op tests based on requested model. Currently only supported
-            # for PyTorch framework.
-            if compiler_cfg.extract_tvm_unique_ops_config or compiler_cfg.tvm_generate_unique_ops_tests:
-
-                # Commenting the below verification between framework outputs and generated forge module outputs
-                # because most of the models are failing with the pcc issue which leads to skip the models in model analysis
-
-                # file_path = os.path.join(writer.module_directory, writer.filename)
-                # module = import_from_path(writer.module_name, file_path)
-
-                # TestClass = getattr(module, writer.class_name)
-                # forge_mod = TestClass(writer.module_name)
-                # forge_mod.process_framework_parameters(framework_mod.module)
-
-                # framework_outputs = framework_mod.cpu_eval_forward(*inputs)
-                # forge_outputs = get_forge_outputs([forge_mod], ["TTDevice"], forge_inputs)
-                # verify_framework_vs_forge_codegen(framework_outputs, forge_outputs, verify_cfg=verify_cfg)
-
-                extract_and_generate_unique_ops_tests(
-                    framework_mod,
-                    ops,
-                    current_module_name,
-                    framework,
-                    contains_incompatible_np_floats,
-                    node_name_to_node_type,
-                    params,
-                    constants,
-                    param_names,
-                    param_file_name,
-                    compiler_cfg,
-                    writer.module_directory,
+            if compiler_cfg.extract_tvm_unique_ops_config and compiler_cfg.tvm_generate_unique_ops_tests:
+                raise ValueError(
+                    "Both extract_tvm_unique_ops_config and tvm_generate_unique_ops_tests should not be enabled at the same time."
                 )
 
-                # Exit python progrems without error
-                # - Two different exit methods depending on whether compile is run using
-                # pytest, or as a standalone python script
-                if "pytest" in sys.modules:
-                    pytest.exit("Exiting test without error", returncode=0)
-                else:
-                    sys.exit(0)
+            # Commenting the below verification between framework outputs and generated forge module outputs
+            # because most of the models are failing with the pcc issue which leads to skip the models in model analysis
+
+            # file_path = os.path.join(writer.module_directory, writer.filename)
+            # module = import_from_path(writer.module_name, file_path)
+
+            # TestClass = getattr(module, writer.class_name)
+            # forge_mod = TestClass(writer.module_name)
+            # forge_mod.process_framework_parameters(framework_mod.module)
+
+            # framework_outputs = framework_mod.cpu_eval_forward(*inputs)
+            # forge_outputs = get_forge_outputs([forge_mod], ["TTDevice"], forge_inputs)
+            # verify_framework_vs_forge_codegen(framework_outputs, forge_outputs, verify_cfg=verify_cfg)
+
+            extract_and_generate_unique_ops_tests(
+                framework_mod,
+                ops,
+                current_module_name,
+                framework,
+                contains_incompatible_np_floats,
+                node_name_to_node_type,
+                params,
+                constants,
+                param_names,
+                param_file_name,
+                compiler_cfg,
+                writer.module_directory,
+            )
+
+            # Exit python progrems without error
+            # - Two different exit methods depending on whether compile is run using
+            # pytest, or as a standalone python script
+            if "pytest" in sys.modules:
+                pytest.exit("Exiting test without error", returncode=0)
+            else:
+                sys.exit(0)
 
     if compiler_cfg.retain_tvm_python_files:
         save_writers_metadata(modules, flattened_pytorch_inputs, forge_inputs, graph_name)

--- a/forge/test/conftest.py
+++ b/forge/test/conftest.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import os
 import random
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Dict, Tuple
 from loguru import logger
 from dataclasses import dataclass
 import subprocess
@@ -15,7 +15,6 @@ import torch.multiprocessing as mp
 import torch
 import tensorflow as tf
 
-from forge._C import ExecutionDepth
 
 # This is a workaround to set RTLD_GLOBAL flag to load emulation ZeBu library.
 # Essentially symbol names have to be unique in global scope to work with ZeBu,
@@ -34,7 +33,6 @@ import forge
 from forge.config import CompilerConfig
 from forge.verify.config import TestKind
 from forge.torch_compile import reset_state
-from forge.forge_property_utils import ForgePropertyHandler, ForgePropertyStore
 
 import test.utils
 
@@ -77,20 +75,6 @@ def pytest_sessionstart(session):
             print(f"{key}={value}")
 
 
-@pytest.fixture(scope="function")
-def forge_property_recorder(record_property):
-    forge_property_store = ForgePropertyStore()
-
-    forge_property_handler = ForgePropertyHandler(forge_property_store)
-
-    # Set CI_FAILURE as default execution depth
-    forge_property_handler.record_execution_depth(ExecutionDepth.CI_FAILURE)
-
-    yield forge_property_handler
-
-    forge_property_handler.store_property(record_property)
-
-
 @pytest.fixture(autouse=True)
 def reset_seeds_fixture():
     test.utils.reset_seeds()
@@ -102,6 +86,84 @@ def reset_device():
         # Reset device between tests
         # For this to work, pytest must be called with --forked
         subprocess.check_call(["device/bin/silicon/reset.sh"], cwd=os.environ["FORGE_HOME"])
+
+
+def run_command(cmd: List[str]) -> str:
+    """
+    Executes a shell command using subprocess.run and returns the command's output.
+
+    Args:
+        cmd (List[str]): The command to execute as a list of arguments.
+
+    Returns:
+        str: The standard output from the command execution.
+    """
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=True)
+        logger.debug(f"Command '{' '.join(cmd)}' executed successfully.")
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        cmd_str = " ".join(cmd)
+        logger.error(f"Error executing '{cmd_str}': {e}")
+        return ""
+
+
+def parse_pip_freeze(freeze_output: str) -> Dict[str, str]:
+    """
+    Parses the output of 'pip freeze' and returns a dictionary of package names and versions.
+
+    Args:
+        freeze_output (str): The output string from 'pip freeze'.
+
+    Returns:
+        Dict[str, str]: A dictionary where keys are package names and values are their versions.
+    """
+    packages = {}
+    for line in freeze_output.splitlines():
+        if "==" in line:
+            pkg, version = line.split("==", maxsplit=1)
+            packages[pkg.strip()] = version.strip()
+    return packages
+
+
+@pytest.fixture(scope="function")
+def restore_package_versions():
+    """
+    A pytest fixture that ensures package versions remain consistent during tests.
+
+    This fixture captures the installed packages before the test runs, and after the test,
+    compares the versions. If any package version has changed, it logs the difference and attempts
+    to revert the package back to its original version.
+    """
+    # Capture the state of installed packages before test execution.
+    logger.info("Capturing the initial state of installed packages using 'pip freeze'.")
+    before_freeze = run_command(["pip", "freeze"])
+    before_packages = parse_pip_freeze(before_freeze)
+
+    yield
+
+    # Capture the state after test execution.
+    logger.info("Capturing the final state of installed packages using 'pip freeze'.")
+    after_freeze = run_command(["pip", "freeze"])
+    after_packages = parse_pip_freeze(after_freeze)
+
+    # Determine which packages have changed versions.
+    diff_packages: Dict[str, Tuple[str, str]] = {}
+    for pkg, orig_version in before_packages.items():
+        if pkg in after_packages:
+            new_version = after_packages[pkg]
+            if new_version != orig_version:
+                diff_packages[pkg] = (orig_version, new_version)
+
+    # If differences are detected, log and revert the changed packages.
+    if diff_packages:
+        logger.info("Detected changes in package versions during the test:")
+        for pkg, (orig_version, new_version) in diff_packages.items():
+            logger.info(f"Package '{pkg}': current version {new_version}; reverting to {orig_version}")
+            cmd_output = run_command(["pip", "install", f"{pkg}=={orig_version}"])
+            logger.info(cmd_output)
+    else:
+        logger.info("No package version changes detected after the test.")
 
 
 def pytest_addoption(parser):

--- a/forge/test/models/onnx/text/bert/test_bert.py
+++ b/forge/test/models/onnx/text/bert/test_bert.py
@@ -68,7 +68,9 @@ def test_bert_masked_lm_onnx(forge_property_recorder, variant, tmp_path, opset_v
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile framework model
-    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)
+    compiled_model = forge.compile(
+        onnx_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+    )
 
     # Model Verification
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
@@ -128,7 +130,9 @@ def test_bert_question_answering_onnx(forge_property_recorder, variant, tmp_path
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile framework model
-    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)
+    compiled_model = forge.compile(
+        onnx_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+    )
 
     # Model Verification
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
@@ -172,7 +176,9 @@ def test_bert_sentence_embedding_generation_onnx(forge_property_recorder, varian
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile framework model
-    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)
+    compiled_model = forge.compile(
+        onnx_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+    )
 
     # Model Verification
     _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)

--- a/forge/test/models/onnx/text/minilm/test_minilm.py
+++ b/forge/test/models/onnx/text/minilm/test_minilm.py
@@ -55,7 +55,9 @@ def test_minilm_sequence_classification_onnx(forge_property_recorder, variant, t
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile framework model
-    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)
+    compiled_model = forge.compile(
+        onnx_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+    )
 
     # Model Verification
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)

--- a/forge/test/models/onnx/vision/detr/test_detr.py
+++ b/forge/test/models/onnx/vision/detr/test_detr.py
@@ -52,7 +52,9 @@ def test_detr_detection_onnx(forge_property_recorder, variant, tmp_path):
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile framework model
-    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)
+    compiled_model = forge.compile(
+        onnx_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+    )
 
     # Model Verification
     _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
@@ -94,7 +96,9 @@ def test_detr_segmentation_onnx(forge_property_recorder, variant, tmp_path):
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile framework model
-    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)
+    compiled_model = forge.compile(
+        onnx_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+    )
 
     # Model Verification
     _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)

--- a/forge/test/models/onnx/vision/resnet/test_resnet.py
+++ b/forge/test/models/onnx/vision/resnet/test_resnet.py
@@ -57,7 +57,9 @@ def test_resnet_onnx(forge_property_recorder, variant, tmp_path, opset_version):
 
     # Compile model
     input_sample = [input_sample]
-    compiled_model = forge.compile(onnx_model, input_sample, forge_property_handler=forge_property_recorder)
+    compiled_model = forge.compile(
+        onnx_model, input_sample, module_name=module_name, forge_property_handler=forge_property_recorder
+    )
 
     # Verify data on sample input
     verify(

--- a/forge/test/models/pytorch/text/mistral/test_mistral.py
+++ b/forge/test/models/pytorch/text/mistral/test_mistral.py
@@ -38,8 +38,6 @@ def test_mistral(forge_property_recorder, variant):
     tokenizer = AutoTokenizer.from_pretrained(variant)
 
     framework_model.eval()
-    for param in framework_model.parameters():
-        param.requires_grad = False
 
     # test should work for batch size 1 and seqlen <= 128
     # for larger seqlen, a DRAM allocation problem might occur (this model is already near maximum model size for single chip)

--- a/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
+++ b/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
@@ -44,10 +44,6 @@ def test_rcnn_pytorch(forge_property_recorder):
 
     framework_model.eval()
 
-    # Cancel gradient tracking
-    for param in framework_model.parameters():
-        param.requires_grad = False
-
     # Image
     img = cv2.imread("forge/test/models/files/samples/images/car.jpg")
 

--- a/forge/test/models/pytorch/vision/resnet/test_resnet.py
+++ b/forge/test/models/pytorch/vision/resnet/test_resnet.py
@@ -51,7 +51,9 @@ def test_resnet_hf(variant, forge_property_recorder):
 
     # Compile model
     input_sample = [torch.rand(1, 3, 224, 224)]
-    compiled_model = forge.compile(framework_model, input_sample, forge_property_handler=forge_property_recorder)
+    compiled_model = forge.compile(
+        framework_model, input_sample, module_name=module_name, forge_property_handler=forge_property_recorder
+    )
 
     # Verify data on sample input
     verify(

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -34,7 +34,7 @@ size = [
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size)
-def test_yolov5_320x320(forge_property_recorder, size):
+def test_yolov5_320x320(restore_package_versions, forge_property_recorder, size):
     if size != "s":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
@@ -89,7 +89,7 @@ size = [
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size)
-def test_yolov5_640x640(forge_property_recorder, size):
+def test_yolov5_640x640(restore_package_versions, forge_property_recorder, size):
     if size != "s":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
@@ -143,7 +143,7 @@ size = [
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size)
-def test_yolov5_480x480(forge_property_recorder, size):
+def test_yolov5_480x480(restore_package_versions, forge_property_recorder, size):
     if size != "n":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
@@ -177,7 +177,7 @@ def test_yolov5_480x480(forge_property_recorder, size):
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["yolov5s"])
-def test_yolov5_1280x1280(forge_property_recorder, variant):
+def test_yolov5_1280x1280(restore_package_versions, forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Build Module Name

--- a/scripts/model_analysis/models_ops_test_failure_update.py
+++ b/scripts/model_analysis/models_ops_test_failure_update.py
@@ -6,7 +6,7 @@ import ast
 import re
 from loguru import logger
 import argparse
-from utils import check_path, run_precommit
+from utils import check_path, run_precommit, extract_test_file_path_and_test_case_func
 from typing import Dict, Optional, List, Tuple
 from forge.utils import create_excel_file
 import pandas as pd
@@ -133,28 +133,6 @@ def rename_marker(marker: str) -> str:
         return "xpass"
     else:
         return marker_lower
-
-
-def extract_test_file_path_and_test_case_func(test_case: str):
-    """
-    Extracts the test file path and test case function name from a given test case string.
-
-    Args:
-        test_case (str): A test case string in the format 'file_path::test_function'.
-
-    Returns:
-        Tuple[Optional[str], Optional[str]]: A tuple containing:
-            - test_file_path (str or None): The extracted file path if present.
-            - test_case_func (str or None): The extracted test case function name if present.
-    """
-    test_file_path = None
-    test_case_func = None
-
-    # Check if test case contains '::' separator
-    if "::" in test_case:
-        test_file_path, test_case_func = test_case.split("::", 1)  # Splitting into two parts
-
-    return test_file_path, test_case_func
 
 
 def extract_unique_test_file_paths(test_cases: List[str]) -> set:

--- a/scripts/model_analysis/run_analysis_and_generate_md_files.py
+++ b/scripts/model_analysis/run_analysis_and_generate_md_files.py
@@ -334,6 +334,7 @@ def run_models_unique_op_tests(unique_operations, unique_ops_output_directory_pa
                     for model_variant_info in model_variant_info_list:
                         log_file_dir_path = os.path.join(
                             unique_ops_output_directory_path,
+                            framework,
                             model_variant_info["model_name"],
                             model_variant_info["variant_name"],
                             op_name,

--- a/scripts/model_analysis/utils.py
+++ b/scripts/model_analysis/utils.py
@@ -330,3 +330,37 @@ def get_commit_id(repo_path="."):
         logger.warning(f"Error while fetching commit id: {e}")
 
         return None, None
+
+
+def extract_framework_from_test_file_path(test_file_path: str):
+    if "forge/test/models/pytorch" in test_file_path:
+        framework = "pytorch"
+    elif "forge/test/models/onnx" in test_file_path:
+        framework = "onnx"
+    elif "forge/test/models/paddlepaddle" in test_file_path:
+        framework = "paddlepaddle"
+    else:
+        framework = "unknown"
+    return framework
+
+
+def extract_test_file_path_and_test_case_func(test_case: str):
+    """
+    Extracts the test file path and test case function name from a given test case string.
+
+    Args:
+        test_case (str): A test case string in the format 'file_path::test_function'.
+
+    Returns:
+        Tuple[Optional[str], Optional[str]]: A tuple containing:
+            - test_file_path (str or None): The extracted file path if present.
+            - test_case_func (str or None): The extracted test case function name if present.
+    """
+    test_file_path = None
+    test_case_func = None
+
+    # Check if test case contains '::' separator
+    if "::" in test_case:
+        test_file_path, test_case_func = test_case.split("::", 1)  # Splitting into two parts
+
+    return test_file_path, test_case_func


### PR DESCRIPTION
1. Added support for **paddlepaddle** and **onnx** framework in **model analysis ops test generation pipeline**.
2. In the model analysis, remove the old `record_forge_property` fixture and updated it with `forge_property_recorder` fixture.
3. Moved the forge_property_recorder pytest fixture function from `tt-forge-fe/forge/test/conftest.py` path to `tt-forge-fe/fconftest.py` because the model analysis markdown generation pipeline will generate unique ops test in the `generated_modules/unique_ops/ `directory by default but the pytest fixture is not visible when it is present inside the `tt-forge-fe/forge/test/conftest.py`.
4. Created a pytest fixture(i.e `restore_package_versions`) which ensures  package versions remain consistent during tests execution and added the fixture in yolov5 models tests. In the yolov5 model tests(i.e `forge/test/models/pytorch/vision/yolo/test_yolo_v5.py`), the numpy version is upgraded  from 1.23.1 to 2.2.4 which causes below issues
```
AttributeError: _ARRAY_API not found

A module that was compiled using NumPy 1.x cannot be run in
NumPy 2.2.4 as it may crash. To support both 1.x and 2.x
versions of NumPy, modules must be compiled with NumPy 2.0.
Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.

If you are a user of the module, the easiest solution will be to
downgrade to 'numpy<2' or try to upgrade the affected module.
We expect that some modules will need time to support NumPy 2.
```

5. Refactored the `ForgePropertyStore` and `ForgePropertyHandler` to record the inputs and outputs tensor description inside the tags property.
6. Removed the requires_grad=False setting in the Mistral and RCNN models because it caused the forge module to treat model weights as constants instead of parameters.
7. In the model analysis ops test generation, for advindex op, added maximum int calculation which helps to generate indicies tensor with the range of reference tensor.
8. Added support for dumping logs while extracting the unique ops configuration for models in model analysis pipeline which helps for debugging the test failures.