### PR TITLE
Fix pcc drop in vilt model

### DIFF
--- a/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
+++ b/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
@@ -45,7 +45,7 @@ def generate_model_vilt_question_answering_hf_pytorch(variant):
 
     # Wrapper
     text_vision_embedding_model = ViLtEmbeddingWrapper(model)
-    vilt_model = ViltModelWrapper(model, task=Task.QA)
+    vilt_model = ViltModelWrapper(model, task=Task.QA.short)
 
     embedding_output, attention_mask = text_vision_embedding_model(**encoding)
 
@@ -56,7 +56,7 @@ variants = ["dandelin/vilt-b32-finetuned-vqa"]
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
+@pytest.mark.push
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_vilt_question_answering_hf_pytorch(forge_property_recorder, variant):
     # Record Forge Property


### PR DESCRIPTION
### Ticket

- This PR fixes: https://github.com/tenstorrent/tt-forge-fe/issues/1753


### Problem Description

- The ViLT model, when used without these [specific layers](https://github.com/tenstorrent/tt-forge-fe/blob/e87bfbce8c4f80e092639e29fcaa3df19dd73adc/forge/test/models/pytorch/multimodal/vilt/utils/model.py#L82C13-L84C64), results in a PCC of -0.5130984882329126 during runtime.

**Root Cause**:

- In [PR #1681](https://github.com/tenstorrent/tt-forge-fe/pull/1681), the Task class was updated such that QA = "qa" was changed to QA = ("qa", "Question Answering"). However, the [model layers](https://github.com/tenstorrent/tt-forge-fe/blob/e87bfbce8c4f80e092639e29fcaa3df19dd73adc/forge/test/models/pytorch/multimodal/vilt/utils/model.py#L82C13-L84C64) are added only when task == "qa", not when it’s a tuple. As a result, the required QA-specific layers were skipped during model creation.

### What’s Changed

- The task name is now passed correctly to ensure the relevant model layers are included during model creation.

### Logs

- [vilt_before_fix.log](https://github.com/user-attachments/files/19838590/apr21_vilt_before_fix_1.log)
- [vilt_after_fix.log](https://github.com/user-attachments/files/19838588/apr21_vilt_after_fix_1.log)


