### PR TITLE
Re-enable the skipped set4 tests in CI

### DIFF
--- a/forge/test/models/pytorch/text/distilbert/test_distilbert.py
+++ b/forge/test/models/pytorch/text/distilbert/test_distilbert.py
@@ -17,20 +17,16 @@ from forge.verify.verify import verify
 from test.utils import download_model
 
 variants = [
-    pytest.param(
-        "distilbert-base-uncased",
-        marks=[pytest.mark.xfail],
-    ),
+    "distilbert-base-uncased",
     "distilbert-base-cased",
     "distilbert-base-multilingual-cased",
 ]
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_distilbert_masked_lm_pytorch(forge_property_recorder, variant):
-    if variant != "distilbert-base-uncased":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -72,9 +68,9 @@ def test_distilbert_masked_lm_pytorch(forge_property_recorder, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["distilbert-base-cased-distilled-squad"])
 def test_distilbert_question_answering_pytorch(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -122,9 +118,9 @@ def test_distilbert_question_answering_pytorch(forge_property_recorder, variant)
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["distilbert-base-uncased-finetuned-sst-2-english"])
 def test_distilbert_sequence_classification_pytorch(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -166,9 +162,9 @@ def test_distilbert_sequence_classification_pytorch(forge_property_recorder, var
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["Davlan/distilbert-base-multilingual-cased-ner-hrl"])
 def test_distilbert_token_classification_pytorch(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/text/dpr/test_dpr.py
+++ b/forge/test/models/pytorch/text/dpr/test_dpr.py
@@ -28,8 +28,6 @@ params = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", params)
 def test_dpr_context_encoder_pytorch(forge_property_recorder, variant):
-    if variant != "facebook/dpr-ctx_encoder-single-nq-base":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -87,7 +85,6 @@ variants = ["facebook/dpr-question_encoder-single-nq-base", "facebook/dpr-questi
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_dpr_question_encoder_pytorch(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -152,9 +149,9 @@ variants = ["facebook/dpr-reader-single-nq-base", "facebook/dpr-reader-multiset-
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_dpr_reader_pytorch(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/text/gptneo/test_gptneo.py
+++ b/forge/test/models/pytorch/text/gptneo/test_gptneo.py
@@ -27,18 +27,24 @@ GPTNeoModel._prepare_4d_causal_attention_mask_with_cache_position = (
 variants = [
     pytest.param(
         "EleutherAI/gpt-neo-125M",
-        marks=[pytest.mark.xfail],
+        marks=pytest.mark.xfail,
     ),
-    "EleutherAI/gpt-neo-1.3B",
-    "EleutherAI/gpt-neo-2.7B",
+    pytest.param(
+        "EleutherAI/gpt-neo-1.3B",
+        marks=pytest.mark.xfail,
+    ),
+    pytest.param(
+        "EleutherAI/gpt-neo-2.7B",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 28 GB during compile time)"
+        ),
+    ),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_gptneo_causal_lm(forge_property_recorder, variant):
-    if variant != "EleutherAI/gpt-neo-125M":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -93,16 +99,28 @@ def test_gptneo_causal_lm(forge_property_recorder, variant):
 
 
 variants = [
-    "EleutherAI/gpt-neo-125M",
-    "EleutherAI/gpt-neo-1.3B",
-    "EleutherAI/gpt-neo-2.7B",
+    pytest.param(
+        "EleutherAI/gpt-neo-125M",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 24 GB during compile time)"
+        ),
+    ),
+    pytest.param(
+        "EleutherAI/gpt-neo-1.3B",
+        marks=pytest.mark.xfail,
+    ),
+    pytest.param(
+        "EleutherAI/gpt-neo-2.7B",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 28 GB during compile time)"
+        ),
+    ),
 ]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants)
 def test_gptneo_sequence_classification(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
+++ b/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
@@ -26,9 +26,9 @@ variants = [
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_retinanet(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(


### PR DESCRIPTION
 This PR enables the following skipped test cases:

````
pt_distilbert_distilbert_base_multilingual_cased_mlm_hf - Maximum: 2947.54 MB
pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf - Maximum: 2140.17 MB
pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf - Maximum: 1769.78 MB
pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf - Maximum: 2314.73 MB
pt_dpr_facebook_dpr_ctx_encoder_multiset_base_qa_hf_context_encoder - Maximum: 3079.29 MB
pt_dpr_facebook_dpr_question_encoder_single_nq_base_qa_hf_question_encoder - Maximum: 2852.17 MB
pt_dpr_facebook_dpr_question_encoder_multiset_base_qa_hf_question_encoder - Maximum: 3271.79 MB
pt_dpr_facebook_dpr_reader_single_nq_base_qa_hf_reader - Maximum: 3783.77 MB
pt_dpr_facebook_dpr_reader_multiset_base_qa_hf_reader - Maximum: 3776.66 MB
pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf - Maximum: 13554.30 MB
pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf - Maximum: 17818.66 MB
pt_retinanet_retinanet_rn18fpn_obj_det_hf - Maximum: 2426.83 MB
pt_retinanet_retinanet_rn34fpn_obj_det_hf - Maximum: 3642.73 MB
pt_retinanet_retinanet_rn50fpn_obj_det_hf - Maximum: 6476.77 MB
pt_retinanet_retinanet_rn101fpn_obj_det_hf - Maximum: 6476.77 MB
pt_retinanet_retinanet_rn152fpn_obj_det_hf - Maximum: 9050.76 MB
````
logs:
[distilbert_1.log](https://github.com/user-attachments/files/20164219/distilbert_1.log)
[dpr.log](https://github.com/user-attachments/files/20164224/dpr.log)
[retinanet.log](https://github.com/user-attachments/files/20164246/retinanet.log)
[gptneo_may12.log](https://github.com/user-attachments/files/20165957/gptneo_may12.log)

