### PR TITLE
Add changes to record model properties

### DIFF
--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -13,6 +13,81 @@ from forge.config import CompilerConfig
 from forge._C import ExecutionDepth
 
 
+class StrEnum(str, Enum):
+    def __str__(self):
+        return self.value
+
+
+class BaseEnum(Enum):
+    """Base Enum to handle short and full name attributes."""
+
+    def __init__(self, short: str, full: str):
+        self.short = short  # Short identifier (e.g., "hf" for Hugging Face)
+        self.full = full  # Full descriptive name (e.g., "Hugging Face")
+
+
+class Framework(BaseEnum):
+    PYTORCH = ("pt", "PyTorch")
+    TENSORFLOW = ("tf", "TensorFlow")
+    ONNX = ("onnx", "ONNX")
+    PADDLE = ("pd", "PaddlePaddle")
+
+
+class Task(BaseEnum):
+    SPEECH_TRANSLATE = ("speech_translate", "Speech Translation")
+    MUSIC_GENERATION = ("music_generation", "Music Generation")
+    SPEECH_RECOGNITION = ("speech_recognition", "Speech Recognition")
+    QA = ("qa", "Question Answering")
+    MASKED_LM = ("mlm", "Masked Language Modeling")
+    CAUSAL_LM = ("clm", "Causal Language Modeling")
+    TOKEN_CLASSIFICATION = ("token_cls", "Token Classification")
+    SEQUENCE_CLASSIFICATION = ("seq_cls", "Sequence Classification")
+    IMAGE_CLASSIFICATION = ("img_cls", "Image Classification")
+    IMAGE_SEGMENTATION = ("img_seg", "Image Segmentation")
+    POSE_ESTIMATION = ("pose_estimation", "Pose Estimation")
+    DEPTH_PREDICTION = ("depth_prediction", "Depth Prediction")
+    TEXT_GENERATION = ("text_gen", "Text Generation")
+    OBJECT_DETECTION = ("obj_det", "Object Detection")
+    SEMANTIC_SEGMENTATION = ("sem_seg", "Semantic Segmentation")
+    MASKED_IMAGE_MODELING = ("masked_img", "Masked Image Modeling")
+    CONDITIONAL_GENERATION = ("cond_gen", "Conditional Generation")
+    IMAGE_ENCODING = ("img_enc", "Image Encoding")
+    VISUAL_BACKBONE = ("visual_bb", "Visual Backbone")
+    DEPTH_ESTIMATION = ("depth_estimation", "Depth Estimation")
+    SCENE_TEXT_RECOGNITION = ("scene_text_recognition", "Scene Text Recognition")
+    TEXT_TO_SPEECH = ("text_to_speech", "Text to Speech")
+    SENTENCE_EMBEDDING_GENERATION = ("sentence_embed_gen", "Sentence Embedding Generation")
+    MULTIMODAL_TEXT_GENERATION = ("multimodal_text_gen", "Multimodal Text Generation")
+    ATOMIC_ML = ("atomic_ml", "Atomic Machine Learning")
+
+
+class Source(BaseEnum):
+    HUGGINGFACE = ("hf", "Hugging Face")
+    TORCH_HUB = ("torchhub", "Torch Hub")
+    TIMM = ("timm", "TIMM")
+    OSMR = ("osmr", "OSMR")
+    TORCHVISION = ("torchvision", "Torchvision")
+    GITHUB = ("github", "GitHub")
+    PADDLE = ("paddlemodels", "Paddle Models")
+
+
+def build_module_name(
+    framework: Framework,
+    model: str,
+    task: Task,
+    source: Source,
+    variant: str = "base",
+    suffix: str | None = None,
+) -> str:
+    module_name = f"{framework}_{model}_{variant}_{task}_{source}"
+    if suffix is not None:
+        module_name += f"_{suffix}"
+    module_name = re.sub(r"[^a-zA-Z0-9_]", "_", module_name)
+    module_name = re.sub(r"_+", "_", module_name)
+    module_name = module_name.lower()
+    return module_name
+
+
 class ExecutionStage(Enum):
     FAILED_BEFORE_FORGE_COMPILATION_INITIATION = auto()
     FAILED_TVM_RELAY_IRMODULE_GENERATION = auto()
@@ -159,6 +234,16 @@ class Config:
 
 @dataclass_json
 @dataclass
+class ModelInfo:
+    framework: str = ""
+    model_arch: str = ""
+    variant_name: str = ""
+    task: str = ""
+    source: str = ""
+
+
+@dataclass_json
+@dataclass
 class Tags:
     model_name: Optional[Union[List[str], str]] = None
     bringup_status: str = ""
@@ -169,6 +254,7 @@ class Tags:
     op_params: Dict[str, Any] = field(default_factory=lambda: dict())
     inputs: Optional[List[TensorDesc]] = None
     outputs: Optional[List[TensorDesc]] = None
+    model_info: Optional[ModelInfo] = None
 
 
 @dataclass_json
@@ -523,3 +609,43 @@ class ForgePropertyHandler:
         cleaned_property_store = self.clean_store()
         for property_name, property_value in cleaned_property_store.items():
             record_property(property_name, property_value)
+
+    def record_model_properties(
+        self,
+        framework: Framework,
+        model: str,
+        task: Task,
+        source: Source,
+        variant: str = "base",
+        suffix: str | None = None,
+    ) -> str:
+        """
+        Records model properties and generates a module name and stores it.
+
+        Args:
+            framework: The framework used (e.g., pt,tf, etc.)
+            model: The model name (e.g., bert)
+            variant: The model variant (e.g., bert-base-uncased)
+            task: The task type (e.g., qa,mlm, etc.)
+            source: The model source (e.g., hf,torchhub etc.)
+            suffix: Optional suffix to append to the module name
+
+        Returns:
+            The generated module name
+        """
+
+        # Record individual properties
+        self.add("tags.model_info.framework", framework.full)
+        self.add("tags.model_info.model_arch", model)
+        self.add("tags.model_info.variant_name", variant)
+        self.add("tags.model_info.task", task.full)
+        self.add("tags.model_info.source", source.full)
+
+        # Build and return the module name
+        module_name = build_module_name(
+            framework=framework.short, model=model, variant=variant, task=task.short, source=source.short, suffix=suffix
+        )
+
+        # Record model_name
+        self.record_model_name(module_name)
+        return module_name

--- a/forge/test/mlir/llama/tests/test_llama_prefil.py
+++ b/forge/test/mlir/llama/tests/test_llama_prefil.py
@@ -9,7 +9,7 @@ import forge
 from test.mlir.llama.utils.utils import load_model
 from forge.verify.compare import compare_with_golden
 from forge.verify.verify import verify
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 
 class LlamaPrefillModel(torch.nn.Module):
@@ -78,7 +78,7 @@ def test_llama_prefil_on_device_decode_on_cpu(forge_property_recorder, model_pat
         group = "generality"
 
     # Record model details
-    module_name = build_module_name(
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model=model_name,
         variant=variant,
@@ -86,7 +86,6 @@ def test_llama_prefil_on_device_decode_on_cpu(forge_property_recorder, model_pat
         task=Task.TEXT_GENERATION,
     )
     forge_property_recorder.record_group(group)
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Llama model and tokenizer
     model, tokenizer = load_model(model_path, return_dict=True)

--- a/forge/test/models/onnx/text/bert/test_bert.py
+++ b/forge/test/models/onnx/text/bert/test_bert.py
@@ -14,7 +14,7 @@ from transformers import (
 import forge
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.models.models_utils import mean_pooling
 from test.utils import download_model
 
@@ -28,8 +28,8 @@ opset_versions = [9, 17]
 @pytest.mark.parametrize("variant", ["bert-base-uncased"])
 @pytest.mark.parametrize("opset_version", opset_versions, ids=opset_versions)
 def test_bert_masked_lm_onnx(forge_property_recorder, variant, tmp_path, opset_version):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="bert",
         variant=variant,
@@ -37,7 +37,6 @@ def test_bert_masked_lm_onnx(forge_property_recorder, variant, tmp_path, opset_v
         source=Source.HUGGINGFACE,
     )
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Bert tokenizer and model from HuggingFace
     tokenizer = download_model(BertTokenizer.from_pretrained, variant)
@@ -80,8 +79,8 @@ def test_bert_masked_lm_onnx(forge_property_recorder, variant, tmp_path, opset_v
 @pytest.mark.parametrize("variant", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("opset_version", opset_versions, ids=opset_versions)
 def test_bert_question_answering_onnx(forge_property_recorder, variant, tmp_path, opset_version):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="bert",
         variant=variant,
@@ -89,7 +88,6 @@ def test_bert_question_answering_onnx(forge_property_recorder, variant, tmp_path
         source=Source.HUGGINGFACE,
     )
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Bert tokenizer and model from HuggingFace
     tokenizer = download_model(BertTokenizer.from_pretrained, variant)
@@ -143,8 +141,8 @@ def test_bert_question_answering_onnx(forge_property_recorder, variant, tmp_path
 @pytest.mark.parametrize("variant", ["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr"])
 def test_bert_sentence_embedding_generation_onnx(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="bert",
         variant=variant,
@@ -154,7 +152,6 @@ def test_bert_sentence_embedding_generation_onnx(forge_property_recorder, varian
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer
     tokenizer = download_model(BertTokenizer.from_pretrained, variant)

--- a/forge/test/models/onnx/text/bi_lstm_crf/test_bilstm_crf.py
+++ b/forge/test/models/onnx/text/bi_lstm_crf/test_bilstm_crf.py
@@ -10,7 +10,7 @@ import forge
 from forge.verify.verify import verify
 
 from test.models.onnx.text.bi_lstm_crf.utils.model import get_model
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 
 @pytest.mark.nightly
@@ -18,7 +18,7 @@ from test.models.utils import Framework, Source, Task, build_module_name
 def test_birnn_crf_pypi(forge_property_recorder, tmp_path):
 
     # Build Module Name
-    module_name = build_module_name(
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="BiRnnCrf_PyPI",
         task=Task.TOKEN_CLASSIFICATION,
@@ -27,7 +27,6 @@ def test_birnn_crf_pypi(forge_property_recorder, tmp_path):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     test_sentence = ["apple", "corporation", "is", "in", "georgia"]
 

--- a/forge/test/models/onnx/text/gemma/test_gemma_v1.py
+++ b/forge/test/models/onnx/text/gemma/test_gemma_v1.py
@@ -8,7 +8,7 @@ import forge
 from forge.verify.verify import verify
 from test.utils import download_model
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 import onnx
 import torch
 
@@ -31,14 +31,13 @@ import torch
 )
 def test_gemma_v1_onnx(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX, model="gemma", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/onnx/text/gemma/test_gemma_v2.py
+++ b/forge/test/models/onnx/text/gemma/test_gemma_v2.py
@@ -10,7 +10,7 @@ from transformers import (
 )
 import forge
 from forge.verify.verify import verify
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.utils import download_model
 import onnx
 
@@ -31,14 +31,13 @@ import onnx
 )
 def test_gemma_v2_onnx(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX, model="gemma", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/onnx/text/llama/test_llama3.py
+++ b/forge/test/models/onnx/text/llama/test_llama3.py
@@ -18,7 +18,7 @@ from transformers.models.llama.modeling_llama import (
 import forge
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.models.models_utils import build_optimum_cli_command
 from test.utils import download_model
 import subprocess
@@ -151,8 +151,8 @@ LlamaModel._update_causal_mask = _update_causal_mask
 )
 def test_llama3_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX, model="llama3", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
@@ -165,7 +165,6 @@ def test_llama3_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer
     framework_model = download_model(AutoModelForCausalLM.from_pretrained, variant, use_cache=False, return_dict=False)

--- a/forge/test/models/onnx/text/minilm/test_minilm.py
+++ b/forge/test/models/onnx/text/minilm/test_minilm.py
@@ -9,7 +9,7 @@ from transformers import BertModel, BertTokenizer
 import forge
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.utils import download_model
 
 
@@ -22,8 +22,8 @@ opset_versions = [9, 17]
 @pytest.mark.parametrize("variant", ["sentence-transformers/all-MiniLM-L6-v2"])
 @pytest.mark.parametrize("opset_version", opset_versions, ids=opset_versions)
 def test_minilm_sequence_classification_onnx(forge_property_recorder, variant, tmp_path, opset_version):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="minilm",
         variant=variant,
@@ -31,7 +31,6 @@ def test_minilm_sequence_classification_onnx(forge_property_recorder, variant, t
         source=Source.HUGGINGFACE,
     )
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load MiniLM tokenizer and model from HuggingFace
     tokenizer = download_model(BertTokenizer.from_pretrained, variant)

--- a/forge/test/models/onnx/text/ministral/test_ministral.py
+++ b/forge/test/models/onnx/text/ministral/test_ministral.py
@@ -7,7 +7,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 import forge
 from forge.verify.verify import verify
 from test.utils import download_model
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.models.models_utils import build_optimum_cli_command
 import subprocess
 import onnx
@@ -20,8 +20,8 @@ variants = ["ministral/Ministral-3b-instruct"]
 @pytest.mark.parametrize("variant", variants)
 def test_ministral(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="ministral",
         variant=variant,
@@ -31,7 +31,6 @@ def test_ministral(forge_property_recorder, variant, tmp_path):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant, return_tensors="pt")

--- a/forge/test/models/onnx/text/mistral/test_mistral.py
+++ b/forge/test/models/onnx/text/mistral/test_mistral.py
@@ -9,7 +9,7 @@ import forge
 from forge.verify.verify import verify
 
 from test.models.pytorch.text.mistral.utils.utils import get_current_weather
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.utils import download_model
 import torch
 import onnx
@@ -22,8 +22,8 @@ variants = ["mistralai/Mistral-7B-Instruct-v0.3"]
 @pytest.mark.xfail
 def test_mistral_v0_3_onnx(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="mistral",
         variant=variant,
@@ -33,7 +33,6 @@ def test_mistral_v0_3_onnx(forge_property_recorder, variant, tmp_path):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/onnx/text/phi1/test_phi1.py
+++ b/forge/test/models/onnx/text/phi1/test_phi1.py
@@ -14,7 +14,7 @@ from transformers import (
 import forge
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.models.models_utils import build_optimum_cli_command
 from test.utils import download_model
 
@@ -26,8 +26,8 @@ variants = ["microsoft/phi-1"]
 @pytest.mark.parametrize("variant", variants)
 def test_phi_causal_lm(forge_property_recorder, variant, tmp_path):
 
-    # Record model details
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="phi1",
         variant=variant,
@@ -35,7 +35,6 @@ def test_phi_causal_lm(forge_property_recorder, variant, tmp_path):
         task=Task.CAUSAL_LM,
     )
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model from HuggingFace
     framework_model = download_model(PhiForCausalLM.from_pretrained, variant, return_dict=False, use_cache=False)

--- a/forge/test/models/onnx/text/phi1/test_phi1_5.py
+++ b/forge/test/models/onnx/text/phi1/test_phi1_5.py
@@ -8,7 +8,7 @@ from transformers import AutoTokenizer, PhiForCausalLM
 import forge
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.models.models_utils import build_optimum_cli_command
 
 from test.utils import download_model
@@ -22,8 +22,8 @@ variants = ["microsoft/phi-1_5"]
 @pytest.mark.parametrize("variant", variants)
 def test_phi1_5_clm_onnx(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="phi_1_5",
         variant=variant,
@@ -33,7 +33,6 @@ def test_phi1_5_clm_onnx(forge_property_recorder, variant, tmp_path):
 
     # Record model details
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant, return_tensors="pt")

--- a/forge/test/models/onnx/text/phi2/test_phi2.py
+++ b/forge/test/models/onnx/text/phi2/test_phi2.py
@@ -7,7 +7,7 @@ from transformers import AutoTokenizer, PhiForCausalLM
 import forge
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.models.models_utils import build_optimum_cli_command
 
 from test.utils import download_model
@@ -21,8 +21,8 @@ variants = ["microsoft/phi-2"]
 @pytest.mark.parametrize("variant", variants)
 def test_phi2_clm_onnx(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="phi2",
         variant=variant,
@@ -32,7 +32,6 @@ def test_phi2_clm_onnx(forge_property_recorder, variant, tmp_path):
 
     # Record model details
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant, return_tensors="pt", trust_remote_code=True)

--- a/forge/test/models/onnx/text/phi3/test_phi3.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3.py
@@ -12,7 +12,7 @@ import subprocess
 import onnx
 from forge.verify.verify import verify
 from test.utils import download_model
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.models.models_utils import build_optimum_cli_command
 
 variants = ["microsoft/phi-3-mini-4k-instruct", "microsoft/Phi-3-mini-128k-instruct"]
@@ -23,8 +23,8 @@ variants = ["microsoft/phi-3-mini-4k-instruct", "microsoft/Phi-3-mini-128k-instr
 @pytest.mark.skip(reason="Transient test - Out of memory due to other tests in CI pipeline")
 def test_phi3_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX, model="phi3", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
@@ -33,7 +33,6 @@ def test_phi3_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant, return_tensors="pt", trust_remote_code=True)

--- a/forge/test/models/onnx/text/phi3/test_phi3_5.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3_5.py
@@ -7,7 +7,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 import forge
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.models.models_utils import build_optimum_cli_command
 from test.utils import download_model
 import subprocess
@@ -21,14 +21,13 @@ variants = ["microsoft/Phi-3.5-mini-instruct"]
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_5_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX, model="phi3_5", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/onnx/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/onnx/text/qwen/test_qwen_v2.py
@@ -7,7 +7,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 import forge
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.models.models_utils import build_optimum_cli_command
 import subprocess
 import onnx
@@ -34,14 +34,13 @@ import torch
 )
 def test_qwen_clm_onnx(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX, model="qwen_v2", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer
     framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu", return_dict=False)

--- a/forge/test/models/onnx/vision/detr/test_detr.py
+++ b/forge/test/models/onnx/vision/detr/test_detr.py
@@ -12,7 +12,7 @@ import torch
 import onnx
 from forge.verify.verify import verify
 from test.utils import download_model
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from test.models.models_utils import preprocess_input_data
 
 
@@ -20,8 +20,8 @@ from test.models.models_utils import preprocess_input_data
 @pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["facebook/detr-resnet-50"])
 def test_detr_detection_onnx(forge_property_recorder, variant, tmp_path):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="detr",
         variant=variant,
@@ -31,7 +31,6 @@ def test_detr_detection_onnx(forge_property_recorder, variant, tmp_path):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model
     framework_model = download_model(DetrForObjectDetection.from_pretrained, variant, return_dict=False)
@@ -64,8 +63,8 @@ def test_detr_detection_onnx(forge_property_recorder, variant, tmp_path):
 @pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["facebook/detr-resnet-50-panoptic"])
 def test_detr_segmentation_onnx(forge_property_recorder, variant, tmp_path):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="detr",
         variant=variant,
@@ -75,7 +74,6 @@ def test_detr_segmentation_onnx(forge_property_recorder, variant, tmp_path):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model
     framework_model = download_model(DetrForSegmentation.from_pretrained, variant, return_dict=False)

--- a/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
+++ b/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
@@ -14,7 +14,8 @@ from forge.verify.config import VerifyConfig, AutomaticValueChecker
 from utils import load_inputs
 from urllib.request import urlopen
 from PIL import Image
-from test.models.utils import Framework, Source, Task, build_module_name, print_cls_results
+from test.models.utils import print_cls_results
+from forge.forge_property_utils import Framework, Source, Task
 
 params = [
     pytest.param("mobilenetv2_050"),
@@ -28,8 +29,8 @@ params = [
 @pytest.mark.nightly
 def test_mobilenetv2_onnx(variant, forge_property_recorder, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="mobilenetv2",
         variant=variant,
@@ -40,10 +41,8 @@ def test_mobilenetv2_onnx(variant, forge_property_recorder, tmp_path):
     # Record Forge Property
     if variant == "mobilenetv2_050":
         forge_property_recorder.record_group("red")
-        forge_property_recorder.record_priority("p1")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load mobilenetv2 model
     model = timm.create_model(variant, pretrained=True)

--- a/forge/test/models/onnx/vision/resnet/test_resnet.py
+++ b/forge/test/models/onnx/vision/resnet/test_resnet.py
@@ -13,7 +13,7 @@ from forge.verify.verify import verify
 from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 
 variants = [
@@ -33,7 +33,7 @@ def test_resnet_onnx(forge_property_recorder, variant, tmp_path, opset_version):
     random.seed(0)
 
     # Record model details
-    module_name = build_module_name(
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="resnet",
         variant="50",
@@ -41,7 +41,6 @@ def test_resnet_onnx(forge_property_recorder, variant, tmp_path, opset_version):
         task=Task.IMAGE_CLASSIFICATION,
     )
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Export model to ONNX
     torch_model = ResNetForImageClassification.from_pretrained(variant)

--- a/forge/test/models/onnx/vision/segformer/test_segformer.py
+++ b/forge/test/models/onnx/vision/segformer/test_segformer.py
@@ -9,7 +9,7 @@ import pytest
 import onnx
 import torch
 from forge.verify.verify import verify
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from transformers import SegformerForSemanticSegmentation, SegformerForImageClassification
 from test.models.models_utils import get_sample_data
 from test.utils import download_model
@@ -32,8 +32,8 @@ def test_segformer_image_classification_onnx(forge_property_recorder, variant, t
     if variant != "nvidia/mit-b0":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="segformer",
         variant=variant,
@@ -48,7 +48,6 @@ def test_segformer_image_classification_onnx(forge_property_recorder, variant, t
         forge_property_recorder.record_group("generality")
 
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model from HuggingFace
     torch_model = download_model(SegformerForImageClassification.from_pretrained, variant, return_dict=False)
@@ -98,8 +97,8 @@ def test_segformer_semantic_segmentation_onnx(forge_property_recorder, variant, 
     if variant != "nvidia/segformer-b0-finetuned-ade-512-512":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="segformer",
         variant=variant,
@@ -112,7 +111,6 @@ def test_segformer_semantic_segmentation_onnx(forge_property_recorder, variant, 
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model from HuggingFace
     torch_model = download_model(SegformerForSemanticSegmentation.from_pretrained, variant, return_dict=False)

--- a/forge/test/models/onnx/vision/swin/test_swin.py
+++ b/forge/test/models/onnx/vision/swin/test_swin.py
@@ -14,7 +14,7 @@ import forge
 
 from test.models.pytorch.vision.swin.utils.image_utils import load_image
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 
 @pytest.mark.nightly
@@ -22,18 +22,15 @@ from test.models.utils import Framework, Source, Task, build_module_name
 @pytest.mark.xfail
 def test_swin_v2_tiny_image_classification_onnx(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="swin",
         variant=variant,
         task=Task.IMAGE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
     )
-
-    # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model
     framework_model = Swinv2ForImageClassification.from_pretrained(variant)
@@ -66,18 +63,15 @@ def test_swin_v2_tiny_image_classification_onnx(forge_property_recorder, variant
 @pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
 def test_swin_v2_tiny_4_256_hf_pytorch(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="swin",
         variant=variant,
         source=Source.HUGGINGFACE,
         task=Task.IMAGE_CLASSIFICATION,
     )
-
-    # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model
     framework_model = Swinv2Model.from_pretrained(variant)
@@ -110,18 +104,15 @@ def test_swin_v2_tiny_4_256_hf_pytorch(forge_property_recorder, variant, tmp_pat
 @pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
 def test_swin_v2_tiny_masked_onnx(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="swin",
         variant=variant,
         task=Task.MASKED_IMAGE_MODELLING,
         source=Source.HUGGINGFACE,
     )
-
-    # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model
     framework_model = Swinv2ForMaskedImageModeling.from_pretrained(variant)
@@ -157,18 +148,15 @@ variants_with_weights = {"swin_v2_t": "Swin_V2_T_Weights"}
 @pytest.mark.parametrize("variant", ["swin_v2_t"])
 def test_swin_torchvision(forge_property_recorder, variant, tmp_path):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="swin",
         variant=variant,
         task=Task.IMAGE_CLASSIFICATION,
         source=Source.TORCHVISION,
     )
-
-    # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     weight_name = variants_with_weights[variant]

--- a/forge/test/models/onnx/vision/unet/test_unet.py
+++ b/forge/test/models/onnx/vision/unet/test_unet.py
@@ -7,7 +7,7 @@ import numpy as np
 import forge
 import onnx
 from forge.verify.verify import verify
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 from utils import load_inputs
 
 
@@ -16,7 +16,7 @@ from utils import load_inputs
 def test_unet_onnx(forge_property_recorder, tmp_path):
 
     # Build Module Name
-    module_name = build_module_name(
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX, model="unet", variant="base", source=Source.TORCH_HUB, task=Task.IMAGE_SEGMENTATION
     )
 
@@ -24,7 +24,6 @@ def test_unet_onnx(forge_property_recorder, tmp_path):
     forge_property_recorder.record_group("red")
     # TODO: this needs to be added
     # forge_property_recorder.record_priority("p1")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the torch model
     torch_model = torch.hub.load(

--- a/forge/test/models/onnx/vision/vit/test_vit.py
+++ b/forge/test/models/onnx/vision/vit/test_vit.py
@@ -8,7 +8,7 @@ import onnx
 import forge
 from transformers import ViTForImageClassification
 from forge.verify.verify import verify
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 
 variants = [
@@ -21,8 +21,8 @@ variants = [
 @pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_vit_classify_224(forge_property_recorder, variant, tmp_path):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="vit_base",
         variant=variant,
@@ -35,7 +35,6 @@ def test_vit_classify_224(forge_property_recorder, variant, tmp_path):
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the torch model
     torch_model = ViTForImageClassification.from_pretrained(variant)

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v10.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v10.py
@@ -10,14 +10,14 @@ import forge
 from forge.verify.verify import verify
 
 from test.models.onnx.vision.yolo.utils.yolo_utils import load_yolo_model_and_image, YoloWrapper
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 
 @pytest.mark.xfail()
 @pytest.mark.nightly
 def test_yolov10(forge_property_recorder, tmp_path):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="Yolov10",
         variant="default",
@@ -25,7 +25,6 @@ def test_yolov10(forge_property_recorder, tmp_path):
         source=Source.GITHUB,
     )
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load  model and input
     model, image_tensor = load_yolo_model_and_image(

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v8.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v8.py
@@ -10,14 +10,14 @@ import forge
 from forge.verify.verify import verify
 
 from test.models.onnx.vision.yolo.utils.yolo_utils import load_yolo_model_and_image, YoloWrapper
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 
 @pytest.mark.xfail()
 @pytest.mark.nightly
 def test_yolov8(forge_property_recorder, tmp_path):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="Yolov8",
         variant="default",
@@ -25,7 +25,6 @@ def test_yolov8(forge_property_recorder, tmp_path):
         source=Source.GITHUB,
     )
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load  model and input
     model, image_tensor = load_yolo_model_and_image(

--- a/forge/test/models/paddlepaddle/vision/alexnet/test_alexnet.py
+++ b/forge/test/models/paddlepaddle/vision/alexnet/test_alexnet.py
@@ -11,19 +11,18 @@ from forge.verify.verify import verify
 
 from paddle.vision.models import alexnet
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 
 @pytest.mark.nightly
 def test_alexnet(forge_property_recorder):
     # Record model details
-    module_name = build_module_name(
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PADDLE,
         model="alexnet",
         source=Source.PADDLE,
         task=Task.IMAGE_CLASSIFICATION,
     )
-    forge_property_recorder.record_model_name(module_name)
 
     # Load framework model
     framework_model = alexnet(pretrained=True)

--- a/forge/test/models/paddlepaddle/vision/densenet/test_densenet.py
+++ b/forge/test/models/paddlepaddle/vision/densenet/test_densenet.py
@@ -14,7 +14,7 @@ from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 variants = ["densenet121"]
 
@@ -23,14 +23,13 @@ variants = ["densenet121"]
 @pytest.mark.nightly
 def test_densenet_pd(variant, forge_property_recorder):
     # Record model details
-    module_name = build_module_name(
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PADDLE,
         model="densenet",
         variant=variant[8:],
         source=Source.PADDLE,
         task=Task.IMAGE_CLASSIFICATION,
     )
-    forge_property_recorder.record_model_name(module_name)
 
     # Load framework model
     framework_model = eval(variant)(pretrained=True)

--- a/forge/test/models/paddlepaddle/vision/googlenet/test_googlenet.py
+++ b/forge/test/models/paddlepaddle/vision/googlenet/test_googlenet.py
@@ -11,20 +11,19 @@ from forge.verify.verify import verify
 
 from paddle.vision.models import googlenet
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 
 @pytest.mark.xfail()
 @pytest.mark.nightly
 def test_googlenet(forge_property_recorder):
     # Record model details
-    module_name = build_module_name(
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PADDLE,
         model="googlenet",
         source=Source.PADDLE,
         task=Task.IMAGE_CLASSIFICATION,
     )
-    forge_property_recorder.record_model_name(module_name)
 
     # Load framework model
     framework_model = googlenet(pretrained=True)

--- a/forge/test/models/paddlepaddle/vision/mobilenet/test_mobilenet_v1.py
+++ b/forge/test/models/paddlepaddle/vision/mobilenet/test_mobilenet_v1.py
@@ -11,20 +11,19 @@ from forge.verify.verify import verify
 
 from paddle.vision.models import mobilenet_v1
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 
 @pytest.mark.nightly
 def test_mobilenetv1_basic(forge_property_recorder):
     # Record model details
-    module_name = build_module_name(
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PADDLE,
         model="mobilenetv1",
         variant="basic",
         source=Source.PADDLE,
         task=Task.IMAGE_CLASSIFICATION,
     )
-    forge_property_recorder.record_model_name(module_name)
 
     # Load framework model
     framework_model = mobilenet_v1(pretrained=True)

--- a/forge/test/models/paddlepaddle/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/paddlepaddle/vision/mobilenet/test_mobilenet_v2.py
@@ -11,20 +11,19 @@ from forge.verify.verify import verify
 
 from paddle.vision.models import mobilenet_v2
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 
 @pytest.mark.nightly
 def test_mobilenetv2_basic(forge_property_recorder):
     # Record model details
-    module_name = build_module_name(
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PADDLE,
         model="mobilenetv2",
         variant="basic",
         source=Source.PADDLE,
         task=Task.IMAGE_CLASSIFICATION,
     )
-    forge_property_recorder.record_model_name(module_name)
 
     # Load framework model
     framework_model = mobilenet_v2(pretrained=True)

--- a/forge/test/models/paddlepaddle/vision/resnet/test_resnet.py
+++ b/forge/test/models/paddlepaddle/vision/resnet/test_resnet.py
@@ -14,7 +14,7 @@ from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
+from forge.forge_property_utils import Framework, Source, Task
 
 variants = [
     "resnet18",
@@ -29,14 +29,13 @@ variants = [
 @pytest.mark.nightly
 def test_resnet_pd(variant, forge_property_recorder):
     # Record model details
-    module_name = build_module_name(
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PADDLE,
         model="resnet",
         variant=variant[6:],
         source=Source.PADDLE,
         task=Task.IMAGE_CLASSIFICATION,
     )
-    forge_property_recorder.record_model_name(module_name)
 
     # Load framework model
     framework_model = eval(variant)(pretrained=True)

--- a/forge/test/models/pytorch/atomic/hippynn/test_hippynn.py
+++ b/forge/test/models/pytorch/atomic/hippynn/test_hippynn.py
@@ -11,10 +11,10 @@ import torch
 from hippynn.graphs import inputs
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.atomic.hippynn.utils.model import load_model
-from test.models.utils import Framework, Source, Task, build_module_name
 
 os.environ["HIPPYNN_USE_CUSTOM_KERNELS"] = "False"
 
@@ -36,8 +36,8 @@ class HippynWrapper(torch.nn.Module):
 @pytest.mark.nightly
 def test_hippynn(forge_property_recorder):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="Hippyn",
         variant="default",
@@ -47,7 +47,6 @@ def test_hippynn(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model
     framework_model, output_key = load_model()

--- a/forge/test/models/pytorch/audio/stereo/test_stereo.py
+++ b/forge/test/models/pytorch/audio/stereo/test_stereo.py
@@ -6,10 +6,10 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from .utils import load_inputs, load_model
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants = [
     pytest.param(
@@ -27,8 +27,8 @@ def test_stereo(forge_property_recorder, variant):
     if variant != "facebook/musicgen-small":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="stereo",
         variant=variant,
@@ -38,7 +38,6 @@ def test_stereo(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, processor = load_model(variant)
 

--- a/forge/test/models/pytorch/audio/whisper/test_whisper.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper.py
@@ -10,9 +10,9 @@ import torch
 from transformers import AutoProcessor, WhisperConfig, WhisperForConditionalGeneration
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -33,8 +33,8 @@ def test_whisper(forge_property_recorder, variant):
     if variant != "openai/whisper-tiny":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="whisper",
         variant=variant,
@@ -44,7 +44,6 @@ def test_whisper(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model (with tokenizer and feature extractor)
     processor = download_model(AutoProcessor.from_pretrained, variant)

--- a/forge/test/models/pytorch/audio/whisper/test_whisper_large_v3.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper_large_v3.py
@@ -16,9 +16,8 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 class Wrapper(torch.nn.Module):
@@ -42,8 +41,8 @@ class Wrapper(torch.nn.Module):
 @pytest.mark.parametrize("variant", ["openai/whisper-large-v3-turbo"])
 def test_whisper_large_v3_speech_translation(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="whisper",
         variant=variant,
@@ -53,7 +52,6 @@ def test_whisper_large_v3_speech_translation(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     processor = WhisperProcessor.from_pretrained(variant)
     framework_model = WhisperForConditionalGeneration.from_pretrained(variant)

--- a/forge/test/models/pytorch/multimodal/clip/test_clip.py
+++ b/forge/test/models/pytorch/multimodal/clip/test_clip.py
@@ -7,10 +7,10 @@ from PIL import Image
 from transformers import CLIPModel, CLIPProcessor
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.multimodal.clip.utils.clip_model import CLIPTextWrapper
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -25,8 +25,8 @@ from test.utils import download_model
     ],
 )
 def test_clip_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="clip",
         variant=variant,
@@ -37,7 +37,6 @@ def test_clip_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load processor and model from HuggingFace
     model = download_model(CLIPModel.from_pretrained, variant, torchscript=True)

--- a/forge/test/models/pytorch/multimodal/deepseek_coder/test_deepseek_coder.py
+++ b/forge/test/models/pytorch/multimodal/deepseek_coder/test_deepseek_coder.py
@@ -4,6 +4,7 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.multimodal.deepseek_coder.utils.model_utils import (
@@ -12,7 +13,6 @@ from test.models.pytorch.multimodal.deepseek_coder.utils.model_utils import (
     generate_no_cache,
     pad_inputs,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
@@ -20,8 +20,8 @@ from test.models.utils import Framework, Source, Task, build_module_name
 def test_deepseek_inference_no_cache(forge_property_recorder, variant):
     pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 32 GB during compile time)")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="deepseek", variant=variant, task=Task.QA, source=Source.HUGGINGFACE
     )
 

--- a/forge/test/models/pytorch/multimodal/deepseek_math/test_deepseek_math.py
+++ b/forge/test/models/pytorch/multimodal/deepseek_math/test_deepseek_math.py
@@ -4,13 +4,13 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 
 from test.models.pytorch.multimodal.deepseek_math.utils.model_utils import (
     DeepSeekWrapper,
     download_model_and_tokenizer,
     generation,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.parametrize("variant", ["deepseek-math-7b-instruct"])
@@ -29,14 +29,13 @@ def test_deepseek_inference_no_cache_cpu(variant):
 
 @pytest.mark.parametrize("variant", ["deepseek-math-7b-instruct"])
 def test_deepseek_inference(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="deepseek", variant=variant, task=Task.QA, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     model_name = f"deepseek-ai/{variant}"
     model, tokenizer, input_ids = download_model_and_tokenizer(model_name)

--- a/forge/test/models/pytorch/multimodal/llava/test_llava.py
+++ b/forge/test/models/pytorch/multimodal/llava/test_llava.py
@@ -8,10 +8,10 @@ import torch
 from transformers import AutoProcessor, LlavaForConditionalGeneration
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from .utils import load_inputs
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 class Wrapper(torch.nn.Module):
@@ -40,8 +40,8 @@ variants = ["llava-hf/llava-1.5-7b-hf"]
 def test_llava(forge_property_recorder, variant):
     pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 30 GB)")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="llava",
         variant=variant,
@@ -51,7 +51,6 @@ def test_llava(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, processor = load_model(variant)
     image = "https://www.ilankelman.org/stopsigns/australia.jpg"

--- a/forge/test/models/pytorch/multimodal/phi3/test_phi3_5_vision.py
+++ b/forge/test/models/pytorch/multimodal/phi3/test_phi3_5_vision.py
@@ -7,10 +7,10 @@ import torch
 from transformers import AutoModelForCausalLM, AutoProcessor
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.multimodal.phi3.utils.utils import load_input
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -31,8 +31,8 @@ variants = ["microsoft/Phi-3.5-vision-instruct"]
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_5_vision(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="phi3_5_vision",
         variant=variant,
@@ -42,7 +42,6 @@ def test_phi3_5_vision(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and processor
     model = download_model(

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
+from forge.forge_property_utils import Framework
+
 from test.models.pytorch.multimodal.stable_diffusion.utils.model import (
     denoising_loop,
     stable_diffusion_postprocessing,
     stable_diffusion_preprocessing,
 )
-from test.models.utils import Framework, build_module_name
 
 
 @pytest.mark.skip_model_analysis
@@ -15,12 +16,13 @@ from test.models.utils import Framework, build_module_name
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["CompVis/stable-diffusion-v1-4"])
 def test_stable_diffusion_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(framework=Framework.PYTORCH, model="stable_diffusion", variant=variant)
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
+        framework=Framework.PYTORCH, model="stable_diffusion", variant=variant
+    )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     batch_size = 1
 

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
@@ -6,12 +6,12 @@ import pytest
 import torch
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 
 from test.models.pytorch.multimodal.stable_diffusion.utils.model import (
     load_pipe,
     stable_diffusion_preprocessing_v35,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 class StableDiffusionWrapper(torch.nn.Module):
@@ -55,8 +55,8 @@ class StableDiffusionWrapper(torch.nn.Module):
     ],
 )
 def test_stable_diffusion_v35(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="stable_diffusion",
         variant=variant,
@@ -66,7 +66,6 @@ def test_stable_diffusion_v35(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load pipeline
     pipe = load_pipe(variant, variant_type="v35")

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_xl.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_xl.py
@@ -6,13 +6,13 @@ import pytest
 import torch
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.multimodal.stable_diffusion.utils.model import (
     load_pipe,
     stable_diffusion_preprocessing_xl,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 class StableDiffusionXLWrapper(torch.nn.Module):
@@ -46,8 +46,8 @@ class StableDiffusionXLWrapper(torch.nn.Module):
     ],
 )
 def test_stable_diffusion_generation(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="stable_diffusion",
         variant=variant,
@@ -57,7 +57,6 @@ def test_stable_diffusion_generation(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the pipeline
     pipe = load_pipe(variant, variant_type="xl")

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/utils/model.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/utils/model.py
@@ -13,8 +13,7 @@ from diffusers.pipelines.stable_diffusion.pipeline_stable_diffusion import (
 )
 
 import forge
-
-from test.models.utils import Framework, build_module_name
+from forge.forge_property_utils import Framework
 
 
 def load_pipe(variant, variant_type):
@@ -406,7 +405,9 @@ def denoising_loop(
             # noise_pred_0 = pipeline(latent_model_input.detach()[0:1],timestep_.detach()[0:1],prompt_embeds.detach()[0:1],)
 
             inputs = [latent_model_input.detach()[0:1], timestep_.detach()[0:1], prompt_embeds.detach()[0:1]]
-            module_name = build_module_name(framework=Framework.PYTORCH, model="stable_diffusion", suffix=f"1_{i}")
+            module_name = forge_property_recorder.record_model_properties(
+                framework=Framework.PYTORCH, model="stable_diffusion", suffix=f"1_{i}"
+            )
             compiled_model = forge.compile(
                 pipeline, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
             )
@@ -415,7 +416,9 @@ def denoising_loop(
             # sanity
             # noise_pred_1 = pipeline(latent_model_input.detach()[1:2],timestep_.detach()[1:2],prompt_embeds.detach()[1:2],)
             inputs = [latent_model_input.detach()[1:2], timestep_.detach()[1:2], prompt_embeds.detach()[1:2]]
-            module_name = build_module_name(framework=Framework.PYTORCH, model="stable_diffusion", suffix=f"2_{i}")
+            module_name = forge_property_recorder.record_model_properties(
+                framework=Framework.PYTORCH, model="stable_diffusion", suffix=f"2_{i}"
+            )
             compiled_model = forge.compile(
                 pipeline, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
             )

--- a/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
+++ b/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
@@ -13,13 +13,13 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.multimodal.vilt.utils.model import (
     ViLtEmbeddingWrapper,
     ViltModelWrapper,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 url = "http://images.cocodataset.org/val2017/000000039769.jpg"
@@ -56,17 +56,15 @@ variants = ["dandelin/vilt-b32-finetuned-vqa"]
 
 
 @pytest.mark.nightly
-@pytest.mark.push
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_vilt_question_answering_hf_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="vilt", variant=variant, task=Task.QA, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, model = generate_model_vilt_question_answering_hf_pytorch(variant)
 
@@ -119,14 +117,13 @@ variants = ["dandelin/vilt-b32-mlm"]
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_vilt_maskedlm_hf_pytorch(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="vilt", variant=variant, task=Task.MASKED_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_vilt_maskedlm_hf_pytorch(variant)
 

--- a/forge/test/models/pytorch/text/albert/test_albert.py
+++ b/forge/test/models/pytorch/text/albert/test_albert.py
@@ -13,10 +13,10 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.config import AutomaticValueChecker, VerifyConfig
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 sizes = ["base", "large", "xlarge", "xxlarge"]
@@ -39,8 +39,8 @@ params = [
 @pytest.mark.parametrize("size,variant", params)
 def test_albert_masked_lm_pytorch(forge_property_recorder, size, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="albert",
         variant=f"{size}_{variant}",
@@ -50,7 +50,6 @@ def test_albert_masked_lm_pytorch(forge_property_recorder, size, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     model_ckpt = f"albert-{size}-{variant}"
 
@@ -118,8 +117,8 @@ params = [
 @pytest.mark.parametrize("size,variant", params)
 def test_albert_token_classification_pytorch(forge_property_recorder, size, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="albert",
         variant=f"{size}_{variant}",
@@ -129,7 +128,6 @@ def test_albert_token_classification_pytorch(forge_property_recorder, size, vari
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # NOTE: These model variants are pre-trined only. They need to be fine-tuned
     # on a downstream task. Code is for demonstration purposes only.
@@ -192,8 +190,8 @@ def test_albert_token_classification_pytorch(forge_property_recorder, size, vari
 @pytest.mark.parametrize("variant", ["twmkn9/albert-base-v2-squad2"])
 def test_albert_question_answering_pytorch(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="albert",
         variant=variant,
@@ -203,7 +201,6 @@ def test_albert_question_answering_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Albert tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
@@ -231,8 +228,8 @@ def test_albert_question_answering_pytorch(forge_property_recorder, variant):
 @pytest.mark.parametrize("variant", ["textattack/albert-base-v2-imdb"])
 def test_albert_sequence_classification_pytorch(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="albert",
         variant=variant,
@@ -242,7 +239,6 @@ def test_albert_sequence_classification_pytorch(forge_property_recorder, variant
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Albert tokenizer and model from HuggingFace
     tokenizer = download_model(AlbertTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/bart/test_bart.py
+++ b/forge/test/models/pytorch/text/bart/test_bart.py
@@ -8,9 +8,9 @@ from transformers import BartForSequenceClassification, BartTokenizer
 from transformers.models.bart.modeling_bart import shift_tokens_right
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -35,8 +35,8 @@ class BartWrapper(torch.nn.Module):
     ],
 )
 def test_pt_bart_classifier(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="bart",
         variant=variant,
@@ -46,7 +46,6 @@ def test_pt_bart_classifier(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     model = download_model(BartForSequenceClassification.from_pretrained, variant, torchscript=True)
     tokenizer = download_model(BartTokenizer.from_pretrained, variant, pad_to_max_length=True)

--- a/forge/test/models/pytorch/text/bert/test_bert.py
+++ b/forge/test/models/pytorch/text/bert/test_bert.py
@@ -12,10 +12,10 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.text.bert.utils.utils import mean_pooling
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -23,14 +23,13 @@ from test.utils import download_model
 @pytest.mark.parametrize("variant", ["bert-base-uncased"])
 @pytest.mark.push
 def test_bert_masked_lm_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="bert", variant=variant, task=Task.MASKED_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Bert tokenizer and model from HuggingFace
     tokenizer = BertTokenizer.from_pretrained(variant)
@@ -115,14 +114,13 @@ def test_bert_question_answering_pytorch(forge_property_recorder, variant):
     if variant == "bert-large-cased-whole-word-masking-finetuned-squad":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="bert", variant=variant, task=Task.QA, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, tokenizer = generate_model_bert_qa_hf_pytorch(variant)
     framework_model.eval()
@@ -181,8 +179,8 @@ def generate_model_bert_seqcls_hf_pytorch(variant):
 def test_bert_sequence_classification_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="bert",
         variant=variant,
@@ -192,7 +190,6 @@ def test_bert_sequence_classification_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_bert_seqcls_hf_pytorch(variant)
 
@@ -236,8 +233,8 @@ def generate_model_bert_tkcls_hf_pytorch(variant):
 def test_bert_token_classification_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="bert",
         variant=variant,
@@ -247,7 +244,6 @@ def test_bert_token_classification_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_bert_tkcls_hf_pytorch(variant)
 
@@ -270,8 +266,8 @@ def test_bert_token_classification_pytorch(forge_property_recorder, variant):
 @pytest.mark.parametrize("variant", ["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr"])
 def test_bert_sentence_embedding_generation_pytorch(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="bert",
         variant=variant,
@@ -281,7 +277,6 @@ def test_bert_sentence_embedding_generation_pytorch(forge_property_recorder, var
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer
     tokenizer = download_model(BertTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/bi_lstm_crf/test_bi_lstm_crf.py
+++ b/forge/test/models/pytorch/text/bi_lstm_crf/test_bi_lstm_crf.py
@@ -5,18 +5,18 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.text.bi_lstm_crf.utils.model import get_model
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
 @pytest.mark.xfail
 def test_birnn_crf_pypi(forge_property_recorder):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="BiRnnCrf_PyPI",
         task=Task.TOKEN_CLASSIFICATION,
@@ -25,7 +25,6 @@ def test_birnn_crf_pypi(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     test_sentence = ["apple", "corporation", "is", "in", "georgia"]
 

--- a/forge/test/models/pytorch/text/bloom/test_bloom.py
+++ b/forge/test/models/pytorch/text/bloom/test_bloom.py
@@ -6,9 +6,9 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -35,8 +35,8 @@ class Wrapper(torch.nn.Module):
 )
 def test_bloom(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="bloom",
         variant=variant,
@@ -46,7 +46,6 @@ def test_bloom(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant, padding_side="left")

--- a/forge/test/models/pytorch/text/codegen/test_codegen.py
+++ b/forge/test/models/pytorch/text/codegen/test_codegen.py
@@ -8,9 +8,9 @@ import torch
 from transformers import AutoTokenizer, CodeGenForCausalLM
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -25,14 +25,13 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_codegen(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="codegen", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model (with tokenizer)
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/distilbert/test_distilbert.py
+++ b/forge/test/models/pytorch/text/distilbert/test_distilbert.py
@@ -11,9 +11,9 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -32,14 +32,13 @@ def test_distilbert_masked_lm_pytorch(forge_property_recorder, variant):
     if variant != "distilbert-base-uncased":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="distilbert", variant=variant, task=Task.MASKED_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load DistilBert tokenizer and model from HuggingFace
     # Variants: distilbert-base-uncased, distilbert-base-cased,
@@ -77,14 +76,13 @@ def test_distilbert_masked_lm_pytorch(forge_property_recorder, variant):
 def test_distilbert_question_answering_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="distilbert", variant=variant, task=Task.QA, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Bert tokenizer and model from HuggingFace
     tokenizer = download_model(DistilBertTokenizer.from_pretrained, variant)
@@ -128,8 +126,8 @@ def test_distilbert_question_answering_pytorch(forge_property_recorder, variant)
 def test_distilbert_sequence_classification_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="distilbert",
         variant=variant,
@@ -139,7 +137,6 @@ def test_distilbert_sequence_classification_pytorch(forge_property_recorder, var
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load DistilBert tokenizer and model from HuggingFace
     tokenizer = download_model(DistilBertTokenizer.from_pretrained, variant)
@@ -173,8 +170,8 @@ def test_distilbert_sequence_classification_pytorch(forge_property_recorder, var
 def test_distilbert_token_classification_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="distilbert",
         variant=variant,
@@ -184,7 +181,6 @@ def test_distilbert_token_classification_pytorch(forge_property_recorder, varian
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load DistilBERT tokenizer and model from HuggingFace
     tokenizer = download_model(DistilBertTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/dpr/test_dpr.py
+++ b/forge/test/models/pytorch/text/dpr/test_dpr.py
@@ -13,10 +13,10 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.config import VerifyConfig
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 params = [
@@ -31,8 +31,8 @@ def test_dpr_context_encoder_pytorch(forge_property_recorder, variant):
     if variant != "facebook/dpr-ctx_encoder-single-nq-base":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="dpr",
         variant=variant,
@@ -43,7 +43,6 @@ def test_dpr_context_encoder_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Bert tokenizer and model from HuggingFace
     # Variants: facebook/dpr-ctx_encoder-single-nq-base, facebook/dpr-ctx_encoder-multiset-base
@@ -93,8 +92,8 @@ variants = ["facebook/dpr-question_encoder-single-nq-base", "facebook/dpr-questi
 def test_dpr_question_encoder_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="dpr",
         variant=variant,
@@ -105,7 +104,6 @@ def test_dpr_question_encoder_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Bert tokenizer and model from HuggingFace
     # Variants: facebook/dpr-question_encoder-single-nq-base, facebook/dpr-question_encoder-multiset-base
@@ -161,8 +159,8 @@ variants = ["facebook/dpr-reader-single-nq-base", "facebook/dpr-reader-multiset-
 def test_dpr_reader_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="dpr",
         variant=variant,
@@ -173,7 +171,6 @@ def test_dpr_reader_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Bert tokenizer and model from HuggingFace
     # Variants: facebook/dpr-reader-single-nq-base, facebook/dpr-reader-multiset-base

--- a/forge/test/models/pytorch/text/falcon/test_falcon.py
+++ b/forge/test/models/pytorch/text/falcon/test_falcon.py
@@ -6,9 +6,8 @@ import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer, FalconForCausalLM
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
@@ -16,14 +15,13 @@ from test.models.utils import Framework, Source, Task, build_module_name
 def test_falcon(forge_property_recorder, variant):
     pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 32 GB)")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="falcon", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     tokenizer = AutoTokenizer.from_pretrained(variant)
     model = FalconForCausalLM.from_pretrained(variant)
@@ -69,14 +67,13 @@ def test_falcon_3(forge_property_recorder, variant):
     if variant == "tiiuae/Falcon3-3B-Base":
         pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 25 GB)")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="falcon3", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     tokenizer = AutoTokenizer.from_pretrained(variant)
     model = AutoModelForCausalLM.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/fuyu/test_fuyu_8b.py
+++ b/forge/test/models/pytorch/text/fuyu/test_fuyu_8b.py
@@ -15,13 +15,13 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.text.fuyu.utils.model import (
     FuyuModelWrapper,
     generate_fuyu_embedding,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
@@ -35,14 +35,13 @@ from test.models.utils import Framework, Source, Task, build_module_name
     ],
 )
 def test_fuyu8b(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="fuyu", variant=variant, task=Task.QA, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     config = FuyuConfig.from_pretrained(variant)
     config_dict = config.to_dict()

--- a/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
@@ -12,13 +12,13 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.text.gemma.utils.model_utils import (
     generate_no_cache,
     pad_inputs,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -31,8 +31,8 @@ variants = [
 def test_gemma_2b(forge_property_recorder, variant):
     pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 48 GB)")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="gemma",
         variant=variant,
@@ -42,7 +42,6 @@ def test_gemma_2b(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Random see for reproducibility
     torch.manual_seed(42)
@@ -102,14 +101,13 @@ def test_gemma_2b(forge_property_recorder, variant):
 )
 def test_gemma_pytorch_v2(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="gemma", variant=variant, task=Task.QA, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer from HuggingFace
     tokenizer = AutoTokenizer.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/gemma/test_gemma_v1.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_v1.py
@@ -5,13 +5,13 @@ import pytest
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.text.gemma.utils.model_utils import (
     generate_no_cache,
     pad_inputs,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
@@ -34,14 +34,13 @@ from test.models.utils import Framework, Source, Task, build_module_name
 )
 def test_gemma_pytorch_v1(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="gemma", variant=variant, task=Task.QA, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer from HuggingFace
     tokenizer = AutoTokenizer.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/gliner/test_gliner.py
+++ b/forge/test/models/pytorch/text/gliner/test_gliner.py
@@ -6,6 +6,7 @@ import pytest
 from gliner import GLiNER
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.text.gliner.utils.model_utils import (
@@ -13,7 +14,6 @@ from test.models.pytorch.text.gliner.utils.model_utils import (
     post_processing,
     pre_processing,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants = ["urchade/gliner_multi-v2.1"]
 
@@ -23,8 +23,8 @@ variants = ["urchade/gliner_multi-v2.1"]
 @pytest.mark.parametrize("variant", variants)
 def test_gliner(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="Gliner",
         variant=variant,
@@ -34,7 +34,6 @@ def test_gliner(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model
     model = GLiNER.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/gpt2/test_gpt2.py
+++ b/forge/test/models/pytorch/text/gpt2/test_gpt2.py
@@ -11,9 +11,9 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -38,14 +38,13 @@ class Wrapper(torch.nn.Module):
     ],
 )
 def test_gpt2_text_gen(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="gpt2", variant=variant, task=Task.TEXT_GENERATION, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model from HuggingFace
     config = GPT2Config.from_pretrained(variant)
@@ -84,8 +83,8 @@ def test_gpt2_text_gen(forge_property_recorder, variant):
 )
 def test_gpt2_sequence_classification(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="gpt2",
         variant=variant,
@@ -95,7 +94,6 @@ def test_gpt2_sequence_classification(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant, padding_side="left")

--- a/forge/test/models/pytorch/text/gptneo/test_gptneo.py
+++ b/forge/test/models/pytorch/text/gptneo/test_gptneo.py
@@ -11,9 +11,9 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -32,14 +32,13 @@ def test_gptneo_causal_lm(forge_property_recorder, variant):
     if variant != "EleutherAI/gpt-neo-125M":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="gptneo", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Set random seed for repeatability
     torch.manual_seed(42)
@@ -97,8 +96,8 @@ variants = [
 def test_gptneo_sequence_classification(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="gptneo",
         variant=variant,
@@ -108,7 +107,6 @@ def test_gptneo_sequence_classification(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model from HuggingFace
     # Variants: # EleutherAI/gpt-neo-125M, EleutherAI/gpt-neo-1.3B,

--- a/forge/test/models/pytorch/text/llama/test_llama3.py
+++ b/forge/test/models/pytorch/text/llama/test_llama3.py
@@ -18,9 +18,9 @@ from transformers.models.llama.modeling_llama import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -135,8 +135,8 @@ LlamaModel._update_causal_mask = _update_causal_mask
 def test_llama3_causal_lm(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="llama3", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
@@ -145,7 +145,6 @@ def test_llama3_causal_lm(forge_property_recorder, variant):
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model (with tokenizer)
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
@@ -196,8 +195,8 @@ def test_llama3_causal_lm(forge_property_recorder, variant):
 def test_llama3_sequence_classification(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="llama3",
         variant=variant,
@@ -207,7 +206,6 @@ def test_llama3_sequence_classification(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model (with tokenizer)
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/mamba/test_mamba.py
+++ b/forge/test/models/pytorch/text/mamba/test_mamba.py
@@ -8,9 +8,9 @@ import torch
 from transformers import AutoTokenizer, MambaForCausalLM
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -42,14 +42,13 @@ def test_mamba(forge_property_recorder, variant):
     if variant != "state-spaces/mamba-790m-hf":
         pytest.skip("Skipping this variant; only testing the base model (mamba-790m-hf) for now.")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="mamba", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/mistral/test_mistral.py
+++ b/forge/test/models/pytorch/text/mistral/test_mistral.py
@@ -6,10 +6,10 @@ import pytest
 from transformers import AutoModelForCausalLM, AutoTokenizer, MistralConfig
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.text.mistral.utils.utils import get_current_weather
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = ["mistralai/Mistral-7B-v0.1"]
@@ -20,14 +20,13 @@ variants = ["mistralai/Mistral-7B-v0.1"]
 def test_mistral(forge_property_recorder, variant):
     pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 30 GB)")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="mistral", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     configuration = MistralConfig()
     configuration.sliding_window = None
@@ -65,8 +64,8 @@ variants = ["mistralai/Mistral-7B-Instruct-v0.3"]
 @pytest.mark.parametrize("variant", variants)
 def test_mistral_v0_3(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mistral",
         variant=variant,
@@ -76,7 +75,6 @@ def test_mistral_v0_3(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/nanogpt/test_nanogpt.py
+++ b/forge/test/models/pytorch/text/nanogpt/test_nanogpt.py
@@ -7,9 +7,8 @@ import torch
 from transformers import AutoModel, AutoTokenizer
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 # Wrapper to get around attention mask
@@ -34,8 +33,8 @@ class Wrapper(torch.nn.Module):
 )
 def test_nanogpt_text_generation(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="nanogpt",
         variant=variant,
@@ -45,7 +44,6 @@ def test_nanogpt_text_generation(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model
     tokenizer = AutoTokenizer.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/opt/test_opt.py
+++ b/forge/test/models/pytorch/text/opt/test_opt.py
@@ -11,9 +11,9 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -32,14 +32,13 @@ def test_opt_causal_lm(forge_property_recorder, variant):
     if variant != "facebook/opt-125m":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="opt", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model from HuggingFace
     # Variants: "facebook/opt-125m", "facebook/opt-350m", "facebook/opt-1.3b"
@@ -84,14 +83,13 @@ def test_opt_causal_lm(forge_property_recorder, variant):
 def test_opt_qa(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="opt", variant=variant, task=Task.QA, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model from HuggingFace
     # Variants: "facebook/opt-125m", "facebook/opt-350m", "facebook/opt-1.3b"
@@ -132,8 +130,8 @@ def test_opt_qa(forge_property_recorder, variant):
 def test_opt_sequence_classification(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="opt",
         variant=variant,
@@ -143,7 +141,6 @@ def test_opt_sequence_classification(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model from HuggingFace
     # Variants: "facebook/opt-125m", "facebook/opt-350m", "facebook/opt-1.3b"

--- a/forge/test/models/pytorch/text/perceiverio/test_perceiverio.py
+++ b/forge/test/models/pytorch/text/perceiverio/test_perceiverio.py
@@ -7,9 +7,9 @@ import pytest
 from transformers import PerceiverForMaskedLM, PerceiverTokenizer
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -18,8 +18,8 @@ from test.utils import download_model
 @pytest.mark.parametrize("variant", ["deepmind/language-perceiver"])
 def test_perceiverio_masked_lm_pytorch(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="perceiverio",
         variant=variant,
@@ -29,7 +29,6 @@ def test_perceiverio_masked_lm_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer
     tokenizer = download_model(PerceiverTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/phi2/test_phi2.py
+++ b/forge/test/models/pytorch/text/phi2/test_phi2.py
@@ -13,9 +13,8 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 def _prepare_4d_causal_attention_mask_with_cache_position(
@@ -79,8 +78,8 @@ variants = [
 @pytest.mark.skip(reason="Skipping due to the current CI/CD pipeline limitations")
 def test_phi2_clm(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="phi2", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
@@ -89,7 +88,6 @@ def test_phi2_clm(forge_property_recorder, variant):
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load PhiConfig from pretrained variant, disable return_dict and caching.
     config = PhiConfig.from_pretrained(variant)
@@ -135,8 +133,8 @@ def test_phi2_clm(forge_property_recorder, variant):
 def test_phi2_token_classification(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="phi2",
         variant=variant,
@@ -146,7 +144,6 @@ def test_phi2_token_classification(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # PhiConfig from pretrained variant, disable return_dict and caching.
     config = PhiConfig.from_pretrained(variant)
@@ -182,8 +179,8 @@ def test_phi2_token_classification(forge_property_recorder, variant):
 def test_phi2_sequence_classification(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="phi2",
         variant=variant,
@@ -193,7 +190,6 @@ def test_phi2_sequence_classification(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # PhiConfig from pretrained variant, disable return_dict and caching.
     config = PhiConfig.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/phi3/test_phi3.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3.py
@@ -11,9 +11,8 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants = ["microsoft/phi-3-mini-4k-instruct"]
 
@@ -23,8 +22,8 @@ variants = ["microsoft/phi-3-mini-4k-instruct"]
 def test_phi3_causal_lm(forge_property_recorder, variant):
     pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 64 GB)")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="phi3", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
@@ -33,7 +32,6 @@ def test_phi3_causal_lm(forge_property_recorder, variant):
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Phi3Config from pretrained variant, disable return_dict and caching.
     config = Phi3Config.from_pretrained(variant)
@@ -80,8 +78,8 @@ def test_phi3_causal_lm(forge_property_recorder, variant):
 def test_phi3_token_classification(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="phi3",
         variant=variant,
@@ -91,7 +89,6 @@ def test_phi3_token_classification(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Phi3Config from pretrained variant, disable return_dict and caching.
     config = Phi3Config.from_pretrained(variant)
@@ -126,8 +123,8 @@ def test_phi3_token_classification(forge_property_recorder, variant):
 def test_phi3_sequence_classification(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="phi3",
         variant=variant,
@@ -137,7 +134,6 @@ def test_phi3_sequence_classification(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Phi3Config from pretrained variant, disable return_dict and caching.
     config = Phi3Config.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/phi3/test_phi3_5.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3_5.py
@@ -5,9 +5,9 @@ import pytest
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = ["microsoft/Phi-3.5-mini-instruct"]
@@ -18,14 +18,13 @@ variants = ["microsoft/Phi-3.5-mini-instruct"]
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_5_causal_lm(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="phi3_5", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/qwen/test_qwen.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen.py
@@ -6,9 +6,8 @@ import torch
 from transformers import Qwen2Config, Qwen2ForCausalLM, Qwen2Tokenizer
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
@@ -22,14 +21,13 @@ from test.models.utils import Framework, Source, Task, build_module_name
     ],
 )
 def test_qwen1_5_causal_lm(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="qwen1.5", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Setup model configuration
     config = Qwen2Config.from_pretrained(variant)
@@ -70,14 +68,13 @@ def test_qwen1_5_causal_lm(forge_property_recorder, variant):
 @pytest.mark.parametrize("variant", ["Qwen/Qwen1.5-0.5B-Chat"])
 def test_qwen1_5_chat(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="qwen1.5", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Setup model configuration
     config = Qwen2Config.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
@@ -5,9 +5,8 @@ import pytest
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 # Variants for testing
 variants = [
@@ -30,14 +29,13 @@ def test_qwen_clm(forge_property_recorder, variant):
     if variant != "Qwen/Qwen2.5-Coder-0.5B":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="qwen_coder", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer
     framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu")

--- a/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
@@ -9,9 +9,8 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 # Variants for testing
 variants = [
@@ -35,8 +34,8 @@ def test_qwen_clm(forge_property_recorder, variant):
     if variant != "Qwen/Qwen2.5-0.5B":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="qwen_v2", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
@@ -45,7 +44,6 @@ def test_qwen_clm(forge_property_recorder, variant):
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer
     framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu")
@@ -77,8 +75,8 @@ def test_qwen_clm(forge_property_recorder, variant):
 def test_qwen2_token_classification(forge_property_recorder, variant):
     pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 32 GB during compile time)")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="qwen_v2",
         variant=variant,
@@ -88,7 +86,6 @@ def test_qwen2_token_classification(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and tokenizer
     framework_model = Qwen2ForTokenClassification.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/roberta/test_roberta.py
+++ b/forge/test/models/pytorch/text/roberta/test_roberta.py
@@ -10,9 +10,9 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -24,14 +24,13 @@ from test.utils import download_model
     ],
 )
 def test_roberta_masked_lm(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="roberta", variant=variant, task=Task.MASKED_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Albert tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
@@ -65,8 +64,8 @@ def test_roberta_masked_lm(forge_property_recorder, variant):
 @pytest.mark.parametrize("variant", ["cardiffnlp/twitter-roberta-base-sentiment"])
 def test_roberta_sentiment_pytorch(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="roberta",
         variant=variant,
@@ -76,7 +75,6 @@ def test_roberta_sentiment_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Bart tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/speecht5_tts/test_speecht5_tts.py
+++ b/forge/test/models/pytorch/text/speecht5_tts/test_speecht5_tts.py
@@ -6,9 +6,9 @@ import torch
 from transformers import SpeechT5ForTextToSpeech, SpeechT5Processor
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -33,8 +33,8 @@ class Wrapper(torch.nn.Module):
 )
 def test_speecht5_tts(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="speecht5_tts",
         variant=variant,
@@ -44,7 +44,6 @@ def test_speecht5_tts(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and Processer
     processor = download_model(SpeechT5Processor.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/squeezebert/test_squeezebert.py
+++ b/forge/test/models/pytorch/text/squeezebert/test_squeezebert.py
@@ -5,17 +5,17 @@ import pytest
 from transformers import AutoModelForSequenceClassification, AutoTokenizer
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["squeezebert/squeezebert-mnli"])
 def test_squeezebert_sequence_classification_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="squeezebert",
         variant=variant,
@@ -25,7 +25,6 @@ def test_squeezebert_sequence_classification_pytorch(forge_property_recorder, va
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Bart tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/t5/test_t5.py
+++ b/forge/test/models/pytorch/text/t5/test_t5.py
@@ -6,9 +6,9 @@ import torch
 from transformers import AutoTokenizer, T5Config, T5ForConditionalGeneration
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -45,14 +45,13 @@ def test_t5_generation(forge_property_recorder, variant):
     if variant not in {"t5-small", "google/flan-t5-small", "t5-base", "t5-large"}:
         pytest.skip(f"Skipping {variant} due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="t5", variant=variant, task=Task.TEXT_GENERATION, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tokenizer and model from HuggingFace
     # Variants: t5-small, t5-base, t5-large

--- a/forge/test/models/pytorch/text/xglm/test_xglm.py
+++ b/forge/test/models/pytorch/text/xglm/test_xglm.py
@@ -5,9 +5,9 @@ import pytest
 from transformers import AutoTokenizer, XGLMConfig, XGLMForCausalLM
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -21,14 +21,13 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_xglm_causal_lm(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="xglm", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     config = XGLMConfig.from_pretrained(variant)
     config_dict = config.to_dict()

--- a/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
+++ b/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
@@ -4,6 +4,7 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.timeseries.nbeats.utils.dataset import (
@@ -14,21 +15,19 @@ from test.models.pytorch.timeseries.nbeats.utils.model import (
     NBeatsWithSeasonalityBasis,
     NBeatsWithTrendBasis,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
 @pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["seasionality_basis"])
 def test_nbeats_with_seasonality_basis(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="nbeats", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     x, x_mask = get_electricity_dataset_input()
 
@@ -58,14 +57,13 @@ def test_nbeats_with_seasonality_basis(forge_property_recorder, variant):
 @pytest.mark.parametrize("variant", ["generic_basis"])
 def test_nbeats_with_generic_basis(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="nbeats", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     x, x_mask = get_electricity_dataset_input()
 
@@ -88,14 +86,13 @@ def test_nbeats_with_generic_basis(forge_property_recorder, variant):
 @pytest.mark.parametrize("variant", ["trend_basis"])
 def test_nbeats_with_trend_basis(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="nbeats", variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     x, x_mask = get_electricity_dataset_input()
 

--- a/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
+++ b/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
@@ -10,16 +10,16 @@ from pytorchcv.model_provider import get_model as ptcv_get_model
 from torchvision import transforms
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
 @pytest.mark.nightly
 def test_alexnet_torchhub(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="alexnet",
         variant="alexnet",
@@ -29,7 +29,6 @@ def test_alexnet_torchhub(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "alexnet", pretrained=True)
@@ -69,14 +68,13 @@ def test_alexnet_torchhub(forge_property_recorder):
 def test_alexnet_osmr(forge_property_recorder):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="alexnet", source=Source.OSMR, task=Task.IMAGE_CLASSIFICATION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model
     framework_model = download_model(ptcv_get_model, "alexnet", pretrained=True)

--- a/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
+++ b/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
@@ -10,24 +10,23 @@ import torchvision.transforms as transforms
 from datasets import load_dataset
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.autoencoder.utils.conv_autoencoder import ConvAE
 from test.models.pytorch.vision.autoencoder.utils.linear_autoencoder import LinearAE
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
 @pytest.mark.xfail
 def test_conv_ae_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="autoencoder", variant="conv", task=Task.IMAGE_ENCODING, source=Source.GITHUB
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Instantiate model
     # NOTE: The model has not been pre-trained or fine-tuned.
@@ -65,8 +64,8 @@ def test_conv_ae_pytorch(forge_property_recorder):
 @pytest.mark.push
 @pytest.mark.nightly
 def test_linear_ae_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="autoencoder",
         variant="linear",
@@ -76,7 +75,6 @@ def test_linear_ae_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Instantiate model
     # NOTE: The model has not been pre-trained or fine-tuned.

--- a/forge/test/models/pytorch/vision/beit/test_beit.py
+++ b/forge/test/models/pytorch/vision/beit/test_beit.py
@@ -4,10 +4,10 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.beit.utils.utils import load_input, load_model
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants = [
     pytest.param(
@@ -25,8 +25,8 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_beit_image_classification(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="beit",
         variant=variant,
@@ -36,7 +36,6 @@ def test_beit_image_classification(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     framework_model = load_model(variant)

--- a/forge/test/models/pytorch/vision/blazebase/test_blazepose.py
+++ b/forge/test/models/pytorch/vision/blazebase/test_blazepose.py
@@ -8,9 +8,8 @@ import pytest
 import torch
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 # sys.path = list(set(sys.path + ["third_party/confidential_customer_models/model_2/pytorch/"]))
 # from mediapipepytorch.blazebase import denormalize_detections, resize_pad
@@ -25,8 +24,8 @@ from test.models.utils import Framework, Source, Task, build_module_name
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_blazepose_detector_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="blazepose",
         variant="detector",
@@ -36,7 +35,6 @@ def test_blazepose_detector_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load BlazePose Detector
     framework_model = BlazePose()
@@ -66,8 +64,8 @@ def test_blazepose_detector_pytorch(forge_property_recorder):
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_blazepose_regressor_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="blazepose",
         variant="regressor",
@@ -77,7 +75,6 @@ def test_blazepose_regressor_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load BlazePose Landmark Regressor
     framework_model = BlazePoseLandmark()
@@ -98,14 +95,13 @@ def test_blazepose_regressor_pytorch(forge_property_recorder):
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_blaze_palm_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="blazepose", variant="palm", task=Task.OBJECT_DETECTION, source=Source.GITHUB
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load BlazePalm Detector
     framework_model = BlazePalm()
@@ -136,14 +132,13 @@ def test_blaze_palm_pytorch(forge_property_recorder):
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_blaze_hand_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="blazepose", variant="hand", task=Task.OBJECT_DETECTION, source=Source.GITHUB
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load BlazePalm Detector
     framework_model = BlazeHandLandmark()

--- a/forge/test/models/pytorch/vision/bts/test_bts.py
+++ b/forge/test/models/pytorch/vision/bts/test_bts.py
@@ -8,9 +8,8 @@ from PIL import Image
 from torchvision import transforms
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 # import sys
 
@@ -30,8 +29,8 @@ def test_bts_pytorch(forge_property_recorder, variant):
     if variant != "densenet161_bts":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="bts",
         variant=variant,
@@ -41,7 +40,6 @@ def test_bts_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load sample image
     image_path = "third_party/confidential_customer_models/internal/bts/files/samples/rgb_00315.jpg"

--- a/forge/test/models/pytorch/vision/ddrnet/test_ddrnet.py
+++ b/forge/test/models/pytorch/vision/ddrnet/test_ddrnet.py
@@ -8,9 +8,8 @@ from PIL import Image
 from torchvision import transforms
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 # sys.path.append("third_party/confidential_customer_models/generated/scripts/")
 # from model_ddrnet import DualResNet_23, DualResNet_39, BasicBlock
@@ -29,8 +28,8 @@ def test_ddrnet_pytorch(forge_property_recorder, variant):
     if variant != "ddrnet23s":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="ddrnet",
         variant=variant,
@@ -40,7 +39,6 @@ def test_ddrnet_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     if variant == "ddrnet23s":
@@ -96,8 +94,8 @@ variants = ["ddrnet23s_cityscapes", "ddrnet23_cityscapes"]
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_ddrnet_semantic_segmentation_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="ddrnet",
         variant=variant,
@@ -107,7 +105,6 @@ def test_ddrnet_semantic_segmentation_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # prepare model
     if variant == "ddrnet23s_cityscapes":

--- a/forge/test/models/pytorch/vision/deit/test_deit.py
+++ b/forge/test/models/pytorch/vision/deit/test_deit.py
@@ -6,9 +6,9 @@ from datasets import load_dataset
 from transformers import AutoFeatureExtractor, ViTForImageClassification
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -39,8 +39,8 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_deit_imgcls_hf_pytorch(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="deit",
         variant=variant,
@@ -50,7 +50,6 @@ def test_deit_imgcls_hf_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_deit_imgcls_hf_pytorch(
         variant,

--- a/forge/test/models/pytorch/vision/densenet/test_densenet.py
+++ b/forge/test/models/pytorch/vision/densenet/test_densenet.py
@@ -8,6 +8,7 @@ import torchxrayvision as xrv
 from torchxrayvision.models import fix_resolution, op_norm
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
@@ -16,7 +17,6 @@ from test.models.pytorch.vision.densenet.utils.densenet_utils import (
     get_input_img,
     get_input_img_hf_xray,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = ["densenet121", "densenet121_hf_xray"]
@@ -41,8 +41,8 @@ def test_densenet_121_pytorch(forge_property_recorder, variant):
     if variant == "densenet121":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="densenet",
         variant=variant,
@@ -52,7 +52,6 @@ def test_densenet_121_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     if variant == "densenet121":
@@ -100,8 +99,8 @@ def test_densenet_121_pytorch(forge_property_recorder, variant):
     ],
 )
 def test_densenet_161_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="densenet",
         variant=variant,
@@ -111,7 +110,6 @@ def test_densenet_161_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "densenet161", pretrained=True)
@@ -140,8 +138,8 @@ def test_densenet_161_pytorch(forge_property_recorder, variant):
     ],
 )
 def test_densenet_169_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="densenet",
         variant=variant,
@@ -151,7 +149,6 @@ def test_densenet_169_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "densenet169", pretrained=True)
@@ -175,8 +172,8 @@ def test_densenet_169_pytorch(forge_property_recorder, variant):
 def test_densenet_201_pytorch(forge_property_recorder, variant):
     pytest.skip("Insufficient host DRAM to run this model (requires a more than 32 GB during compile time)")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="densenet",
         variant=variant,
@@ -186,7 +183,6 @@ def test_densenet_201_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "densenet201", pretrained=True)

--- a/forge/test/models/pytorch/vision/detr/test_detr.py
+++ b/forge/test/models/pytorch/vision/detr/test_detr.py
@@ -8,10 +8,10 @@ import pytest
 from transformers import DetrForObjectDetection, DetrForSegmentation
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.detr.utils.image_utils import preprocess_input_data
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
@@ -25,8 +25,8 @@ from test.models.utils import Framework, Source, Task, build_module_name
     ],
 )
 def test_detr_detection(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="detr",
         variant=variant,
@@ -36,7 +36,6 @@ def test_detr_detection(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model
     framework_model = DetrForObjectDetection.from_pretrained(variant)
@@ -68,8 +67,8 @@ def test_detr_detection(forge_property_recorder, variant):
 )
 def test_detr_segmentation(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="detr",
         variant=variant,
@@ -79,7 +78,6 @@ def test_detr_segmentation(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model
     framework_model = DetrForSegmentation.from_pretrained(variant)

--- a/forge/test/models/pytorch/vision/dla/test_dla.py
+++ b/forge/test/models/pytorch/vision/dla/test_dla.py
@@ -4,11 +4,11 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.dla.utils.utils import load_dla_model, post_processing
 from test.models.pytorch.vision.utils.utils import load_timm_model_and_input
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants = [
     "dla34",
@@ -30,14 +30,13 @@ def test_dla_pytorch(forge_property_recorder, variant):
     if variant != "dla34":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="dla", variant=variant, task=Task.VISUAL_BACKBONE, source=Source.TORCHVISION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and prepare input data
     framework_model, inputs = load_dla_model(variant)
@@ -65,8 +64,8 @@ variants = ["dla34.in1k"]
 @pytest.mark.parametrize("variant", variants)
 def test_dla_timm(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="dla",
         variant=variant,
@@ -76,7 +75,6 @@ def test_dla_timm(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and inputs
     framework_model, inputs = load_timm_model_and_input(variant)

--- a/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
@@ -20,15 +20,10 @@ from torchvision.models import (
 from torchvision.models._api import WeightsEnum
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import (
-    Framework,
-    Source,
-    Task,
-    build_module_name,
-    print_cls_results,
-)
+from test.models.utils import print_cls_results
 from test.utils import download_model
 
 ## https://huggingface.co/docs/timm/models/efficientnet
@@ -56,8 +51,8 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_efficientnet_timm(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="efficientnet",
         variant=variant,
@@ -70,7 +65,6 @@ def test_efficientnet_timm(forge_property_recorder, variant):
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model
     framework_model = download_model(timm.create_model, variant, pretrained=True)
@@ -130,8 +124,8 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_efficientnet_torchvision(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="efficientnet",
         variant=variant,
@@ -141,7 +135,6 @@ def test_efficientnet_torchvision(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model
     if variant == "efficientnet_b0":

--- a/forge/test/models/pytorch/vision/efficientnet/test_efficientnet_lite.py
+++ b/forge/test/models/pytorch/vision/efficientnet/test_efficientnet_lite.py
@@ -5,21 +5,21 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.efficientnet.utils import (
     src_efficientnet_lite as efflite,
 )
 from test.models.pytorch.vision.utils.utils import load_timm_model_and_input
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.skip_model_analysis
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_efficientnet_lite_0_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="efficientnet",
         variant="lite_0",
@@ -29,7 +29,6 @@ def test_efficientnet_lite_0_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Model load in Forge
     model_name = "efficientnet_lite0"
@@ -53,8 +52,8 @@ def test_efficientnet_lite_0_pytorch(forge_property_recorder):
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_efficientnet_lite_1_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="efficientnet",
         variant="lite_1",
@@ -64,7 +63,6 @@ def test_efficientnet_lite_1_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Model load in Forge
     model_name = "efficientnet_lite1"
@@ -88,8 +86,8 @@ def test_efficientnet_lite_1_pytorch(forge_property_recorder):
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_efficientnet_lite_2_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="efficientnet",
         variant="lite_2",
@@ -99,7 +97,6 @@ def test_efficientnet_lite_2_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Model load in Forge
     model_name = "efficientnet_lite2"
@@ -123,8 +120,8 @@ def test_efficientnet_lite_2_pytorch(forge_property_recorder):
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_efficientnet_lite_3_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="efficientnet",
         variant="lite_3",
@@ -134,7 +131,6 @@ def test_efficientnet_lite_3_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Model load in Forge
     model_name = "efficientnet_lite3"
@@ -158,8 +154,8 @@ def test_efficientnet_lite_3_pytorch(forge_property_recorder):
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_efficientnet_lite_4_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="efficientnet",
         variant="lite_4",
@@ -169,7 +165,6 @@ def test_efficientnet_lite_4_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Model load in Forge
     model_name = "efficientnet_lite4"
@@ -201,8 +196,8 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_efficientnet_lite_timm(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="efficientnet_lite",
         variant=variant,
@@ -212,7 +207,6 @@ def test_efficientnet_lite_timm(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and inputs
     framework_model, inputs = load_timm_model_and_input(variant)

--- a/forge/test/models/pytorch/vision/fchardnet/test_fchardnet.py
+++ b/forge/test/models/pytorch/vision/fchardnet/test_fchardnet.py
@@ -7,9 +7,8 @@ import torch
 from PIL import Image
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 # sys.path.append("forge/test/model_demos/models")
 # from fchardnet import get_model, fuse_bn_recursively
@@ -19,14 +18,13 @@ from test.models.utils import Framework, Source, Task, build_module_name
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_fchardnet(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="fchardnet", task=Task.IMAGE_CLASSIFICATION, source=Source.TORCHVISION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load and pre-process image
     image_path = "tt-forge-fe/forge/test/model_demos/high_prio/cnn/pytorch/model2/pytorch/pidnet/image/road_scenes.png"

--- a/forge/test/models/pytorch/vision/fpn/test_fpn.py
+++ b/forge/test/models/pytorch/vision/fpn/test_fpn.py
@@ -5,22 +5,21 @@ import pytest
 import torch
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.fpn.utils.model import FPNWrapper
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
 def test_fpn_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="fpn", source=Source.TORCHVISION, task=Task.IMAGE_CLASSIFICATION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load FPN model
     framework_model = FPNWrapper()

--- a/forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py
+++ b/forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py
@@ -5,13 +5,13 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.ghostnet.utils.utils import (
     load_ghostnet_model,
     post_processing,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 params = [
     pytest.param("ghostnet_100", marks=[pytest.mark.push]),
@@ -26,8 +26,8 @@ params = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", params)
 def test_ghostnet_timm(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="ghostnet",
         variant=variant,
@@ -37,7 +37,6 @@ def test_ghostnet_timm(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and prepare input data
     framework_model, inputs = load_ghostnet_model(variant)

--- a/forge/test/models/pytorch/vision/glpn_kitti/test_glpn_kitti.py
+++ b/forge/test/models/pytorch/vision/glpn_kitti/test_glpn_kitti.py
@@ -4,10 +4,10 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.glpn_kitti.utils.utils import load_input, load_model
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
@@ -22,8 +22,8 @@ from test.models.utils import Framework, Source, Task, build_module_name
 )
 def test_glpn_kitti(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="glpn_kitti",
         variant=variant,
@@ -33,7 +33,6 @@ def test_glpn_kitti(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     framework_model = load_model(variant)

--- a/forge/test/models/pytorch/vision/googlenet/test_googlenet.py
+++ b/forge/test/models/pytorch/vision/googlenet/test_googlenet.py
@@ -8,23 +8,21 @@ from PIL import Image
 from torchvision import models, transforms
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
 @pytest.mark.nightly
 @pytest.mark.xfail
 def test_googlenet_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
-        framework=Framework.PYTORCH, model="googlenet", source=Source.TORCHVISION, task=Task.IMAGE_CLASSIFICATION
-    )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
+    module_name = forge_property_recorder.record_model_properties(
+        framework=Framework.PYTORCH, model="googlenet", source=Source.TORCHVISION, task=Task.IMAGE_CLASSIFICATION
+    )
 
     # Create Forge module from PyTorch model
     # Two ways to load the same model

--- a/forge/test/models/pytorch/vision/hardnet/test_hardnet.py
+++ b/forge/test/models/pytorch/vision/hardnet/test_hardnet.py
@@ -9,9 +9,8 @@ from PIL import Image
 from torchvision import transforms
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants = [
     pytest.param("hardnet68", id="hardnet68"),
@@ -26,8 +25,8 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.skip(reason="dependent on CCM repo")
 def test_hardnet_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="hardnet",
         variant=variant,
@@ -37,7 +36,6 @@ def test_hardnet_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # load only the model architecture without pre-trained weights.
     framework_model = torch.hub.load("PingoLH/Pytorch-HarDNet", variant, pretrained=False)

--- a/forge/test/models/pytorch/vision/hrnet/test_hrnet.py
+++ b/forge/test/models/pytorch/vision/hrnet/test_hrnet.py
@@ -14,15 +14,10 @@ from timm.data.transforms_factory import create_transform
 from torchvision import transforms
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import (
-    Framework,
-    Source,
-    Task,
-    build_module_name,
-    print_cls_results,
-)
+from test.models.utils import print_cls_results
 from test.utils import download_model
 
 
@@ -100,14 +95,13 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_hrnet_osmr_pytorch(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="hrnet", variant=variant, source=Source.OSMR, task=Task.POSE_ESTIMATION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_hrnet_imgcls_osmr_pytorch(
         variant,
@@ -199,14 +193,13 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_hrnet_timm_pytorch(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="hrnet", variant=variant, source=Source.TIMM, task=Task.POSE_ESTIMATION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_hrnet_imgcls_timm_pytorch(
         variant,

--- a/forge/test/models/pytorch/vision/inception/test_inception_v4.py
+++ b/forge/test/models/pytorch/vision/inception/test_inception_v4.py
@@ -6,13 +6,13 @@ import pytest
 from pytorchcv.model_provider import get_model as ptcv_get_model
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.inception.utils.model_utils import (
     get_image,
     preprocess_timm_model,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -29,14 +29,13 @@ def generate_model_inceptionV4_imgcls_osmr_pytorch(variant):
 @pytest.mark.nightly
 @pytest.mark.xfail
 def test_inception_v4_osmr_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="inception", variant="v4", source=Source.OSMR, task=Task.IMAGE_CLASSIFICATION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs = generate_model_inceptionV4_imgcls_osmr_pytorch("inceptionv4")
 
@@ -70,8 +69,8 @@ def test_inception_v4_timm_pytorch(forge_property_recorder, variant):
     if variant != "inception_v4.tf_in1k":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="inception",
         variant=variant,
@@ -81,7 +80,6 @@ def test_inception_v4_timm_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs = generate_model_inceptionV4_imgcls_timm_pytorch(variant)
 

--- a/forge/test/models/pytorch/vision/mgp_str_base/test_mgp_str_base.py
+++ b/forge/test/models/pytorch/vision/mgp_str_base/test_mgp_str_base.py
@@ -6,10 +6,10 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.mgp_str_base.utils.utils import load_input, load_model
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
@@ -21,8 +21,8 @@ from test.models.utils import Framework, Source, Task, build_module_name
 )
 def test_mgp_scene_text_recognition(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mgp",
         variant=variant,
@@ -32,7 +32,6 @@ def test_mgp_scene_text_recognition(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     framework_model = load_model(variant)

--- a/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
+++ b/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
@@ -12,9 +12,9 @@ from timm.data import resolve_data_config
 from timm.data.transforms_factory import create_transform
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 varaints = [
@@ -44,8 +44,8 @@ def test_mlp_mixer_timm_pytorch(forge_property_recorder, variant):
     if variant not in ["mixer_b16_224", "mixer_b16_224.goog_in21k"]:
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mlp_mixer",
         variant=variant,
@@ -55,7 +55,6 @@ def test_mlp_mixer_timm_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model = download_model(timm.create_model, variant, pretrained=True)
     config = resolve_data_config({}, model=framework_model)
@@ -86,8 +85,8 @@ def test_mlp_mixer_timm_pytorch(forge_property_recorder, variant):
 @pytest.mark.xfail
 def test_mlp_mixer_pytorch(forge_property_recorder):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mlp_mixer",
         source=Source.GITHUB,
@@ -96,7 +95,6 @@ def test_mlp_mixer_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     framework_model = MLPMixer(

--- a/forge/test/models/pytorch/vision/mnist/test_mnist.py
+++ b/forge/test/models/pytorch/vision/mnist/test_mnist.py
@@ -4,18 +4,18 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.mnist.utils.utils import load_input, load_model
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
 @pytest.mark.xfail
 def test_mnist(forge_property_recorder):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mnist",
         source=Source.GITHUB,
@@ -24,7 +24,6 @@ def test_mnist(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     framework_model = load_model()

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
@@ -7,6 +7,7 @@ from PIL import Image
 from transformers import AutoImageProcessor, AutoModelForImageClassification
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.mobilenet.utils.utils import (
@@ -14,15 +15,14 @@ from test.models.pytorch.vision.mobilenet.utils.utils import (
     post_processing,
 )
 from test.models.pytorch.vision.utils.utils import load_timm_model_and_input
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
 @pytest.mark.nightly
 @pytest.mark.push
 def test_mobilenetv1_basic(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilenet_v1",
         variant="basic",
@@ -32,7 +32,6 @@ def test_mobilenetv1_basic(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and prepare input data
     framework_model, inputs = load_mobilenet_model("mobilenet_v1")
@@ -73,8 +72,8 @@ def generate_model_mobilenetv1_imgcls_hf_pytorch(variant):
 def test_mobilenetv1_192(forge_property_recorder, variant):
     pytest.skip("Hitting segmentation fault in MLIR")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilnet_v1",
         variant=variant,
@@ -84,7 +83,6 @@ def test_mobilenetv1_192(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetv1_imgcls_hf_pytorch(variant)
 
@@ -117,8 +115,8 @@ def generate_model_mobilenetV1I224_imgcls_hf_pytorch(variant):
 def test_mobilenetv1_224(forge_property_recorder, variant):
     pytest.skip("Hitting segmentation fault in MLIR")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilnet_v1",
         variant=variant,
@@ -128,7 +126,6 @@ def test_mobilenetv1_224(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV1I224_imgcls_hf_pytorch(variant)
 
@@ -149,8 +146,8 @@ variants = ["mobilenetv1_100.ra4_e3600_r224_in1k"]
 @pytest.mark.parametrize("variant", variants)
 def test_mobilenet_v1_timm(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilenet_v1",
         variant=variant,
@@ -160,7 +157,6 @@ def test_mobilenet_v1_timm(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and inputs
     framework_model, inputs = load_timm_model_and_input(variant)

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1_ssd.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1_ssd.py
@@ -5,9 +5,8 @@ import pytest
 import torch
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 # sys.path = list(set(sys.path + ["third_party/confidential_customer_models/model_2/pytorch/"]))
 # from mobilenetv1_ssd.vision.ssd.mobilenetv1_ssd import create_mobilenetv1_ssd
@@ -17,8 +16,8 @@ from test.models.utils import Framework, Source, Task, build_module_name
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_mobilenet_v1_ssd_pytorch_1x1(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilenet",
         variant="ssd",
@@ -28,7 +27,6 @@ def test_mobilenet_v1_ssd_pytorch_1x1(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load PASCAL VOC dataset class labels
     label_path = "mobilenetv1_ssd/models/voc-model-labels.txt"

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -18,6 +18,7 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.mobilenet.utils.utils import (
@@ -25,21 +26,15 @@ from test.models.pytorch.vision.mobilenet.utils.utils import (
     post_processing,
 )
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
-from test.models.utils import (
-    Framework,
-    Source,
-    Task,
-    build_module_name,
-    print_cls_results,
-)
+from test.models.utils import print_cls_results
 from test.utils import download_model
 
 
 @pytest.mark.nightly
 @pytest.mark.push
 def test_mobilenetv2_basic(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilenetv2",
         variant="basic",
@@ -49,7 +44,6 @@ def test_mobilenetv2_basic(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and prepare input data
     framework_model, inputs = load_mobilenet_model("mobilenet_v2")
@@ -87,8 +81,8 @@ def generate_model_mobilenetV2I96_imgcls_hf_pytorch(variant):
 def test_mobilenetv2_96(forge_property_recorder, variant):
     pytest.skip("Hitting segmentation fault in MLIR")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilenetv2",
         variant=variant,
@@ -98,7 +92,6 @@ def test_mobilenetv2_96(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV2I96_imgcls_hf_pytorch(variant)
 
@@ -129,8 +122,8 @@ def generate_model_mobilenetV2I160_imgcls_hf_pytorch(variant):
 def test_mobilenetv2_160(forge_property_recorder, variant):
     pytest.skip("Hitting segmentation fault in MLIR")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilenetv2",
         variant=variant,
@@ -140,7 +133,6 @@ def test_mobilenetv2_160(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV2I160_imgcls_hf_pytorch(variant)
 
@@ -173,8 +165,8 @@ def generate_model_mobilenetV2I244_imgcls_hf_pytorch(variant):
 def test_mobilenetv2_224(forge_property_recorder, variant):
     pytest.skip("Hitting segmentation fault in MLIR")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilenetv2",
         variant=variant,
@@ -184,7 +176,6 @@ def test_mobilenetv2_224(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV2I244_imgcls_hf_pytorch(variant)
 
@@ -225,8 +216,8 @@ def generate_model_mobilenetV2_imgcls_timm_pytorch(variant):
 @pytest.mark.parametrize("variant", ["mobilenetv2_100"])
 def test_mobilenetv2_timm(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilenetv2",
         variant=variant,
@@ -236,7 +227,6 @@ def test_mobilenetv2_timm(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV2_imgcls_timm_pytorch(variant)
 
@@ -288,8 +278,8 @@ variants = ["google/deeplabv3_mobilenet_v2_1.0_513"]
 @pytest.mark.parametrize("variant", variants)
 def test_mobilenetv2_deeplabv3(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilnetv2",
         variant=variant,
@@ -299,7 +289,6 @@ def test_mobilenetv2_deeplabv3(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV2_semseg_hf_pytorch(variant)
 
@@ -322,8 +311,8 @@ variants_with_weights = {
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_mobilenetv2_torchvision(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilenetv2",
         variant=variant,
@@ -333,7 +322,6 @@ def test_mobilenetv2_torchvision(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     weight_name = variants_with_weights[variant]

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
@@ -12,13 +12,13 @@ from timm.data import resolve_data_config
 from timm.data.transforms_factory import create_transform
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.mobilenet.utils.utils import (
     load_mobilenet_model,
     post_processing,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -31,8 +31,8 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_mobilenetv3_basic(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilenetv3",
         variant=variant,
@@ -42,7 +42,6 @@ def test_mobilenetv3_basic(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and prepare input data
     framework_model, inputs = load_mobilenet_model(variant)
@@ -98,8 +97,8 @@ variants = ["mobilenetv3_large_100", "mobilenetv3_small_100"]
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_mobilenetv3_timm(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilnetv3",
         source=Source.TIMM,
@@ -109,7 +108,6 @@ def test_mobilenetv3_timm(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_mobilenetV3_imgcls_timm_pytorch(
         variant,

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3_ssd.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3_ssd.py
@@ -4,13 +4,13 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.mobilenet.utils.mobilenet_v3_ssd_utils import (
     load_input,
     load_model,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants_with_weights = {
     "resnet18": "ResNet18_Weights",
@@ -25,8 +25,8 @@ variants_with_weights = {
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_mobilenetv3_ssd(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="mobilenetv3_ssd",
         variant=variant,
@@ -36,7 +36,6 @@ def test_mobilenetv3_ssd(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     weight_name = variants_with_weights[variant]

--- a/forge/test/models/pytorch/vision/monodepth2/test_monodepth2.py
+++ b/forge/test/models/pytorch/vision/monodepth2/test_monodepth2.py
@@ -5,6 +5,7 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.monodepth2.utils.utils import (
@@ -12,7 +13,6 @@ from test.models.pytorch.vision.monodepth2.utils.utils import (
     load_input,
     load_model,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants = [
     "mono_640x192",
@@ -29,8 +29,8 @@ variants = [
 
 @pytest.mark.parametrize("variant", variants)
 def test_monodepth2(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="monodepth2",
         variant=variant,
@@ -40,7 +40,6 @@ def test_monodepth2(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # prepare model and input
     download_model(variant)

--- a/forge/test/models/pytorch/vision/monodle/test_monodle.py
+++ b/forge/test/models/pytorch/vision/monodle/test_monodle.py
@@ -7,23 +7,22 @@ import torchvision.transforms as transforms
 from PIL import Image
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.monodle.utils.model import CenterNet3D
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
 @pytest.mark.skip(reason="Floating point exception(core dumped)")
 def test_monodle_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="monodle", source=Source.TORCHVISION, task=Task.OBJECT_DETECTION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load data sample
     url = "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"

--- a/forge/test/models/pytorch/vision/openpose/test_openpose.py
+++ b/forge/test/models/pytorch/vision/openpose/test_openpose.py
@@ -6,6 +6,7 @@ import torch
 from pytorchcv.model_provider import get_model as ptcv_get_model
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.openpose.utils.model import (
@@ -14,7 +15,6 @@ from test.models.pytorch.vision.openpose.utils.model import (
     get_image_tensor,
     transfer,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -51,8 +51,8 @@ def test_openpose_basic(forge_property_recorder, variant):
     if variant != "body_basic":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="openpose",
         variant=variant,
@@ -62,7 +62,6 @@ def test_openpose_basic(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_openpose_posdet_custom_pytorch(
         variant,
@@ -99,14 +98,13 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_openpose_osmr(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="openpose", variant=variant, source=Source.OSMR, task=Task.POSE_ESTIMATION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_openpose_posdet_osmr_pytorch(
         variant,

--- a/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
+++ b/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
@@ -14,9 +14,8 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 def get_sample_data(model_name):
@@ -51,8 +50,8 @@ def test_perceiverio_for_image_classification_pytorch(forge_property_recorder, v
     if variant != "deepmind/vision-perceiver-conv":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="perceiverio",
         variant=variant,
@@ -62,7 +61,6 @@ def test_perceiverio_for_image_classification_pytorch(forge_property_recorder, v
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Sample Image
     pixel_values = get_sample_data(variant)

--- a/forge/test/models/pytorch/vision/pidnet/test_pidnet.py
+++ b/forge/test/models/pytorch/vision/pidnet/test_pidnet.py
@@ -7,9 +7,8 @@ import pytest
 import torch
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 # sys.path.append("tt-forge-fe/forge/test/model_demos/high_prio/cnn/pytorch/model2/pytorch/pidnet/model")
 # from model_pidnet import update_model_config, get_seg_model
@@ -22,8 +21,8 @@ variants = ["pidnet_s", "pidnet_m", "pidnet_l"]
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_pidnet_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="pidnet",
         variant=variant,
@@ -33,7 +32,6 @@ def test_pidnet_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load and pre-process image
     image_path = "tt-forge-fe/forge/test/model_demos/high_prio/cnn/pytorch/model2/pytorch/pidnet/image/road_scenes.png"

--- a/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
+++ b/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
@@ -9,9 +9,8 @@ import torchvision
 import torchvision.transforms as transforms
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 # Paper - https://arxiv.org/abs/1311.2524
@@ -19,14 +18,13 @@ from test.models.utils import Framework, Source, Task, build_module_name
 @pytest.mark.nightly
 @pytest.mark.xfail
 def test_rcnn_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="rcnn", source=Source.TORCHVISION, task=Task.OBJECT_DETECTION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load Alexnet Model
     framework_model = torchvision.models.alexnet(pretrained=True)
@@ -78,8 +76,8 @@ def test_rcnn_pytorch(forge_property_recorder):
 
         inputs = [rect_transform.unsqueeze(0)]
 
-        # Build Module Name
-        module_name = build_module_name(
+        # Record Forge Property
+        module_name = forge_property_recorder.record_model_properties(
             framework=Framework.PYTORCH,
             model="rcnn",
             suffix=f"rect_{idx}",

--- a/forge/test/models/pytorch/vision/regnet/test_regnet.py
+++ b/forge/test/models/pytorch/vision/regnet/test_regnet.py
@@ -5,18 +5,18 @@ import pytest
 from transformers import RegNetForImageClassification, RegNetModel
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.regnet.utils.image_utils import preprocess_input_data
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["facebook/regnet-y-040"])
 def test_regnet(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="regnet",
         variant=variant,
@@ -26,7 +26,6 @@ def test_regnet(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load RegNet model
     framework_model = RegNetModel.from_pretrained("facebook/regnet-y-040", return_dict=False)
@@ -49,8 +48,8 @@ def test_regnet(forge_property_recorder, variant):
 @pytest.mark.parametrize("variant", ["facebook/regnet-y-040"])
 def test_regnet_img_classification(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="regnet",
         variant=variant,
@@ -60,7 +59,6 @@ def test_regnet_img_classification(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the image processor and the RegNet model
     framework_model = RegNetForImageClassification.from_pretrained("facebook/regnet-y-040")
@@ -120,8 +118,8 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_regnet_torchvision(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="regnet",
         variant=variant,
@@ -131,7 +129,6 @@ def test_regnet_torchvision(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     weight_name = variants_with_weights[variant]

--- a/forge/test/models/pytorch/vision/resnet/test_resnet.py
+++ b/forge/test/models/pytorch/vision/resnet/test_resnet.py
@@ -11,12 +11,12 @@ from tabulate import tabulate
 from transformers import AutoImageProcessor, ResNetForImageClassification
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -31,7 +31,7 @@ def test_resnet_hf(variant, forge_property_recorder):
     random.seed(0)
 
     # Record model details
-    module_name = build_module_name(
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="resnet",
         variant="50",
@@ -40,7 +40,6 @@ def test_resnet_hf(variant, forge_property_recorder):
     )
 
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load tiny dataset
     dataset = load_dataset("zh-plus/tiny-imagenet")
@@ -107,12 +106,11 @@ def run_and_print_results(framework_model, compiled_model, inputs):
 @pytest.mark.nightly
 def test_resnet_timm(forge_property_recorder):
     # Record model details
-    module_name = build_module_name(
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="resnet", source=Source.TIMM, variant="50", task=Task.IMAGE_CLASSIFICATION
     )
 
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load framework model
     framework_model = download_model(timm.create_model, "resnet50", pretrained=True)
@@ -150,8 +148,8 @@ variants_with_weights = {
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_resnet_torchvision(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="resnet",
         variant=variant,
@@ -161,7 +159,6 @@ def test_resnet_torchvision(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     weight_name = variants_with_weights[variant]

--- a/forge/test/models/pytorch/vision/resnext/test_resnext.py
+++ b/forge/test/models/pytorch/vision/resnext/test_resnext.py
@@ -7,6 +7,7 @@ import torch
 from pytorchcv.model_provider import get_model as ptcv_get_model
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.resnext.utils.utils import (
@@ -14,7 +15,6 @@ from test.models.pytorch.vision.resnext.utils.utils import (
     get_resnext_model_and_input,
     post_processing,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -22,8 +22,8 @@ from test.utils import download_model
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["resnext50_32x4d"])
 def test_resnext_50_torchhub_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="resnext",
         source=Source.TORCH_HUB,
@@ -33,7 +33,6 @@ def test_resnext_50_torchhub_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and prepare input data
     framework_model, inputs = get_resnext_model_and_input("pytorch/vision:v0.10.0", variant)
@@ -57,8 +56,8 @@ def test_resnext_50_torchhub_pytorch(forge_property_recorder, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["resnext101_32x8d"])
 def test_resnext_101_torchhub_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="resnext",
         source=Source.TORCH_HUB,
@@ -68,7 +67,6 @@ def test_resnext_101_torchhub_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and prepare input data
     framework_model, inputs = get_resnext_model_and_input("pytorch/vision:v0.10.0", variant)
@@ -93,8 +91,8 @@ def test_resnext_101_torchhub_pytorch(forge_property_recorder, variant):
 def test_resnext_101_32x8d_fb_wsl_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="resnext",
         source=Source.TORCH_HUB,
@@ -104,7 +102,6 @@ def test_resnext_101_32x8d_fb_wsl_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and prepare input data
     framework_model = download_model(torch.hub.load, "facebookresearch/WSL-Images", variant)
@@ -127,8 +124,8 @@ def test_resnext_101_32x8d_fb_wsl_pytorch(forge_property_recorder, variant):
 def test_resnext_14_osmr_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="resnext",
         source=Source.OSMR,
@@ -138,7 +135,6 @@ def test_resnext_14_osmr_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and prepare input data
     framework_model = download_model(ptcv_get_model, variant, pretrained=True)
@@ -161,8 +157,8 @@ def test_resnext_14_osmr_pytorch(forge_property_recorder, variant):
 def test_resnext_26_osmr_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="resnext",
         source=Source.OSMR,
@@ -172,7 +168,6 @@ def test_resnext_26_osmr_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(ptcv_get_model, variant, pretrained=True)
@@ -195,8 +190,8 @@ def test_resnext_26_osmr_pytorch(forge_property_recorder, variant):
 def test_resnext_50_osmr_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="resnext",
         source=Source.OSMR,
@@ -206,7 +201,6 @@ def test_resnext_50_osmr_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(ptcv_get_model, variant, pretrained=True)
@@ -229,8 +223,8 @@ def test_resnext_50_osmr_pytorch(forge_property_recorder, variant):
 def test_resnext_101_osmr_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="resnext",
         source=Source.OSMR,
@@ -240,7 +234,6 @@ def test_resnext_101_osmr_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2: Create Forge module from PyTorch model
     framework_model = download_model(ptcv_get_model, variant, pretrained=True)

--- a/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
+++ b/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
@@ -9,12 +9,12 @@ import pytest
 import requests
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.retinanet.utils.image_utils import img_preprocess
 from test.models.pytorch.vision.retinanet.utils.model import Model
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants = [
     "retinanet_rn18fpn",
@@ -30,8 +30,8 @@ variants = [
 def test_retinanet(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="retinanet",
         variant=variant,
@@ -41,7 +41,6 @@ def test_retinanet(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Prepare model
     url = f"https://github.com/NVIDIA/retinanet-examples/releases/download/19.04/{variant}.zip"
@@ -93,8 +92,8 @@ variants_with_weights = {
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_retinanet_torchvision(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="retinanet",
         variant=variant,
@@ -104,7 +103,6 @@ def test_retinanet_torchvision(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     weight_name = variants_with_weights[variant]

--- a/forge/test/models/pytorch/vision/rmbg/test_rmbg.py
+++ b/forge/test/models/pytorch/vision/rmbg/test_rmbg.py
@@ -5,10 +5,10 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.rmbg.utils.utils import load_input, load_model
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
@@ -16,8 +16,8 @@ from test.models.utils import Framework, Source, Task, build_module_name
 @pytest.mark.parametrize("variant", ["briaai/RMBG-2.0"])
 def test_rmbg(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="rmbg_2_0",
         variant=variant,
@@ -27,7 +27,6 @@ def test_rmbg(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     framework_model = load_model(variant)

--- a/forge/test/models/pytorch/vision/segformer/test_segformer.py
+++ b/forge/test/models/pytorch/vision/segformer/test_segformer.py
@@ -10,10 +10,10 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.segformer.utils.image_utils import get_sample_data
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants_img_classification = [
     "nvidia/mit-b0",
@@ -31,8 +31,8 @@ def test_segformer_image_classification_pytorch(forge_property_recorder, variant
     if variant != "nvidia/mit-b0":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="segformer",
         variant=variant,
@@ -45,7 +45,6 @@ def test_segformer_image_classification_pytorch(forge_property_recorder, variant
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Set model configurations
     config = SegformerConfig.from_pretrained(variant)
@@ -84,8 +83,8 @@ variants_semseg = [
 def test_segformer_semantic_segmentation_pytorch(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="segformer",
         variant=variant,
@@ -95,7 +94,6 @@ def test_segformer_semantic_segmentation_pytorch(forge_property_recorder, varian
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model from HuggingFace
     framework_model = SegformerForSemanticSegmentation.from_pretrained(variant)

--- a/forge/test/models/pytorch/vision/ssd300_resnet50/test_ssd300_resnet50.py
+++ b/forge/test/models/pytorch/vision/ssd300_resnet50/test_ssd300_resnet50.py
@@ -7,23 +7,22 @@ import requests
 import torch
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.ssd300_resnet50.utils.image_utils import prepare_input
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
 @pytest.mark.xfail
 def test_pytorch_ssd300_resnet50(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="ssd300_resnet50", source=Source.TORCH_HUB, task=Task.IMAGE_CLASSIFICATION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2 : prepare model
     framework_model = torch.hub.load("NVIDIA/DeepLearningExamples:torchhub", "nvidia_ssd", pretrained=False)

--- a/forge/test/models/pytorch/vision/ssd300_vgg16/test_ssd300_vgg16.py
+++ b/forge/test/models/pytorch/vision/ssd300_vgg16/test_ssd300_vgg16.py
@@ -4,10 +4,10 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants_with_weights = {
     "ssd300_vgg16": "SSD300_VGG16_Weights",
@@ -19,8 +19,8 @@ variants_with_weights = {
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_ssd300_vgg16(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="ssd300_vgg16",
         variant=variant,
@@ -30,7 +30,6 @@ def test_ssd300_vgg16(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     weight_name = variants_with_weights[variant]

--- a/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3.py
+++ b/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3.py
@@ -4,10 +4,10 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants_with_weights = {
     "ssdlite320_mobilenet_v3_large": "SSDLite320_MobileNet_V3_Large_Weights",
@@ -19,8 +19,8 @@ variants_with_weights = {
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_ssdlite320_mobilenetv3(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="ssdlite320_mobilenetv3",
         variant=variant,
@@ -30,7 +30,6 @@ def test_ssdlite320_mobilenetv3(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     weight_name = variants_with_weights[variant]

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -12,11 +12,11 @@ from transformers import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.swin.utils.image_utils import load_image
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
@@ -30,8 +30,8 @@ from test.models.utils import Framework, Source, Task, build_module_name
     ],
 )
 def test_swin_v1_tiny_4_224_hf_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="swin",
         variant=variant,
@@ -41,7 +41,6 @@ def test_swin_v1_tiny_4_224_hf_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 1: Create Forge module from PyTorch model
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
@@ -73,8 +72,8 @@ def test_swin_v1_tiny_4_224_hf_pytorch(forge_property_recorder, variant):
     ],
 )
 def test_swin_v2_tiny_4_256_hf_pytorch(forge_property_recorder, variant):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="swin",
         variant=variant,
@@ -84,7 +83,6 @@ def test_swin_v2_tiny_4_256_hf_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
     framework_model = Swinv2Model.from_pretrained(variant)
@@ -107,8 +105,8 @@ def test_swin_v2_tiny_4_256_hf_pytorch(forge_property_recorder, variant):
 def test_swin_v2_tiny_image_classification(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="swin",
         variant=variant,
@@ -118,7 +116,6 @@ def test_swin_v2_tiny_image_classification(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
     framework_model = Swinv2ForImageClassification.from_pretrained(variant)
@@ -141,8 +138,8 @@ def test_swin_v2_tiny_image_classification(forge_property_recorder, variant):
 def test_swin_v2_tiny_masked(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="swin",
         variant=variant,
@@ -152,7 +149,6 @@ def test_swin_v2_tiny_masked(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
     framework_model = Swinv2ForMaskedImageModeling.from_pretrained(variant)
@@ -193,8 +189,8 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_swin_torchvision(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="swin",
         variant=variant,
@@ -204,7 +200,6 @@ def test_swin_torchvision(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     weight_name = variants_with_weights[variant]

--- a/forge/test/models/pytorch/vision/tri/test_tri_basic_2.py
+++ b/forge/test/models/pytorch/vision/tri/test_tri_basic_2.py
@@ -9,9 +9,8 @@ import pytest
 import torch
 
 import forge
+from forge.forge_property_utils import Framework, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Task, build_module_name
 
 # import sys
 # sys.path.append("third_party/confidential_customer_models/internal/tri_basic_2/scripts")
@@ -22,14 +21,13 @@ from test.models.utils import Framework, Task, build_module_name
 @pytest.mark.skip(reason="dependent on CCM repo and Hang observed at post_initial_graph_pass")
 @pytest.mark.nightly
 def test_tri_basic_2_sematic_segmentation_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="tri", variant="basic_2", task=Task.SEMANTIC_SEGMENTATION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Sample Input
     image_w = 800

--- a/forge/test/models/pytorch/vision/unet/test_unet.py
+++ b/forge/test/models/pytorch/vision/unet/test_unet.py
@@ -21,10 +21,10 @@ from torchvision.transforms import (
 )
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.unet.utils.model import UNET
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -41,14 +41,13 @@ def generate_model_unet_imgseg_osmr_pytorch(variant):
 @pytest.mark.xfail
 @pytest.mark.nightly
 def test_unet_osmr_cityscape_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="unet", variant="cityscape", source=Source.OSMR, task=Task.IMAGE_SEGMENTATION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_unet_imgseg_osmr_pytorch("unet_cityscapes")
 
@@ -94,8 +93,8 @@ def get_imagenet_sample():
 def test_unet_holocron_pytorch(forge_property_recorder):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="unet",
         variant="holocron",
@@ -105,7 +104,6 @@ def test_unet_holocron_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     from holocron.models.segmentation.unet import unet_tvvgg11
 
@@ -154,8 +152,8 @@ def generate_model_unet_imgseg_smp_pytorch(variant):
 def test_unet_qubvel_pytorch(forge_property_recorder):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="unet",
         variant="qubvel",
@@ -165,7 +163,6 @@ def test_unet_qubvel_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_unet_imgseg_smp_pytorch(None)
 
@@ -217,14 +214,13 @@ def generate_model_unet_imgseg_torchhub_pytorch(variant):
 def test_unet_torchhub_pytorch(forge_property_recorder):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="unet", source=Source.TORCH_HUB, task=Task.IMAGE_SEGMENTATION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_unet_imgseg_torchhub_pytorch(
         "unet",
@@ -244,8 +240,8 @@ def test_unet_torchhub_pytorch(forge_property_recorder):
 @pytest.mark.xfail
 def test_unet_carvana(forge_property_recorder):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="unet_carvana",
         source=Source.GITHUB,
@@ -254,7 +250,6 @@ def test_unet_carvana(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     framework_model = UNET(in_channels=3, out_channels=1)

--- a/forge/test/models/pytorch/vision/vgg/test_vgg.py
+++ b/forge/test/models/pytorch/vision/vgg/test_vgg.py
@@ -15,10 +15,10 @@ from torchvision import transforms
 from vgg_pytorch import VGG
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -37,14 +37,13 @@ def test_vgg_osmr_pytorch(forge_property_recorder, variant):
     if variant != "vgg11":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="vgg", variant=variant, source=Source.OSMR, task=Task.OBJECT_DETECTION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model = download_model(ptcv_get_model, variant, pretrained=True)
     framework_model.eval()
@@ -84,14 +83,13 @@ def test_vgg_osmr_pytorch(forge_property_recorder, variant):
 def test_vgg_19_hf_pytorch(forge_property_recorder):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="vgg", variant="19", source=Source.HUGGINGFACE, task=Task.OBJECT_DETECTION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     """
     # https://pypi.org/project/vgg-pytorch/
@@ -160,14 +158,13 @@ def test_vgg_bn19_timm_pytorch(forge_property_recorder):
 
     variant = "vgg19_bn"
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="vgg", variant="vgg19_bn", source=Source.TIMM, task=Task.OBJECT_DETECTION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     torch.multiprocessing.set_sharing_strategy("file_system")
     framework_model, image_tensor = download_model(preprocess_timm_model, variant)
@@ -187,8 +184,8 @@ def test_vgg_bn19_timm_pytorch(forge_property_recorder):
 def test_vgg_bn19_torchhub_pytorch(forge_property_recorder):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="vgg",
         variant="vgg19_bn",
@@ -198,7 +195,6 @@ def test_vgg_bn19_torchhub_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "vgg19_bn", pretrained=True)
     framework_model.eval()
@@ -265,8 +261,8 @@ def test_vgg_torchvision(forge_property_recorder, variant):
     if variant != "vgg11":
         pytest.skip("Skipping this variant; only testing the small variant(vgg11) for now.")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="vgg",
         variant=variant,
@@ -276,7 +272,6 @@ def test_vgg_torchvision(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     weight_name = variants_with_weights[variant]

--- a/forge/test/models/pytorch/vision/vit/test_vit.py
+++ b/forge/test/models/pytorch/vision/vit/test_vit.py
@@ -6,10 +6,10 @@ from datasets import load_dataset
 from transformers import AutoImageProcessor, ViTForImageClassification
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 dataset = load_dataset("huggingface/cats-image")
@@ -39,8 +39,8 @@ def test_vit_classify_224_hf_pytorch(forge_property_recorder, variant):
     if variant != "google/vit-base-patch16-224":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="vit",
         variant=variant,
@@ -53,7 +53,6 @@ def test_vit_classify_224_hf_pytorch(forge_property_recorder, variant):
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_vit_imgcls_hf_pytorch(variant)
 
@@ -90,8 +89,8 @@ def test_vit_torchvision(forge_property_recorder, variant):
     if variant != "vit_b_16":
         pytest.skip("Skipping this variant; only testing the small variant(vit_b_16) for now.")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="vit",
         variant=variant,
@@ -101,7 +100,6 @@ def test_vit_torchvision(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     weight_name = variants_with_weights[variant]

--- a/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
@@ -5,6 +5,7 @@ import pytest
 from pytorchcv.model_provider import get_model as ptcv_get_model
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.vovnet.utils.model_utils import (
@@ -13,7 +14,6 @@ from test.models.pytorch.vision.vovnet.utils.model_utils import (
     preprocess_timm_model,
 )
 from test.models.pytorch.vision.vovnet.utils.src_vovnet_stigma import vovnet39, vovnet57
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -38,8 +38,8 @@ def test_vovnet_osmr_pytorch(forge_property_recorder, variant):
     if variant != "vovnet27s":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="vovnet", variant=variant, source=Source.OSMR, task=Task.OBJECT_DETECTION
     )
 
@@ -48,7 +48,6 @@ def test_vovnet_osmr_pytorch(forge_property_recorder, variant):
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_vovnet_imgcls_osmr_pytorch(variant)
 
@@ -73,8 +72,8 @@ def test_vovnet_v1_39_stigma_pytorch(forge_property_recorder):
 
     variant = "vovnet39"
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="vovnet_v1",
         variant=variant,
@@ -84,7 +83,6 @@ def test_vovnet_v1_39_stigma_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_vovnet39_imgcls_stigma_pytorch()
 
@@ -110,8 +108,8 @@ def test_vovnet_v1_57_stigma_pytorch(forge_property_recorder):
 
     variant = "vovnet_v1_57"
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="vovnet",
         variant=variant,
@@ -121,7 +119,6 @@ def test_vovnet_v1_57_stigma_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_vovnet57_imgcls_stigma_pytorch()
 
@@ -157,8 +154,8 @@ def test_vovnet_timm_pytorch(forge_property_recorder, variant):
     if variant != "ese_vovnet19b_dw.ra_in1k":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="vovnet",
         variant=variant,
@@ -168,7 +165,6 @@ def test_vovnet_timm_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_vovnet_imgcls_timm_pytorch(
         variant,

--- a/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
+++ b/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
@@ -10,13 +10,13 @@ from timm.data import resolve_data_config
 from timm.data.transforms_factory import create_transform
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.wideresnet.utils.utils import (
     generate_model_wideresnet_imgcls_pytorch,
     post_processing,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 variants = [
@@ -31,8 +31,8 @@ def test_wideresnet_pytorch(forge_property_recorder, variant):
     if variant != "wide_resnet50_2":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="wideresnet",
         variant=variant,
@@ -42,7 +42,6 @@ def test_wideresnet_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load the model and prepare input data
     (framework_model, inputs) = generate_model_wideresnet_imgcls_pytorch(variant)
@@ -87,8 +86,8 @@ variants = ["wide_resnet50_2", "wide_resnet101_2"]
 def test_wideresnet_timm(forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="wideresnet",
         source=Source.TIMM,
@@ -98,7 +97,6 @@ def test_wideresnet_timm(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     (framework_model, inputs) = generate_model_wideresnet_imgcls_timm(variant)
 

--- a/forge/test/models/pytorch/vision/xception/test_xception.py
+++ b/forge/test/models/pytorch/vision/xception/test_xception.py
@@ -10,10 +10,10 @@ from timm.data import resolve_data_config
 from timm.data.transforms_factory import create_transform
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.xception.utils.utils import post_processing
-from test.models.utils import Framework, Source, Task, build_module_name
 from test.utils import download_model
 
 
@@ -54,8 +54,8 @@ def test_xception_timm(forge_property_recorder, variant):
     if variant not in ["xception", "xception71.tf_in1k"]:
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="xception",
         variant=variant,
@@ -65,7 +65,6 @@ def test_xception_timm(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     (framework_model, inputs) = generate_model_xception_imgcls_timm(variant)
 

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v10.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v10.py
@@ -5,20 +5,20 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.yolo.utils.yolo_utils import (
     YoloWrapper,
     load_yolo_model_and_image,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.xfail(reason="AssertionError: Encountered unsupported op types. Check error logs for more details")
 @pytest.mark.nightly
 def test_yolov10(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="Yolov10",
         variant="default",
@@ -26,7 +26,6 @@ def test_yolov10(forge_property_recorder):
         source=Source.GITHUB,
     )
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load  model and input
     model, image_tensor = load_yolo_model_and_image(

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v3.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v3.py
@@ -6,9 +6,8 @@ import torch
 from PIL import Image
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
-
-from test.models.utils import Framework, Source, Task, build_module_name
 
 # https://github.com/holli/yolov3_pytorch
 # sys.path = list(set(sys.path + ["third_party/confidential_customer_models/model_2/pytorch/"]))
@@ -37,8 +36,8 @@ def generate_model_yolotinyV3_imgcls_holli_pytorch():
 @pytest.mark.skip(reason="dependent on CCM repo")
 @pytest.mark.nightly
 def test_yolov3_tiny_holli_pytorch(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="yolov_3",
         variant="tiny_holli_pytorch",
@@ -48,7 +47,6 @@ def test_yolov3_tiny_holli_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_yolotinyV3_imgcls_holli_pytorch()
 
@@ -86,8 +84,8 @@ def generate_model_yoloV3_imgcls_holli_pytorch():
 def test_yolov3_holli_pytorch(forge_property_recorder):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="yolo_v3",
         variant="holli_pytorch",
@@ -97,7 +95,6 @@ def test_yolov3_holli_pytorch(forge_property_recorder):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_yoloV3_imgcls_holli_pytorch()
 

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -5,9 +5,9 @@ import pytest
 import torch
 
 import forge
+from forge.forge_property_utils import Framework
 from forge.verify.verify import verify
 
-from test.models.utils import Framework, build_module_name
 from test.utils import fetch_model, yolov5_loader
 
 base_url = "https://github.com/ultralytics/yolov5/releases/download/v7.0"
@@ -38,8 +38,8 @@ def test_yolov5_320x320(restore_package_versions, forge_property_recorder, size)
     if size != "s":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="yolo_v5",
         variant="yolov5" + size,
@@ -50,7 +50,6 @@ def test_yolov5_320x320(restore_package_versions, forge_property_recorder, size)
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_yoloV5I320_imgcls_torchhub_pytorch(
         "ultralytics/yolov5",
@@ -90,8 +89,8 @@ def test_yolov5_640x640(restore_package_versions, forge_property_recorder, size)
     if size != "s":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="yolo_v5",
         variant="yolov5" + size,
@@ -102,7 +101,6 @@ def test_yolov5_640x640(restore_package_versions, forge_property_recorder, size)
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_yoloV5I640_imgcls_torchhub_pytorch(
         "ultralytics/yolov5",
@@ -141,8 +139,8 @@ def test_yolov5_480x480(restore_package_versions, forge_property_recorder, size)
     if size != "n":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="yolo_v5",
         variant="yolov5" + size,
@@ -153,7 +151,6 @@ def test_yolov5_480x480(restore_package_versions, forge_property_recorder, size)
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model, inputs, _ = generate_model_yoloV5I480_imgcls_torchhub_pytorch(
         "ultralytics/yolov5",
@@ -174,8 +171,8 @@ def test_yolov5_480x480(restore_package_versions, forge_property_recorder, size)
 def test_yolov5_1280x1280(restore_package_versions, forge_property_recorder, variant):
     pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="yolo_v5",
         variant=variant,
@@ -186,7 +183,6 @@ def test_yolov5_1280x1280(restore_package_versions, forge_property_recorder, var
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     framework_model = fetch_model(
         variant,

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
@@ -8,13 +8,13 @@ import requests
 from yolov6 import YOLOV6
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.yolo.utils.yolov6_utils import (
     check_img_size,
     process_image,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 # Didn't dealt with yolov6n6,yolov6s6,yolov6m6,yolov6l6 variants because of its higher input size(1280)
 variants = [
@@ -34,8 +34,8 @@ def test_yolo_v6_pytorch(forge_property_recorder, variant):
     if variant != "yolov6n":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="yolo_v6",
         variant=variant,
@@ -45,7 +45,6 @@ def test_yolo_v6_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # STEP 2 :prepare model
     url = f"https://github.com/meituan/YOLOv6/releases/download/0.3.0/{variant}.pt"

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v8.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v8.py
@@ -6,13 +6,13 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.yolo.utils.yolo_utils import (
     YoloWrapper,
     load_yolo_model_and_image,
 )
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.xfail(
@@ -20,8 +20,8 @@ from test.models.utils import Framework, Source, Task, build_module_name
 )
 @pytest.mark.nightly
 def test_yolov8(forge_property_recorder):
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="Yolov8",
         variant="default",
@@ -29,7 +29,6 @@ def test_yolov8(forge_property_recorder):
         source=Source.GITHUB,
     )
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load  model and input
     model, image_tensor = load_yolo_model_and_image(

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_world.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_world.py
@@ -8,10 +8,10 @@ import torch
 from ultralytics import YOLO
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.yolo.utils.yolovx_utils import get_test_input
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 class YoloWorldWrapper(torch.nn.Module):
@@ -29,8 +29,8 @@ def test_yolo_world_inference(forge_property_recorder):
 
     model_url = "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8s-worldv2.pt"
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="yolo_world",
         variant="default",
@@ -41,7 +41,6 @@ def test_yolo_world_inference(forge_property_recorder):
     # Record Forge property
 
     forge_property_recorder.record_group("red")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load framework_model and input
 

--- a/forge/test/models/pytorch/vision/yolo/test_yolos.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolos.py
@@ -4,10 +4,10 @@
 import pytest
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.yolo.utils.yolos_utils import load_input, load_model
-from test.models.utils import Framework, Source, Task, build_module_name
 
 
 @pytest.mark.nightly
@@ -22,8 +22,8 @@ from test.models.utils import Framework, Source, Task, build_module_name
 )
 def test_yolos(forge_property_recorder, variant):
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="yolos",
         variant=variant,
@@ -33,7 +33,6 @@ def test_yolos(forge_property_recorder, variant):
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and input
     framework_model = load_model(variant)

--- a/forge/test/models/pytorch/vision/yolo/test_yolox.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolox.py
@@ -28,12 +28,12 @@ import torch
 from yolox.exp import get_exp
 
 import forge
+from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.yolo.utils.yolox_utils import preprocess
-from test.models.utils import Framework, Source, Task, build_module_name
 
 variants = [
     "yolox_nano",
@@ -54,14 +54,13 @@ def test_yolox_pytorch(forge_property_recorder, variant):
         pcc = 0.99
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
-    # Build Module Name
-    module_name = build_module_name(
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH, model="yolox", variant=variant, source=Source.TORCH_HUB, task=Task.OBJECT_DETECTION
     )
 
     # Record Forge Property
     forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # prepare model
     weight_name = f"{variant}.pth"

--- a/forge/test/models/utils.py
+++ b/forge/test/models/utils.py
@@ -1,85 +1,9 @@
 # SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-import re
-from enum import Enum
 import torch
-import os
 from tabulate import tabulate
 import json
-
-
-class StrEnum(str, Enum):
-    def __str__(self):
-        return self.value
-
-
-class Framework(StrEnum):
-    PYTORCH = "pt"
-    TENSORFLOW = "tf"
-    ONNX = "onnx"
-    PADDLE = "pd"
-
-
-class Task(StrEnum):
-    SPEECH_TRANSLATE = "speech_translate"
-    MUSIC_GENERATION = "music_generation"
-    SPEECH_RECOGNITION = "speech_recognition"
-    QA = "qa"
-    MASKED_LM = "mlm"
-    CAUSAL_LM = "clm"
-    TOKEN_CLASSIFICATION = "token_cls"
-    SEQUENCE_CLASSIFICATION = "seq_cls"
-    IMAGE_CLASSIFICATION = "img_cls"
-    IMAGE_SEGMENTATION = "img_seg"
-    POSE_ESTIMATION = "pose_estimation"
-    DEPTH_PREDICTION = "depth_prediction"
-    TEXT_GENERATION = "text_gen"
-    OBJECT_DETECTION = "obj_det"
-    SEMANTIC_SEGMENTATION = "sem_seg"
-    MASKED_IMAGE_MODELLING = "masked_img"
-    CONDITIONAL_GENERATION = "cond_gen"
-    IMAGE_ENCODING = "img_enc"
-    VISUAL_BACKBONE = "visual_bb"
-    DEPTH_ESTIMATION = "depth_estimation"
-    SCENE_TEXT_RECOGNITION = "scene_text_recognition"
-    TEXT_TO_SPEECH = "text_to_speech"
-    SENTENCE_EMBEDDING_GENERATION = "sentence_embed_gen"
-    MULTIMODAL_TEXT_GENERATION = "multimodal_text_gen"
-    ATOMIC_ML = "atomic_ml"
-
-
-class Source(StrEnum):
-    HUGGINGFACE = "hf"
-    TORCH_HUB = "torchhub"
-    TIMM = "timm"
-    OSMR = "osmr"
-    TORCHVISION = "torchvision"
-    GITHUB = "github"
-    PADDLE = "paddlemodels"
-
-
-def build_module_name(
-    framework: Framework,
-    model: str,
-    task: Task,
-    source: Source,
-    variant: str = "base",
-    suffix: str | None = None,
-) -> str:
-    module_name = f"{framework}_{model}"
-    if variant is not None:
-        module_name += f"_{variant}"
-    module_name += f"_{task}"
-    module_name += f"_{source}"
-    if suffix is not None:
-        module_name += f"_{suffix}"
-
-    module_name = re.sub(r"[^a-zA-Z0-9_]", "_", module_name)
-    module_name = re.sub(r"_+", "_", module_name)
-    module_name = module_name.lower()
-    return module_name
-
 
 imagenet_class_index_path = "forge/test/models/files/labels/imagenet_class_index.json"
 


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-forge-fe/issues/1674


### Problem description

Enhance property recording by storing below model-related attributes along with module_name:
- framework
- model arch name
- variant name
- task
- source


### What's changed

- Added a new method `record_model_properties` in ForgePropertyHandler to store the required properties. This method generates and returns a module_name using the build_module_name function.




