### PR TITLE
[verification] disable codegen verification

### DIFF
--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -2126,7 +2126,7 @@ def compile_tvm_to_python(
     is_training = False if verify_cfg == None else verify_cfg.test_kind.is_training()
 
     framework = get_framework(framework_mod)
-    if framework == "pytorch":
+    if framework in ["pytorch", "paddle"]:
         if is_training:
             framework_mod.module.train()
             verify_cfg.verify_tvm_compile = False

--- a/forge/forge/verify/config.py
+++ b/forge/forge/verify/config.py
@@ -113,7 +113,7 @@ class DepricatedVerifyConfig:
     verify_tvm_compile: bool = False  # Should tvm run forward and verify the results
     verify_pipeline_result_vs_framework: bool = False  # Compare Framework output on CPU vs module pipline outputs
     verify_forge_codegen_vs_framework: bool = (
-        True  # Compare Framework output on CPU vs forge codegen from TVM json graphs
+        False  # Compare Framework output on CPU vs forge codegen from TVM json graphs
     )
     # Setting this to true will enable intermediate outputs to remain in graph
     # If false, all unused outputs will be removed. This needs to be true for intermediate golden verification


### PR DESCRIPTION
Disabling forge codegen verification by default - this aligns with other golden checks during compile time, i.e. they are not being executed by default.

This will help us with memory usage and slightly speed up the tests as well.

Small fix related to paddle was needed to make the paddle tests pass. The module was only being set to `eval()` when running the forge codegen verification, so when the verification was skipped the following assertion failure was being hit (`forge_utils.py:40`):

```python
assert model.training == False
```

Closes #1737