### PR TITLE
Fix build workflow for unit tests build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -167,6 +167,21 @@ jobs:
             git submodule foreach --recursive git clean -ffdx
             git submodule foreach --recursive git reset --hard
 
+      - name: Update submodule if mlir_override is set
+        if: ${{ inputs.mlir_override }}
+        run: |
+          cd third_party/tt-mlir
+          git fetch
+          git checkout ${{ inputs.mlir_override }}
+          branch_name=$(git rev-parse --abbrev-ref HEAD)
+          commit_sha=$(git rev-parse HEAD)
+          commit_title=$(git log -1 --pretty=%s)
+          echo "Branch name: $branch_name"
+          echo "Commit SHA: $commit_sha"
+          echo "Commit title: $commit_title"
+          echo "::notice::Using tt-mlir branch: $branch_name, commit: $commit_sha, title: $commit_title"
+          cd ../..
+
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge-fe/issues/1706

### Problem description
`.github/workflows/build.yml` applies tt-mlir input override to forge build but doesn't apply it to unit tests build.

### What's changed
Added tt-mlir input override check to unit tests build too.

### Checklist
- [x] New/Existing tests provide coverage for changes
