### PR TITLE
Add xfail marker for cast, softmax, subtract and where models ops tests

### DIFF
--- a/forge/test/models_ops/test_cast.py
+++ b/forge/test/models_ops/test_cast.py
@@ -96,18 +96,21 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.float32"},
         },
     ),
-    (
-        Cast0,
-        [((2, 1, 1, 13), torch.bool)],
-        {
-            "model_name": [
-                "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-            ],
-            "pcc": 0.99,
-            "op_params": {"dtype": "torch.float32"},
-        },
+    pytest.param(
+        (
+            Cast0,
+            [((2, 1, 1, 13), torch.bool)],
+            {
+                "model_name": [
+                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
+                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+                ],
+                "pcc": 0.99,
+                "op_params": {"dtype": "torch.float32"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Cast0,
@@ -118,23 +121,29 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.float32"},
         },
     ),
-    (
-        Cast0,
-        [((2, 1, 7, 7), torch.bool)],
-        {
-            "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
-            "pcc": 0.99,
-            "op_params": {"dtype": "torch.float32"},
-        },
+    pytest.param(
+        (
+            Cast0,
+            [((2, 1, 7, 7), torch.bool)],
+            {
+                "model_name": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
+                "pcc": 0.99,
+                "op_params": {"dtype": "torch.float32"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Cast0,
-        [((1, 596, 4096), torch.bool)],
-        {
-            "model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"],
-            "pcc": 0.99,
-            "op_params": {"dtype": "torch.float32"},
-        },
+    pytest.param(
+        (
+            Cast0,
+            [((1, 596, 4096), torch.bool)],
+            {
+                "model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"],
+                "pcc": 0.99,
+                "op_params": {"dtype": "torch.float32"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Cast1,
@@ -222,30 +231,33 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.float32"},
         },
     ),
-    (
-        Cast0,
-        [((1, 1, 256, 256), torch.bool)],
-        {
-            "model_name": [
-                "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
-                "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
-                "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
-                "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
-                "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
-                "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
-                "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
-                "pt_opt_facebook_opt_1_3b_clm_hf",
-                "pt_opt_facebook_opt_350m_clm_hf",
-                "pt_opt_facebook_opt_125m_clm_hf",
-                "pt_phi2_microsoft_phi_2_pytdml_clm_hf",
-                "pt_phi2_microsoft_phi_2_clm_hf",
-                "pt_phi3_5_microsoft_phi_3_5_mini_instruct_clm_hf",
-                "pt_xglm_facebook_xglm_1_7b_clm_hf",
-                "pt_xglm_facebook_xglm_564m_clm_hf",
-            ],
-            "pcc": 0.99,
-            "op_params": {"dtype": "torch.float32"},
-        },
+    pytest.param(
+        (
+            Cast0,
+            [((1, 1, 256, 256), torch.bool)],
+            {
+                "model_name": [
+                    "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
+                    "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
+                    "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
+                    "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
+                    "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
+                    "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
+                    "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
+                    "pt_opt_facebook_opt_1_3b_clm_hf",
+                    "pt_opt_facebook_opt_350m_clm_hf",
+                    "pt_opt_facebook_opt_125m_clm_hf",
+                    "pt_phi2_microsoft_phi_2_pytdml_clm_hf",
+                    "pt_phi2_microsoft_phi_2_clm_hf",
+                    "pt_phi3_5_microsoft_phi_3_5_mini_instruct_clm_hf",
+                    "pt_xglm_facebook_xglm_1_7b_clm_hf",
+                    "pt_xglm_facebook_xglm_564m_clm_hf",
+                ],
+                "pcc": 0.99,
+                "op_params": {"dtype": "torch.float32"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Cast1,
@@ -317,14 +329,17 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Cast0,
-        [((1, 12, 384, 384), torch.bool)],
-        {
-            "model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
-            "pcc": 0.99,
-            "op_params": {"dtype": "torch.float32"},
-        },
+    pytest.param(
+        (
+            Cast0,
+            [((1, 12, 384, 384), torch.bool)],
+            {
+                "model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
+                "pcc": 0.99,
+                "op_params": {"dtype": "torch.float32"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     pytest.param(
         (
@@ -391,20 +406,23 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.int64"},
         },
     ),
-    (
-        Cast0,
-        [((1, 12, 128, 128), torch.bool)],
-        {
-            "model_name": [
-                "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
-                "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
-                "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
-                "pt_distilbert_distilbert_base_cased_mlm_hf",
-                "pt_distilbert_distilbert_base_uncased_mlm_hf",
-            ],
-            "pcc": 0.99,
-            "op_params": {"dtype": "torch.float32"},
-        },
+    pytest.param(
+        (
+            Cast0,
+            [((1, 12, 128, 128), torch.bool)],
+            {
+                "model_name": [
+                    "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
+                    "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
+                    "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
+                    "pt_distilbert_distilbert_base_cased_mlm_hf",
+                    "pt_distilbert_distilbert_base_uncased_mlm_hf",
+                ],
+                "pcc": 0.99,
+                "op_params": {"dtype": "torch.float32"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Cast1,
@@ -476,23 +494,26 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dtype": "torch.int32"},
         },
     ),
-    (
-        Cast0,
-        [((1, 1, 32, 32), torch.bool)],
-        {
-            "model_name": [
-                "pt_llama3_meta_llama_llama_3_2_3b_clm_hf",
-                "pt_llama3_huggyllama_llama_7b_clm_hf",
-                "pt_opt_facebook_opt_1_3b_qa_hf",
-                "pt_opt_facebook_opt_350m_seq_cls_hf",
-                "pt_opt_facebook_opt_350m_qa_hf",
-                "pt_opt_facebook_opt_125m_qa_hf",
-                "pt_opt_facebook_opt_125m_seq_cls_hf",
-                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-            ],
-            "pcc": 0.99,
-            "op_params": {"dtype": "torch.float32"},
-        },
+    pytest.param(
+        (
+            Cast0,
+            [((1, 1, 32, 32), torch.bool)],
+            {
+                "model_name": [
+                    "pt_llama3_meta_llama_llama_3_2_3b_clm_hf",
+                    "pt_llama3_huggyllama_llama_7b_clm_hf",
+                    "pt_opt_facebook_opt_1_3b_qa_hf",
+                    "pt_opt_facebook_opt_350m_seq_cls_hf",
+                    "pt_opt_facebook_opt_350m_qa_hf",
+                    "pt_opt_facebook_opt_125m_qa_hf",
+                    "pt_opt_facebook_opt_125m_seq_cls_hf",
+                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                ],
+                "pcc": 0.99,
+                "op_params": {"dtype": "torch.float32"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Cast1,

--- a/forge/test/models_ops/test_softmax.py
+++ b/forge/test/models_ops/test_softmax.py
@@ -226,14 +226,17 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dim": "-1"},
         },
     ),
-    (
-        Softmax1,
-        [((64, 1, 1), torch.float32)],
-        {
-            "model_name": ["pt_stereo_facebook_musicgen_large_music_generation_hf"],
-            "pcc": 0.99,
-            "op_params": {"dim": "-1"},
-        },
+    pytest.param(
+        (
+            Softmax1,
+            [((64, 1, 1), torch.float32)],
+            {
+                "model_name": ["pt_stereo_facebook_musicgen_large_music_generation_hf"],
+                "pcc": 0.99,
+                "op_params": {"dim": "-1"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
     (
         Softmax1,
@@ -257,14 +260,17 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dim": "-1"},
         },
     ),
-    (
-        Softmax1,
-        [((32, 1, 1), torch.float32)],
-        {
-            "model_name": ["pt_stereo_facebook_musicgen_small_music_generation_hf"],
-            "pcc": 0.99,
-            "op_params": {"dim": "-1"},
-        },
+    pytest.param(
+        (
+            Softmax1,
+            [((32, 1, 1), torch.float32)],
+            {
+                "model_name": ["pt_stereo_facebook_musicgen_small_music_generation_hf"],
+                "pcc": 0.99,
+                "op_params": {"dim": "-1"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
     (
         Softmax1,
@@ -275,14 +281,17 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dim": "-1"},
         },
     ),
-    (
-        Softmax1,
-        [((48, 1, 1), torch.float32)],
-        {
-            "model_name": ["pt_stereo_facebook_musicgen_medium_music_generation_hf"],
-            "pcc": 0.99,
-            "op_params": {"dim": "-1"},
-        },
+    pytest.param(
+        (
+            Softmax1,
+            [((48, 1, 1), torch.float32)],
+            {
+                "model_name": ["pt_stereo_facebook_musicgen_medium_music_generation_hf"],
+                "pcc": 0.99,
+                "op_params": {"dim": "-1"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
     (
         Softmax1,
@@ -293,17 +302,20 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dim": "-1"},
         },
     ),
-    (
-        Softmax1,
-        [((1, 6, 1, 1), torch.float32)],
-        {
-            "model_name": [
-                "pt_whisper_openai_whisper_tiny_speech_recognition_hf",
-                "pt_t5_google_flan_t5_small_text_gen_hf",
-            ],
-            "pcc": 0.99,
-            "op_params": {"dim": "-1"},
-        },
+    pytest.param(
+        (
+            Softmax1,
+            [((1, 6, 1, 1), torch.float32)],
+            {
+                "model_name": [
+                    "pt_whisper_openai_whisper_tiny_speech_recognition_hf",
+                    "pt_t5_google_flan_t5_small_text_gen_hf",
+                ],
+                "pcc": 0.99,
+                "op_params": {"dim": "-1"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
     (
         Softmax1,
@@ -323,14 +335,17 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dim": "-1"},
         },
     ),
-    (
-        Softmax1,
-        [((1, 20, 1, 1), torch.float32)],
-        {
-            "model_name": ["pt_whisper_openai_whisper_large_speech_recognition_hf"],
-            "pcc": 0.99,
-            "op_params": {"dim": "-1"},
-        },
+    pytest.param(
+        (
+            Softmax1,
+            [((1, 20, 1, 1), torch.float32)],
+            {
+                "model_name": ["pt_whisper_openai_whisper_large_speech_recognition_hf"],
+                "pcc": 0.99,
+                "op_params": {"dim": "-1"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
     (
         Softmax1,
@@ -350,18 +365,21 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dim": "-1"},
         },
     ),
-    (
-        Softmax1,
-        [((1, 12, 1, 1), torch.float32)],
-        {
-            "model_name": [
-                "pt_whisper_openai_whisper_small_speech_recognition_hf",
-                "pt_t5_google_flan_t5_base_text_gen_hf",
-                "pt_t5_t5_base_text_gen_hf",
-            ],
-            "pcc": 0.99,
-            "op_params": {"dim": "-1"},
-        },
+    pytest.param(
+        (
+            Softmax1,
+            [((1, 12, 1, 1), torch.float32)],
+            {
+                "model_name": [
+                    "pt_whisper_openai_whisper_small_speech_recognition_hf",
+                    "pt_t5_google_flan_t5_base_text_gen_hf",
+                    "pt_t5_t5_base_text_gen_hf",
+                ],
+                "pcc": 0.99,
+                "op_params": {"dim": "-1"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
     (
         Softmax1,
@@ -381,18 +399,21 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dim": "-1"},
         },
     ),
-    (
-        Softmax1,
-        [((1, 16, 1, 1), torch.float32)],
-        {
-            "model_name": [
-                "pt_whisper_openai_whisper_medium_speech_recognition_hf",
-                "pt_t5_t5_large_text_gen_hf",
-                "pt_t5_google_flan_t5_large_text_gen_hf",
-            ],
-            "pcc": 0.99,
-            "op_params": {"dim": "-1"},
-        },
+    pytest.param(
+        (
+            Softmax1,
+            [((1, 16, 1, 1), torch.float32)],
+            {
+                "model_name": [
+                    "pt_whisper_openai_whisper_medium_speech_recognition_hf",
+                    "pt_t5_t5_large_text_gen_hf",
+                    "pt_t5_google_flan_t5_large_text_gen_hf",
+                ],
+                "pcc": 0.99,
+                "op_params": {"dim": "-1"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
     (
         Softmax1,
@@ -412,14 +433,17 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"dim": "-1"},
         },
     ),
-    (
-        Softmax1,
-        [((1, 8, 1, 1), torch.float32)],
-        {
-            "model_name": ["pt_whisper_openai_whisper_base_speech_recognition_hf", "pt_t5_t5_small_text_gen_hf"],
-            "pcc": 0.99,
-            "op_params": {"dim": "-1"},
-        },
+    pytest.param(
+        (
+            Softmax1,
+            [((1, 8, 1, 1), torch.float32)],
+            {
+                "model_name": ["pt_whisper_openai_whisper_base_speech_recognition_hf", "pt_t5_t5_small_text_gen_hf"],
+                "pcc": 0.99,
+                "op_params": {"dim": "-1"},
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
     (
         Softmax1,

--- a/forge/test/models_ops/test_subtract.py
+++ b/forge/test/models_ops/test_subtract.py
@@ -444,29 +444,35 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Subtract4,
-        [((1, 384), torch.int32)],
-        {"model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"], "pcc": 0.99},
+    pytest.param(
+        (
+            Subtract4,
+            [((1, 384), torch.int32)],
+            {"model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"], "pcc": 0.99},
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
     (
         Subtract0,
         [((1, 12, 384, 384), torch.float32)],
         {"model_name": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"], "pcc": 0.99},
     ),
-    (
-        Subtract4,
-        [((1, 128), torch.int32)],
-        {
-            "model_name": [
-                "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
-                "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
-                "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
-                "pt_distilbert_distilbert_base_cased_mlm_hf",
-                "pt_distilbert_distilbert_base_uncased_mlm_hf",
-            ],
-            "pcc": 0.99,
-        },
+    pytest.param(
+        (
+            Subtract4,
+            [((1, 128), torch.int32)],
+            {
+                "model_name": [
+                    "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
+                    "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
+                    "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
+                    "pt_distilbert_distilbert_base_cased_mlm_hf",
+                    "pt_distilbert_distilbert_base_uncased_mlm_hf",
+                ],
+                "pcc": 0.99,
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
     (
         Subtract0,
@@ -508,31 +514,40 @@ forge_modules_and_shapes_dtypes_list = [
         },
     ),
     (Subtract0, [((1, 1, 1, 256), torch.float32)], {"model_name": ["pt_gpt2_gpt2_text_gen_hf"], "pcc": 0.99}),
-    (
-        Subtract4,
-        [((1, 1, 256, 256), torch.int32)],
-        {
-            "model_name": [
-                "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
-                "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
-                "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
-                "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
-                "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
-                "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
-                "pt_phi2_microsoft_phi_2_pytdml_clm_hf",
-                "pt_phi2_microsoft_phi_2_clm_hf",
-            ],
-            "pcc": 0.99,
-        },
+    pytest.param(
+        (
+            Subtract4,
+            [((1, 1, 256, 256), torch.int32)],
+            {
+                "model_name": [
+                    "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
+                    "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
+                    "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
+                    "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
+                    "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
+                    "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
+                    "pt_phi2_microsoft_phi_2_pytdml_clm_hf",
+                    "pt_phi2_microsoft_phi_2_clm_hf",
+                ],
+                "pcc": 0.99,
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
-    (Subtract4, [((1, 4), torch.int32)], {"model_name": ["pt_llama3_huggyllama_llama_7b_seq_cls_hf"], "pcc": 0.99}),
-    (
-        Subtract4,
-        [((1, 1, 32, 32), torch.int32)],
-        {
-            "model_name": ["pt_llama3_meta_llama_llama_3_2_3b_clm_hf", "pt_llama3_huggyllama_llama_7b_clm_hf"],
-            "pcc": 0.99,
-        },
+    pytest.param(
+        (Subtract4, [((1, 4), torch.int32)], {"model_name": ["pt_llama3_huggyllama_llama_7b_seq_cls_hf"], "pcc": 0.99}),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
+    ),
+    pytest.param(
+        (
+            Subtract4,
+            [((1, 1, 32, 32), torch.int32)],
+            {
+                "model_name": ["pt_llama3_meta_llama_llama_3_2_3b_clm_hf", "pt_llama3_huggyllama_llama_7b_clm_hf"],
+                "pcc": 0.99,
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
     (
         Subtract0,

--- a/forge/test/models_ops/test_where.py
+++ b/forge/test/models_ops/test_where.py
@@ -270,41 +270,50 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Where2,
-        [((1, 1, 7, 7), torch.bool)],
-        {
-            "model_name": [
-                "pt_gpt2_mnoukhov_gpt2_imdb_sentiment_classifier_seq_cls_hf",
-                "pt_nanogpt_financialsupport_nanogpt_text_gen_hf",
-            ],
-            "pcc": 0.99,
-        },
+    pytest.param(
+        (
+            Where2,
+            [((1, 1, 7, 7), torch.bool)],
+            {
+                "model_name": [
+                    "pt_gpt2_mnoukhov_gpt2_imdb_sentiment_classifier_seq_cls_hf",
+                    "pt_nanogpt_financialsupport_nanogpt_text_gen_hf",
+                ],
+                "pcc": 0.99,
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
-    (
-        Where2,
-        [((1, 1, 256, 256), torch.bool)],
-        {
-            "model_name": [
-                "pt_gpt2_gpt2_text_gen_hf",
-                "pt_gptneo_eleutherai_gpt_neo_2_7b_clm_hf",
-                "pt_gptneo_eleutherai_gpt_neo_125m_clm_hf",
-                "pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf",
-            ],
-            "pcc": 0.99,
-        },
+    pytest.param(
+        (
+            Where2,
+            [((1, 1, 256, 256), torch.bool)],
+            {
+                "model_name": [
+                    "pt_gpt2_gpt2_text_gen_hf",
+                    "pt_gptneo_eleutherai_gpt_neo_2_7b_clm_hf",
+                    "pt_gptneo_eleutherai_gpt_neo_125m_clm_hf",
+                    "pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf",
+                ],
+                "pcc": 0.99,
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
-    (
-        Where2,
-        [((1, 1, 32, 32), torch.bool)],
-        {
-            "model_name": [
-                "pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf",
-                "pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf",
-                "pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf",
-            ],
-            "pcc": 0.99,
-        },
+    pytest.param(
+        (
+            Where2,
+            [((1, 1, 32, 32), torch.bool)],
+            {
+                "model_name": [
+                    "pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf",
+                    "pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf",
+                    "pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf",
+                ],
+                "pcc": 0.99,
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
     pytest.param(
         (


### PR DESCRIPTION
In the [latest nightly Models Ops pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/14543537818/job/40812152816), the Softmax, Subtract, and Where Ops tests are failing with `AssertionError: PCC is NaN, but tensors are not equal` and the Cast Op test is failing due to a` Data mismatch between the framework output and the compiled model output`. So I have added xfail markers for the models ops failed tests.

Note: All of these tests passed in Friday’s nightly run. @pdeviTT  is working on bisecting the above failed models ops test.

Generated Models Ops test report:
[model_ops_tests_report.xlsx](https://github.com/user-attachments/files/19833056/model_ops_tests_report.xlsx)

