### PR TITLE
Add push markers and post-processing for P1 RED models passing E2E

### DIFF
--- a/forge/test/models/models_utils.py
+++ b/forge/test/models/models_utils.py
@@ -101,3 +101,53 @@ def print_cls_results(fw_out, compiled_model_out):
         ["Top 1 Predicted Class Probability", fw_top1_class_prob, compiled_model_top1_class_prob],
     ]
     print(tabulate(table, headers="firstrow", tablefmt="grid"))
+
+
+def generate_no_cache(max_new_tokens, model, inputs, seq_len, tokenizer):
+    """
+    Generates text autoregressively without using a KV cache, iteratively predicting one token at a time.
+    The function stops generation if the maximum number of new tokens is reached or an end-of-sequence (EOS) token is encountered.
+
+    Args:
+        max_new_tokens (int): The maximum number of new tokens to generate.
+        model (torch.nn.Module): The language model used for token generation.
+        inputs (torch.Tensor): Input tensor of shape (batch_size, seq_len), representing tokenized text.
+        seq_len (int): The current sequence length before generation starts.
+        tokenizer: The tokenizer used to decode token IDs into text.
+
+    Returns:
+        str: The generated text after decoding the new tokens.
+    """
+    current_pos = seq_len
+
+    for _ in range(max_new_tokens):
+        logits = model(inputs)
+
+        # Get only the logits corresponding to the last valid token
+        if isinstance(logits, (list, tuple)):
+            logits = logits[0]
+        else:
+            raise TypeError(f"Expected logits to be a list or tuple, but got {type(logits)}")
+        next_token_logits = logits[:, current_pos - 1, :]
+        next_token_id = torch.argmax(next_token_logits, dim=-1)
+        # Stop if EOS token is encountered
+        if next_token_id.item() == tokenizer.eos_token_id:
+            break
+
+        inputs[:, current_pos] = next_token_id
+
+        current_pos += 1  # Move to next position
+
+    # Decode valid tokens
+    valid_tokens = inputs[:, seq_len:current_pos].view(-1).tolist()
+    answer = tokenizer.decode(valid_tokens, skip_special_tokens=True)
+
+    return answer
+
+
+def pad_inputs(inputs, max_new_tokens=512):
+    batch_size, seq_len = inputs.shape
+    max_seq_len = seq_len + max_new_tokens
+    padded_inputs = torch.zeros((batch_size, max_seq_len), dtype=inputs.dtype, device=inputs.device)
+    padded_inputs[:, :seq_len] = inputs
+    return padded_inputs, seq_len

--- a/forge/test/models/pytorch/multimodal/deepseek_coder/test_deepseek_coder.py
+++ b/forge/test/models/pytorch/multimodal/deepseek_coder/test_deepseek_coder.py
@@ -7,11 +7,10 @@ import forge
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
+from test.models.models_utils import generate_no_cache, pad_inputs
 from test.models.pytorch.multimodal.deepseek_coder.utils.model_utils import (
     DeepSeekWrapper,
     download_model_and_tokenizer,
-    generate_no_cache,
-    pad_inputs,
 )
 
 

--- a/forge/test/models/pytorch/multimodal/deepseek_coder/utils/model_utils.py
+++ b/forge/test/models/pytorch/multimodal/deepseek_coder/utils/model_utils.py
@@ -6,54 +6,6 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
 
 
-def generate_no_cache(max_new_tokens, model, inputs, seq_len, tokenizer):
-    """
-    Generates text autoregressively without using a KV cache, iteratively predicting one token at a time.
-    The function stops generation if the maximum number of new tokens is reached or an end-of-sequence (EOS) token is encountered.
-
-    Args:
-        max_new_tokens (int): The maximum number of new tokens to generate.
-        model (torch.nn.Module): The language model used for token generation.
-        inputs (torch.Tensor): Input tensor of shape (batch_size, seq_len), representing tokenized text.
-        seq_len (int): The current sequence length before generation starts.
-        tokenizer: The tokenizer used to decode token IDs into text.
-
-    Returns:
-        str: The generated text after decoding the new tokens.
-    """
-    current_pos = seq_len
-
-    for _ in range(max_new_tokens):
-        logits = model(inputs)
-
-        # Get only the logits corresponding to the last valid token
-        if isinstance(logits, list):
-            logits = logits[0]
-        next_token_logits = logits[:, current_pos - 1, :]
-        next_token_id = torch.argmax(next_token_logits, dim=-1)
-        # Stop if EOS token is encountered
-        if next_token_id.item() == tokenizer.eos_token_id:
-            break
-
-        inputs[:, current_pos] = next_token_id
-
-        current_pos += 1  # Move to next position
-
-    # Decode valid tokens
-    valid_tokens = inputs[:, seq_len:current_pos].view(-1).tolist()
-    answer = tokenizer.decode(valid_tokens, skip_special_tokens=True)
-
-    return answer
-
-
-def pad_inputs(inputs, max_new_tokens=512):
-    batch_size, seq_len = inputs.shape
-    max_seq_len = seq_len + max_new_tokens
-    padded_inputs = torch.zeros((batch_size, max_seq_len), dtype=inputs.dtype, device=inputs.device)
-    padded_inputs[:, :seq_len] = inputs
-    return padded_inputs, seq_len
-
-
 def download_model_and_tokenizer(model_name, **kwargs):
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
     model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)

--- a/forge/test/models/pytorch/text/falcon/test_falcon.py
+++ b/forge/test/models/pytorch/text/falcon/test_falcon.py
@@ -9,6 +9,9 @@ import forge
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
+from test.models.models_utils import generate_no_cache, pad_inputs
+from test.utils import download_model
+
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["tiiuae/falcon-7b-instruct"])
@@ -51,21 +54,25 @@ def test_falcon(forge_property_recorder, variant):
 
 
 variants = [
-    "tiiuae/Falcon3-1B-Base",
-    "tiiuae/Falcon3-3B-Base",
-    "tiiuae/Falcon3-7B-Base",
-    "tiiuae/Falcon3-Mamba-7B-Base",
+    pytest.param("tiiuae/Falcon3-1B-Base", marks=pytest.mark.push),
+    pytest.param(
+        "tiiuae/Falcon3-3B-Base",
+        marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 25 GB)"),
+    ),
+    pytest.param(
+        "tiiuae/Falcon3-7B-Base",
+        marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 36 GB)"),
+    ),
+    pytest.param(
+        "tiiuae/Falcon3-Mamba-7B-Base",
+        marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 36 GB)"),
+    ),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_falcon_3(forge_property_recorder, variant):
-
-    if variant == "tiiuae/Falcon3-Mamba-7B-Base" or variant == "tiiuae/Falcon3-7B-Base":
-        pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 36 GB)")
-    if variant == "tiiuae/Falcon3-3B-Base":
-        pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 25 GB)")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -78,18 +85,30 @@ def test_falcon_3(forge_property_recorder, variant):
     else:
         forge_property_recorder.record_group("generality")
 
-    tokenizer = AutoTokenizer.from_pretrained(variant)
-    model = AutoModelForCausalLM.from_pretrained(variant)
-    model.config.use_cache = False
-    model.config.return_dict = False
+    # Load model and tokenizer
+    tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
+    framework_model = download_model(AutoModelForCausalLM.from_pretrained, variant, return_dict=False, use_cache=False)
+    framework_model.eval()
 
+    # prepare input
     input_text = "Write a function to calculate the factorial of a number"
-    input_data = tokenizer.encode(input_text, return_tensors="pt")
+    inputs = tokenizer.encode(input_text, return_tensors="pt")
+    padded_inputs, seq_len = pad_inputs(inputs)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        model, sample_inputs=input_data, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=[padded_inputs],
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
     )
 
     # Model Verification
-    verify([input_data], model, compiled_model, forge_property_handler=forge_property_recorder)
+    verify([padded_inputs], framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # post processing
+    generated_text = generate_no_cache(
+        max_new_tokens=500, model=framework_model, inputs=padded_inputs, seq_len=seq_len, tokenizer=tokenizer
+    )
+
+    print("generated_text : ", generated_text)

--- a/forge/test/models/pytorch/text/phi3/test_phi3.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3.py
@@ -28,10 +28,7 @@ def test_phi3_causal_lm(forge_property_recorder, variant):
     )
 
     # Record Forge Property
-    if variant in ["microsoft/phi-3-mini-4k-instruct"]:
-        forge_property_recorder.record_group("red")
-    else:
-        forge_property_recorder.record_group("generality")
+    forge_property_recorder.record_group("red")
 
     # Phi3Config from pretrained variant, disable return_dict and caching.
     config = Phi3Config.from_pretrained(variant)

--- a/forge/test/models/pytorch/vision/segformer/test_segformer.py
+++ b/forge/test/models/pytorch/vision/segformer/test_segformer.py
@@ -16,7 +16,7 @@ from forge.verify.verify import verify
 from test.models.pytorch.vision.segformer.utils.image_utils import get_sample_data
 
 variants_img_classification = [
-    "nvidia/mit-b0",
+    pytest.param("nvidia/mit-b0", marks=pytest.mark.push),
     "nvidia/mit-b1",
     "nvidia/mit-b2",
     "nvidia/mit-b3",
@@ -66,7 +66,12 @@ def test_segformer_image_classification_pytorch(forge_property_recorder, variant
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Post processing
+    logits = co_out[0]
+    predicted_label = logits.argmax(-1).item()
+    print("Predicted class: ", framework_model.config.id2label[predicted_label])
 
 
 variants_semseg = [

--- a/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
@@ -8,6 +8,7 @@ import forge
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
 from test.models.pytorch.vision.vovnet.utils.model_utils import (
     get_image,
     preprocess_steps,
@@ -16,17 +17,8 @@ from test.models.pytorch.vision.vovnet.utils.model_utils import (
 from test.models.pytorch.vision.vovnet.utils.src_vovnet_stigma import vovnet39, vovnet57
 from test.utils import download_model
 
-
-def generate_model_vovnet_imgcls_osmr_pytorch(variant):
-    # STEP 2: Create Forge module from PyTorch model
-    model = download_model(ptcv_get_model, variant, pretrained=True)
-    image_tensor = get_image()
-
-    return model, [image_tensor], {}
-
-
 varaints = [
-    "vovnet27s",
+    pytest.param("vovnet27s", marks=pytest.mark.push),
     "vovnet39",
     "vovnet57",
 ]
@@ -40,7 +32,7 @@ def test_vovnet_osmr_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
-        framework=Framework.PYTORCH, model="vovnet", variant=variant, source=Source.OSMR, task=Task.OBJECT_DETECTION
+        framework=Framework.PYTORCH, model="vovnet", variant=variant, source=Source.OSMR, task=Task.IMAGE_CLASSIFICATION
     )
 
     # Record Forge Property
@@ -49,7 +41,12 @@ def test_vovnet_osmr_pytorch(forge_property_recorder, variant):
     else:
         forge_property_recorder.record_group("generality")
 
-    framework_model, inputs, _ = generate_model_vovnet_imgcls_osmr_pytorch(variant)
+    # Load model
+    framework_model = download_model(ptcv_get_model, variant, pretrained=True)
+
+    # prepare input
+    image_tensor = get_image()
+    inputs = [image_tensor]
 
     # Forge compile framework model
     compiled_model = forge.compile(
@@ -57,7 +54,10 @@ def test_vovnet_osmr_pytorch(forge_property_recorder, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])
 
 
 def generate_model_vovnet39_imgcls_stigma_pytorch():


### PR DESCRIPTION
## Summary 

- push markers and post-processing steps added for P1 RED models passing E2E

## Logs 

- [falcon3_1b.log](https://github.com/user-attachments/files/19708178/apr11_falcon3_1b_pp_final.log)
- [segformer.log](https://github.com/user-attachments/files/19708180/apr11_segformer_pp.log)
- [vit.log](https://github.com/user-attachments/files/19708181/apr11_vit_pp.log)
- [vovnet.log](https://github.com/user-attachments/files/19708182/apr11_vovnet_pp_final.log)
