### PR TITLE
Add support for einsum pattern(nhwpqc->nchpwq)

### DIFF
--- a/forge/forge/tvm_calls/relay/op/forge_passes.py
+++ b/forge/forge/tvm_calls/relay/op/forge_passes.py
@@ -2013,6 +2013,16 @@ class DecomposeEinsum(DFPatternCallback):
             )
 
             return result
+
+        elif match_einsum_pattern("nhwpqc->nchpwq", equation):
+            # Ensure the einsum pattern is matched, and there should be one input node
+            assert len(node_map[self.act][0]) == 1
+
+            src = node_map[self.act][0][0]  # (n, h, w, p, q, c)
+            result = tvm.relay.transpose(src, axes=[0, 5, 1, 3, 2, 4])  # (n, c, h, p, w, q)
+
+            return result
+
         else:
             assert False, f"TVM einsum decomposition does not support {equation} yet."
 

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
@@ -7,6 +7,7 @@ import torch
 
 import forge
 from forge.forge_property_utils import Framework, Source, Task
+from forge.verify.verify import verify
 
 from test.models.pytorch.multimodal.stable_diffusion.utils.model import (
     load_pipe,
@@ -35,7 +36,7 @@ class StableDiffusionWrapper(torch.nn.Module):
 
 @pytest.mark.nightly
 @pytest.mark.skip(
-    reason="Insufficient host DRAM to run this model (requires a bit more than 40 GB during compile time)"
+    reason="Insufficient host DRAM to run this model (requires a bit more than 54 GB during compile time)"
 )
 @pytest.mark.parametrize(
     "variant",


### PR DESCRIPTION
## Summary 

- support added for einsum pattern(**nhwpqc->nchpwq**) to unblock stable-diffusion-3.5-medium,stable-diffusion-3.5-large,stable-diffusion-3.5-large-turbo models.

## Logs

Sanity 

- [sanity_before_fix.log](https://github.com/user-attachments/files/19849237/apr22_einsum_before_fix.log)
- [sanity_after_fix.log](https://github.com/user-attachments/files/19849235/apr22_einsum_after_fix.log)

Model 

- [stable_diffusion_v3_5_medium_before_fix.log](https://github.com/user-attachments/files/19849249/apr22_stable_diffusion_v35_medium_after_fix.log)
- [stable_diffusion_v3_5_large_before_fix.log](https://github.com/user-attachments/files/19849246/apr22_stable_diffusion_v35_large_after_fix.log)
- [stable_diffusion_v3_5_large_turbo_before_fix.log](https://github.com/user-attachments/files/19849248/apr22_stable_diffusion_v35_large_turbo_after_fix.log)
- [stable_diff_medium_after_fix.log](https://github.com/user-attachments/files/19849264/apr22_stable_diff_medium_after_einsum_fix_1.log)
- [stable_diff_large_after_fix.log](https://github.com/user-attachments/files/19849258/apr22_stable_diff_large_einsum_fix.log)
- [stable_diff_large_turbo_after_fix.log](https://github.com/user-attachments/files/19849261/apr22_stable_diff_large_turbo_einsum_fix.log)




