### PR TITLE
[ci] build docs as part of On PR workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,73 @@
+name: Build Docs
+
+on:
+  workflow_call:
+    inputs:
+      docker-image:
+        description: 'Docker image to use for build'
+        required: true
+        type: string
+
+# Sets permissions for:
+#   - downloading docker container
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        build:
+          - runs-on:
+            - ubuntu-latest
+
+    runs-on: ${{ matrix.build.runs-on }}
+
+    container:
+      image: ${{ inputs.docker-image }}
+
+    env:
+      MDBOOK_VERSION: 0.4.36
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+          submodules: recursive
+          fetch-depth: 0 # Fetch all history and tags
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      run: |
+        echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
+        echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
+
+    - name: Git safe dir
+      run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
+
+    - name: Install mdBook
+      shell: bash
+      run: |
+        source env/activate
+        apt install cargo -y
+        cargo install --version ${MDBOOK_VERSION} mdbook --locked
+
+    - name: Setup Pages
+      id: pages
+      uses: actions/configure-pages@v5
+
+    - name: Build Docs
+      shell: bash
+      run: |
+        source env/activate
+        export PATH="/github/home/.cargo/bin:$PATH"
+        cmake -G Ninja -B build .
+        cmake --build build -- docs
+
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: ./build/docs/book

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,62 +20,12 @@ jobs:
     uses: ./.github/workflows/build-image.yml
     secrets: inherit
 
-  build:
+  build-docs:
     needs: docker-build
-    strategy:
-      fail-fast: false
-      matrix:
-        build:
-          - runs-on:
-            - ubuntu-latest
-
-    runs-on: ${{ matrix.build.runs-on }}
-
-    container:
-      image: ${{ needs.docker-build.outputs.docker-image }}
-
-    env:
-      MDBOOK_VERSION: 0.4.36
-
-    steps:
-    - uses: actions/checkout@v4
-      with:
-          submodules: recursive
-          fetch-depth: 0 # Fetch all history and tags
-
-    - name: Set reusable strings
-      id: strings
-      shell: bash
-      run: |
-        echo "work-dir=$(pwd)" >> "$GITHUB_OUTPUT"
-        echo "build-output-dir=$(pwd)/build" >> "$GITHUB_OUTPUT"
-
-    - name: Git safe dir
-      run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
-
-    - name: Install mdBook
-      shell: bash
-      run: |
-        source env/activate
-        apt install cargo -y
-        cargo install --version ${MDBOOK_VERSION} mdbook --locked
-
-    - name: Setup Pages
-      id: pages
-      uses: actions/configure-pages@v5
-
-    - name: Build Docs
-      shell: bash
-      run: |
-        source env/activate
-        export PATH="/github/home/.cargo/bin:$PATH"
-        cmake -G Ninja -B build .
-        cmake --build build -- docs
-
-    - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
-      with:
-        path: ./build/docs/book
+    uses: ./.github/workflows/build-docs.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
 
   # Deployment job
   deploy:
@@ -84,7 +34,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     runs-on: ubuntu-latest
-    needs: build
+    needs: build-docs
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -33,6 +33,12 @@ jobs:
     with:
       mlir_override: ${{ inputs.mlir_override }}
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
+  build-docs:
+    needs: docker-build
+    uses: ./.github/workflows/build-docs.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
   test:
     needs:
       - docker-build
@@ -52,6 +58,7 @@ jobs:
       - pre-commit
       - spdx
       - docker-build
+      - build-docs
       - build
       - test
     runs-on: Ubuntu-latest


### PR DESCRIPTION
Build docs as part of the `On PR` workflow - to minimize chances of
breaking the docs build.

Separates docs build into a single workflow, which gets called either
from `on-pr.yml` or `docs.yml`.