### PR TITLE
Make forge_property_handler optional in Python bindings and handle inf/-inf in JSON parsing

### DIFF
--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -217,8 +217,16 @@ PYBIND11_MODULE(_C, m)
         &run_pre_lowering_passes,
         py::arg("graph"),
         py::arg("default_df_override") = std::optional<DataFormat>{});
-    m.def("run_mlir_compiler", &passes::run_mlir_compiler);
-    m.def("run_mlir_compiler_to_cpp", &passes::run_mlir_compiler_to_cpp);
+    m.def(
+        "run_mlir_compiler",
+        &passes::run_mlir_compiler,
+        py::arg("module"),
+        py::arg("forge_property_handler") = std::nullopt);
+    m.def(
+        "run_mlir_compiler_to_cpp",
+        &passes::run_mlir_compiler_to_cpp,
+        py::arg("module"),
+        py::arg("forge_property_handler") = std::nullopt);
     m.def("split_graph", &passes::split_graph);
 
     m.def(

--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -4,6 +4,7 @@
 
 from enum import Enum, auto
 import json
+import re
 from dataclasses import dataclass, is_dataclass, field
 from dataclasses_json import dataclass_json
 from typing import Union, List, Optional, Any, get_origin, get_args, Dict
@@ -431,6 +432,8 @@ class ForgePropertyHandler:
         Args:
             binary_json_str (str): The JSON string representation of the flatbuffer binary.
         """
+        binary_json_str = re.sub(r":\s*-inf\s*([,}])", r': "-inf"\1', binary_json_str)
+        binary_json_str = re.sub(r":\s*inf\s*([,}])", r': "inf"\1', binary_json_str)
         binary_json = json.loads(binary_json_str)
 
         flatbuffer_details_extractor = FlatbufferDetailsExtractor(binary_json)


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-forge-fe/issues/1703
Fixes https://github.com/tenstorrent/tt-forge-fe/issues/1702

1. Updated the Python bindings for `run_mlir_compiler` and `run_mlir_compiler_to_cpp` by making the `forge_property_handler` parameter optional with a default value of std::nullopt. This enables the functions to be called without explicitly passing this argument from Python, defaulting to an empty optional when omitted.
2. Improved JSON parsing by converting special float values like inf and -inf into strings before parsing. This ensures compatibility with json.loads, as these values are not valid in standard JSON.