### PR TITLE
Change verification of Resnet Benchmark Model

### DIFF
--- a/forge/test/benchmark/benchmark/models/efficientnet_timm.py
+++ b/forge/test/benchmark/benchmark/models/efficientnet_timm.py
@@ -16,6 +16,7 @@ import torch
 
 # Forge modules
 import forge
+from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 from forge._C.runtime.experimental import configure_devices, DeviceSettings
 
@@ -58,31 +59,32 @@ def test_efficientnet_timm(training, batch_size, input_size, channel_size, loop_
 
     module_name = "EfficientNetTimmB0"
 
-    # Load model
-    framework_model = download_model(timm.create_model, "efficientnet_b0", pretrained=True)
-    framework_model.eval()
-
     torch.manual_seed(1)
     input_sample = [torch.randn(batch_size, channel_size, input_size[0], input_size[1])]
 
+    # Load model
+    framework_model = download_model(timm.create_model, "efficientnet_b0", pretrained=True)
+    framework_model.eval()
+    fw_out = framework_model(*input_sample)
+
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=input_sample, module_name=module_name)
-
-    # Model Verification
-    verify(input_sample, framework_model, compiled_model)
 
     # Enable program cache on all devices
     settings = DeviceSettings()
     settings.enable_program_cache = True
     configure_devices(device_settings=settings)
 
-    # Run for the first time to warm up the model.
+    # Run for the first time to warm up the model, it will be done by verify function.
     # This is required to get accurate performance numbers.
-    compiled_model(*input_sample)
+    verify(input_sample, framework_model, compiled_model)
     start = time.time()
     for _ in range(loop_count):
-        compiled_model(*input_sample)
+        co_out = compiled_model(*input_sample)
     end = time.time()
+
+    co_out = [co.to("cpu") for co in co_out]
+    AutomaticValueChecker().check(fw_out=fw_out, co_out=co_out[0])
 
     date = datetime.now().strftime("%d-%m-%Y")
     machine_name = socket.gethostname()
@@ -96,7 +98,7 @@ def test_efficientnet_timm(training, batch_size, input_size, channel_size, loop_
     num_layers = 82  # Number of layers in the model, in this case number of convolutional layers
 
     print("====================================================================")
-    print("| Efficient Net Benchmark Results:                                        |")
+    print("| Efficient Net Benchmark Results:                                 |")
     print("--------------------------------------------------------------------")
     print(f"| Model: {model_name}")
     print(f"| Model type: {model_type}")

--- a/forge/test/benchmark/benchmark/models/resnet_hf.py
+++ b/forge/test/benchmark/benchmark/models/resnet_hf.py
@@ -18,9 +18,9 @@ from datasets import load_dataset
 
 # Forge modules
 import forge
-from forge.verify.value_checkers import AutomaticValueChecker
-from forge.verify.verify import verify
 from forge.verify.config import VerifyConfig
+from forge.verify.verify import verify
+from forge.verify.value_checkers import AutomaticValueChecker
 from forge._C.runtime.experimental import configure_devices, DeviceSettings
 from forge._C import DataFormat
 from forge.config import CompilerConfig
@@ -82,6 +82,7 @@ def test_resnet_hf(
     # dataset = load_dataset("zh-plus/tiny-imagenet")
     # images = random.sample(dataset["valid"]["image"], 10)
 
+    torch.manual_seed(1)
     # Random data
     input_sample = [torch.rand(batch_size, channel_size, *input_size)]
     if data_format == "bfloat16":
@@ -110,8 +111,12 @@ def test_resnet_hf(
 
     # Run for the first time to warm up the model, it will be done by verify function.
     # This is required to get accurate performance numbers.
-    verify(input_sample, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95)))
-    co_out = compiled_model(*input_sample)
+    verify(
+        input_sample,
+        framework_model,
+        compiled_model,
+        verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95)),
+    )
     start = time.time()
     for _ in range(loop_count):
         co_out = compiled_model(*input_sample)


### PR DESCRIPTION
Add standard way of verification of result correctness for benchmark model Resnet. No, resnet, like other models, uses verify function.
