### PR TITLE
[CI tests] removed xfailed and skipped one test

### DIFF
--- a/forge/test/models/onnx/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/onnx/text/qwen/test_qwen_v2.py
@@ -32,7 +32,7 @@ import torch
         ),
         pytest.param(
             "Qwen/Qwen2.5-0.5B-Instruct",
-            marks=pytest.mark.xfail,
+            marks=pytest.mark.skip("Transient test - Out of memory due to other tests in CI pipeline"),
         ),
         pytest.param(
             "Qwen/Qwen2.5-1.5B-Instruct",

--- a/forge/test/models/pytorch/vision/mnist/test_mnist.py
+++ b/forge/test/models/pytorch/vision/mnist/test_mnist.py
@@ -11,7 +11,6 @@ from test.models.pytorch.vision.mnist.utils.utils import load_input, load_model
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 def test_mnist(forge_property_recorder):
 
     # Record Forge Property


### PR DESCRIPTION
### What's changed
Skipped one test due to transient failure and removed `xfail` mark from one test as it is passing now.