### PR TITLE
Remove xfail marker from cumsum, reshape and unsqueeze models ops tests

### DIFF
--- a/forge/test/models_ops/test_cumsum.py
+++ b/forge/test/models_ops/test_cumsum.py
@@ -69,55 +69,46 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="RuntimeError: Generated MLIR module failed verification.")],
     ),
-    pytest.param(
-        (
-            Cumsum2,
-            [((1, 32), torch.int64)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "1"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cumsum2,
+        [((1, 32), torch.int64)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "1"},
+        },
     ),
-    pytest.param(
-        (
-            Cumsum2,
-            [((1, 256), torch.int64)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "1"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cumsum2,
+        [((1, 256), torch.int64)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "1"},
+        },
     ),
-    pytest.param(
-        (
-            Cumsum2,
-            [((1, 128), torch.int32)],
-            {
-                "model_name": [
-                    "pt_roberta_xlm_roberta_base_mlm_hf",
-                    "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "1"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cumsum2,
+        [((1, 128), torch.int32)],
+        {
+            "model_name": [
+                "pt_roberta_xlm_roberta_base_mlm_hf",
+                "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "1"},
+        },
     ),
 ]
 

--- a/forge/test/models_ops/test_reshape.py
+++ b/forge/test/models_ops/test_reshape.py
@@ -14863,21 +14863,18 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 512, 1, 1), torch.float32)],
         {"model_name": ["pt_vovnet_vovnet27s_obj_det_osmr"], "pcc": 0.99, "op_params": {"shape": "(1, 512)"}},
     ),
-    pytest.param(
-        (
-            Reshape109,
-            [((8, 1), torch.int64)],
-            {
-                "model_name": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"shape": "(2, 4, 1)"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Reshape109,
+        [((8, 1), torch.int64)],
+        {
+            "model_name": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"shape": "(2, 4, 1)"},
+        },
     ),
     (
         Reshape110,
@@ -30256,17 +30253,14 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"shape": "(1, 56, 56, 96)"},
         },
     ),
-    pytest.param(
-        (
-            Reshape1412,
-            [((49, 49), torch.int64)],
-            {
-                "model_name": ["pt_swin_microsoft_swin_tiny_patch4_window7_224_img_cls_hf"],
-                "pcc": 0.99,
-                "op_params": {"shape": "(2401,)"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Reshape1412,
+        [((49, 49), torch.int64)],
+        {
+            "model_name": ["pt_swin_microsoft_swin_tiny_patch4_window7_224_img_cls_hf"],
+            "pcc": 0.99,
+            "op_params": {"shape": "(2401,)"},
+        },
     ),
     (
         Reshape1292,

--- a/forge/test/models_ops/test_unsqueeze.py
+++ b/forge/test/models_ops/test_unsqueeze.py
@@ -3960,37 +3960,31 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dim": "0"},
         },
     ),
-    pytest.param(
-        (
-            Unsqueeze0,
-            [((2, 13), torch.int64)],
-            {
-                "model_name": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "1"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Unsqueeze0,
+        [((2, 13), torch.int64)],
+        {
+            "model_name": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "1"},
+        },
     ),
-    pytest.param(
-        (
-            Unsqueeze1,
-            [((2, 13), torch.int64)],
-            {
-                "model_name": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "op_params": {"dim": "2"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Unsqueeze1,
+        [((2, 13), torch.int64)],
+        {
+            "model_name": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "op_params": {"dim": "2"},
+        },
     ),
     (
         Unsqueeze1,
@@ -4045,17 +4039,14 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dim": "1"},
         },
     ),
-    pytest.param(
-        (
-            Unsqueeze0,
-            [((2, 7), torch.int64)],
-            {
-                "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
-                "pcc": 0.99,
-                "op_params": {"dim": "1"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Unsqueeze0,
+        [((2, 7), torch.int64)],
+        {
+            "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
+            "pcc": 0.99,
+            "op_params": {"dim": "1"},
+        },
     ),
     (
         Unsqueeze1,


### PR DESCRIPTION
In the[ latest models ops nightly pipeline,](https://github.com/tenstorrent/tt-forge-fe/actions/runs/14526889878/job/40760341295) `Data mismatch between framework output and compiled model output` was resolved in the cumsum, reshape and unsqueeze models ops tests so removed xfail marker for those tests.

Tests:
```
forge/test/models_ops/test_unsqueeze.py::test_module[Unsqueeze0-[((2, 13), torch.int64)]]
forge/test/models_ops/test_reshape.py::test_module[Reshape109-[((8, 1), torch.int64)]]
forge/test/models_ops/test_unsqueeze.py::test_module[Unsqueeze0-[((2, 7), torch.int64)]]
forge/test/models_ops/test_unsqueeze.py::test_module[Unsqueeze1-[((2, 13), torch.int64)]]
forge/test/models_ops/test_cumsum.py::test_module[Cumsum2-[((1, 128), torch.int32)]]
forge/test/models_ops/test_cumsum.py::test_module[Cumsum2-[((1, 256), torch.int64)]]
forge/test/models_ops/test_cumsum.py::test_module[Cumsum2-[((1, 32), torch.int64)]]
forge/test/models_ops/test_reshape.py::test_module[Reshape1412-[((49, 49), torch.int64)]]
```

Generated models ops test report: 
[model_ops_tests_report.xlsx](https://github.com/user-attachments/files/19810342/model_ops_tests_report.xlsx)


