### PR TITLE
Uplift runtime tensor creation API changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,6 +189,21 @@ jobs:
             git submodule foreach --recursive git clean -ffdx
             git submodule foreach --recursive git reset --hard
 
+      - name: Update submodule if mlir_override is set
+        if: ${{ inputs.mlir_override }}
+        run: |
+          cd third_party/tt-mlir
+          git fetch
+          git checkout ${{ inputs.mlir_override }}
+          branch_name=$(git rev-parse --abbrev-ref HEAD)
+          commit_sha=$(git rev-parse HEAD)
+          commit_title=$(git log -1 --pretty=%s)
+          echo "Branch name: $branch_name"
+          echo "Commit SHA: $commit_sha"
+          echo "Commit title: $commit_title"
+          echo "::notice::Using tt-mlir branch: $branch_name, commit: $commit_sha, title: $commit_title"
+          cd ../..
+
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -189,21 +189,6 @@ jobs:
             git submodule foreach --recursive git clean -ffdx
             git submodule foreach --recursive git reset --hard
 
-      - name: Update submodule if mlir_override is set
-        if: ${{ inputs.mlir_override }}
-        run: |
-          cd third_party/tt-mlir
-          git fetch
-          git checkout ${{ inputs.mlir_override }}
-          branch_name=$(git rev-parse --abbrev-ref HEAD)
-          commit_sha=$(git rev-parse HEAD)
-          commit_title=$(git log -1 --pretty=%s)
-          echo "Branch name: $branch_name"
-          echo "Commit SHA: $commit_sha"
-          echo "Commit title: $commit_title"
-          echo "::notice::Using tt-mlir branch: $branch_name, commit: $commit_sha, title: $commit_title"
-          cd ../..
-
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:

--- a/forge/csrc/runtime/tensor.hpp
+++ b/forge/csrc/runtime/tensor.hpp
@@ -101,12 +101,6 @@ class TensorImpl : public std::enable_shared_from_this<TensorImpl>
     {
     }
 
-    std::shared_ptr<void> borrow_host_data() const
-    {
-        TT_ASSERT(host_storage.has_value());
-        return host_storage->borrow_data();
-    }
-
     runtime::Tensor& get_runtime_tensor()
     {
         TT_ASSERT(rt_tensor.has_value());
@@ -169,7 +163,7 @@ class TensorImpl : public std::enable_shared_from_this<TensorImpl>
     void update_host_data()
     {
         TT_ASSERT(
-            rt_tensor.has_value() && borrow_host_data().get() != nullptr,
+            rt_tensor.has_value() && host_storage.has_value(),
             "We expect the tensor to have a host buffer as well as a handle to the device tensor");
 
         constexpr bool untilize_tensor = true;
@@ -178,7 +172,7 @@ class TensorImpl : public std::enable_shared_from_this<TensorImpl>
 
         auto host = sharded_tensor[0];
 
-        tt::runtime::memcpy(borrow_host_data().get(), host);
+        tt::runtime::memcpy(host_storage->data_ptr(), host);
     }
 
     bool on_device() const { return rt_tensor.has_value(); }

--- a/forge/csrc/tt_torch_device/tt_device.cpp
+++ b/forge/csrc/tt_torch_device/tt_device.cpp
@@ -129,12 +129,8 @@ std::vector<std::uint32_t> fromIntArrayRef(torch::IntArrayRef arr)
 
 runtime::Tensor create_tensor(const torch::Tensor& tensor)
 {
-    auto data = std::shared_ptr<void>(
+    return runtime::createBorrowedHostTensor(
         tensor.data_ptr(),
-        [tensor](void*) { (void)tensor; }  // Capture tensor by value to increase ref count and keep it alive
-    );
-    return runtime::createTensor(
-        data,
         fromIntArrayRef(tensor.sizes()),
         fromIntArrayRef(tensor.strides()),
         tensor.element_size(),


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge-fe/issues/1705

### Problem description
I'm introducing changes in runtime tensor creation API (described in https://github.com/tenstorrent/tt-mlir/issues/2757), which need to be picked up by frontends after PR https://github.com/tenstorrent/tt-mlir/pull/2842 is merged so we can remove deprecated runtime API.

### What's changed
Updated places where old API was used.

### Checklist
- [x] New/Existing tests provide coverage for changes

CI on-pr passed on my branch (with GH workflow [issue](https://github.com/tenstorrent/tt-forge-fe/issues/1706) fix which I will send on separate PR): https://github.com/tenstorrent/tt-forge-fe/actions/runs/14286335280

It will currently fail on this PR until my tt-mlir PR is merged and uplifted, I will update this PR when that happens.