### PR TITLE
Solve Detr attribute error

### DIFF
--- a/forge/forge/tvm_calls/relay/op/forge_passes.py
+++ b/forge/forge/tvm_calls/relay/op/forge_passes.py
@@ -4687,6 +4687,17 @@ class DecomposeFloor(DFPatternCallback):
         return floor_result
 
 
+class DecomposeZerosToFull(DFPatternCallback):
+    def __init__(self):
+        super().__init__()
+        self.pattern = is_op("zeros")()
+
+    def callback(self, pre, post, node_map):
+        shape = pre.attrs.shape
+        dtype = pre.attrs.dtype
+        return tvm.relay.full(tvm.relay.const(0, dtype=dtype), shape=shape, dtype=dtype)
+
+
 class DecomposeMeshgrid(DFPatternCallback):
     def __init__(self):
         super().__init__()
@@ -4782,6 +4793,7 @@ def run_forge_compile_passes(
     return run_pattern_callbacks(
         relay_module,
         [
+            DecomposeZerosToFull(),
             DecomposeMeshgrid(),
             DecomposeGridSample(),
             DecomposeFloor(),

--- a/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
+++ b/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
@@ -971,3 +971,35 @@ def test_zero(forge_property_recorder, hidden_dim):
     compiled_model = forge.compile(model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)
 
     verify(inputs, model, compiled_model, forge_property_handler=forge_property_recorder)
+
+
+@pytest.mark.parametrize(
+    "input_shape",
+    [
+        (2, 3, 4),
+        (1, 10),
+        (5, 5, 5),
+        (8,),
+    ],
+)
+@pytest.mark.xfail
+def test_zeros_like(forge_property_recorder, input_shape):
+    class ZerosLikeModel(torch.nn.Module):
+        def forward(self, x):
+            z = torch.zeros_like(x)
+            cond = x > 0
+            return torch.where(cond, x, z)
+
+    input_tensor = torch.randn(input_shape)
+    inputs = [input_tensor]
+
+    model = ZerosLikeModel()
+    model.eval()
+
+    compiled_model = forge.compile(
+        model,
+        sample_inputs=inputs,
+        forge_property_handler=forge_property_recorder,
+    )
+
+    verify(inputs, model, compiled_model, forge_property_handler=forge_property_recorder)


### PR DESCRIPTION
Fixes #1094 
## Summary 

Core part of the issue is due to SimplifyExpr pass present in run_relay_passes [here](https://github.com/tenstorrent/tt-tvm/blob/3e17dbedc5b33efdd071c3ca1dbfd2b44e4a9cfb/python/tvm/relay/op/contrib/forge/relay_passes.py#L65), after this pass zeros_like op is converted to zeros op as mentioned [here](https://github.com/apache/tvm/blob/d6c1489b5d030c03fa9132accdb2d72f237f3e3e/src/relay/transforms/simplify_expr.cc#L552), due to this only shapes get sent as input to this op which arises as an issue later as mentioned in below stages.

Later in transform.[AnnotateTarget](https://github.com/tenstorrent/tt-tvm/blob/3e17dbedc5b33efdd071c3ca1dbfd2b44e4a9cfb/python/tvm/relay/op/contrib/forge/forge.py#L1994) pass in partition_for_forge, compiler_begin and compiler_end wrapper gets added for all ops but this is skipped for zeros op since inputs for it is shape and not a tensor.

[Ref](https://github.com/apache/tvm/blob/d6c1489b5d030c03fa9132accdb2d72f237f3e3e/src/relay/transforms/annotate_target.cc#L93) - So this part mentions that the zeros operations would be treated as input variables when they are used as call nodes with no arguments.This is because the code specifically checks if a call node has no arguments (i.e., call->args.size() == 0). For functions like zeros() only shape is passed as input so the code treats them as special tensor operations and directly adds them to the compiler_ends list, without wrapping them with compiler_begin and compiler_end. So zeros op are not wrapped between compiler_begin and compiler_end and considered as input var.

In [PartitionGraph](https://github.com/tenstorrent/tt-tvm/blob/3e17dbedc5b33efdd071c3ca1dbfd2b44e4a9cfb/python/tvm/relay/op/contrib/forge/forge.py#L2002) pass which happens few steps later AnnotateTarget, ops wrapped between compiler_begin and compiler_end are only brought into tvmgen_default_forge_main_0 , so as a result these ops stay unbinded after partition graph pass and cause this issue.

## Fix

A DFPattern callback has been added which decomposes zeros op to full op similar to decomposition in [pytorch.py](https://github.com/tenstorrent/tt-tvm/blob/1cfbad7028df3ec85962b4efa22d275e19996bd0/python/tvm/relay/frontend/pytorch.py#L954), this change ensures that zeros op doesn't stay unbinded during partitioning.
