### PR TITLE
Add support for resolve_neg, resolve_conj ops to unblock Phi-3.5-vision-instruct

### DIFF
--- a/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
+++ b/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
@@ -867,3 +867,46 @@ def test_einsum(forge_property_recorder, pattern, input_shape):
     compiled_model = forge.compile(model, sample_inputs=inputs, forge_property_handler=forge_property_recorder)
 
     verify(inputs, model, compiled_model, forge_property_handler=forge_property_recorder)
+
+
+@pytest.mark.parametrize("shape", [(8,), (4, 4), (3, 5, 7), (2, 6, 4, 8), (2, 3, 5, 7, 9)])
+@pytest.mark.push
+def test_res_conj(shape):
+    class res_conj(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            output = x.resolve_conj()
+            return output
+
+    model = res_conj()
+    model.eval()
+
+    inputs = [torch.randn(shape)]
+
+    compiled_model = forge.compile(model, sample_inputs=inputs)
+    verify(inputs, model, compiled_model)
+
+
+@pytest.mark.parametrize("shape", [(8,), (4, 4), (3, 5, 7), (2, 6, 4, 8), (2, 3, 5, 7, 9)])
+@pytest.mark.push
+def test_res_neg(shape):
+    class res_neg(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x):
+            output = x.resolve_neg()
+            return output
+
+    model = res_neg()
+    model.eval()
+
+    inputs = [torch.randn(shape)]
+
+    # Forge compile framework model
+    compiled_model = forge.compile(model, sample_inputs=inputs)
+
+    # Model Verification
+    verify(inputs, model, compiled_model)


### PR DESCRIPTION
## summary 

- This PR tracks this [changes](https://github.com/tenstorrent/tt-tvm/pull/76/files) and adds sanity to verify the changes.

## Logs 

Sanity 

- [res_conj_sanity_before_fix.log](https://github.com/user-attachments/files/19890066/apr24_res_conj_s_bf_cc.log)
- [res_conj_sanity_after_fix.log](https://github.com/user-attachments/files/19890065/apr24_res_conj_s_af_cc.log)
- [res_neg_sanity_before_fix.log](https://github.com/user-attachments/files/19889964/apr24_res_neg_s_bf.log)
- [res_neg_sanity_after_fix.log](https://github.com/user-attachments/files/19889963/apr24_res_neg_s_af.log)


Model 

- [phi3_5_v_before_fix.log](https://github.com/user-attachments/files/19889960/apr24_phi3_5_v_bf.log)
- [phi3_5_vision_after_fix.log](https://github.com/user-attachments/files/19889959/apr24_phi3_5_v_af.log)


