### PR TITLE
Fix build when using clang18 as compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,16 +2,6 @@ cmake_minimum_required(VERSION 3.24.0)
 
 project(ttforge LANGUAGES CXX)
 
-find_program(CLANG_17 clang++-17)
-find_program(CLANG clang)
-if(CLANG_17 AND CLANG)
-    message(STATUS "Found Clang-17 here: ${CLANG_17}")
-    set(CMAKE_CXX_COMPILER "${CLANG_17}")
-    set(CMAKE_C_COMPILER "${CLANG}")
-else()
-    message(FATAL_ERROR "Clang++-17 or clang not found!!!")
-endif()
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.24.0)
 
 project(ttforge LANGUAGES CXX)
 
+if(NOT (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "17" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "18"))
+    message(STATUS "CXX compiler in use: ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION}")
+    message(WARNING "The compiler you are using is not officially tested - you may run into issues. Official builds are created with Clang-17.")
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/forge/csrc/graph_lib/query.hpp
+++ b/forge/csrc/graph_lib/query.hpp
@@ -156,7 +156,7 @@ class Filter
     using Reference = typename IterT::reference;
     using Value = typename IterT::value_type;
 
-    class Iterator : public std::iterator<std::input_iterator_tag, Value>
+    class Iterator
     {
        public:
         Iterator(IterT iter, IterT end, Predicate<Value, ViewT> const& p) : iter(iter), end(end), p(&p)

--- a/forge/csrc/lower_to_forge/common.hpp
+++ b/forge/csrc/lower_to_forge/common.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <array>
 #include <cstdint>
 #include <map>
 #include <ostream>
@@ -10,7 +11,6 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
-#include <array>
 
 namespace tt
 {

--- a/forge/csrc/lower_to_forge/common.hpp
+++ b/forge/csrc/lower_to_forge/common.hpp
@@ -10,6 +10,7 @@
 #include <unordered_map>
 #include <variant>
 #include <vector>
+#include <array>
 
 namespace tt
 {

--- a/forge/csrc/shared_utils/pretty_table.cpp
+++ b/forge/csrc/shared_utils/pretty_table.cpp
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "pretty_table.hpp"
 
+#include <cstdint>
 #include <stdexcept>
 #include <string>
 #include <vector>
-#include <cstdint>
 
 namespace tt::utils
 {

--- a/forge/csrc/shared_utils/pretty_table.cpp
+++ b/forge/csrc/shared_utils/pretty_table.cpp
@@ -6,6 +6,7 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace tt::utils
 {


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Forge-FE does not build on clang18 for the following reasons. Each leading to a compilation error
1. CMake force detection of existence of clang17
2. Missing includes
3. Use of deprecated STL components

### What's changed
1. Removed force check for clang 17
2. Add missing includes needed on clang 18
3. Remove use of deprecated STL components

### Checklist
- [ ] New/Existing tests provide coverage for changes
