### PR TITLE
Re-enable the skipped set5 tests in CI

### DIFF
--- a/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
+++ b/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
@@ -36,9 +36,14 @@ def get_sample_data(model_name):
 
 variants = [
     pytest.param("deepmind/vision-perceiver-conv", id="deepmind/vision-perceiver-conv"),
-    pytest.param("deepmind/vision-perceiver-learned", id="deepmind/vision-perceiver-learned"),
+    pytest.param(
+        "deepmind/vision-perceiver-learned",
+        marks=pytest.mark.xfail,
+        id="deepmind/vision-perceiver-learned",
+    ),
     pytest.param(
         "deepmind/vision-perceiver-fourier",
+        marks=pytest.mark.xfail,
         id="deepmind/vision-perceiver-fourier",
     ),
 ]
@@ -47,8 +52,6 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_perceiverio_for_image_classification_pytorch(forge_property_recorder, variant):
-    if variant != "deepmind/vision-perceiver-conv":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/unet/test_unet.py
+++ b/forge/test/models/pytorch/vision/unet/test_unet.py
@@ -150,8 +150,8 @@ def generate_model_unet_imgseg_smp_pytorch(variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 def test_unet_qubvel_pytorch(forge_property_recorder):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -212,8 +212,8 @@ def generate_model_unet_imgseg_torchhub_pytorch(variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 def test_unet_torchhub_pytorch(forge_property_recorder):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/vgg/test_vgg.py
+++ b/forge/test/models/pytorch/vision/vgg/test_vgg.py
@@ -18,24 +18,23 @@ import forge
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
 from test.utils import download_model
 
 variants = [
-    "vgg11",
-    "vgg13",
-    "vgg16",
-    "vgg19",
-    "bn_vgg19",
-    "bn_vgg19b",
+    pytest.param("vgg11"),
+    pytest.param("vgg13"),
+    pytest.param("vgg16"),
+    pytest.param("vgg19", marks=pytest.mark.xfail),
+    pytest.param("bn_vgg19"),
+    pytest.param("bn_vgg19b", marks=pytest.mark.xfail),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_vgg_osmr_pytorch(forge_property_recorder, variant):
-    if variant != "vgg11":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -76,12 +75,14 @@ def test_vgg_osmr_pytorch(forge_property_recorder, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])
 
 
 @pytest.mark.nightly
 def test_vgg_19_hf_pytorch(forge_property_recorder):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -130,7 +131,10 @@ def test_vgg_19_hf_pytorch(forge_property_recorder):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])
 
 
 def preprocess_timm_model(model_name):
@@ -154,7 +158,6 @@ def preprocess_timm_model(model_name):
 
 @pytest.mark.nightly
 def test_vgg_bn19_timm_pytorch(forge_property_recorder):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     variant = "vgg19_bn"
 
@@ -177,12 +180,14 @@ def test_vgg_bn19_timm_pytorch(forge_property_recorder):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])
 
 
 @pytest.mark.nightly
 def test_vgg_bn19_torchhub_pytorch(forge_property_recorder):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -227,7 +232,10 @@ def test_vgg_bn19_torchhub_pytorch(forge_property_recorder):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])
 
 
 variants_with_weights = {
@@ -241,10 +249,7 @@ variants_with_weights = {
 }
 
 variants = [
-    pytest.param(
-        "vgg11",
-        marks=[pytest.mark.xfail],
-    ),
+    "vgg11",
     "vgg11_bn",
     "vgg13",
     "vgg13_bn",
@@ -255,11 +260,9 @@ variants = [
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_vgg_torchvision(forge_property_recorder, variant):
-
-    if variant != "vgg11":
-        pytest.skip("Skipping this variant; only testing the small variant(vgg11) for now.")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(


### PR DESCRIPTION
 This PR enables the following skipped test cases:

````
pt_perceiverio_deepmind_vision_perceiver_learned_img_cls_hf - Maximum: 7623.23 MB
pt_perceiverio_deepmind_vision_perceiver_fourier_img_cls_hf - Maximum: 9941.92 MB
pt_unet_qubvel_img_seg_torchhub - Maximum: 3249.37 MB
pt_unet_base_img_seg_torchhub - Maximum: 2420.82 MB
pt_vgg_vgg13_obj_det_osmr - Maximum: 3335.95 MB
pt_vgg_vgg16_obj_det_osmr - Maximum: 4460.41 MB
pt_vgg_vgg19_obj_det_osmr - Maximum: 5377.75 MB
pt_vgg_bn_vgg19_obj_det_osmr - Maximum: 7143.82 MB
pt_vgg_bn_vgg19b_obj_det_osmr - Maximum: 8934.28 MB
pt_vgg_19_obj_det_hf - Maximum: 10440.89 MB
pt_vgg_vgg19_bn_obj_det_timm - Maximum: 11727.37 MB
pt_vgg_vgg19_bn_obj_det_torchhub - Maximum: 11262.25 MB
pt_vgg_vgg11_bn_img_cls_torchvision - Maximum: 7639.77 MB
pt_vgg_vgg13_img_cls_torchvision - Maximum: 8424.12 MB
pt_vgg_vgg13_bn_img_cls_torchvision - Maximum: 9272.06 MB
pt_vgg_vgg16_img_cls_torchvision - Maximum: 10183.74 MB
pt_vgg_vgg16_bn_img_cls_torchvision - Maximum: 11096.08 MB
pt_vgg_vgg19_img_cls_torchvision - Maximum: 12030.28 MB
````
logs:
[unet_qubvel.log](https://github.com/user-attachments/files/20165340/unet_qubvel.log)
[unet_torchhub.log](https://github.com/user-attachments/files/20165343/unet_torchhub.log)
[percieverio.log](https://github.com/user-attachments/files/20165344/percieverio.log)
[vgg_may12.log](https://github.com/user-attachments/files/20165742/vgg_may12.log)

