### PR TITLE
[build] add option for skipping tt-mlir env build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20.0)
+cmake_minimum_required(VERSION 3.24.0)
 
 project(ttforge LANGUAGES CXX)
 

--- a/docs/src/build.md
+++ b/docs/src/build.md
@@ -35,9 +35,9 @@ python3 --version
 ```
 
 ## Build environment
-This is one off step to build the toolchain and create virtual environment for tt-forge. Generally you need to run this step only once, unless you want to update the toolchain (LLVM).
+This is one off step to build the toolchain and create virtual environment for `tt-forge-fe`.Generally, you need to run this step only once, unless you want to update the toolchain. Since `tt-forge-fe` is using `tt-mlir`, this step also builds the `tt-mlir` environment (toolchain).
 
-First, it's required to create toolchain directories. Proposed example creates directories in default paths. You can change the paths if you want to use different locations (see build environment section below).
+First, it's required to create toolchain directories. Proposed example creates directories in default paths. You can change the paths if you want to use different locations (see [Useful build environment variables](#useful-build-environment-flags) section below).
 ```sh
 # FFE related toolchain (dafault path)
 sudo mkdir -p /opt/ttforge-toolchain
@@ -60,6 +60,14 @@ git submodule update --init --recursive -f
 cmake -B env/build env
 cmake --build env/build
 ```
+
+> **Expert tip:** If you already have the `tt-mlir` toolchain built, you can use the `TTFORGE_SKIP_BUILD_TTMLIR_ENV` option to skip rebuilding the `tt-mlir` environment (toolchain) to save time.
+> ```sh
+> cmake -B env/build env -DTTFORGE_SKIP_BUILD_TTMLIR_ENV=ON
+> cmake --build env/build
+> ```
+>
+> **NOTE:** special care should be taken to ensure that the already built `tt-mlir` environment (toolchain) version is compatible with the one `tt-forge-fe` is using.
 
 ## Build Forge
 ```sh

--- a/env/CMakeLists.txt
+++ b/env/CMakeLists.txt
@@ -8,6 +8,8 @@ get_filename_component(PARENT_DIR ${CMAKE_CURRENT_SOURCE_DIR} DIRECTORY)
 list(APPEND CMAKE_MODULE_PATH ${PARENT_DIR}/cmake)
 include(Utils)
 
+option(TTFORGE_SKIP_BUILD_TTMLIR_ENV "Skip building the tt-mlir environment" OFF)
+
 # Check if the environment variable is set, if not error out
 check_required_env_var(TTFORGE_PYTHON_VERSION)
 check_required_env_var(TTFORGE_TOOLCHAIN_DIR)
@@ -37,11 +39,13 @@ add_custom_target(python-venv
     TTFORGE_VENV_DIR=${TTFORGE_VENV_DIR}
     bash ${CMAKE_CURRENT_SOURCE_DIR}/create_venv.sh)
 
-add_custom_target(build_tt_mlir_env ALL
-    COMMAND ${CMAKE_COMMAND} -E env
-    TTMLIR_TOOLCHAIN_DIR=${TTMLIR_TOOLCHAIN_DIR} # Export TTMLIR_TOOLCHAIN_DIR to use
-    TTMLIR_VENV_DIR=${TTMLIR_VENV_DIR} # Export TTMLIR_VENV_DIR to use
-    bash ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/build_mlir_env.sh
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/tt-mlir
-    USES_TERMINAL
-)
+if (NOT TTFORGE_SKIP_BUILD_TTMLIR_ENV)
+    add_custom_target(build_tt_mlir_env ALL
+        COMMAND ${CMAKE_COMMAND} -E env
+        TTMLIR_TOOLCHAIN_DIR=${TTMLIR_TOOLCHAIN_DIR} # Export TTMLIR_TOOLCHAIN_DIR to use
+        TTMLIR_VENV_DIR=${TTMLIR_VENV_DIR} # Export TTMLIR_VENV_DIR to use
+        bash ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/build_mlir_env.sh
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../third_party/tt-mlir
+        USES_TERMINAL
+    )
+endif()


### PR DESCRIPTION
Introducing `-DTTFORGE_SKIP_BUILD_TTMLIR_ENV` cmake option, when building `tt-forge-fe` environment.

By default, as part of building our environment, we also build `tt-mlir` env as well. This can be problematic for developers which want to work on multiple active repos (either `tt-mlir` or other FEs) and already have the `tt-mlir` toolchain built - because our env build will (by default) rebuild the `tt-mlir` toolchain from scratch, even if it is not necessary.

In those cases, the introduced option can be used, so that you can point to the already built `tt-mlir` toolchain dir (via `TTMLIR_TOOLCHAIN_DIR` env variable) and skip rebuilding it when building `tt-forge-fe` env.

```bash
cmake -B env/build -DTTFORGE_SKIP_BUILD_TTMLIR_ENV=ON env
```

NOTE: if you skip the `tt-mlir` env build, you need to make sure that your already existing `tt-mlir` env (toolchain) version is compatible with `tt-forge-fe`.