### PR TITLE
[CI] Change model-analysis runner

### DIFF
--- a/.github/workflows/model-analysis.yml
+++ b/.github/workflows/model-analysis.yml
@@ -24,7 +24,7 @@ jobs:
 
   model-analysis:
     needs: docker-build
-    runs-on: performance
+    runs-on: tt-beta-ubuntu-2204-n150-large-stable
     timeout-minutes: 5760 # Set job execution time to 4 days(default: 6 hours)
 
     container:


### PR DESCRIPTION
### Ticket
f2f

### Problem description
Performance runners are for performance benchmarks and not for long runs.

### What's changed
Changed to shared company runner.
