### PR TITLE
Concatenate operator - remove failing fule

### DIFF
--- a/forge/test/operators/pytorch/eltwise_nary/test_concatenate.py
+++ b/forge/test/operators/pytorch/eltwise_nary/test_concatenate.py
@@ -240,16 +240,6 @@ TestParamsData.test_plan = TestPlan(
             kwargs=[{"dim": 1}],
             failing_reason=FailingReasons.UNSUPPORTED_SPECIAL_CASE,
         ),
-        # ValueError: Dtype mismatch: framework_model.dtype=torch.int8, compiled_model.dtype=torch.uint8
-        TestCollection(
-            operators=TestParamsData.operators,
-            input_sources=TestCollectionCommon.single.input_sources,
-            input_shapes=[(TestCollectionCommon.single.input_shapes[0],) * 2],
-            kwargs=[{"dim": 0}],
-            dev_data_formats=[torch.int8],
-            math_fidelities=TestCollectionCommon.single.math_fidelities,
-            failing_reason=FailingReasons.DTYPE_MISMATCH,
-        ),
     ],
 )
 


### PR DESCRIPTION
The failing rule that caused the test to XPASS (unexpected pass) was removed.