### PR TITLE
Fixing latest CI nightly runs

### DIFF
--- a/forge/test/models/onnx/vision/vit/test_vit.py
+++ b/forge/test/models/onnx/vision/vit/test_vit.py
@@ -18,7 +18,6 @@ variants = [
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_vit_classify_224(forge_property_recorder, variant, tmp_path):
     # Record Forge Property

--- a/forge/test/models/paddlepaddle/vision/mobilenet/test_mobilenet_v1.py
+++ b/forge/test/models/paddlepaddle/vision/mobilenet/test_mobilenet_v1.py
@@ -15,6 +15,7 @@ from forge.forge_property_utils import Framework, Source, Task
 
 
 @pytest.mark.nightly
+@pytest.mark.skip(reason="Transient failure: Causing seg faults while building Metal kernels")
 def test_mobilenetv1_basic(forge_property_recorder):
     # Record model details
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
+++ b/forge/test/models/pytorch/vision/rcnn/test_rcnn.py
@@ -16,7 +16,6 @@ from forge.verify.verify import verify
 # Paper - https://arxiv.org/abs/1311.2524
 # Repo - https://github.com/object-detection-algorithm/R-CNN
 @pytest.mark.nightly
-@pytest.mark.xfail
 def test_rcnn_pytorch(forge_property_recorder):
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -34,6 +34,7 @@ size = [
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size)
+@pytest.mark.xfail
 def test_yolov5_320x320(restore_package_versions, forge_property_recorder, size):
     if size != "s":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")
@@ -135,6 +136,7 @@ size = [
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size)
+@pytest.mark.xfail
 def test_yolov5_480x480(restore_package_versions, forge_property_recorder, size):
     if size != "n":
         pytest.skip("Skipping due to the current CI/CD pipeline limitations")


### PR DESCRIPTION
### Problem description
- New passing models: ViT and RCNN (will trakc them to confirm if these are transiet passes/falilures, or they're rather stable)
- Skipping PaddlePaddle MobileNet v1 due to transient seg faults caused during build of Metal kernels #1747
- XFailing Yolo v5 model due to recent regressions #1746