### PR TITLE
Enhance models ops test generation and regenerate models ops test for pad op

### DIFF
--- a/forge/test/models_ops/test_pad.py
+++ b/forge/test/models_ops/test_pad.py
@@ -20,7 +20,7 @@ class Pad0(ForgeModule):
         super().__init__(name)
 
     def forward(self, pad_input_0):
-        pad_output_1 = forge.op.Pad("", pad_input_0, pad=(0, 0, 2, 2), mode="constant", channel_last=True)
+        pad_output_1 = forge.op.Pad("", pad_input_0, pad=(0, 0, 0, 0, 2, 2, 0, 0, 0, 0), mode="constant", pad_len=10)
         return pad_output_1
 
 
@@ -29,7 +29,7 @@ class Pad1(ForgeModule):
         super().__init__(name)
 
     def forward(self, pad_input_0):
-        pad_output_1 = forge.op.Pad("", pad_input_0, pad=(1, 1, 1, 1), mode="reflect", channel_last=False)
+        pad_output_1 = forge.op.Pad("", pad_input_0, pad=(0, 0, 0, 0, 1, 1, 1, 1), mode="reflect", pad_len=8)
         return pad_output_1
 
 
@@ -45,277 +45,122 @@ forge_modules_and_shapes_dtypes_list = [
             Pad0,
             [((1, 1, 96, 54, 54), torch.float32)],
             {
-                "model_name": ["pt_alexnet_base_img_cls_osmr"],
+                "model_names": ["pt_alexnet_base_img_cls_osmr"],
                 "pcc": 0.99,
-                "op_params": {"pad": "(0, 0, 2, 2)", "mode": '"constant"', "channel_last": "True"},
+                "args": {"pad": "(0, 0, 0, 0, 2, 2, 0, 0, 0, 0)", "mode": '"constant"', "pad_len": "10"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Generated MLIR module failed verification.")],
+        marks=[
+            pytest.mark.xfail(
+                reason="RuntimeError: TT_FATAL @ /proj_sw/user_dev/pchandrasekaran/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp:40: input_tensor.get_padded_shape()[2] + this->input_tensor_start[2] <= this->output_padded_shape[2] info: Output size cannot fit input with offset"
+            )
+        ],
     ),
     pytest.param(
         (
             Pad0,
             [((1, 1, 256, 27, 27), torch.float32)],
             {
-                "model_name": ["pt_alexnet_base_img_cls_osmr"],
+                "model_names": ["pt_alexnet_base_img_cls_osmr"],
                 "pcc": 0.99,
-                "op_params": {"pad": "(0, 0, 2, 2)", "mode": '"constant"', "channel_last": "True"},
+                "args": {"pad": "(0, 0, 0, 0, 2, 2, 0, 0, 0, 0)", "mode": '"constant"', "pad_len": "10"},
             },
         ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: Generated MLIR module failed verification.")],
-    ),
-    (
-        Pad1,
-        [((1, 512, 6, 20), torch.float32)],
-        {
-            "model_name": [
-                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-            ],
-            "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
-        },
-    ),
-    (
-        Pad1,
-        [((1, 512, 12, 40), torch.float32)],
-        {
-            "model_name": [
-                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-            ],
-            "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
-        },
-    ),
-    (
-        Pad1,
-        [((1, 256, 12, 40), torch.float32)],
-        {
-            "model_name": [
-                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-            ],
-            "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
-        },
-    ),
-    (
-        Pad1,
-        [((1, 256, 24, 80), torch.float32)],
-        {
-            "model_name": [
-                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-            ],
-            "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
-        },
-    ),
-    (
-        Pad1,
-        [((1, 128, 24, 80), torch.float32)],
-        {
-            "model_name": [
-                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-            ],
-            "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
-        },
-    ),
-    (
-        Pad1,
-        [((1, 128, 48, 160), torch.float32)],
-        {
-            "model_name": [
-                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-            ],
-            "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
-        },
-    ),
-    (
-        Pad1,
-        [((1, 64, 48, 160), torch.float32)],
-        {
-            "model_name": [
-                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-            ],
-            "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
-        },
-    ),
-    (
-        Pad1,
-        [((1, 96, 96, 320), torch.float32)],
-        {
-            "model_name": [
-                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-            ],
-            "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
-        },
-    ),
-    (
-        Pad1,
-        [((1, 32, 96, 320), torch.float32)],
-        {
-            "model_name": [
-                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-            ],
-            "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
-        },
-    ),
-    pytest.param(
-        (
-            Pad1,
-            [((1, 16, 192, 640), torch.float32)],
-            {
-                "model_name": [
-                    "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
-            },
-        ),
-        marks=[pytest.mark.skip(reason="Killed while executing ttnn binary")],
+        marks=[
+            pytest.mark.xfail(
+                reason="RuntimeError: TT_FATAL @ /proj_sw/user_dev/pchandrasekaran/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp:40: input_tensor.get_padded_shape()[2] + this->input_tensor_start[2] <= this->output_padded_shape[2] info: Output size cannot fit input with offset"
+            )
+        ],
     ),
     (
         Pad1,
         [((1, 512, 10, 32), torch.float32)],
         {
-            "model_name": [
+            "model_names": [
                 "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
         },
     ),
     (
         Pad1,
         [((1, 512, 20, 64), torch.float32)],
         {
-            "model_name": [
+            "model_names": [
                 "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
         },
     ),
     (
         Pad1,
         [((1, 256, 20, 64), torch.float32)],
         {
-            "model_name": [
+            "model_names": [
                 "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
         },
     ),
     (
         Pad1,
         [((1, 256, 40, 128), torch.float32)],
         {
-            "model_name": [
+            "model_names": [
                 "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
         },
     ),
     (
         Pad1,
         [((1, 128, 40, 128), torch.float32)],
         {
-            "model_name": [
+            "model_names": [
                 "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
         },
     ),
     (
         Pad1,
         [((1, 128, 80, 256), torch.float32)],
         {
-            "model_name": [
+            "model_names": [
                 "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
         },
     ),
     (
         Pad1,
         [((1, 64, 80, 256), torch.float32)],
         {
-            "model_name": [
+            "model_names": [
                 "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
         },
     ),
     pytest.param(
@@ -323,13 +168,13 @@ forge_modules_and_shapes_dtypes_list = [
             Pad1,
             [((1, 96, 160, 512), torch.float32)],
             {
-                "model_name": [
+                "model_names": [
                     "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                     "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                     "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
                 ],
                 "pcc": 0.99,
-                "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
+                "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
             },
         ),
         marks=[pytest.mark.skip(reason="Segmentation fault occurs while executing ttnn binary")],
@@ -339,13 +184,13 @@ forge_modules_and_shapes_dtypes_list = [
             Pad1,
             [((1, 32, 160, 512), torch.float32)],
             {
-                "model_name": [
+                "model_names": [
                     "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                     "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                     "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
                 ],
                 "pcc": 0.99,
-                "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
+                "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
             },
         ),
         marks=[pytest.mark.skip(reason="Segmentation fault occurs while executing ttnn binary")],
@@ -355,13 +200,13 @@ forge_modules_and_shapes_dtypes_list = [
             Pad1,
             [((1, 16, 320, 1024), torch.float32)],
             {
-                "model_name": [
+                "model_names": [
                     "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                     "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                     "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
                 ],
                 "pcc": 0.99,
-                "op_params": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False"},
+                "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
             },
         ),
         marks=[
@@ -369,6 +214,169 @@ forge_modules_and_shapes_dtypes_list = [
                 reason="RuntimeError: [enforce fail at alloc_cpu.cpp:91] err == 0. DefaultCPUAllocator: can't allocate memory: you tried to allocate 433025187840 bytes. Error code 12 (Cannot allocate memory)"
             )
         ],
+    ),
+    (
+        Pad1,
+        [((1, 512, 6, 20), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+        },
+    ),
+    (
+        Pad1,
+        [((1, 512, 12, 40), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+        },
+    ),
+    (
+        Pad1,
+        [((1, 256, 12, 40), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+        },
+    ),
+    (
+        Pad1,
+        [((1, 256, 24, 80), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+        },
+    ),
+    (
+        Pad1,
+        [((1, 128, 24, 80), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+        },
+    ),
+    (
+        Pad1,
+        [((1, 128, 48, 160), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+        },
+    ),
+    (
+        Pad1,
+        [((1, 64, 48, 160), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+        },
+    ),
+    (
+        Pad1,
+        [((1, 96, 96, 320), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+        },
+    ),
+    (
+        Pad1,
+        [((1, 32, 96, 320), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+        },
+    ),
+    pytest.param(
+        (
+            Pad1,
+            [((1, 16, 192, 640), torch.float32)],
+            {
+                "model_names": [
+                    "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                    "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+                    "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                    "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                    "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                    "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            },
+        ),
+        marks=[pytest.mark.skip(reason="Killed while executing ttnn binary")],
     ),
 ]
 
@@ -385,12 +393,14 @@ def test_module(forge_module_and_shapes_dtypes, forge_property_recorder):
     pcc = metadata.pop("pcc")
 
     for metadata_name, metadata_value in metadata.items():
-        if metadata_name == "model_name":
+        if metadata_name == "model_names":
             forge_property_recorder.record_op_model_names(metadata_value)
-        elif metadata_name == "op_params":
+        elif metadata_name == "args":
             forge_property_recorder.record_forge_op_args(metadata_value)
         else:
-            logger.warning("no utility function in forge property handler")
+            logger.warning(
+                "No utility function available in forge property handler to record %s property", metadata_name
+            )
 
     max_int = 1000
     inputs = [

--- a/scripts/model_analysis/unique_ops_utils.py
+++ b/scripts/model_analysis/unique_ops_utils.py
@@ -6,7 +6,7 @@ import json
 from loguru import logger
 import subprocess
 import pandas as pd
-from typing import List
+from typing import List, Optional
 import ast
 
 import torch
@@ -17,6 +17,7 @@ from utils import (
     collect_all_model_analysis_test,
     extract_framework_from_test_file_path,
     extract_test_file_path_and_test_case_func,
+    filter_tests,
 )
 
 
@@ -25,6 +26,7 @@ def generate_and_export_unique_ops_tests(
     unique_ops_output_directory_path: str,
     extract_tvm_unique_ops_config: bool = False,
     timeout: int = 1200,
+    tests_to_filter: Optional[List[str]] = None,
 ):
     """
     Collect all the tests that doesn't contain skip_model_analysis marker in the test_directory_or_file_path specified by the user
@@ -36,6 +38,8 @@ def generate_and_export_unique_ops_tests(
     test_list = collect_all_model_analysis_test(test_directory_or_file_path, unique_ops_output_directory_path)
 
     assert test_list != [], f"No tests found in the {test_directory_or_file_path} path"
+
+    test_list = filter_tests(test_list, tests_to_filter)
 
     # Create a dictonary contains framework as key and value as another dictonary containing model_name as key and list of test command as values
     framework_and_model_name_to_tests = {}


### PR DESCRIPTION
1. In the [latest models ops pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/14653932373/job/41135717160), pad ops tests is failing with `TypeError: Pad() got an unexpected keyword argument 'channel_last'` .
The Forge Pad Op is reimplemented in this [commit](https://github.com/tenstorrent/tt-forge-fe/commit/d73a641af79a43bcf1dc67b567e0ecb179fab1fe) in which `channel_last` argument was removed and pad argument calculation was also modified in the populate_pad_args present in tvm_to_python.py file in this [commit](https://github.com/tenstorrent/tt-forge-fe/commit/d73a641af79a43bcf1dc67b567e0ecb179fab1fe). So I have regenerated models ops test for Pad Op.
2. Added feature to generate models ops test for specific models analysis test instead of all the model analysis tests collected and specific forge op. 

Models Ops Test Report: 
[Models Ops Test Report (25-April-2025).xlsx](https://github.com/user-attachments/files/19904802/Models.Ops.Test.Report.25-April-2025.xlsx)
