### PR TITLE
Add Phi3.5 vision onnx test

### DIFF
--- a/forge/test/models/onnx/text/phi3/test_phi3_5_vision.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3_5_vision.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import onnx
+from transformers import AutoModelForCausalLM, AutoProcessor
+
+import forge
+from forge.forge_property_utils import Framework, ModelArch, Source, Task, record_model_properties
+from forge.verify.verify import verify
+
+from test.models.pytorch.multimodal.phi3.model_utils.utils import load_input
+from test.utils import download_model
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids, attention_mask, pixel_values, image_sizes):
+        return self.model(input_ids, attention_mask, None, None, None, pixel_values, image_sizes)
+
+
+variants = ["microsoft/Phi-3.5-vision-instruct"]
+
+
+@pytest.mark.nightly
+@pytest.mark.skip("Segmentation Fault")
+@pytest.mark.parametrize("variant", variants)
+def test_phi3_5_vision(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.PHI35VISION,
+        variant=variant,
+        task=Task.MULTIMODAL_TEXT_GENERATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Load model and processor
+    model = download_model(
+        AutoModelForCausalLM.from_pretrained,
+        variant,
+        return_dict=False,
+        trust_remote_code=True,
+        use_cache=False,
+        _attn_implementation="eager",
+    )
+    model.eval()
+    framework_model = Wrapper(model)
+    processor = download_model(AutoProcessor.from_pretrained, variant, trust_remote_code=True, num_crops=4)
+
+    # prepare input
+    inputs = load_input(processor)
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/model.onnx"
+    input_ids, attention_mask, pixel_values, image_sizes = inputs
+    torch.onnx.export(
+        framework_model, (input_ids, attention_mask, pixel_values, image_sizes), onnx_path, opset_version=17
+    )
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+
+    onnx.checker.check_model(onnx_path)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )


### PR DESCRIPTION
This PR adds onnx test for phi3.5 vision onnx model. Model ends up with either segmentation fault or gets killed during generate_initial_graph pass stage , this behaviour will be debugged further.

Logs:
[phi3_5_vision_onnx.log](https://github.com/user-attachments/files/20450969/phi3_5_vision_onnx.log)
