### PR TITLE
[Reportify] Add support for dynamic shapes in reportify's TupleGetItem handling

### DIFF
--- a/forge/forge/tvm_calls/relay/op/reportify.py
+++ b/forge/forge/tvm_calls/relay/op/reportify.py
@@ -108,7 +108,7 @@ class CreateJson(ExprVisitor):
     def visit_constant(self, const):
         name = f"constant_{self.node_idx}"
         op = self.get_default_op(name)
-        op["cahce"] = {"shape": [int(dim) for dim in const.checked_type.shape]}
+        op["cache"] = {"shape": [int(dim) for dim in const.checked_type.shape]}
         op["opcode"] = "Input"
         op["class"] = "Input::"
         op["type"] = "Input::constant"
@@ -130,10 +130,9 @@ class CreateJson(ExprVisitor):
             name = f"{op_type}_{self.node_idx}"
             op = self.get_default_op(name)
             if hasattr(t.checked_type, "shape"):
-                assert not any(
-                    isinstance(dim, tvm.tir.expr.Any) for dim in t.checked_type.shape
-                ), "Dynamic shapes not supported"
-                op["cache"] = {"shape": [int(dim) for dim in t.checked_type.shape]}
+                op["cache"] = {
+                    "shape": [int(dim) if not isinstance(dim, tvm.tir.expr.Any) else -1 for dim in t.checked_type.shape]
+                }
             else:
                 op["cache"] = {"shape": []}
             op["class"] = op_type


### PR DESCRIPTION
### Ticket
fixes: #1819 

### Problem description
This PR changes `visit_tuple_getitem` method in `forge/tvm_calls/relay/op/reportify.py` to support processing of TVM models with dynamic shapes. The changes align it with existing TVM conventions by representing dynamic dimensions as `-1` in the shape information.

### What's changed
1. Removed the assertion that was blocking dynamic shapes in `visit_tuple_getitem` method
2. Updated the implementation to handle dynamic dimensions by representing `tvm.tir.expr.Any` as `-1` in the shape list
3. Fixed a typo in the `visit_constant` method (changed "cahce" to "cache")
