### PR TITLE
Fix pcc drop in phi3 pytorch model

### DIFF
--- a/forge/test/models/pytorch/text/phi3/test_phi3.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3.py
@@ -2,17 +2,77 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+import torch
 from transformers import (
     AutoTokenizer,
+    Cache,
     Phi3Config,
     Phi3ForCausalLM,
     Phi3ForSequenceClassification,
     Phi3ForTokenClassification,
+    Phi3Model,
+    SlidingWindowCache,
 )
 
 import forge
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
+
+
+def _prepare_4d_causal_attention_mask_with_cache_position(
+    self,
+    attention_mask: torch.Tensor,
+    sequence_length: int,
+    target_length: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    cache_position: torch.Tensor,
+    batch_size: int,
+    config: Phi3Config,
+    past_key_values: Cache,
+):
+
+    if attention_mask is not None and attention_mask.dim() == 4:
+        # In this case we assume that the mask comes already in inverted form and requires no inversion or slicing.
+        causal_mask = attention_mask
+    else:
+        min_dtype = torch.finfo(dtype).min
+        causal_mask = torch.full((sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device)
+        diagonal_attend_mask = torch.arange(target_length, device=device) > cache_position.reshape(-1, 1)
+        if config.sliding_window is not None:
+            # if we have sliding window, we should not attend to tokens beyond sliding window length, so we mask them out also
+            # the check is needed to verify is current checkpoint was trained with sliding window or not
+            if not isinstance(past_key_values, SlidingWindowCache) or sequence_length > target_length:
+                sliding_attend_mask = torch.arange(target_length, device=device) <= (
+                    cache_position.reshape(-1, 1) - config.sliding_window
+                )
+                diagonal_attend_mask.bitwise_or_(sliding_attend_mask)
+        causal_mask *= diagonal_attend_mask
+        causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)
+        if attention_mask is not None:
+            causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
+            if attention_mask.shape[-1] > target_length:
+                attention_mask = attention_mask[:, :target_length]
+            mask_length = attention_mask.shape[-1]
+            padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :]
+            padding_mask = padding_mask == 0
+
+            # Replace Implace Slice Update
+            # causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
+            #     padding_mask, min_dtype
+            # )
+            if causal_mask.shape[-1] > mask_length:
+                part_1 = causal_mask[:, :, :, :mask_length]
+                part_2 = causal_mask[:, :, :, mask_length:]
+                part_1 = part_1.masked_fill(padding_mask, min_dtype)
+                causal_mask = torch.cat([part_1, part_2], dim=-1)
+            else:
+                causal_mask = causal_mask.masked_fill(padding_mask, min_dtype)
+    return causal_mask
+
+
+Phi3Model._prepare_4d_causal_attention_mask_with_cache_position = _prepare_4d_causal_attention_mask_with_cache_position
+
 
 variants = ["microsoft/phi-3-mini-4k-instruct"]
 
@@ -20,7 +80,7 @@ variants = ["microsoft/phi-3-mini-4k-instruct"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_causal_lm(forge_property_recorder, variant):
-    pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 64 GB)")
+    pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 38 GB)")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(


### PR DESCRIPTION
### Ticket
- N/A

### Problem description

- A **0.6038455628647957** PCC drop was observed in the phi3 model's causal LM task due to this [inplace update operation ](https://github.com/huggingface/transformers/blob/5d7739f15a6e50de416977fe2cc9cb516d67edda/src/transformers/models/phi3/modeling_phi3.py#L1149C17-L1151C18) 


### What's changed

**Monkey Patched Problematic Function:**
- The problematic in-place update in the attention mask update logic has been patched to avoid in-place modifications.


## Logs 

- [phi3_clm_before_fix.log](https://github.com/user-attachments/files/19718380/apr12_phi3_before_fix.log)
- [phi3_clm_after_fix.log](https://github.com/user-attachments/files/19718379/apr12_phi3_after_fix.log)

