### PR TITLE
Disable internal post processing steps in YOLOV10

### DIFF
--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v10.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v10.py
@@ -14,7 +14,7 @@ from test.models.pytorch.vision.yolo.utils.yolo_utils import (
 )
 
 
-@pytest.mark.xfail(reason="AssertionError: Encountered unsupported op types. Check error logs for more details")
+@pytest.mark.xfail
 @pytest.mark.nightly
 def test_yolov10(forge_property_recorder):
     # Record Forge Property

--- a/forge/test/models/pytorch/vision/yolo/utils/yolo_utils.py
+++ b/forge/test/models/pytorch/vision/yolo/utils/yolo_utils.py
@@ -12,10 +12,11 @@ class YoloWrapper(torch.nn.Module):
     def __init__(self, model):
         super().__init__()
         self.model = model
+        self.model.model[-1].end2end = False  # Disable internal post processing steps
 
     def forward(self, image: torch.Tensor):
-        result = self.model(image)[0]
-        return result[0]
+        y, x = self.model(image)
+        return (y, *x)
 
 
 def load_yolo_model_and_image(url):


### PR DESCRIPTION

### Problem description

- Yolov10 encountered below error on latest main.

```
2025-04-18 12:47:57.559 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2235 - Encountered unsupported op node type: topk, on device: tt
2025-04-18 12:47:57.560 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2235 - Encountered unsupported op node type: gather, on device: tt
2025-04-18 12:47:57.560 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2235 - Encountered unsupported op node type: gather, on device: tt
2025-04-18 12:47:57.560 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2235 - Encountered unsupported op node type: topk, on device: tt
2025-04-18 12:47:57.560 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2235 - Encountered unsupported op node type: floor_divide, on device: tt

E AssertionError: Encountered unsupported op types. Check error logs for more details
```
- The root cause is this [post processing block](https://github.com/ultralytics/ultralytics/blob/d3d523bcbd528e2d11c6c273ec8919291abe3477/ultralytics/nn/modules/head.py#L151C1-L172C110), which introduces above mentioned unsupported ops.

### What's changed


- This [post processing block](https://github.com/ultralytics/ultralytics/blob/d3d523bcbd528e2d11c6c273ec8919291abe3477/ultralytics/nn/modules/head.py#L151C1-L172C110) can be disabled which eliminates the need of adding support for those ops

### Logs

- [apr18_yolov10_before_fix.log](https://github.com/user-attachments/files/19812897/apr18_yolov10_before_fix.log)
- [apr18_yolov10_after_fix.log](https://github.com/user-attachments/files/19812896/apr18_yolov10_after_fix.log)

