### PR TITLE
Revert "Fix build-if-neccessary job for nightly xfail (#1677)"

### DIFF
--- a/.github/workflows/on-nightly-xfail.yml
+++ b/.github/workflows/on-nightly-xfail.yml
@@ -24,11 +24,14 @@ jobs:
       secrets: inherit
 
   build-if-neccessary:
-    if: ${{ !(github.event.workflow_run.id || github.event.inputs.run_id) }}
+    runs-on: ubuntu-latest
     needs: docker-build
-    uses: ./.github/workflows/build.yml
-    with:
-      docker-image: ${{ needs.docker-build.outputs.docker-image }}
+    steps:
+      - name: Build the wheel if necessary
+        if: ${{ !(github.event.workflow_run.id || github.event.inputs.run_id) }}
+        uses: ./.github/workflows/build.yml
+        with:
+          docker-image: ${{ needs.docker-build.outputs.docker-image }}
 
     # Only build if no existing run ID is available
   test_full_model_xfailing:


### PR DESCRIPTION
This reverts commit b34ce428b55bcebdbf9f6c8c85437732966a5e5d.

### Ticket
Relates to #1676

### Problem description
PR #1677 broke nightly xfail when run id is passed.

### What's changed
Revert PR #1677

### Checklist
- [ ] New/Existing tests provide coverage for changes
