### PR TITLE
[mlir] basic support for configuring MLIR pipeline

### DIFF
--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -209,6 +209,22 @@ PYBIND11_MODULE(_C, m)
 
     py::register_exception<UnsupportedHWOpsError>(m, "UnsupportedHWOpsError");
 
+    py::class_<tt::passes::MLIRConfig>(m, "MLIRConfig")
+        .def(py::init<>())
+        .def_readwrite("enable_consteval", &tt::passes::MLIRConfig::enable_consteval)
+        .def(
+            "set_enable_consteval",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_consteval(enable); },
+            py::arg("enable"))
+        .def(
+            "to_json",
+            [](tt::passes::MLIRConfig const &mlir_config)
+            {
+                nlohmann::json j = mlir_config;
+                return j;
+            })
+        .def("from_json", [](nlohmann::json const &j) { return j.template get<tt::passes::MLIRConfig>(); });
+
     m.def("link_past_cache_ios", &passes::link_past_cache_ios);
     m.def("move_index_to_mm_weights", &passes::move_index_to_mm_weights);
     m.def("run_post_initial_graph_passes", &run_post_initial_graph_passes);
@@ -225,11 +241,13 @@ PYBIND11_MODULE(_C, m)
         "run_mlir_compiler",
         &passes::run_mlir_compiler,
         py::arg("module"),
+        py::arg("mlir_config") = std::nullopt,
         py::arg("forge_property_handler") = std::nullopt);
     m.def(
         "run_mlir_compiler_to_cpp",
         &passes::run_mlir_compiler_to_cpp,
         py::arg("module"),
+        py::arg("mlir_config") = std::nullopt,
         py::arg("forge_property_handler") = std::nullopt);
     m.def("split_graph", &passes::split_graph);
 

--- a/forge/csrc/passes/mlir_compiler.hpp
+++ b/forge/csrc/passes/mlir_compiler.hpp
@@ -8,6 +8,7 @@
 #include <pybind11/pybind11.h>
 #pragma clang diagnostic pop
 
+#include "nlohmann/json_fwd.hpp"
 #include "tt/runtime/types.h"
 
 namespace py = pybind11;
@@ -19,11 +20,32 @@ class ForgeGraphModule;
 
 namespace tt::passes
 {
+
+/// Struct to hold the configuration for the MLIR compiler.
+struct MLIRConfig
+{
+    bool enable_consteval = false;
+
+    MLIRConfig& set_enable_consteval(bool enable)
+    {
+        enable_consteval = enable;
+        return *this;
+    }
+};
+
+void to_json(nlohmann::json& j, const MLIRConfig& p);
+void from_json(const nlohmann::json& j, MLIRConfig& p);
+
 /// Public API for running MLIR passes and generating binary.
 runtime::Binary run_mlir_compiler(
-    tt::ForgeGraphModule& module, const std::optional<py::object>& forge_property_handler = std::nullopt);
+    tt::ForgeGraphModule& module,
+    const std::optional<MLIRConfig>& mlir_config = std::nullopt,
+    const std::optional<py::object>& forge_property_handler = std::nullopt);
 
 /// Public API for lowering to MLIR, running MLIR passes and generate C++ code.
 std::string run_mlir_compiler_to_cpp(
-    tt::ForgeGraphModule& module, const std::optional<py::object>& forge_property_handler = std::nullopt);
+    tt::ForgeGraphModule& module,
+    const std::optional<MLIRConfig>& mlir_config = std::nullopt,
+    const std::optional<py::object>& forge_property_handler = std::nullopt);
+
 }  // namespace tt::passes

--- a/forge/csrc/passes/mlir_passes.hpp
+++ b/forge/csrc/passes/mlir_passes.hpp
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+
+#include <optional>
+
 namespace mlir
 {
 class ModuleOp;
@@ -11,6 +14,8 @@ class OwningOpRef;
 namespace tt::passes
 {
 
+struct MLIRConfig;
+
 enum class MLIROutputKind
 {
     Flatbuffer,
@@ -19,6 +24,6 @@ enum class MLIROutputKind
 
 /// Public API for running MLIR passes (pipeline) depending on the desired output.
 template <MLIROutputKind output>
-void run_mlir_passes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module);
+void run_mlir_passes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module, const std::optional<MLIRConfig> &mlir_config);
 
 }  // namespace tt::passes

--- a/forge/forge/compile.py
+++ b/forge/forge/compile.py
@@ -1001,11 +1001,18 @@ def split_graph(context: CompileContext) -> CompileDepth:
 
 
 def run_mlir_compiler(context: CompileContext) -> CompileDepth:
-    assert context.forge_module is not None
-    if context.forge_property_handler is not None:
-        context.forge_property_handler.record_execution_stage(ExecutionStage.FAILED_FORGE_MLIR_COMPILATION)
+    forge_module, compiler_cfg, forge_property_handler = (
+        context.forge_module,
+        context.compiler_cfg,
+        context.forge_property_handler,
+    )
+    assert forge_module is not None
+    assert compiler_cfg is not None
 
-    context.compiled_binary = forge._C.run_mlir_compiler(context.forge_module, context.forge_property_handler)
+    if forge_property_handler is not None:
+        forge_property_handler.record_execution_stage(ExecutionStage.FAILED_FORGE_MLIR_COMPILATION)
+
+    context.compiled_binary = forge._C.run_mlir_compiler(forge_module, compiler_cfg.mlir_config, forge_property_handler)
 
     return CompileDepth.FINISH_COMPILE
 

--- a/forge/forge/config.py
+++ b/forge/forge/config.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Tuple, Dict, List, Optional, Union, Set
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from forge._C import DataFormat, MathFidelity, AMPNodeProperties
+from forge._C import DataFormat, MathFidelity, AMPNodeProperties, MLIRConfig
 import forge.query as query
 from dataclasses_json import dataclass_json, config
 
@@ -144,6 +144,8 @@ class CompilerConfig:
     amp_properties: List[AMPNodeProperties] = field(
         default_factory=lambda: list(), metadata=list_as_json(AMPNodeProperties)
     )
+
+    mlir_config: Optional[MLIRConfig] = field(default=None, metadata=optional_as_json(MLIRConfig))
 
     # TODO: add reportify dir
 


### PR DESCRIPTION
Adding structure `MLIRConfig` to enable setting some of the pipeline options in `tt-mlir`. This structure is part of the `CompilerConfig` and is set to `None` by default.

For now, the only config we expose is the one controlling consteval in `tt-mlir`. Settings for enabling optimizer will follow.

Also, marking tests in `test_api.py` to be ran on `push`.

Closes #1869 