### PR TITLE
[onnx] don't create onnx session twice

### DIFF
--- a/forge/forge/tvm_calls/forge_compile.py
+++ b/forge/forge/tvm_calls/forge_compile.py
@@ -746,62 +746,6 @@ def clean_names(json_graph, forge_params, param_name_lookup={}):
     return json_graph
 
 
-def duplicate_dequantize_nodes_in_onnx_graph(onnx_module):
-    from collections import defaultdict
-
-    # Create a dictionary to store the consumers of each tensor
-    tensor_consumers = defaultdict(list)
-
-    graph = onnx_module.graph
-    # Populate the tensor_consumers dictionary
-    for node in graph.node:
-        for input_name in node.input:
-            tensor_consumers[input_name].append(node.name)
-
-    # Find and duplicate nodes with output branches
-    nodes_to_add = []
-    nodes_to_remove = []
-    indices_for_adding = []
-    for node_ind, node in enumerate(graph.node):
-
-        if node.op_type != "DequantizeLinear":
-            continue
-
-        output_name = node.output[0]
-        consumers = tensor_consumers[output_name]
-
-        if len(consumers) > 1:
-            # Duplicate the node for each consumer
-            for i, consumer_name in enumerate(consumers):
-                new_node_name = node.name + f"_clone{i}"
-                new_output_name = output_name + f"_clone{i}"
-                attrs = {"axis": node.attribute[0].i} if len(node.attribute) > 0 else {}
-                cloned_node = onnx.helper.make_node(
-                    node.op_type, node.input, [new_output_name], name=new_node_name, **attrs
-                )
-
-                # Add the cloned node to the list of nodes to add
-                nodes_to_add.append(cloned_node)
-                indices_for_adding.append((cloned_node, node_ind))
-
-                # Update the consumer to use the cloned node's output
-                consumer_node = next(n for n in graph.node if n.name == consumer_name)
-                for j, input_name in enumerate(consumer_node.input):
-                    if input_name == output_name:
-                        consumer_node.input[j] = new_output_name
-
-            # Remove the original node since it will be replaced by its clones
-            nodes_to_remove.append(node)
-
-    # This is needed to remain the order of the nodes in graph
-    # since graph is not put in topsort order when visiting nodes
-    for i, (node, insertion_index) in enumerate(indices_for_adding):
-        graph.node.insert(insertion_index + i, node)
-
-    for node in nodes_to_remove:
-        graph.node.remove(node)
-
-
 def compile_onnx_for_forge(
     onnx_mod, onnx_path, *inputs, graph_name, compiler_cfg, verify_cfg=None, forge_property_handler=None
 ):
@@ -817,10 +761,10 @@ def compile_onnx_for_forge(
     else:
         onnx_model = onnx_mod.SerializeToString()
 
-    ort_sess = ort.InferenceSession(onnx_model, sess_options=so, providers=["CPUExecutionProvider"])
+    onnx_session = ort.InferenceSession(onnx_model, sess_options=so, providers=["CPUExecutionProvider"])
 
     input_names = []
-    for inp in ort_sess.get_inputs():
+    for inp in onnx_session.get_inputs():
         input_names.append(inp.name)
 
     input_dict = {}
@@ -831,15 +775,18 @@ def compile_onnx_for_forge(
 
     assert len(input_names) == len(inputs), "Number of input names must match number of inputs"
 
-    duplicate_dequantize_nodes_in_onnx_graph(onnx_mod)
     framework_outputs = extract_framework_model_outputs(
         framework="onnx",
         model=onnx_mod,
-        onnx_path=onnx_path,
         inputs=inputs,
         verify_tvm_compile=verify_cfg.verify_tvm_compile,
         input_dict=input_dict,
+        onnx_session=onnx_session,
     )
+
+    # These are large objects - release them since we don't need them anymore.
+    del onnx_session
+    del onnx_model
 
     graph_hash = hashlib.sha256()
     if is_tvm_cache_enabled():

--- a/forge/forge/tvm_calls/forge_utils.py
+++ b/forge/forge/tvm_calls/forge_utils.py
@@ -31,7 +31,7 @@ def extract_framework_model_outputs(
     inputs,
     verify_tvm_compile: bool = False,
     input_dict={},
-    onnx_path: Optional[str] = None,
+    onnx_session: Optional[ort.InferenceSession] = None,
 ):
     framework_outputs = []
 
@@ -118,16 +118,8 @@ def extract_framework_model_outputs(
         for out in model.graph.output:
             output_names.append(out.name)
 
-        so = ort.SessionOptions()
-        so.inter_op_num_threads = 2
-        so.intra_op_num_threads = 2
-
-        if onnx_path is not None:
-            onnx_model = onnx_path
-        else:
-            onnx_model = model.SerializeToString()
-        ort_sess = ort.InferenceSession(onnx_model, sess_options=so)
-        framework_outputs = ort_sess.run(output_names, input_dict)
+        assert onnx_session is not None
+        framework_outputs = onnx_session.run(output_names, input_dict)
 
     elif framework == "tflite":
         input_details = model.get_input_details()


### PR DESCRIPTION
When compiling ONNX models, we are creating the inference session twice.

Since this is not needed and the amount of memory required by the session is not trivial - this change reuses the session which was originally created.

Because the session and the `onnx_model` objects can be quite large, I am calling the `del` operator explicitly, to minimize their lifetime.

Additionally, removing the unused code related to `dequantize`.

Closes #1800