### PR TITLE
DO NOT MERGE: workaround for blackhole compilation

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -160,8 +160,9 @@ class MLIRGenerator
     mlir::ModuleOp emit_mlir(tt::ForgeGraphModule &module)
     {
         graphModule_ = mlir::ModuleOp::create(get_module_location(module), module.name());
+        std::string sysDescPath("/localdev/gfeng/mlir/ttrt-artifacts/system_desc.ttsys");
         graphModule_->setAttr(
-            mlir::tt::SystemDescAttr::name, mlir::tt::SystemDescAttr::getDefault(builder_.getContext()));
+            mlir::tt::SystemDescAttr::name, mlir::tt::SystemDescAttr::getFromPath(builder_.getContext(), sysDescPath));
         builder_.setInsertionPointToStart(&graphModule_.getBodyRegion().front());
 
         // Collect all the supported TTIR operations


### PR DESCRIPTION
This allows the lowering to use a BH system descriptor.

### Ticket
https://github.com/tenstorrent/tt-forge-fe/issues/1516

### Problem description
We were always lowering on to a hard-coded WH system (https://github.com/tenstorrent/tt-mlir/blob/003c711842c5c757c143ef4f64d1fcc478d9e5da/lib/Dialect/TT/IR/TTOpsTypes.cpp#L41).

### Changes
Please first create a system descriptor by running `ttrt query --disable-eth-dispatch --save-artifact` in tt-mlir. (see https://github.com/tenstorrent/tt-mlir/issues/2632 if you run into any issues)

Then change the path in `lower_to_mlir.cpp`.

A more proper fix is needed. Maybe we should hardcode the BH values and add arch_name as an additional parameter to `mlir::tt::SystemDescAttr::getDefault()`?

### Checklist
- [ ] New/Existing tests provide coverage for changes
