### PR TITLE
All op naming convention

### DIFF
--- a/forge/forge/op_repo/pytorch_operators.py
+++ b/forge/forge/op_repo/pytorch_operators.py
@@ -5,12 +5,18 @@
 # PyTorch repostiory operators
 
 
-from .datatypes import OperatorDefinition, OperatorRepository
-from .datatypes import OperatorParamNumber
+from .datatypes import OperandNumRange, OperatorDefinition, OperatorRepository, OperatorParamNumber
 
 
 # TODO describe operand and shapes
 _OPERATORS = [
+    # nn operators
+    OperatorDefinition(
+        "embedding",
+        "torch.nn.Embedding",
+        1,
+        instantiate=True,
+    ),
     OperatorDefinition(
         "linear",
         "torch.nn.Linear",
@@ -46,13 +52,35 @@ _OPERATORS = [
     OperatorDefinition("rsqrt", "torch.rsqrt", 1),
     OperatorDefinition("sin", "torch.sin", 1),
     OperatorDefinition("square", "torch.square", 1),
-    OperatorDefinition("pow", "torch.pow", 1),
-    OperatorDefinition("clamp", "torch.clamp", 1),
+    OperatorDefinition(
+        "pow",
+        "torch.pow",
+        1,
+        forward_params=[
+            OperatorParamNumber("exponent", int, -10, 10),
+        ],
+    ),
+    OperatorDefinition(
+        "clamp",
+        "torch.clamp",
+        1,
+        forward_params=[
+            OperatorParamNumber("min", int, -100, 100),
+            OperatorParamNumber("max", int, -100, 100),
+        ],
+    ),
     OperatorDefinition("log", "torch.log", 1),
     OperatorDefinition("log1p", "torch.log1p", 1),
     OperatorDefinition("gelu", "torch.nn.functional.gelu", 1),
     OperatorDefinition("leaky_relu", "torch.nn.functional.leaky_relu", 1),
-    OperatorDefinition("cumsum", "torch.cumsum", 1),
+    OperatorDefinition(
+        "cumsum",
+        "torch.cumsum",
+        1,
+        forward_params=[
+            OperatorParamNumber("dim", int, -3, 3),
+        ],
+    ),
     OperatorDefinition("softmax", "torch.softmax", 1),
     # Unary operators (not implemented)
     OperatorDefinition("acos", "torch.acos", 1),
@@ -106,7 +134,44 @@ _OPERATORS = [
     OperatorDefinition("mul", "torch.mul", 2),
     OperatorDefinition("div", "torch.div", 2),
     OperatorDefinition("ge", "torch.ge", 2),
+    OperatorDefinition("ne", "torch.ne", 2),
+    OperatorDefinition("gt", "torch.gt", 2),
+    OperatorDefinition("lt", "torch.lt", 2),
+    OperatorDefinition("maximum", "torch.maximum", 2),
+    OperatorDefinition("minimum", "torch.minimum", 2),
+    # Binary operators (not implemented)
+    OperatorDefinition("atan2", "torch.atan2", 2),
+    OperatorDefinition("arctan2", "torch.arctan2", 2),
+    OperatorDefinition("bitwise_and", "torch.bitwise_and", 2),
+    OperatorDefinition("bitwise_or", "torch.bitwise_or", 2),
+    OperatorDefinition("bitwise_xor", "torch.bitwise_xor", 2),
+    OperatorDefinition("bitwise_left_shift", "torch.bitwise_left_shift", 2),
+    OperatorDefinition("bitwise_right_shift", "torch.bitwise_right_shift", 2),
+    OperatorDefinition("floor_divide", "torch.floor_divide", 2),
+    OperatorDefinition("fmod", "torch.fmod", 2),
+    OperatorDefinition("logaddexp", "torch.logaddexp", 2),
+    OperatorDefinition("logaddexp2", "torch.logaddexp2", 2),
+    OperatorDefinition("nextafter", "torch.nextafter", 2),
+    OperatorDefinition("remainder", "torch.remainder", 2),
+    OperatorDefinition("fmax", "torch.fmax", 2),
+    OperatorDefinition("fmin", "torch.fmin", 2),
+    OperatorDefinition("eq", "torch.eq", 2),
+    OperatorDefinition("le", "torch.le", 2),
+    # Matmul
     OperatorDefinition("matmul", "torch.matmul", 2),
+    # Nary operators
+    OperatorDefinition("concatenate", "torch.concatenate", input_num_range=(2, 7)),
+    # Reduce operators
+    OperatorDefinition("max", "torch.max", 1),
+    OperatorDefinition("sum", "torch.sum", 1),
+    OperatorDefinition("mean", "torch.mean", 1),
+    # TM operators
+    OperatorDefinition("repeat_interleave", "torch.repeat_interleave", 1),
+    OperatorDefinition("reshape", "torch.reshape", 1),
+    OperatorDefinition("squeeze", "torch.squeeze", 1),
+    OperatorDefinition("unsqueeze", "torch.unsqueeze", 1),
+    OperatorDefinition("transpose", "torch.transpose", 1),
+    OperatorDefinition("layer_norm", "torch.nn.LayerNorm", 1),
 ]
 
 

--- a/forge/test/operators/pytorch/eltwise_binary/test_binary.py
+++ b/forge/test/operators/pytorch/eltwise_binary/test_binary.py
@@ -70,6 +70,7 @@ from test.operators.utils import FailingRulesConverter
 from test.operators.utils import TestCollectionCommon
 from test.operators.utils import FailingReasons
 from test.operators.utils.compat import TestDevice
+from test.operators.utils.utils import PytorchUtils
 
 from forge.op_repo import TensorShape
 
@@ -133,7 +134,7 @@ class TestVerification:
         if dev_data_format is None:
             value_range = ValueRanges.SMALL_POSITIVE
 
-        operator = getattr(torch, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
 
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 

--- a/forge/test/operators/pytorch/eltwise_nary/test_concatenate.py
+++ b/forge/test/operators/pytorch/eltwise_nary/test_concatenate.py
@@ -10,16 +10,19 @@ import torch
 from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AllCloseValueChecker, AutomaticValueChecker
 
-from test.operators.utils import VerifyUtils
-from test.operators.utils import InputSource
-from test.operators.utils import TestVector
-from test.operators.utils import TestPlan
-from test.operators.utils import FailingReasons
+from test.operators.utils import (
+    VerifyUtils,
+    InputSource,
+    TestVector,
+    TestPlan,
+    FailingReasons,
+    TestCollection,
+    TestCollectionCommon,
+    TestCollectionTorch,
+    ValueRanges,
+)
 from test.operators.utils.compat import TestDevice
-from test.operators.utils import TestCollection
-from test.operators.utils import TestCollectionCommon
-from test.operators.utils import TestCollectionTorch
-from test.operators.utils import ValueRanges
+from test.operators.utils.utils import PytorchUtils
 
 
 class ModelFromAnotherOp(torch.nn.Module):
@@ -105,7 +108,7 @@ class TestVerification:
     ):
         """Common verification function for all tests"""
 
-        operator = getattr(torch, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
 
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 

--- a/forge/test/operators/pytorch/eltwise_unary/test_unary.py
+++ b/forge/test/operators/pytorch/eltwise_unary/test_unary.py
@@ -86,8 +86,7 @@ class TestVerification:
         warm_reset: bool = False,
     ):
 
-        module = PytorchUtils.get_pytorch_module(test_vector.operator)
-        operator = getattr(module, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
 
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 

--- a/forge/test/operators/pytorch/nn/test_conv2d.py
+++ b/forge/test/operators/pytorch/nn/test_conv2d.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+# Tests for testing of linear operators
+#
+# In this test we test pytorch conv2d operator
+
 from dataclasses import dataclass
 from functools import reduce
 import math
@@ -32,6 +36,7 @@ from test.operators.utils import (
 )
 from test.operators.utils.compat import TestDevice, TestTensorsUtils
 from test.operators.utils.test_data import TestCollectionTorch
+from test.operators.utils.utils import PytorchUtils
 
 
 class ModelFromAnotherOp(torch.nn.Module):
@@ -117,7 +122,7 @@ class TestVerification:
     ):
         """Common verification function for all tests"""
 
-        operator = getattr(torch.nn, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
 
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 
@@ -606,7 +611,7 @@ class TestCollectionData:
 
     all = TestCollection(
         operators=[
-            "Conv2d",  # 00
+            "conv2d",  # 00
         ],
         input_sources=TestCollectionCommon.all.input_sources,
         # only 4D input tensors are supported

--- a/forge/test/operators/pytorch/nn/test_conv2d_ids_failed_inference_froze.txt
+++ b/forge/test/operators/pytorch/nn/test_conv2d_ids_failed_inference_froze.txt
@@ -1,6 +1,6 @@
-Conv2d-FROM_ANOTHER_OP-{'in_channels': 10, 'out_channels': 10, 'kernel_size': (74, 1), 'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 10, 'bias': False, 'padding_mode': 'zeros'}-(10, 10, 10000, 1)-None-None
-Conv2d-FROM_ANOTHER_OP-{'in_channels': 10, 'out_channels': 10, 'kernel_size': (59, 1), 'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 10, 'bias': False, 'padding_mode': 'zeros'}-(1, 10, 10000, 1)-None-None
-Conv2d-FROM_HOST-{'in_channels': 10, 'out_channels': 10, 'kernel_size': (59, 1), 'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 10, 'bias': False, 'padding_mode': 'zeros'}-(1, 10, 10000, 1)-None-None
-Conv2d-FROM_HOST-{'in_channels': 10, 'out_channels': 10, 'kernel_size': (74, 1), 'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 10, 'bias': False, 'padding_mode': 'zeros'}-(10, 10, 10000, 1)-None-None
-Conv2d-CONST_EVAL_PASS-{'in_channels': 10, 'out_channels': 10, 'kernel_size': (59, 1), 'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 10, 'bias': False, 'padding_mode': 'zeros'}-(1, 10, 10000, 1)-None-None
-Conv2d-CONST_EVAL_PASS-{'in_channels': 10, 'out_channels': 10, 'kernel_size': (74, 1), 'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 10, 'bias': False, 'padding_mode': 'zeros'}-(10, 10, 10000, 1)-None-None
+conv2d-FROM_ANOTHER_OP-{'in_channels': 10, 'out_channels': 10, 'kernel_size': (74, 1), 'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 10, 'bias': False, 'padding_mode': 'zeros'}-(10, 10, 10000, 1)-None-None
+conv2d-FROM_ANOTHER_OP-{'in_channels': 10, 'out_channels': 10, 'kernel_size': (59, 1), 'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 10, 'bias': False, 'padding_mode': 'zeros'}-(1, 10, 10000, 1)-None-None
+conv2d-FROM_HOST-{'in_channels': 10, 'out_channels': 10, 'kernel_size': (59, 1), 'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 10, 'bias': False, 'padding_mode': 'zeros'}-(1, 10, 10000, 1)-None-None
+conv2d-FROM_HOST-{'in_channels': 10, 'out_channels': 10, 'kernel_size': (74, 1), 'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 10, 'bias': False, 'padding_mode': 'zeros'}-(10, 10, 10000, 1)-None-None
+conv2d-CONST_EVAL_PASS-{'in_channels': 10, 'out_channels': 10, 'kernel_size': (59, 1), 'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 10, 'bias': False, 'padding_mode': 'zeros'}-(1, 10, 10000, 1)-None-None
+conv2d-CONST_EVAL_PASS-{'in_channels': 10, 'out_channels': 10, 'kernel_size': (74, 1), 'stride': 1, 'padding': 0, 'dilation': 1, 'groups': 10, 'bias': False, 'padding_mode': 'zeros'}-(10, 10, 10000, 1)-None-None

--- a/forge/test/operators/pytorch/nn/test_embedding.py
+++ b/forge/test/operators/pytorch/nn/test_embedding.py
@@ -6,51 +6,6 @@
 #
 # In this test we test pytorch embedding operator
 
-# GENERAL OP SUPPORT TEST PLAN:
-# 1. Operand type - any supported type
-# 2. Operand source(s):
-# (+)  2.1 From another op
-#       - Operator -> input
-# (+)  2.2 From DRAM queue - removed from test plan
-#       - Operator is first node in network
-#       - Input_queue flag = false
-# (+)  2.3 Const Inputs (const eval pass)
-#       - Operator where all inputs are constants.
-# (+)  2.4 From host
-#       - Input tensor as input of network
-#       - Operator is first node in network
-#       - Input_queue flag = true
-# 3 Operand shapes type(s):
-# (+)  3.1 Full tensor (i.e. full expected shape)
-#       - 3-4 by default P1 (high prioriy)
-#       - 2, 5, ++ include P2 (lower prioriy)
-# (+)  3.2 Tensor reduce on one or more dims to 1
-#       - Vector
-#       - Only one dim is not equal to 1
-# (+)  3.3 Scalar P2
-#       - Create tensor of dimension equal to 0 (tensor from scalar) or just to use scalar as simple value
-# 4. Operand / output size of dimensions (few examples of each, 10 values total)
-# (+)  4.1 Divisible by 32
-# (+)  4.2 Prime numbers
-# (+)  4.3 Very large (thousands, 10s of thousands)
-#       - 100x100, 100x1000
-#       - maybe nightly only
-# (+)  4.4 Extreme ratios between height/width
-#      4.5 ...probably many more interesting combinations here
-# 5. Data format - all supported formats
-# (/)  5.1 Output DF
-# (/)  5.2 Intermediate DF
-# (/)  5.3 Accumulation DF
-# (+)  5.4 Operand DFs
-#       - Fix HiFi4 for math fidelity value
-# (+) 6. Math fidelity - LoFi, HiFi2a, Hifi2b, Hifi3, Hifi4
-#       - Fix fp16b (default) for data format value
-# (/) 7. Special attributes - if applicable.. like approx_mode for Exp, for example
-# (/) 8. Special cases - if applicable
-# 9. Variable number of operands - if applicable
-# (/) Few representative values
-# (/) Reuse inputs for selected operators
-
 
 from functools import reduce
 import math
@@ -65,15 +20,19 @@ import forge.op
 from loguru import logger
 
 
-from test.operators.utils import InputSourceFlags, VerifyUtils
-from test.operators.utils import InputSource
-from test.operators.utils import TestVector
-from test.operators.utils import TestPlan
-from test.operators.utils import FailingReasons
-from test.operators.utils.compat import TestDevice
-from test.operators.utils import TestCollection
-from test.operators.utils import TestCollectionCommon
+from test.operators.utils import (
+    InputSourceFlags,
+    VerifyUtils,
+    InputSource,
+    TestVector,
+    TestPlan,
+    FailingReasons,
+    TestCollection,
+    TestCollectionCommon,
+)
 from test.operators.utils.datatypes import ValueRange
+from test.operators.utils.compat import TestDevice
+from test.operators.utils.utils import PytorchUtils
 
 
 class ModelFromAnotherOp(torch.nn.Module):
@@ -178,7 +137,7 @@ class TestVerification:
     ):
         """Common verification function for all tests"""
 
-        operator = getattr(torch.nn, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
 
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 
@@ -270,7 +229,7 @@ class TestCollectionData:
 
     all = TestCollection(
         operators=[
-            "Embedding",  # 00
+            "embedding",  # 00
         ],
         input_sources=TestCollectionCommon.all.input_sources,
         input_shapes=[

--- a/forge/test/operators/pytorch/nn/test_linear.py
+++ b/forge/test/operators/pytorch/nn/test_linear.py
@@ -2,54 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 #
-# Tests for testing of embedding operators
+# Tests for testing of linear operators
 #
-# In this test we test pytorch embedding operator
-
-# GENERAL OP SUPPORT TEST PLAN:
-# 1. Operand type - any supported type
-# 2. Operand source(s):
-# (+)  2.1 From another op
-#       - Operator -> input
-# (+)  2.2 From DRAM queue - Removed from test plan
-#       - Operator is first node in network
-#       - Input_queue flag = false
-# (+)  2.3 Const Inputs (const eval pass)
-#       - Operator where all inputs are constants.
-# (+)  2.4 From host
-#       - Input tensor as input of network
-#       - Operator is first node in network
-#       - Input_queue flag = true
-# 3 Operand shapes type(s):
-# (+)  3.1 Full tensor (i.e. full expected shape)
-#       - 3-4 by default P1 (high prioriy)
-#       - 2, 5, ++ include P2 (lower prioriy)
-# (+)  3.2 Tensor reduce on one or more dims to 1
-#       - Vector
-#       - Only one dim is not equal to 1
-# (+)  3.3 Scalar P2
-#       - Create tensor of dimension equal to 0 (tensor from scalar) or just to use scalar as simple value
-# 4. Operand / output size of dimensions (few examples of each, 10 values total)
-# (+)  4.1 Divisible by 32
-# (+)  4.2 Prime numbers
-# (+)  4.3 Very large (thousands, 10s of thousands)
-#       - 100x100, 100x1000
-#       - maybe nightly only
-# (+)  4.4 Extreme ratios between height/width
-#      4.5 ...probably many more interesting combinations here
-# 5. Data format - all supported formats
-# (/)  5.1 Output DF
-# (/)  5.2 Intermediate DF
-# (/)  5.3 Accumulation DF
-# (+)  5.4 Operand DFs
-#       - Fix HiFi4 for math fidelity value
-# (+) 6. Math fidelity - LoFi, HiFi2a, Hifi2b, Hifi3, Hifi4
-#       - Fix fp16b (default) for data format value
-# (/) 7. Special attributes - if applicable.. like approx_mode for Exp, for example
-# (/) 8. Special cases - if applicable
-# 9. Variable number of operands - if applicable
-# (/) Few representative values
-# (/) Reuse inputs for selected operators
+# In this test we test pytorch linear operator
 
 
 from functools import reduce
@@ -66,15 +21,19 @@ import forge.op
 from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AllCloseValueChecker
 
-from test.operators.utils import InputSourceFlags, VerifyUtils, ValueRanges
-from test.operators.utils import InputSource
-from test.operators.utils import TestVector
-from test.operators.utils import TestPlan
-from test.operators.utils import FailingReasons
-from test.operators.utils.compat import TestDevice
-from test.operators.utils.compat import TestTensorsUtils
-from test.operators.utils import TestCollection
-from test.operators.utils import TestCollectionCommon
+from test.operators.utils import (
+    InputSourceFlags,
+    VerifyUtils,
+    ValueRanges,
+    InputSource,
+    TestVector,
+    TestPlan,
+    FailingReasons,
+    TestCollection,
+    TestCollectionCommon,
+)
+from test.operators.utils.compat import TestDevice, TestTensorsUtils
+from test.operators.utils.utils import PytorchUtils
 
 
 class ModelFromAnotherOp(torch.nn.Module):
@@ -83,7 +42,7 @@ class ModelFromAnotherOp(torch.nn.Module):
 
     def __init__(self, operator, opname, shape, kwargs):
         super(ModelFromAnotherOp, self).__init__()
-        self.testname = "Embedding_pytorch_operator_" + opname + "_test_op_src_from_another_op"
+        self.testname = "Linear_pytorch_operator_" + opname + "_test_op_src_from_another_op"
         self.operator = operator
         self.opname = opname
         self.shape = shape
@@ -95,7 +54,7 @@ class ModelFromAnotherOp(torch.nn.Module):
         self.l1 = self.operator(**self.kwargs)
 
     def forward(self, x: torch.Tensor):
-        # we use Add operator to create one operands which is input for the embedding operator
+        # we use Add operator to create one operands which is input for the linear operator
         add = torch.add(x, x)
         output = self.l1(add)
         return output
@@ -107,7 +66,7 @@ class ModelDirect(torch.nn.Module):
 
     def __init__(self, operator, opname, shape, kwargs):
         super(ModelDirect, self).__init__()
-        self.testname = "Embedding_pytorch_operator_" + opname + "_test_op_src_from_host"
+        self.testname = "Linear_pytorch_operator_" + opname + "_test_op_src_from_host"
         self.operator = operator
         self.opname = opname
         self.shape = shape
@@ -129,7 +88,7 @@ class ModelConstEvalPass(torch.nn.Module):
 
     def __init__(self, operator, opname, shape, kwargs, dtype):
         super(ModelConstEvalPass, self).__init__()
-        self.testname = "Embedding_pytorch_operator_" + opname + "_test_op_src_const_eval_pass"
+        self.testname = "Linear_pytorch_operator_" + opname + "_test_op_src_const_eval_pass"
         self.operator = operator
         self.opname = opname
         self.shape = shape
@@ -169,7 +128,7 @@ class TestVerification:
     ):
         """Common verification function for all tests"""
 
-        operator = getattr(torch.nn, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
 
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 
@@ -248,7 +207,7 @@ class TestCollectionData:
 
     all = TestCollection(
         operators=[
-            "Linear",  # 00
+            "linear",  # 00
         ],
         input_sources=TestCollectionCommon.all.input_sources,
         input_shapes=TestCollectionCommon.all.input_shapes,

--- a/forge/test/operators/pytorch/nn/test_softmax.py
+++ b/forge/test/operators/pytorch/nn/test_softmax.py
@@ -43,8 +43,9 @@ class TestVerification:
         input_params: List[Dict] = [],
         warm_reset: bool = False,
     ):
-        module = PytorchUtils.get_pytorch_module(test_vector.operator)
-        operator = getattr(module, test_vector.operator)
+
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
+
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
         model_type = cls.MODEL_TYPES[test_vector.input_source]
 

--- a/forge/test/operators/pytorch/reduce/test_max.py
+++ b/forge/test/operators/pytorch/reduce/test_max.py
@@ -25,6 +25,7 @@ from test.operators.utils.compat import TestDevice
 from test.operators.utils import TestCollection
 from test.operators.utils import TestCollectionCommon
 from test.operators.utils import ValueRanges
+from test.operators.utils.utils import PytorchUtils
 
 from test.operators.pytorch.eltwise_unary import ModelFromAnotherOp, ModelDirect, ModelConstEvalPass
 
@@ -89,7 +90,7 @@ class TestVerification:
         warm_reset: bool = False,
     ):
 
-        operator = getattr(torch, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 
         if not kwargs:

--- a/forge/test/operators/pytorch/reduce/test_reduce.py
+++ b/forge/test/operators/pytorch/reduce/test_reduce.py
@@ -76,6 +76,7 @@ from test.operators.utils import TestCollection
 from test.operators.utils import TestPlanUtils
 from test.operators.utils import TestCollectionCommon
 from test.operators.utils import ValueRanges
+from test.operators.utils.utils import PytorchUtils
 
 
 class ModelFromAnotherOp(torch.nn.Module):
@@ -156,7 +157,7 @@ class TestVerification:
     ):
         """Common verification function for all tests"""
 
-        operator = getattr(torch, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
 
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 

--- a/forge/test/operators/pytorch/tm/test_layernorm.py
+++ b/forge/test/operators/pytorch/tm/test_layernorm.py
@@ -27,13 +27,15 @@ from test.operators.utils.compat import TestDevice
 from test.operators.utils import TestCollection
 from test.operators.utils import TestCollectionCommon
 from test.operators.utils import ValueRanges
+from test.operators.utils.utils import PytorchUtils
 
 
 class ModelFromAnotherOp(torch.nn.Module):
-    def __init__(self, kwargs):
+    def __init__(self, operator, kwargs):
         super().__init__()
         self.testname = "Layernorm_operator_test_op_src_from_another_op"
-        self.lnorm = torch.nn.LayerNorm(**kwargs)
+        self.operator = operator
+        self.lnorm = self.operator(**kwargs)
 
     def forward(self, x):
         xx = torch.add(x, x)
@@ -41,20 +43,22 @@ class ModelFromAnotherOp(torch.nn.Module):
 
 
 class ModelDirect(torch.nn.Module):
-    def __init__(self, kwargs):
+    def __init__(self, operator, kwargs):
         super().__init__()
         self.testname = "Layernorm_operator_test_op_src_direct"
-        self.lnorm = torch.nn.LayerNorm(**kwargs)
+        self.operator = operator
+        self.lnorm = self.operator(**kwargs)
 
     def forward(self, x):
         return self.lnorm(x)
 
 
 class ModelConstEvalPass(torch.nn.Module):
-    def __init__(self, input_shape, kwargs):
+    def __init__(self, operator, input_shape, kwargs):
         super().__init__()
         self.testname = "Layernorm_operator_test_op_src_const_eval_pass"
-        self.lnorm = torch.nn.LayerNorm(**kwargs)
+        self.operator = operator
+        self.lnorm = self.operator(**kwargs)
         self.const = (torch.rand(input_shape, requires_grad=False) - 0.5).detach()
 
     def forward(self, x):
@@ -79,14 +83,15 @@ class TestVerification:
         input_params: List[Dict] = [],
         warm_reset: bool = False,
     ):
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
 
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 
         model_type = cls.MODEL_TYPES[test_vector.input_source]
         pytorch_model = (
-            model_type(test_vector.input_shape, kwargs)
+            model_type(operator, test_vector.input_shape, kwargs)
             if test_vector.input_source in (InputSource.CONST_EVAL_PASS,)
-            else model_type(kwargs)
+            else model_type(operator, kwargs)
         )
 
         input_shapes = tuple([test_vector.input_shape])

--- a/forge/test/operators/pytorch/tm/test_repeat_interleave.py
+++ b/forge/test/operators/pytorch/tm/test_repeat_interleave.py
@@ -25,6 +25,7 @@ from test.operators.utils.compat import TestDevice
 from test.operators.utils import TestCollection
 from test.operators.utils import TestCollectionCommon
 from test.operators.utils import ValueRanges
+from test.operators.utils.utils import PytorchUtils
 
 from test.operators.pytorch.eltwise_unary import ModelFromAnotherOp, ModelDirect, ModelConstEvalPass
 
@@ -46,7 +47,7 @@ class TestVerification:
         warm_reset: bool = False,
     ):
 
-        operator = getattr(torch, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 
         model_type = cls.MODEL_TYPES[test_vector.input_source]

--- a/forge/test/operators/pytorch/tm/test_reshape.py
+++ b/forge/test/operators/pytorch/tm/test_reshape.py
@@ -30,6 +30,7 @@ from test.operators.utils.compat import TestDevice
 from test.operators.utils import TestCollection
 from test.operators.utils import TestCollectionCommon
 from test.operators.utils import ValueRanges
+from test.operators.utils.utils import PytorchUtils
 
 from test.operators.pytorch.eltwise_unary import ModelFromAnotherOp, ModelDirect, ModelConstEvalPass
 
@@ -111,7 +112,7 @@ class TestVerification:
         warm_reset: bool = False,
     ):
 
-        operator = getattr(torch, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 
         model_type = cls.MODEL_TYPES[test_vector.input_source]

--- a/forge/test/operators/pytorch/tm/test_squeeze.py
+++ b/forge/test/operators/pytorch/tm/test_squeeze.py
@@ -26,6 +26,7 @@ from test.operators.utils.compat import TestDevice
 from test.operators.utils import TestCollection
 from test.operators.utils import TestCollectionCommon
 from test.operators.utils import ValueRanges
+from test.operators.utils.utils import PytorchUtils
 
 from test.operators.pytorch.eltwise_unary import ModelFromAnotherOp, ModelDirect, ModelConstEvalPass
 
@@ -47,7 +48,7 @@ class TestVerification:
         warm_reset: bool = False,
     ):
 
-        operator = getattr(torch, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 
         model_type = cls.MODEL_TYPES[test_vector.input_source]

--- a/forge/test/operators/pytorch/tm/test_transpose.py
+++ b/forge/test/operators/pytorch/tm/test_transpose.py
@@ -71,6 +71,7 @@ from test.operators.utils import FailingReasons
 from test.operators.utils.compat import TestDevice
 from test.operators.utils import TestCollection
 from test.operators.utils import TestCollectionCommon
+from test.operators.utils.utils import PytorchUtils
 
 
 class ModelFromAnotherOp(torch.nn.Module):
@@ -150,7 +151,7 @@ class TestVerification:
     ):
         """Common verification function for all tests"""
 
-        operator = getattr(torch, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
 
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 

--- a/forge/test/operators/pytorch/tm/test_unsqueeze.py
+++ b/forge/test/operators/pytorch/tm/test_unsqueeze.py
@@ -21,6 +21,7 @@ from test.operators.utils.compat import TestDevice
 from test.operators.utils import TestCollection
 from test.operators.utils import TestCollectionCommon
 from test.operators.utils import ValueRanges
+from test.operators.utils.utils import PytorchUtils
 
 from test.operators.pytorch.eltwise_unary import ModelFromAnotherOp, ModelDirect, ModelConstEvalPass
 
@@ -42,7 +43,7 @@ class TestVerification:
         warm_reset: bool = False,
     ):
 
-        operator = getattr(torch, test_vector.operator)
+        operator = PytorchUtils.get_op_class_by_name(test_vector.operator)
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 
         model_type = cls.MODEL_TYPES[test_vector.input_source]

--- a/forge/test/operators/utils/utils.py
+++ b/forge/test/operators/utils/utils.py
@@ -337,13 +337,19 @@ class PytorchUtils:
     """Utility functions for PyTorch operators"""
 
     @staticmethod
-    def get_pytorch_module(module_name: str):
-        """Retrieving the module that contains a given operator, based on its full name.\n
-        For example, for "torch.nn.functional.gelu", the function returns module torch.nn.functional."""
-        repo_operator = pytorch_operator_repository.get_by_name(module_name).full_name
-        module_name = repo_operator.rsplit(".", 1)[0]
-        # module = importlib.import_module(module_name)  # bad performance
+    def get_op_class_by_name(op_name: str) -> Type:
+        """Get class name of the given operator"""
+        # Get the module that contains the operator
+        op_full_name = pytorch_operator_repository.get_by_name(op_name).full_name
+        module_name = op_full_name.rsplit(".", 1)[0]
+        ## module = importlib.import_module(module_name)  # bad performance
         module = torch
         if module_name == "torch.nn.functional":
             module = torch.nn.functional
-        return module
+        if module_name == "torch.nn":
+            module = torch.nn
+        # Get operator name from full name
+        name = op_full_name.rsplit(".", 1)[-1]
+        # Get the operator class from the module
+        op_class = getattr(module, name)
+        return op_class


### PR DESCRIPTION
### Ticket
Closes [#1742](https://github.com/tenstorrent/tt-forge-fe/issues/1742)

### Problem description
Update all ops to support naming convention

### What's changed
All ops are respecting naming convention.
All tests now use uniform way to get operator classes
Update conv2d skipped tests id file to support new naming convention

