### PR TITLE
[ci] log memory usage in a file

### DIFF
--- a/.github/workflows/test-sub.yml
+++ b/.github/workflows/test-sub.yml
@@ -157,6 +157,7 @@ jobs:
                  --splitting-algorithm least_duration \
                  -m "${{ inputs.test_mark }}" \
                  --junit-xml=${{ steps.strings.outputs.test_report_path }} \
+                 --log-memory-usage \
                  2>&1 | tee pytest.log
 
       - name: Upload Test Log
@@ -165,6 +166,13 @@ jobs:
         with:
           name: test-log-${{ matrix.build.runs-on }}-${{ matrix.test_group_id }}-${{ inputs.test_mark }}-${{ steps.fetch-job-id.outputs.job_id }}
           path: pytest.log
+
+      - name: Upload Memory Usage Log
+        uses: actions/upload-artifact@v4
+        if: success() || failure()
+        with:
+          name: memory-usage-${{ matrix.build.runs-on }}-${{ matrix.test_group_id }}-${{ inputs.test_mark }}-${{ steps.fetch-job-id.outputs.job_id }}
+          path: pytest-memory-usage.csv
 
       - name: Upload Test Report
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Implements logging of memory usage in a file and uploads it as an artifact during test execution on CI.

This is done to enable more effective debugging of memory issues in CI.

After each test, we update the file with test memory usage stats. The file is in CSV format.

Also, improves the calculation for total memory allocation by test - sometimes we have peaks which go down before test completes, so estimating test memory usage with `max_mem - start_mem` seems better than `end_mem - start_mem`.

Closes #1874