### PR TITLE
adv_index general support and rewrite

### DIFF
--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -1044,7 +1044,9 @@ def decompose(type, attr, dc, inputs):
         # Idea is to reshape the input tensor to [in0_shape[dim], -1] and then apply the embedding operation
         # The embedding operation will select the appropriate indices from the reshaped tensor
         # and then we will reshape the output back to the original shape.
-        # For example, if the input tensor is of shape [N, C, H, W] and we want to index along dim = 2 with indeces shape [X],
+        #
+        # For example:
+        # If the input tensor is of shape [N, C, H, W] and we want to index along dim = 2 with indeces shape [X],
         # we will first reshape it: [N, C, H, W] -> [N, H, C, W] and [N, H, C, W] -> [H, N, C, W] (permuted)
         # and then reshape it to [H, N * C * W] (flattening the last 3 dimensions)
         # and then apply the embedding operation to select the appropriate indices [H, N * C * W] -> [X, N * C * W].

--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -112,7 +112,7 @@ def eval(type, attr, ops):
         assert len(attr) == 1, "AdvIndex should have 1 attributes"
         assert len(t_ops[1].shape) == 1 or len(t_ops[1].shape) == 2, "indices should be 1D or 2D"
         dim = attr[0]
-        indices = t_ops[1]
+        indices = t_ops[1].type(torch.LongTensor)
         if len(indices.shape) == 2:
             # Indices are 2D, we need to reshape them to 1D
             indices = indices.reshape(-1)

--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -110,7 +110,7 @@ def eval(type, attr, ops):
 
     if type == "adv_index":
         assert len(attr) == 1, "AdvIndex should have 1 attributes"
-        assert len(t_ops[1].shape) == 1 or len(t_ops[1].shape) == 2, "Indeces should be 1D or 2D"
+        assert len(t_ops[1].shape) == 1 or len(t_ops[1].shape) == 2, "indices should be 1D or 2D"
         dim = attr[0]
         indices = t_ops[1].type(torch.LongTensor)
         if len(indices.shape) == 2:
@@ -394,7 +394,7 @@ def shape(type, attr, ops):
 
     if type == "adv_index":
         assert len(attr) == 1, "AdvIndex should have 1 attributes"
-        assert len(ops[1]) == 1 or len(ops[1]) == 2, "Indeces should be 1D or 2D"
+        assert len(ops[1]) == 1 or len(ops[1]) == 2, "indices should be 1D or 2D"
         dim = attr[0]
         shape = list(ops[0])
         shape[dim] = ops[1][-1]
@@ -1033,16 +1033,16 @@ def decompose(type, attr, dc, inputs):
     if type == "adv_index":
         dim = attr[0]
         in0_shape = inputs[0].shape.as_list()
-        indeces_shape = inputs[1].shape.as_list()
+        indices_shape = inputs[1].shape.as_list()
 
-        assert len(indeces_shape) == 2 or len(indeces_shape) == 1, "Indeces tensor should be 1D or 2D"
+        assert len(indices_shape) == 2 or len(indices_shape) == 1, "indices tensor should be 1D or 2D"
 
         # Idea is to reshape the input tensor to [in0_shape[dim], -1] and then apply the embedding operation
         # The embedding operation will select the appropriate indices from the reshaped tensor
         # and then we will reshape the output back to the original shape.
         #
         # For example:
-        # If the input tensor is of shape [N, C, H, W] and we want to index along dim = 2 with indeces shape [X],
+        # If the input tensor is of shape [N, C, H, W] and we want to index along dim = 2 with indices shape [X],
         # we will first reshape it: [N, C, H, W] -> [N, H, C, W] and [N, H, C, W] -> [H, N, C, W] (permuted)
         # and then reshape it to [H, N * C * W] (flattening the last 3 dimensions)
         # and then apply the embedding operation to select the appropriate indices [H, N * C * W] -> [X, N * C * W].
@@ -1074,7 +1074,7 @@ def decompose(type, attr, dc, inputs):
 
         # Step 4: Reshape back to appropriate dimensions
         # The new shape replaces the indexed dimension with the indices shape
-        output_shape = indeces_shape + permuted_shape[1:]
+        output_shape = indices_shape + permuted_shape[1:]
 
         reshaped_output = dc.op_with_named_attrs("reshape", [selected], {"shape": output_shape}, output_shape)
 

--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -1062,7 +1062,12 @@ def decompose(type, attr, dc, inputs):
 
         # Step 2: Reshape to [in0_shape[dim], -1]
         # Calculate product of all dimensions except the first (after transposition)
-        permuted_shape = in0_shape[dim : dim + 1] + in0_shape[:dim] + in0_shape[dim + 1 :] if dim != 0 else in0_shape
+
+        # Calculate permuted shape, by popping the element at indexed dim and inserting it at the begging
+        permuted_shape = in0_shape.copy()  # copy is needed to avoid modifying the original shape
+        indexed_dim_shape = permuted_shape.pop(dim)
+        permuted_shape = [indexed_dim_shape, *permuted_shape]
+
         rest_dims_product = math.prod(permuted_shape[1:])
 
         reshape_dims = [in0_shape[dim], rest_dims_product]

--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -1066,10 +1066,8 @@ def decompose(type, attr, dc, inputs):
 
         # Step 2: Reshape to [in0_shape[dim], -1]
         # Calculate product of all dimensions except the first (after transposition)
-        rest_dims_product = 1
         permuted_shape = in0_shape[dim : dim + 1] + in0_shape[:dim] + in0_shape[dim + 1 :] if dim != 0 else in0_shape
-        for i in range(1, len(permuted_shape)):
-            rest_dims_product *= permuted_shape[i]
+        rest_dims_product = math.prod(permuted_shape[1:])
 
         reshape_dims = [in0_shape[dim], rest_dims_product]
         reshaped = dc.op_with_named_attrs("reshape", [permuted], {"shape": reshape_dims}, reshape_dims)

--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -112,7 +112,7 @@ def eval(type, attr, ops):
         assert len(attr) == 1, "AdvIndex should have 1 attributes"
         assert len(t_ops[1].shape) == 1 or len(t_ops[1].shape) == 2, "indices should be 1D or 2D"
         dim = attr[0]
-        indices = t_ops[1].type(torch.LongTensor)
+        indices = t_ops[1]
         if len(indices.shape) == 2:
             # Indices are 2D, we need to reshape them to 1D
             indices = indices.reshape(-1)

--- a/forge/test/mlir/forge_ops/test_adv_index.py
+++ b/forge/test/mlir/forge_ops/test_adv_index.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import pytest
+
+import forge
+import forge.op
+from forge import ForgeModule
+from forge import Tensor, compile
+from forge.verify.verify import verify
+from forge.verify.value_checkers import AutomaticValueChecker
+from forge.verify.config import VerifyConfig
+
+
+class AdvIndexWrapper(ForgeModule):
+    def __init__(self, name, dim=0):
+        self.dim = dim
+        super().__init__(name)
+
+    def forward(self, advindex_input, indeces):
+        advindex_output = forge.op.AdvIndex("", advindex_input, indeces, self.dim)
+        return advindex_output
+
+
+@pytest.mark.parametrize(
+    "operand_shapes_dtypes, dim",
+    [
+        # 1D tensor
+        ((((16,), torch.float32), ((2,), torch.int32)), 0),
+        # 2D tensor
+        ((((8, 16), torch.float32), ((2,), torch.int32)), 1),
+        ((((8, 16), torch.float32), ((2,), torch.int32)), 0),
+        # 3D tensor
+        ((((4, 8, 16), torch.float32), ((2,), torch.int32)), 2),
+        ((((4, 8, 16), torch.float32), ((2,), torch.int32)), 1),
+        ((((4, 8, 16), torch.float32), ((2,), torch.int32)), 0),
+        # 4D tensor
+        ((((2, 4, 8, 16), torch.float32), ((2,), torch.int32)), 3),
+        ((((2, 4, 8, 16), torch.float32), ((2,), torch.int32)), 2),
+        ((((2, 4, 8, 16), torch.float32), ((2,), torch.int32)), 1),
+        ((((2, 4, 8, 16), torch.float32), ((2,), torch.int32)), 0),
+        # 5D tensor
+        ((((1, 2, 4, 8, 16), torch.float32), ((2,), torch.int32)), 4),
+        ((((1, 2, 4, 8, 16), torch.float32), ((2,), torch.int32)), 3),
+        ((((1, 2, 4, 8, 16), torch.float32), ((2,), torch.int32)), 2),
+        ((((1, 2, 4, 8, 16), torch.float32), ((2,), torch.int32)), 1),
+        ((((1, 2, 4, 8, 16), torch.float32), ((2,), torch.int32)), 0),
+    ],
+)
+def test_adv_indexing(operand_shapes_dtypes, dim):
+
+    # Make sure we don't go out of bounds for the dimension we're indexing
+    max_int = operand_shapes_dtypes[0][0][dim] - 1
+
+    inputs = [
+        Tensor.create_from_shape(operand_shape, operand_dtype, max_int=max_int)
+        for operand_shape, operand_dtype in operand_shapes_dtypes
+    ]
+
+    framework_model = AdvIndexWrapper("advindex_op", dim=dim)
+
+    compiled_model = compile(framework_model, sample_inputs=inputs)
+
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.99)),
+    )

--- a/forge/test/mlir/forge_ops/test_adv_index.py
+++ b/forge/test/mlir/forge_ops/test_adv_index.py
@@ -48,6 +48,7 @@ class AdvIndexWrapper(ForgeModule):
         ((((1, 2, 4, 8, 16), torch.float32), ((2,), torch.int32)), 0),
     ],
 )
+@pytest.mark.push
 def test_adv_indexing(operand_shapes_dtypes, dim):
 
     # Make sure we don't go out of bounds for the dimension we're indexing

--- a/forge/test/mlir/operators/indexing/test_advanced_masking.py
+++ b/forge/test/mlir/operators/indexing/test_advanced_masking.py
@@ -16,7 +16,6 @@ from forge.verify.verify import verify
             torch.arange(10, dtype=torch.float32),  # 1D tensor
             torch.tensor([True, False, True, False, True, False, True, False, True, False]),  # Mask
             id="1d_masked_select",
-            marks=pytest.mark.xfail(reason="AssertionError: Dynamic shapes not supported"),
         ),
         pytest.param(
             torch.arange(16, dtype=torch.float32).reshape(4, 4),  # 2D tensor

--- a/forge/test/mlir/operators/indexing/test_basic_indexing.py
+++ b/forge/test/mlir/operators/indexing/test_basic_indexing.py
@@ -49,12 +49,7 @@ def test_python_indexing(forge_property_recorder, index_shape: Literal[0] | Lite
 @pytest.mark.parametrize(
     "index_shape",
     [
-        pytest.param(
-            ([0, 2, 4], (10,)),  # vector
-            marks=pytest.mark.xfail(
-                reason="ValueError: Shape mismatch: framework_model.shape=torch.Size([3]), compiled_model.shape=torch.Size([10])"
-            ),
-        ),
+        ([0, 2, 4], (10,)),  # vector
         pytest.param(
             ([[0, 1], [2, 3]], (5, 5)),  # 2D matrix indexing
             marks=pytest.mark.xfail(
@@ -93,12 +88,7 @@ def test_python_indexing_with_lists(forge_property_recorder, index_shape: list[i
 @pytest.mark.parametrize(
     "index_shape",
     [
-        pytest.param(
-            ([0, 2, 4], (10,)),  # vector
-            marks=pytest.mark.xfail(
-                reason="ValueError: Shape mismatch: framework_model.shape=torch.Size([3]), compiled_model.shape=torch.Size([10])"
-            ),
-        ),
+        ([0, 2, 4], (10,)),  # vector
         pytest.param(
             ([[0, 1], [2, 3]], (5, 5)),  # 2D matrix indexing
             marks=pytest.mark.xfail(

--- a/forge/test/mlir/operators/indexing/test_basic_slicing.py
+++ b/forge/test/mlir/operators/indexing/test_basic_slicing.py
@@ -60,9 +60,6 @@ def test_slicing(forge_property_recorder, input_tensor_slice):
         pytest.param(
             (torch.arange(27, dtype=torch.float32).reshape(3, 3, 3), (0, 0, [0, 2])),
             id="specific_rows_columns",
-            marks=pytest.mark.xfail(
-                reason="ValueError: Shape mismatch: framework_model.shape=torch.Size([2]), compiled_model.shape=torch.Size([3])"
-            ),
         ),
         pytest.param(
             (torch.arange(27, dtype=torch.float32).reshape(3, 3, 3), (slice(None), slice(1, 3), slice(None))),

--- a/forge/test/mlir/test_ops_paddle.py
+++ b/forge/test/mlir/test_ops_paddle.py
@@ -308,6 +308,7 @@ def test_convbn_pp(forge_property_recorder):
 @pytest.mark.parametrize("token_num", [12])
 @pytest.mark.parametrize("embedding_dim", [3200])
 @pytest.mark.push
+@pytest.mark.xfail(reason="paddle embedding not supported yet")
 def test_embedding_pp(forge_property_recorder, vocab_size, token_num, embedding_dim):
     class Embedding(paddle.nn.Layer):
         def __init__(self):

--- a/forge/test/models_ops/test_advindex.py
+++ b/forge/test/models_ops/test_advindex.py
@@ -139,7 +139,7 @@ forge_modules_and_shapes_dtypes_list = [
             [((2359296,), torch.float32), ((2441216,), torch.int32)],
             {"model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"], "pcc": 0.99, "max_int": 2359295},
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Node not found")],
+        marks=[pytest.mark.xfail(reason="RuntimeError: circular buffers grow beyond max L1 size")],
     ),
     (
         Advindex0,


### PR DESCRIPTION
### Ticket
Fixes: #1616 

### What's changed
Refactored the core logic for `adv_index` decomposition to ensure comprehensive support for all cases, expanding beyond the previous constraints of `dim=0` and `input_length` of 2