### PR TITLE
Add latest tag to CI image when merged to main

### DIFF
--- a/.github/build-docker-images.sh
+++ b/.github/build-docker-images.sh
@@ -5,42 +5,97 @@
 
 set -e
 
-REPO=tenstorrent/tt-forge-fe
-BASE_IMAGE_NAME=ghcr.io/$REPO/tt-forge-fe-base-ubuntu-22-04
-CI_IMAGE_NAME=ghcr.io/$REPO/tt-forge-fe-ci-ubuntu-22-04
-BASE_IRD_IMAGE_NAME=ghcr.io/$REPO/tt-forge-fe-base-ird-ubuntu-22-04
-IRD_IMAGE_NAME=ghcr.io/$REPO/tt-forge-fe-ird-ubuntu-22-04
+# postiional arguments
+image_name=$1
+dockerfile=$2
+branch_name=$3
+from_image=$4
+
+# Check if the environment variables are set
+if [ -z "$DOCKER_TAG" ]; then
+    printf "\n$DOCKER_TAG is enviroment var is empty"
+    exit 1
+fi
+
+if [ -z "$REGISTRY" ]; then
+    printf "\n$REGISTRY is enviroment var is empty"
+    exit 1
+fi
+
+if [ -z "$REPO" ]; then
+    printf "\n$REPO is enviroment var is empty"
+    exit 1
+fi
+
+if [ -z "$GHCR_TOKEN" ]; then
+    printf "\n$GHCR_TOKEN is enviroment var is empty"
+    exit 1
+fi
 
 # Compute the hash of the Dockerfile
-DOCKER_TAG=$(./.github/get-docker-tag.sh)
-echo "Docker tag: $DOCKER_TAG"
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+full_image="$REGISTRY/$REPO/$image_name:$DOCKER_TAG"
+printf "\n\n## Running build-docker-images.sh for $full_image ##\n\n"
 
-build_and_push() {
-    local image_name=$1
-    local dockerfile=$2
-    local from_image=$3
-
-    if docker manifest inspect $image_name:$DOCKER_TAG > /dev/null; then
-        echo "Image $image_name:$DOCKER_TAG already exists"
-    else
-        echo "Building image $image_name:$DOCKER_TAG"
-        docker build \
-            --progress=plain \
-            --build-arg FROM_TAG=$DOCKER_TAG \
-            ${from_image:+--build-arg FROM_IMAGE=$from_image} \
-            -t $image_name:$DOCKER_TAG \
-            -f $dockerfile .
-
-        echo "Pushing image $image_name:$DOCKER_TAG"
-        docker push $image_name:$DOCKER_TAG
+if [ ! -z "$branch_name" ]; then
+    printf "\nChecking if image can build on branch $branch_name"
+    if [ "$BRANCH" != "$branch_name" ]; then
+        printf "\nSkipping build for $full_image since branch $BRANCH does not match $branch_name"
+        exit 0
     fi
-}
+fi
 
-build_and_push $BASE_IMAGE_NAME .github/Dockerfile.base
-build_and_push $BASE_IRD_IMAGE_NAME .github/Dockerfile.ird base
-build_and_push $CI_IMAGE_NAME .github/Dockerfile.ci
-build_and_push $IRD_IMAGE_NAME .github/Dockerfile.ird ci
+GHCR_TOKEN=$(printf $GHCR_TOKEN | base64)
+# Check if the image tag already exists in ghcr.io
+printf "\nChecking $REGISTRY for tag: $DOCKER_TAG"
+set +e
+match_tag=$(curl -s -H "Authorization: Bearer $GHCR_TOKEN" https://$REGISTRY/v2/$REPO/$image_name/tags/list | jq -r --arg tag "$DOCKER_TAG" '.tags[]' | grep -o $DOCKER_TAG)
+set -e
 
-echo "All images built and pushed successfully"
-echo "CI_IMAGE_NAME:"
-echo $CI_IMAGE_NAME:$DOCKER_TAG
+# Check if the tag exists in ghcr.io
+if [ ! -z "$match_tag" ]; then
+   printf "\n$full_image exists in ghcr.io"
+
+    # Check if the image tag already exists in the local docker
+   local_cache=$(docker image ls --filter=reference="$full_image" --format json)
+
+    if [ ! -z "$local_cache" ]; then
+        printf "\n$full_image exists in local docker cache"
+        if [ "$BRANCH" != "main" ]; then
+            printf "\nUsing $full_image for CI Dev branch"
+            exit 0
+        fi
+
+        printf "\n$full_image updating with latest tag since on main branch"
+        docker tag $full_image $REGISTRY/$REPO/$image_name:latest
+        docker push $REGISTRY/$REPO/$image_name:latest
+        exit 0
+    fi
+    if [ "$BRANCH" != "main" ]; then
+        printf "\nPulling $full_image for CI Dev branch since tag exists in ghcr.io but not in local docker"
+        docker pull $full_image
+        exit 0
+    fi
+
+    printf "\nPulling $full_image and updating with latest tag since on main branch"
+    docker pull $full_image
+    docker tag $full_image $REGISTRY/$REPO/$image_name:latest
+    docker push $REGISTRY/$REPO/$image_name:latest
+    exit 0
+fi
+
+printf "\n$full_image does not exist in ghcr.io"
+
+build_args=("--build-arg" "FROM_TAG=$DOCKER_TAG")
+
+# Add FROM_IMAGE tag if declared
+if [ -z "$from_image" ]; then
+    build_args+=("--build-arg" "FROM_IMAGE=$image_name")
+fi
+
+# Add the required tag and dockerfile
+build_args+=("-t" "$full_image" "-f" "$dockerfile" ".")
+
+# Execute the docker build command with all arguments
+printf "\nDocker build arguments: ${build_args[@]}"
+docker build --push "${build_args[@]}"

--- a/.github/workflows/build-image-weekly.yml
+++ b/.github/workflows/build-image-weekly.yml
@@ -1,0 +1,45 @@
+name: Weekly Build Docker Image
+
+on:
+  schedule:
+    - cron: '0 0 * * SAT'
+
+jobs:
+
+  build-image:
+    runs-on: builder
+    outputs:
+      docker-image: ${{ steps.build.outputs.docker-image }}
+    steps:
+      - name: Fix permissions
+        shell: bash
+        run: sudo chown ubuntu:ubuntu -R $(pwd)
+
+      - uses: actions/checkout@v4
+        with:
+            submodules: recursive
+            fetch-depth: 0 # Fetch all history and tags
+
+      - name: Cleanup submodules
+        run: |
+          git submodule foreach --recursive git clean -ffdx
+          git submodule foreach --recursive git reset --hard
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker images and output the image name
+        id: build
+        shell: bash
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY: ghcr.io
+          REPO: tenstorrent/tt-forge-fe
+        run: |
+          export DOCKER_TAG=$(./.github/get-docker-tag.sh)
+          .github/build-docker-images.sh tt-forge-fe-base-ird-ubuntu-22-04 .github/Dockerfile.ird base
+          .github/build-docker-images.sh tt-forge-fe-base-ubuntu-22-04 .github/Dockerfile.base

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -64,33 +64,22 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Docker images and output the image name
+      - name: Build Docker images
         id: build
         shell: bash
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REGISTRY: ghcr.io
+          REPO: tenstorrent/tt-forge-fe
         run: |
-          # Output the image name
-          set pipefail
-          .github/build-docker-images.sh | tee docker.log
-          DOCKER_CI_IMAGE=$(tail -n 1 docker.log)
-          echo "DOCKER_CI_IMAGE $DOCKER_CI_IMAGE"
-          echo "docker-image=$DOCKER_CI_IMAGE" >> "$GITHUB_OUTPUT"
+          # Create Docker tag
+          export DOCKER_TAG=$(./.github/get-docker-tag.sh)
 
-  set-latest:
-    # Set the latest tag on the IRD image
-    runs-on: ubuntu-latest
-    needs: build-image
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    steps:
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set latest tag on the image
-        run: |
-          DOCKER_CI_IMAGE=${{ needs.build-image.outputs.docker-image }}
-          DOCKER_TAG=$(echo $DOCKER_CI_IMAGE | sed 's/^.*://')
-          IMAGE_NAME=ghcr.io/${{ github.repository }}/tt-forge-fe-ird-ubuntu-22-04
-          echo "Setting latest tag on the image $IMAGE_NAME:$DOCKER_TAG"
-          skopeo copy "docker://$IMAGE_NAME:$DOCKER_TAG" "docker://$IMAGE_NAME:latest"
+          # Build the docker images for CI and
+          .github/build-docker-images.sh tt-forge-fe-ci-ubuntu-22-04 .github/Dockerfile.ci
+
+          # Pass the name of the image to the next job
+          echo "docker-image=$REGISTRY/$REPO/tt-forge-fe-ci-ubuntu-22-04:$DOCKER_TAG" >> "$GITHUB_OUTPUT"
+
+          # Build the docker image for IRD
+          .github/build-docker-images.sh tt-forge-fe-ird-ubuntu-22-04 .github/Dockerfile.ird main ci


### PR DESCRIPTION
The major changes to this script were made to increase its portability, so it can reside in `tt-forge` and be shared with other repositories.

## Changes
*  Ensure image is in resgistry and/or local cache (docker inspect manifest would slient failover to check reg if not there)
* Added weekly build and lastest tag option when merge to main (https://github.com/tenstorrent/github-ci-infra/pull/593) to be used for shared org runners


## Test
### Cache Build 
* https://github.com/tenstorrent/tt-forge-fe/actions/runs/14585147741/job/40909256375  
### Cache Build and  skip IRD (only for main branch) 
* https://github.com/tenstorrent/tt-forge-fe/actions/runs/14585321382/job/40909706088#step:8:23