### PR TITLE
Enable program cache in benchmark models mobilenet and efficientnet.

### DIFF
--- a/forge/test/benchmark/benchmark/models/efficientnet_timm.py
+++ b/forge/test/benchmark/benchmark/models/efficientnet_timm.py
@@ -72,10 +72,9 @@ def test_efficientnet_timm(training, batch_size, input_size, channel_size, loop_
     verify(input_sample, framework_model, compiled_model)
 
     # Enable program cache on all devices
-    # This feature introduces a bug in tt-metal, we enable it when we solve the issue
-    # settings = DeviceSettings()
-    # settings.enable_program_cache = True
-    # configure_devices(device_settings=settings)
+    settings = DeviceSettings()
+    settings.enable_program_cache = True
+    configure_devices(device_settings=settings)
 
     # Run for the first time to warm up the model.
     # This is required to get accurate performance numbers.

--- a/forge/test/benchmark/benchmark/models/mobilenetv2_basic.py
+++ b/forge/test/benchmark/benchmark/models/mobilenetv2_basic.py
@@ -78,10 +78,9 @@ def test_mobilenetv2_basic(training, batch_size, input_size, channel_size, loop_
     verify(input_sample, framework_model, compiled_model)
 
     # Enable program cache on all devices
-    # This feature introduces a bug in tt-metal, we enable it when we solve the issue
-    # settings = DeviceSettings()
-    # settings.enable_program_cache = True
-    # configure_devices(device_settings=settings)
+    settings = DeviceSettings()
+    settings.enable_program_cache = True
+    configure_devices(device_settings=settings)
 
     # Run for the first time to warm up the model.
     # This is required to get accurate performance numbers.


### PR DESCRIPTION
Program cache works again on mobilenet and efficientnet, so we enable it.
