### PR TITLE
Fix nonzero_numpy conversion for as_tuple=True to unblock Phi-3.5-vision-instruct

### DIFF
--- a/forge/test/mlir/operators/indexing/test_advanced_slicing.py
+++ b/forge/test/mlir/operators/indexing/test_advanced_slicing.py
@@ -208,19 +208,19 @@ def test_take(forge_property_recorder, input_tensor_indices):
         pytest.param(
             (torch.tensor([0.0, 1.1, 0.0, 2.2, 0.0, 3.3], dtype=torch.float32), True),
             marks=pytest.mark.xfail(
-                reason=" AttributeError: <class 'tvm.relay.expr.Call'> has no attribute type_annotation"
+                reason="InternalError: Check failed: (pval != nullptr) is false: Cannot allocate memory symbolic tensor shape [T.Any()]"
             ),
         ),
         pytest.param(
             (torch.tensor([[0.0, 1.1], [2.2, 0.0], [0.0, 3.3]], dtype=torch.float32), True),
             marks=pytest.mark.xfail(
-                reason=" AttributeError: <class 'tvm.relay.expr.Call'> has no attribute type_annotation"
+                reason="InternalError: Check failed: (pval != nullptr) is false: Cannot allocate memory symbolic tensor shape [T.Any()]"
             ),
         ),
         pytest.param(
             (torch.tensor([[[0.0], [1.1]], [[2.2], [0.0]], [[0.0], [3.3]]], dtype=torch.float32), True),
             marks=pytest.mark.xfail(
-                reason=" AttributeError: <class 'tvm.relay.expr.Call'> has no attribute type_annotation"
+                reason="InternalError: Check failed: (pval != nullptr) is false: Cannot allocate memory symbolic tensor shape [T.Any()]"
             ),
         ),
         pytest.param(


### PR DESCRIPTION
## Summary 

- This PR tracks this [changes ](https://github.com/tenstorrent/tt-tvm/pull/77).

## Logs

Sanity

- [non_zero_sanity_before_fix.log](https://github.com/user-attachments/files/19897029/apr24_non_zero_before_fix.log)
- [non_zero_sanity_after_fix.log](https://github.com/user-attachments/files/19897028/apr24_non_zero_after_fix.log)

Model

- [phi3_5_vision_before_fix.log](https://github.com/user-attachments/files/19897031/apr24_phi3_5_vision_bf.log)
- [phi3_5_vision_after_fix.log](https://github.com/user-attachments/files/19897030/apr24_phi3_5_vision_af.log)






