### PR TITLE
Handle None inputs for gamma and beta in layer_norm for affine=False case

### DIFF
--- a/forge/test/mlir/operators/tm/test_tm.py
+++ b/forge/test/mlir/operators/tm/test_tm.py
@@ -163,24 +163,32 @@ def test_cast(forge_property_recorder, operand_and_cast_dtype):
 
 
 @pytest.mark.parametrize(
-    "batch_size, num_channels, height, width",
+    "input_shape,elementwise_affine, eps",
     [
-        (1, 32, 56, 56),
+        ((2, 128), False, 1e-6),
+        ((2, 4096, 1536), False, 1e-6),
+        ((1, 32, 56, 56), True, 1e-5),
+        ((1, 5, 3, 7, 9), True, 1e-3),
     ],
 )
 @pytest.mark.push
-def test_layernorm(forge_property_recorder, batch_size, num_channels, height, width):
+def test_layernorm(forge_property_recorder, input_shape, elementwise_affine, eps):
+    class LayerNorm(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = nn.LayerNorm(input_shape[-1], elementwise_affine=elementwise_affine, eps=eps)
 
-    # framework_model = nn.LayerNorm((num_channels, height, width)) # Support only normalization over last one dimension
-    framework_model = nn.LayerNorm((width))
+        def forward(self, x):
+            return self.norm(x)
 
-    inputs = [torch.rand(batch_size, num_channels, height, width)]
+    model = LayerNorm()
+    model.eval()
 
-    compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder
-    )
+    inputs = [torch.randn(*input_shape)]
 
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    compiled_model = forge.compile(model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)
+
+    verify(inputs, model, compiled_model, forge_property_handler=forge_property_recorder)
 
 
 params = [

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
@@ -40,18 +40,9 @@ class StableDiffusionWrapper(torch.nn.Module):
 @pytest.mark.parametrize(
     "variant",
     [
-        pytest.param(
-            "stable-diffusion-3.5-medium",
-            marks=pytest.mark.xfail,
-        ),
-        pytest.param(
-            "stable-diffusion-3.5-large",
-            marks=pytest.mark.xfail,
-        ),
-        pytest.param(
-            "stable-diffusion-3.5-large-turbo",
-            marks=pytest.mark.xfail,
-        ),
+        "stable-diffusion-3.5-medium",
+        "stable-diffusion-3.5-large",
+        "stable-diffusion-3.5-large-turbo",
     ],
 )
 def test_stable_diffusion_v35(forge_property_recorder, variant):


### PR DESCRIPTION

## summary 

- This PR tracks [changes](https://github.com/tenstorrent/tt-tvm/pull/75/files) to Handle None inputs for gamma and beta in layer_norm for affine=False case and adds sanity to verify the fix.

## Logs

- [sanity_before_fix.log](https://github.com/user-attachments/files/19846079/apr22_lm_s_before_fix_1.log)
- [sanity_after_fix.log](https://github.com/user-attachments/files/19846077/apr22_lm_s_after_fix_1.log)

