### PR TITLE
Enable device perf collection on CI for Llama benchmark model.

### DIFF
--- a/.github/workflows/perf-benchmark-sub.yml
+++ b/.github/workflows/perf-benchmark-sub.yml
@@ -20,7 +20,7 @@ jobs:
         build: [
           { runs-on: "n150", name: "mnist_linear",      dir: "MNISTLinear", bs: 32, lp: 32 },
           { runs-on: "n150", name: "resnet50_hf",       dir: "ResNetForImageClassification", bs: 3, lp: 32 },
-          { runs-on: "n150", name: "llama",             dir: "LlamaModel", bs: 1, lp: 32, allow-fail: true }, # TTRT does not support llama model yet, so allow it to fail
+          { runs-on: "n150", name: "llama",             dir: "LlamaModel", bs: 1, lp: 32 },
           { runs-on: "n150", name: "mobilenetv2_basic", dir: "MobileNetv2Basic", bs: 1, lp: 32 },
           { runs-on: "n150", name: "efficientnet_timm", dir: "EfficientNetTimmB0", bs: 1, lp: 32 }
         ]


### PR DESCRIPTION
Now, we are able to run device run on Llama benchmark model, too. So, we enable it. The issue with TTRT is solved. There is the [issue](https://github.com/tenstorrent/tt-mlir/issues/2752#issuecomment-2786438092).
