### PR TITLE
[test] update xpass tests

### DIFF
--- a/forge/test/models/pytorch/vision/unet/test_unet.py
+++ b/forge/test/models/pytorch/vision/unet/test_unet.py
@@ -238,7 +238,6 @@ def test_unet_torchhub_pytorch(forge_property_recorder):
 
 # Reference: https://github.com/arief25ramadhan/carvana-unet-segmentation
 @pytest.mark.nightly
-@pytest.mark.xfail
 def test_unet_carvana(forge_property_recorder):
 
     # Record Forge Property

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
@@ -18,10 +18,7 @@ from test.models.pytorch.vision.yolo.utils.yolov6_utils import (
 
 # Didn't dealt with yolov6n6,yolov6s6,yolov6m6,yolov6l6 variants because of its higher input size(1280)
 variants = [
-    pytest.param(
-        "yolov6n",
-        marks=[pytest.mark.xfail],
-    ),
+    "yolov6n",
     "yolov6s",
     "yolov6m",
     "yolov6l",


### PR DESCRIPTION
The following tests are passing in the latest nightly:
- `test_yolo_v6.py::test_yolo_v6_pytorch[yolov6n]`
- `test_unet.py::test_unet_carvana`

Removing the xfail marks.