### PR TITLE
Enable lower data format user override.

### DIFF
--- a/forge/csrc/forge_passes.cpp
+++ b/forge/csrc/forge_passes.cpp
@@ -80,6 +80,7 @@ run_post_initial_graph_passes(
     std::shared_ptr<void> compiler_cfg = make_shared_py_object(compiler_cfg_object);
 
     passes::print_graph(graph, "INITIAL");
+    passes::apply_user_data_format_override(graph, compiler_cfg_object);
     passes::generate_initial_flops_estimate(graph);
     passes::decompose_nd_reshape_split(graph);
     passes::erase_unnecessary_4d_tm_sequence(graph);
@@ -211,12 +212,6 @@ graphlib::Graph *run_pre_lowering_passes(graphlib::Graph *graph, const std::opti
     // Manually convert broadcast ops to tms, so insert tile broadcast ops can work generically
     // Note this is not lowering, these are still forge tms
     convert_broadcast_ops_to_tms(graph);
-
-    //
-    // Data formats
-    //
-    // Apply user overrides
-    passes::configure_output_data_formats(graph, default_df_override);
 
     passes::remove_nops(graph);
 

--- a/forge/csrc/passes/dataformat.hpp
+++ b/forge/csrc/passes/dataformat.hpp
@@ -11,6 +11,7 @@
 #include "graph_lib/defines.hpp"
 #include "lower_to_forge/common.hpp"
 #include "passes/amp.hpp"
+#include "python_bindings_common.hpp"
 
 namespace tt
 {
@@ -40,6 +41,7 @@ void configure_a_b_format_conversion(
 void validate_data_formats(const graphlib::Graph *graph, const DeviceConfig &device_config);
 void validate_post_placer_data_formats(const graphlib::Graph *graph, const DeviceConfig &device_config);
 void configure_output_data_formats(graphlib::Graph *graph, std::optional<DataFormat> default_df_override);
+void apply_user_data_format_override(graphlib::Graph *graph, py::object compiler_cfg_object);
 
 void run_dataformat_passes(
     graphlib::Graph *graph,

--- a/forge/test/mlir/test_dataformats.py
+++ b/forge/test/mlir/test_dataformats.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+from torch import nn
+import torch.nn.functional as F
+
+import tensorflow as tf
+import onnx
+import onnxruntime as ort
+import onnx.helper
+import onnx.numpy_helper
+
+import forge
+from forge.verify.verify import verify
+from forge.config import CompilerConfig
+from forge._C import DataFormat
+
+
+# PyTorch test remains the same
+@pytest.mark.parametrize("shape", [(1, 3, 8, 8)])
+@pytest.mark.push
+def test_conv2d_bnorm_bfloat16_pytorch(forge_property_recorder, shape):
+    class TinyBNNet(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = nn.Conv2d(3, 16, kernel_size=3, stride=1, padding=1, bias=False)
+            self.bn = nn.BatchNorm2d(16, eps=1e-5)
+            self.relu = nn.ReLU()
+
+        def forward(self, x):
+            x = self.conv(x)
+            x = self.bn(x)
+            x = self.relu(x)
+            return x
+
+    inputs = [torch.rand(shape).to(torch.bfloat16)]
+    framework_model = TinyBNNet().to(torch.bfloat16)
+
+    compiler_cfg = CompilerConfig(default_df_override=DataFormat.Float16_b)
+
+    compiled_model = forge.compile(
+        framework_model,
+        sample_inputs=inputs,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
+    )
+
+    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+
+@pytest.mark.parametrize(
+    "in_channels, out_channels, kernel_size, stride, padding, groups, bias, dilation, padding_mode, input_shape",
+    [
+        pytest.param(
+            64,
+            128,
+            (7, 7),
+            4,
+            (3, 5),
+            1,
+            False,
+            1,
+            "zeros",
+            (16, 64, 80, 80),
+            marks=pytest.mark.xfail(reason="Out of Memory: Not enough space to allocate 13107200 B L1 buffer"),
+        ),
+    ],
+)
+@pytest.mark.push
+def test_convtranspose2d_bfloat16_pytorch(
+    forge_property_recorder,
+    in_channels,
+    out_channels,
+    kernel_size,
+    stride,
+    padding,
+    groups,
+    bias,
+    dilation,
+    padding_mode,
+    input_shape,
+):
+    inputs = [torch.randn(*input_shape).to(torch.bfloat16)]
+
+    framework_model = torch.nn.ConvTranspose2d(
+        in_channels=in_channels,
+        out_channels=out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        groups=groups,
+        bias=bias,
+        dilation=dilation,
+        padding_mode=padding_mode,
+    ).to(torch.bfloat16)
+
+    compiler_cfg = CompilerConfig(default_df_override=DataFormat.Float16_b)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder, compiler_cfg=compiler_cfg
+    )
+
+    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+
+@pytest.mark.parametrize("shape", [(1, 3, 32, 32)])
+@pytest.mark.parametrize(
+    "padding",
+    [
+        pytest.param((1, 1, 1, 1)),
+    ],
+)
+@pytest.mark.push
+def test_conv2d_and_matmul_bfloat16_pytorch(forge_property_recorder, shape, padding):
+    class PaddingAndConv2d(nn.Module):
+        def __init__(self, padding):
+            super().__init__()
+            self.padding = padding
+            self.conv = nn.Conv2d(3, 3, kernel_size=3, stride=1, padding=0)
+
+        def forward(self, x):
+            k = nn.functional.pad(x, self.padding, mode="constant", value=0)
+            y = self.conv(k)
+            return y @ x
+            # return self.conv(x)
+
+    pad_top, pad_bottom, pad_left, pad_right = padding
+    if pad_top != pad_bottom or pad_left != pad_right:
+        pytest.xfail(
+            "TTNN only supports padding height/width attributes. Thus, padding_top "
+            "must equal padding_bottom for the op to execute as expected."
+        )
+
+    inputs = [torch.rand(shape).to(torch.bfloat16)]
+
+    framework_model = PaddingAndConv2d(padding=padding).to(torch.bfloat16)
+    compiler_cfg = CompilerConfig(default_df_override=DataFormat.Float16_b)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder, compiler_cfg=compiler_cfg
+    )
+
+    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)

--- a/pytest.ini
+++ b/pytest.ini
@@ -29,6 +29,7 @@ testpaths =
 
     # Features
     forge/test/mlir/test_features.py
+    forge/test/mlir/test_dataformats.py
 
     # Training
     forge/test/mlir/test_loss.py


### PR DESCRIPTION
### Ticket
Closes #1804 

### Problem description
Optimizer needs a way to use lower precision data formats. Since TVM requires traced model to be in float32 (due to its numpy base), generated initial graph is in float32. To transfer this to bfloat16 (or some other lower data format) two things needed to be done:
1. cast all input tensors (Inputs, weights, constants) to lower data format.
2. convert output data format in whole graph

We used existing config `default_df_override`. By setting this to some data format, compiler will cast the input tensors and operations to that lower data format. Therefore enabling optimizer to have smaller memory footprint and enable higher batch size. 

### What's changed
- Set user-defined data format override in post-initial graph pass.
  Insert cast nodes on all input edges to ensure that constants, buffers, and parameters are in the lowered dtype.
- Move TVM module generation inside the block where the traced model is in float32, since that is the format supported by TVM (due to its NumPy base).
- Extend ConvertEmulatedDtypes to convert model buffers (e.g., BatchNorm runing mean and variance) to the desired dtype. Buffers are not considered parameters but are inputs to the computational graph and must be aligned in data format with the rest of the model.

- Added pytorch tests for casting model to bfloat16.

### 
What is not done:

Casting model to bfp8_b. There are some concerns regarding bfp8_b implementation in forge (mainly because torch doesn't support float8 and block formats and we rely on torch for verification and model tracing before TVM). Also currently there is no support for lowering bfp8_b to mlir. 

