### PR TITLE
- Adding training intermediate verification.

### DIFF
--- a/forge/csrc/graph_lib/python_bindings.cpp
+++ b/forge/csrc/graph_lib/python_bindings.cpp
@@ -50,7 +50,8 @@ eval_graph(
     float pcc,
     std::string const &dump_tensors_path,
     bool allow_modified_shapes,
-    bool return_intermediates);
+    bool return_intermediates,
+    std::optional<py::object> optimizer = std::nullopt);
 
 py::object get_constant_input_value(graphlib::Node *node, bool is_forge);
 py::object eval_input(
@@ -164,6 +165,7 @@ void GraphModule(py::module &m_graph)
         .def("get_ordered_input_tile_dims", &Graph::get_ordered_input_tile_dims)
         .def("get_ordered_parameter_tile_dims", &Graph::get_ordered_parameter_tile_dims)
         .def("get_ordered_constant_tile_dims", &Graph::get_ordered_constant_tile_dims)
+        .def("contains_bwd_nodes", &Graph::contains_bwd_nodes)
         .def(
             "get_input_runtime_tensor_transforms",
             [](Graph *graph) -> std::vector<graphlib::RuntimeTensorTransform>
@@ -628,7 +630,8 @@ void GraphModule(py::module &m_graph)
            const std::vector<py::object> &losses,
            const std::vector<py::object> &targets,
            std::string const &dump_tensors_path,
-           bool allow_modified_shapes)
+           bool allow_modified_shapes,
+           std::optional<py::object> optimizer)
         {
             auto ret = eval_graph(
                 graph,
@@ -641,7 +644,8 @@ void GraphModule(py::module &m_graph)
                 pcc,
                 dump_tensors_path,
                 allow_modified_shapes,
-                false);
+                false,
+                optimizer.value_or(py::none()));
             return std::make_tuple(std::get<0>(ret), std::get<1>(ret), std::get<2>(ret), std::get<3>(ret));
         },
         py::arg("graph"),
@@ -653,7 +657,8 @@ void GraphModule(py::module &m_graph)
         py::arg("losses") = std::vector<py::object>(),
         py::arg("targets") = std::vector<py::object>(),
         py::arg("dump_tensors_path") = "",
-        py::arg("allow_modified_shapes") = false);
+        py::arg("allow_modified_shapes") = false,
+        py::arg("optimizer") = py::none());
 
     m_graph.def(
         "remove_node",
@@ -774,16 +779,6 @@ py::object eval_relu(py::object tensor, graphlib::OpType type)
         tensor = eval_op(relu, inputs, graphlib::IRLevel::IR_TT_FORGE);
     }
     return tensor;
-}
-
-py::object eval_t_streaming_tms(py::object tensor, graphlib::Graph *graph, graphlib::Node *node, std::string const &dir)
-{
-    return tensor;
-}
-
-py::object eval_t_streaming_tms(py::object tensor, graphlib::Graph *graph, graphlib::Node *node)
-{
-    return eval_t_streaming_tms(tensor, graph, node, "Redo");
 }
 
 py::object eval_golden_transforms(graphlib::Node *node, py::object tensor, bool eval_for_output = false)
@@ -1367,8 +1362,13 @@ bool is_gradient_comparison_valid(Graph *graph, const graphlib::Edge &gradient_e
     return is_gradient_comparison_valid;
 }
 
+// Returns a map of input_name → tensor.
+// Supported input types include: activations, parameters (weights), constant inputs, and optimizer parameters.
 std::unordered_map<std::string, py::object> get_graph_input_mapping(
-    Graph *graph, const std::vector<py::object> &inputs, const std::unordered_map<std::string, py::object> &parameters)
+    Graph *graph,
+    const std::vector<py::object> &inputs,
+    const std::unordered_map<std::string, py::object> &parameters,
+    std::optional<py::object> optimizer)
 {
     std::vector<std::string> ordered_input_names = graph->get_ordered_input_names();
     std::unordered_map<std::string, py::object> graph_inputs = parameters;
@@ -1380,6 +1380,21 @@ std::unordered_map<std::string, py::object> get_graph_input_mapping(
         graph_inputs.insert({ordered_input_names[i], inputs[i]});
     }
 
+    py::object optimizer_params = py::none();
+    if (!optimizer->is_none())
+    {
+        optimizer_params = optimizer->attr("get_optimizer_params")();
+        // optimizer_params is a dictionary of optimizer parameters that looks like this:
+        // E.g. for 'l1.weight' trainable parameter, the optimizer parameters could be learning rate and momentum.
+        // If that was the only trainable parameter in our example, the optimizer_params dictionary would look like
+        // this:
+        // {
+        // ('l1.weight', 'lr'): 0.01,
+        // ('l1.weight', 'momentum'): 0.9,
+        // }
+        // So key to this dictionary is a tuple of parameter name and optimizer parameter name.
+    }
+
     for (Node *node : tt::graphlib::topological_sort(*graph))
     {
         if (node->node_type() != NodeType::kInput)
@@ -1389,60 +1404,49 @@ std::unordered_map<std::string, py::object> get_graph_input_mapping(
         {
             graph_inputs.insert({input->name(), get_constant_input_value(input, is_forge)});
         }
+        else if (input->is_optimizer_parameter())
+        {
+            // Finds values of optimizer parameters
+            TT_ASSERT(
+                not(!optimizer.has_value() or optimizer->is_none()),
+                "Optimizer is not provided but one of inputs is optimizer parameter");
+
+            TT_ASSERT(
+                !optimizer_params.is_none(), " Optimizer params is None but one of inputs is optimizer parameter");
+
+            std::vector<graphlib::Edge> optimizer_edges = graph->operand_edges(
+                input, [](const auto &edge) { return edge.edge_type == graphlib::EdgeType::kAutogradFwdToOptimizer; });
+            TT_ASSERT(optimizer_edges.size() == 1);
+            // optimizer parameter (eg. input_opt_linear_relu_stack.0.weight_0.lr) always has one input edge that comes
+            // from parameter it is referring to (linear_relu_stack.0.weight). That edge is kAutogradFwdToOptimizer
+            // type.
+            Node *node_to_train = graph->node_by_id(optimizer_edges[0].producer_node_id);
+
+            // Parse out the optimizer-param suffix string to find optimizer parameter name.
+            std::string optimizer_input_name = input->name();
+            std::string::size_type optimizer_param_idx = optimizer_input_name.rfind('.');
+            TT_ASSERT(
+                optimizer_param_idx != std::string::npos,
+                "Expecting optimizer node to have a '.<optimizer-param>' suffix identifier");
+
+            // optimizer_param_key will be string like "lr", "momentum" etc.
+            // second part of the key to index into optimizer_params is name of the node this optimizer parameter is
+            // referring to. we get that from node_to_train->name().
+            std::string optimizer_parameter_name = optimizer_input_name.substr(optimizer_param_idx + 1);
+            std::string parameter_name = node_to_train->name();
+            py::tuple optimizer_param_key = py::make_tuple(parameter_name, optimizer_parameter_name);
+            py::object opt_tensor = optimizer_params.attr("get")(optimizer_param_key);
+            if (opt_tensor.is_none())
+                log_fatal(
+                    "optimizer_param key: {} not found for node: {}",
+                    std::string(py::str(optimizer_param_key)),
+                    optimizer_input_name);
+            graph_inputs.insert({input->name(), opt_tensor.attr("value")().cast<py::object>()});
+        }
     }
 
     return graph_inputs;
 }
-// static std::unordered_map<std::string, py::object> get_graph_input_mapping(
-//     Graph *graph, const std::unordered_map<std::string, py::object> &parameters, py::object optimizer)
-// {
-//     const bool is_forge = graph->get_ir_level() == graphlib::IRLevel::IR_FORGE;
-//     std::unordered_map<std::string, py::object> graph_inputs = parameters;
-
-//     for (Node *node : tt::graphlib::topological_sort(*graph))
-//     {
-//         graphlib::InputNode *input = dynamic_cast<graphlib::InputNode *>(node);
-//         if (not input)
-//             continue;
-
-//         if (input->is_constant())
-//         {
-//             graph_inputs.insert({input->name(), get_constant_input_value(input, is_forge)});
-//         }
-//         else if (input->is_optimizer_parameter())
-//         {
-//             // Finds values of optimizer parameters
-//             TT_ASSERT(not optimizer.is_none());
-
-//             std::vector<graphlib::Edge> optimizer_edges = graph->operand_edges(
-//                 input, [](const auto &edge) { return edge.edge_type == graphlib::EdgeType::kAutogradFwdToOptimizer;
-//                 });
-//             TT_ASSERT(optimizer_edges.size() == 1);
-
-//             std::string param_name = graph->node_by_id(optimizer_edges[0].producer_node_id)->name();
-//             py::object optimizer_params = optimizer.attr("get_optimizer_params")(param_name, is_forge);
-//             if (optimizer_params.is_none())
-//                 continue;
-
-//             // Parse out the optimizer-param suffix string and do a lookup to get the tensor
-//             std::string optimizer_input_name = input->name();
-//             std::string::size_type optimizer_param_idx = optimizer_input_name.rfind('.');
-//             TT_ASSERT(
-//                 optimizer_param_idx != std::string::npos,
-//                 "Expecting optimizer node to have a '.<optimizer-param>' suffix identifier");
-
-//             std::string optimizer_param_key = optimizer_input_name.substr(optimizer_param_idx + 1);
-//             py::object opt_tensor = optimizer_params.attr("get")(optimizer_param_key);
-//             if (opt_tensor.is_none())
-//                 log_fatal("optimizer_param key: {} not found for node: {}", optimizer_param_key,
-//                 optimizer_input_name);
-
-//             graph_inputs.insert({input->name(), opt_tensor.attr("value")().cast<py::object>()});
-//         }
-//     }
-
-//     return graph_inputs;
-// }
 
 // Evaluate graph with given inputs, and return list of outputs. If intermediate golden tensors are
 // provided, compare each matching node ID
@@ -1468,7 +1472,8 @@ eval_graph(
     float pcc,
     std::string const &dump_tensors_path,
     bool allow_modified_shapes,
-    bool return_intermediates)
+    bool return_intermediates,
+    std::optional<py::object> optimizer)
 {
     log_debug(LogEval, "Eval graph: {}", graph->name());
 
@@ -1478,7 +1483,8 @@ eval_graph(
     std::unordered_map<std::string, py::object> updated_parameter_mapping;
     std::unordered_map<std::string, py::object> intermediate_tensors;
 
-    std::unordered_map<std::string, py::object> graph_inputs = get_graph_input_mapping(graph, inputs, parameters);
+    std::unordered_map<std::string, py::object> graph_inputs =
+        get_graph_input_mapping(graph, inputs, parameters, optimizer);
 
     const bool is_forge = graph->get_ir_level() == graphlib::IRLevel::IR_FORGE;
 
@@ -1509,52 +1515,6 @@ eval_graph(
         }
     }
 
-    // Populate loss tensor mapping
-    if (losses.size() > 0)
-    {
-        size_t losses_index = 0;
-        std::vector<std::string> output_gradient_names = graph->get_ordered_output_gradient_names();
-        TT_ASSERT(
-            output_gradient_names.size() == losses.size(),
-            "The number of output gradient ports (" + std::to_string(output_gradient_names.size()) + ") and losses (" +
-                std::to_string(losses.size()) + ") should match.");
-
-        std::vector<Node *> nodes;
-        for (auto name : output_gradient_names) nodes.push_back(graph->get_node_by_name(name));
-        std::vector<py::object> loss_tensors = eval_runtime_tensor_transform(graph, nodes, losses);
-        for (std::string loss_name : graph->get_ordered_output_gradient_names())
-        {
-            py::object loss = loss_tensors.at(losses_index);
-            Node *node = graph->get_node_by_name(loss_name);
-            TT_ASSERT(
-                (node->node_type() == NodeType::kInput) && node->as<graphlib::InputNode>()->is_loss(),
-                "Expected that this node is a loss");
-            log_debug(tt::LogTest, "Populating bwd loss: {}", node->name());
-            node_outputs[node->id()].push_back(loss);
-            ++losses_index;
-        }
-    }
-
-    // Populate target tensor mapping
-    if (targets.size() > 0)
-    {
-        size_t targets_index = 0;
-        std::vector<std::string> target_inputs = graph->get_ordered_target_names();
-        TT_ASSERT(
-            target_inputs.size() == targets.size(),
-            "The number of target inputs (" + std::to_string(target_inputs.size()) + ") and targets (" +
-                std::to_string(targets.size()) + ") should match.");
-        for (std::string target : target_inputs)
-        {
-            Node *node = graph->get_node_by_name(target);
-            TT_ASSERT(
-                (node->node_type() == NodeType::kInput) && node->as<graphlib::InputNode>()->is_target(),
-                "Expected that this node is a target input");
-            log_debug(tt::LogTest, "Populating target input: {}", node->name());
-            node_outputs[node->id()].push_back(targets.at(targets_index++));
-        }
-    }
-
     // Populate Forge input tensor mapping
     int input_index = 0;
     std::vector<py::object> input_tensors =
@@ -1566,7 +1526,7 @@ eval_graph(
         log_debug(tt::LogTest, "Populating module input: {}", node->name());
         input_index++;
     }
-
+    log_debug(LogGraphCompiler, "\033[1mComparing intermediate tensors\033[0m");
     for (Node *node : tt::graphlib::topological_sort(*graph))
     {
         if (node->node_type() == NodeType::kInput)
@@ -1661,8 +1621,14 @@ eval_graph(
                             if (!grad.is(py::none()))
                             {
                                 py::object calculated = eval_golden_transforms(producer, obj);
+                                log_debug(
+                                    LogGraphCompiler,
+                                    "Comparing intermediate gradient for node: {}. Backward node calculating gradient: "
+                                    "{}",
+                                    producer->name(),
+                                    node->name());
                                 compare_tensor_to_golden(
-                                    node->name() + " from " + producer->name(),
+                                    node->name() + ", that is gradient with respect to " + producer->name(),
                                     grad,
                                     calculated,
                                     relative_atol,
@@ -1706,12 +1672,6 @@ eval_graph(
                     py::object ret = eval_golden_transforms(node, obj);
                     if (producer->node_type() == NodeType::kInput)
                     {
-                        auto operands = graph->data_operands(producer);
-                        if (operands.size() == 1)
-                        {
-                            graphlib::Node *optimizer = operands[0];
-                            ret = eval_t_streaming_tms(ret, graph, optimizer);
-                        }
                         ret = eval_input_bw(producer, ret, is_forge);
                         ret = eval_runtime_tensor_transform(graph, {producer}, {ret}, true).at(0);
                     }

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -2634,7 +2634,7 @@ def compile_tvm_to_python(
             delete_inputs = not verify_cfg.enable_op_level_comparision
             if not delete_inputs:
                 logger.warning(
-                    "Preserving Intermediate tensor values in ForgeModule forward may causes out-of-memory issues"
+                    "Preserving Intermediate tensor values in ForgeModule forward may cause out-of-memory issues"
                 )
             writer = ForgeWriter(
                 current_module_name,

--- a/forge/forge/verify/verify.py
+++ b/forge/forge/verify/verify.py
@@ -33,33 +33,21 @@ from forge.verify.utils import convert_to_supported_pytorch_dtype
 from forge.forge_property_utils import ForgePropertyHandler, ExecutionStage
 
 
-def _generate_random_losses(outputs, is_forge):
+def _generate_random_losses(outputs):
     losses = []
     for out in outputs:
         if out.requires_grad:
             shape = list(out.shape.get_pytorch_shape())
-            if is_forge:
-                while len(shape) < 4:
-                    shape.insert(0, 1)
-                while len(shape) > 4:
-                    shape.pop(0)
-
-                shape[-1] = align_up_tile(shape[-1])
-                shape[-2] = align_up_tile(shape[-2])
-
             losses.append(torch.rand(shape, dtype=out.pt_data_format))
     return losses
 
 
-def _run_pytorch_backward(outputs, device, losses):
+def _run_pytorch_backward(outputs, losses):
     retain_graph = True
     for i, o in enumerate(outputs):
         if o.requires_grad:
-            if device.loss_module is None:
-                loss = narrow_forge_tensor_to_pytorch(losses[i], o.value().shape)
-                o.value().backward(loss, retain_graph=retain_graph)
-            else:
-                o.value().backward(retain_graph=True)  # this is loss
+            loss = narrow_forge_tensor_to_pytorch(losses[i], o.value().shape)
+            o.value().backward(loss, retain_graph=retain_graph)
 
 
 def get_intermediate_tensors(
@@ -84,7 +72,6 @@ def get_intermediate_tensors(
 
 def do_verify(
     stage_name: str,
-    training: bool,
     graph: pygraph.Graph,
     inputs: Tuple[Tensor, ...],
     parameters: Dict[str, torch.Tensor],
@@ -95,6 +82,7 @@ def do_verify(
     is_forge: bool,
     losses=None,
     targets: List[Tensor] = [],
+    optimizer=None,
 ):
     """
     Verify graph vs. pytorch golden
@@ -103,6 +91,7 @@ def do_verify(
     torch_targets: List[torch.Tensor] = [i if isinstance(i, torch.Tensor) else i.to_pytorch() for i in targets]
 
     logger.info("Verifying stage {}", stage_name)
+    training = graph.contains_bwd_nodes()
     if not training:
 
         pcc = 0.0 if verify_cfg.pcc is None else verify_cfg.pcc
@@ -122,42 +111,29 @@ def do_verify(
         for i, result in enumerate(zip(outputs, trace_outputs)):
             evaled = result[1]
             golden = result[0].value()
-            ok &= compare_tensor_to_golden(f"Output {i}", golden, evaled, verify_cfg=verify_cfg)
+            ok &= compare_tensor_to_golden(f"output {i}", golden, evaled, verify_cfg=verify_cfg)
 
     else:
-        raise RuntimeError("Verification of training is not supported yet.")
-        if losses is None and device.loss_module is None:
-            losses = _generate_random_losses(outputs, is_forge)
-        elif losses is None:
-            losses = []
+        if losses is None:
+            losses = _generate_random_losses(outputs)
 
         # retain intermediate gradients for verification
         for t in intermediate_golden_tensors.values():
             if t.requires_grad == True:
                 t.retain_grad()
 
-        # Calculate pytorch gradients
-        run_backward = False
-        for i, o in enumerate(outputs):
-            # Check if we need to run, or if gradients have been calculated already
-            if o.value().grad is None and o.requires_grad:
-                run_backward = True
-                break
-        if run_backward:
-            _run_pytorch_backward(outputs, device, losses)
-
         pcc = 0.0 if verify_cfg.pcc is None else verify_cfg.pcc
         trace_outputs, parameter_to_gradients, bwd_gradients, parameter_to_updated_parameter = pygraph.eval(
             graph,
             torch_inputs,
             parameters,
-            tt_device=device,
             relative_atol=verify_cfg.relative_atol,
             pcc=pcc,
             intermediate_golden_tensors=intermediate_golden_tensors,
             losses=losses,
             targets=torch_targets,
             dump_tensors_path=verify_cfg.dump_tensors_path,
+            optimizer=optimizer,
         )
 
         # Verify forward pass results
@@ -167,50 +143,49 @@ def do_verify(
             golden = result[0].value()
             ok &= compare_tensor_to_golden(f"Output {i}", golden, evaled, verify_cfg=verify_cfg)
 
-        # Verify bwd gradients
-        # allow 0 on golden below because on the first post-autograd pass we don't have golden input grads yet
-        assert len(golden_input_grads) == 0 or (
-            len(golden_input_grads) == len(bwd_gradients)
+        # Verify gradients of inputs (if input tensors require gradients)
+        # TODO: Here, we rely on the fact that golden inputs are ordered in the same way as in the graph.
+        # This is true for now, but it is bad to rely on.
+        logger.debug("Verify gradients of inputs")
+        assert len(golden_input_grads) == len(
+            bwd_gradients
         ), f"Golden has {len(golden_input_grads)} input gradients, but graph eval returned {len(bwd_gradients)}"
         for bwd_index, golden_input_grad in enumerate(golden_input_grads):
             evaled = bwd_gradients[bwd_index]
             ok &= compare_tensor_to_golden(
-                f"Bwd gradient {bwd_index}", golden_input_grad, evaled, verify_cfg=verify_cfg
+                f"gradient of input {bwd_index}", golden_input_grad, evaled, verify_cfg=verify_cfg
             )
 
-        # Verify parameter gradients:
-        device_parameters = device.get_parameters()
-        for parameter in device_parameters:
-            if parameter.requires_grad:
-                parameter_name = parameter.get_name()
+        logger.debug("Verify gradients of parameters")
+        for parameter_name, parameter_tensor in parameters.items():
+            if parameter_tensor.requires_grad:
                 if not parameter_name in parameter_to_gradients:
                     logger.warning("Parameter {} not used.", parameter_name)
                     continue
 
-                golden = parameter.value().grad
+                golden = parameter_tensor.grad
                 assert golden is not None
                 evaled = parameter_to_gradients[parameter_name]
                 warning_only = should_waive_gradient(parameter_name, verify_cfg)
                 ok &= compare_tensor_to_golden(
-                    f"Gradient for {parameter_name}",
+                    f"gradient of parameter {parameter_name}",
                     golden,
                     evaled,
                     verify_cfg=verify_cfg,
                     warning_only=warning_only,
                 )
 
-        # Verify parameter updates:
-        optimizer = device.get_optimizer()
+        # Verify parameter updates if optimizer is not None:
         if optimizer:
-            for parameter in device_parameters:
-                if parameter.requires_grad:
-                    parameter_name = parameter.get_name()
+            logger.debug("Verify updates of parameters")
+            for parameter_name, parameter_tensor in parameters.items():
+                if parameter_tensor.requires_grad:
                     if not parameter_name in parameter_to_updated_parameter:
                         logger.warning("Parameter {} not used.", parameter_name)
                         continue
 
                     golden = optimizer.torch_parameter_update(
-                        parameter_name=parameter_name, parameter=parameter.value(), gradient=parameter.value().grad
+                        parameter_name=parameter_name, parameter=parameter_tensor, gradient=parameter_tensor.grad
                     )
                     evaled = parameter_to_updated_parameter[parameter_name]
                     warning_only = should_waive_gradient(parameter_name, verify_cfg)

--- a/forge/test/mlir/mnist/training/test_training.py
+++ b/forge/test/mlir/mnist/training/test_training.py
@@ -13,6 +13,8 @@ import forge
 from forge.op.loss import CrossEntropyLoss, L1Loss
 from forge.tensor import to_forge_tensors
 from forge.verify import compare_with_golden, verify, VerifyConfig, AutomaticValueChecker
+from forge.verify.config import DepricatedVerifyConfig
+from forge.config import CompileDepth
 from ..utils import *
 from test.mlir.utils import *
 
@@ -622,12 +624,16 @@ def test_e2e_device(forge_property_recorder):
     framework_loss = torch.nn.CrossEntropyLoss()
     tt_optimizer = forge.optimizers.SGD(learning_rate=learning_rate)
 
+    verify_cfg = DepricatedVerifyConfig()
+    verify_cfg.stages_for_intermediate_verification = {CompileDepth.AUTOGRAD}
+    verify_cfg.enable_op_level_comparision = True
     tt_model = forge.compile(
         framework_model,
         sample_inputs=[torch.rand(batch_size, 784)],
         optimizer=tt_optimizer,
         training=True,
         forge_property_handler=forge_property_recorder,
+        verify_cfg=verify_cfg,
     )
 
     loss_inputs = [torch.rand(batch_size, 10).requires_grad_(True), torch.rand(batch_size, 10)]

--- a/forge/test/mlir/test_golden_verification.py
+++ b/forge/test/mlir/test_golden_verification.py
@@ -6,7 +6,10 @@ import torch
 from torch import nn
 
 import forge
-from forge.verify.verify import verify
+from forge.verify.verify import verify, verify_backward, DepricatedVerifyConfig
+from forge.config import CompileDepth
+from forge.verify.config import VerifyConfig
+from forge.verify.value_checkers import AutomaticValueChecker
 
 
 @pytest.mark.parametrize(
@@ -74,3 +77,53 @@ def test_constant_add(batch_size, lhs, rhs):
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, verify_cfg=verify_cfg)
 
     verify(inputs, framework_model, compiled_model)
+
+
+compile_depths_to_test = [
+    "ALL",  # this will activate verify_all = True
+    *[depth for depth in CompileDepth if depth.value <= CompileDepth.SPLIT_GRAPH.value],
+]
+
+
+@pytest.mark.parametrize("verify_stage", compile_depths_to_test, ids=lambda x: x if isinstance(x, str) else x.name)
+@pytest.mark.parametrize(
+    "shapes, train",
+    [
+        (((1, 11, 2048), (2048, 128256), (128256, 2048)), True),
+    ],
+)
+@pytest.mark.push
+def test_matmuls(forge_property_recorder, shapes, train, verify_stage):
+    shape1, shape2, shape3 = shapes
+
+    class Matmul(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.rhs_param = nn.Parameter(torch.rand(shape3), requires_grad=train)
+
+        def forward(self, x, y):
+            intermediate = torch.matmul(x, y)
+            return torch.matmul(intermediate, self.rhs_param)
+
+    inputs = [
+        torch.rand(shape1, requires_grad=train),
+        torch.rand(shape2, requires_grad=train),
+    ]
+
+    framework_model = Matmul()
+    framework_model.train() if train else framework_model.eval()
+
+    verify_cfg = DepricatedVerifyConfig()
+    if verify_stage == "ALL":
+        verify_cfg.verify_all = True
+    else:
+        verify_cfg.stages_for_intermediate_verification = {verify_stage}
+    verify_cfg.enable_op_level_comparision = True
+
+    compiled_model = forge.compile(
+        framework_model,
+        sample_inputs=inputs,
+        training=train,
+        forge_property_handler=forge_property_recorder,
+        verify_cfg=verify_cfg,
+    )

--- a/pytest.ini
+++ b/pytest.ini
@@ -67,6 +67,9 @@ testpaths =
     # Verification utilities
     forge/test/test_verify.py
 
+    # Intermediate golden verification
+    forge/test/mlir/test_golden_verification.py
+
     # Testing Model parts
     forge/test/test_model_parts.py
 


### PR DESCRIPTION



### Ticket
Closes #1667 

### What's changed
- Training verification includes comparison of:
		intermediate gradients (gradients with respect to outputs of intermediate operations),
		parameter gradients,
		input (activations) gradients (if inputs require grad),
		parameter updates (if optimizer is on device)
- Adding a small end to end test with verification included.
- Cleanup redundant code. Remove redundant calls to calculate_grads and _run_pytorch_backward. Calling backward once for output tensor is enough to have golden gradients for comparison


Training verification can be performed in compile stages after autograd pass (since before we don't have backward graph). Graph is evaled op by op (forward and backward) and corresponding gradients are compared to the result of pytorch backward.

Few implementation details not to miss:
- Previously, compile context attributes `context.outputs `and `context.parameter_dict` were not from the same computational graph. Namely, context.outputs was output of ForgeModule forward, while context.parameter_dict was from PytorchModule. So essentially, we took PytorchModule extracted parameters, then translated to ForgeModule and took outputs from forward. This is why outputs.backward() didn't produce change in parameter gradients… 
Solution: use ForgeModule to extract parameter_dict

- From now, we pass optimizer to do_verify function. Optimizer parameters are inputs to the graph, so we use them to calculate updates of trainable parameters.

