### PR TITLE
[log_softmax] - Fixed named attrs for softmax

### DIFF
--- a/forge/forge/op/eval/forge/nn.py
+++ b/forge/forge/op/eval/forge/nn.py
@@ -394,7 +394,7 @@ def decompose(op_type, attr, dc, inputs):
         x = inputs[0]
         dim = attr[0]
         stable = attr[1]
-        result = dc.op("softmax", (x,), (dim, stable))
+        result = dc.op_with_named_attrs("softmax", (x,), {"dimension": dim}, (dim, stable))
         result = dc.op(Log.create(), (result,))
         dc.fuse(result)
         return

--- a/forge/test/mlir/operators/nn/test_nn.py
+++ b/forge/test/mlir/operators/nn/test_nn.py
@@ -291,6 +291,36 @@ def test_softmax(forge_property_recorder):
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
 
+@pytest.mark.push
+@pytest.mark.parametrize(
+    "input_shape, dim",
+    [
+        ((1, 128), 1),
+        ((4, 32), 1),
+        ((2, 3, 5), 2),
+        ((2, 3, 5), -1),
+        ((10,), 0),
+    ],
+)
+def test_log_softmax(forge_property_recorder, input_shape, dim):
+    class LogSoftmax(nn.Module):
+        def __init__(self, dim):
+            super().__init__()
+            self.log_softmax = nn.LogSoftmax(dim=dim)
+
+        def forward(self, a):
+            return self.log_softmax(a)
+
+    inputs = [torch.rand(*input_shape)]
+
+    framework_model = LogSoftmax(dim)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder
+    )
+
+    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+
 # @pytest.mark.parametrize("vocab_size", [2048, 16384, 32000])
 # @pytest.mark.parametrize("token_num", [1, 7, 32])
 # @pytest.mark.parametrize("embedding_dim", [128, 512, 3200])

--- a/forge/test/models_ops/test_logsoftmax.py
+++ b/forge/test/models_ops/test_logsoftmax.py
@@ -37,7 +37,6 @@ forge_modules_and_shapes_dtypes_list = [
             [((1, 10), torch.float32)],
             {"model_name": ["pt_mnist_base_img_cls_github"], "pcc": 0.99, "op_params": {"dim": "1"}},
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Generated MLIR module failed verification.")],
     ),
 ]
 


### PR DESCRIPTION
### Ticket
fixes: #1640 

### Problem description
named attrs for softmax were not passed and it failed verification.

### What's changed
- fixed named attrs for softmax
- added tests for log_softmax

