### PR TITLE
Remove xfail markers for advindex, conv2dtranspose, cimsum, max and reshape ops

### DIFF
--- a/forge/test/models_ops/test_advindex.py
+++ b/forge/test/models_ops/test_advindex.py
@@ -133,13 +133,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((448, 1280), torch.float32), ((1, 2), torch.int64)],
         {"model_name": ["pt_whisper_openai_whisper_large_v3_turbo_speech_translate_hf"], "pcc": 0.99, "max_int": 447},
     ),
-    pytest.param(
-        (
-            Advindex0,
-            [((2359296,), torch.float32), ((2441216,), torch.int32)],
-            {"model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"], "pcc": 0.99, "max_int": 2359295},
-        ),
-        marks=[pytest.mark.xfail(reason="RuntimeError: circular buffers grow beyond max L1 size")],
+    (
+        Advindex0,
+        [((2359296,), torch.float32), ((2441216,), torch.int32)],
+        {"model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"], "pcc": 0.99, "max_int": 2359295},
     ),
     (
         Advindex0,

--- a/forge/test/models_ops/test_conv2dtranspose.py
+++ b/forge/test/models_ops/test_conv2dtranspose.py
@@ -384,47 +384,37 @@ def ids_func(param):
 
 
 forge_modules_and_shapes_dtypes_list = [
-    pytest.param(
-        (
-            Conv2Dtranspose0,
-            [((1, 4, 7, 7), torch.float32)],
-            {
-                "model_name": ["pt_autoencoder_conv_img_enc_github"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose0,
+        [((1, 4, 7, 7), torch.float32)],
+        {
+            "model_name": ["pt_autoencoder_conv_img_enc_github"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose1,
-            [((1, 16, 14, 14), torch.float32)],
-            {
-                "model_name": ["pt_autoencoder_conv_img_enc_github"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose1,
+        [((1, 16, 14, 14), torch.float32)],
+        {
+            "model_name": ["pt_autoencoder_conv_img_enc_github"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:980: tt::exception info: Statically allocated circular buffers in program 8502 clash with L1 buffers on core range [(x=0,y=0) - (x=0,y=0)]. L1 buffer allocated at 1227648 and static circular buffer region ends at 1342496"
-            )
-        ],
+        },
     ),
     pytest.param(
         (
@@ -506,74 +496,53 @@ forge_modules_and_shapes_dtypes_list = [
             )
         ],
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose6,
-            [((1, 256, 32, 32), torch.float32)],
-            {
-                "model_name": ["pt_unet_base_img_seg_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose6,
+        [((1, 256, 32, 32), torch.float32)],
+        {
+            "model_name": ["pt_unet_base_img_seg_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=0,y=0) - (x=7,y=0)] grow to 6405152 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose7,
-            [((1, 128, 64, 64), torch.float32)],
-            {
-                "model_name": ["pt_unet_base_img_seg_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose7,
+        [((1, 128, 64, 64), torch.float32)],
+        {
+            "model_name": ["pt_unet_base_img_seg_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:140: tt::exception info: Out of Memory: Not enough space to allocate 8520192 B L1 buffer across 4 banks, where each bank needs to store 2130048 B"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose8,
-            [((1, 64, 128, 128), torch.float32)],
-            {
-                "model_name": ["pt_unet_base_img_seg_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose8,
+        [((1, 64, 128, 128), torch.float32)],
+        {
+            "model_name": ["pt_unet_base_img_seg_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:140: tt::exception info: Out of Memory: Not enough space to allocate 4194304 B L1 buffer across 2 banks, where each bank needs to store 2097152 B"
-            )
-        ],
+        },
     ),
     pytest.param(
         (
@@ -598,258 +567,181 @@ forge_modules_and_shapes_dtypes_list = [
             )
         ],
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose5,
-            [((1, 512, 28, 28), torch.float32)],
-            {
-                "model_name": ["pt_unet_carvana_base_img_seg_github"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose5,
+        [((1, 512, 28, 28), torch.float32)],
+        {
+            "model_name": ["pt_unet_carvana_base_img_seg_github"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=0,y=0) - (x=7,y=1)] grow to 4930592 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose6,
-            [((1, 256, 56, 56), torch.float32)],
-            {
-                "model_name": ["pt_unet_carvana_base_img_seg_github"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose6,
+        [((1, 256, 56, 56), torch.float32)],
+        {
+            "model_name": ["pt_unet_carvana_base_img_seg_github"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:140: tt::exception info: Out of Memory: Not enough space to allocate 13075456 B L1 buffer across 8 banks, where each bank needs to store 1634432 B"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose7,
-            [((1, 128, 112, 112), torch.float32)],
-            {
-                "model_name": ["pt_unet_carvana_base_img_seg_github"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose7,
+        [((1, 128, 112, 112), torch.float32)],
+        {
+            "model_name": ["pt_unet_carvana_base_img_seg_github"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:140: tt::exception info: Out of Memory: Not enough space to allocate 6422528 B L1 buffer across 4 banks, where each bank needs to store 1605632 B"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose10,
-            [((1, 64, 14, 20), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v6_yolov6n_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose10,
+        [((1, 64, 14, 20), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v6_yolov6n_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=0,y=0) - (x=1,y=0)] grow to 1838112 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose11,
-            [((1, 32, 28, 40), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v6_yolov6n_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose11,
+        [((1, 32, 28, 40), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v6_yolov6n_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=0,y=0) - (x=0,y=0)] grow to 6999072 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose12,
-            [((1, 192, 14, 20), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose12,
+        [((1, 192, 14, 20), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=0,y=0) - (x=5,y=0)] grow to 1838112 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose13,
-            [((1, 96, 28, 40), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose13,
+        [((1, 96, 28, 40), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=0,y=0) - (x=2,y=0)] grow to 6999072 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose14,
-            [((1, 256, 14, 20), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v6_yolov6l_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose14,
+        [((1, 256, 14, 20), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v6_yolov6l_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=0,y=0) - (x=7,y=0)] grow to 1838112 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose15,
-            [((1, 128, 28, 40), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v6_yolov6l_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose15,
+        [((1, 128, 28, 40), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v6_yolov6l_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=0,y=0) - (x=3,y=0)] grow to 6999072 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose15,
-            [((1, 128, 14, 20), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v6_yolov6s_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose15,
+        [((1, 128, 14, 20), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v6_yolov6s_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=0,y=0) - (x=3,y=0)] grow to 1838112 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+        },
     ),
-    pytest.param(
-        (
-            Conv2Dtranspose10,
-            [((1, 64, 28, 40), torch.float32)],
-            {
-                "model_name": ["pt_yolo_v6_yolov6s_obj_det_torchhub"],
-                "pcc": 0.99,
-                "op_params": {
-                    "stride": "2",
-                    "padding": "0",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                    "output_padding": "[0, 0]",
-                },
+    (
+        Conv2Dtranspose10,
+        [((1, 64, 28, 40), torch.float32)],
+        {
+            "model_name": ["pt_yolo_v6_yolov6s_obj_det_torchhub"],
+            "pcc": 0.99,
+            "op_params": {
+                "stride": "2",
+                "padding": "0",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+                "output_padding": "[0, 0]",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=0,y=0) - (x=1,y=0)] grow to 6999072 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+        },
     ),
 ]
 

--- a/forge/test/models_ops/test_cumsum.py
+++ b/forge/test/models_ops/test_cumsum.py
@@ -61,12 +61,10 @@ forge_modules_and_shapes_dtypes_list = [
             )
         ],
     ),
-    pytest.param(
-        (
-            Cumsum1,
-            [((1, 32), torch.int64)],
-            {"model_name": ["pt_bloom_bigscience_bloom_1b1_clm_hf"], "pcc": 0.99, "op_params": {"dim": "-1"}},
-        ),
+    (
+        Cumsum1,
+        [((1, 32), torch.int64)],
+        {"model_name": ["pt_bloom_bigscience_bloom_1b1_clm_hf"], "pcc": 0.99, "op_params": {"dim": "-1"}},
     ),
     (
         Cumsum2,

--- a/forge/test/models_ops/test_max.py
+++ b/forge/test/models_ops/test_max.py
@@ -42,85 +42,36 @@ def ids_func(param):
 
 
 forge_modules_and_shapes_dtypes_list = [
-    pytest.param(
-        (
-            Max0,
-            [((2441216,), torch.int32)],
-            {"model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (Max0, [((2441216,), torch.int32)], {"model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"], "pcc": 0.99}),
+    (
+        Max1,
+        [((1, 32, 32, 32), torch.float32)],
+        {"model_name": ["pt_opt_facebook_opt_1_3b_qa_hf", "pt_opt_facebook_opt_1_3b_seq_cls_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Max1,
-            [((1, 32, 32, 32), torch.float32)],
-            {"model_name": ["pt_opt_facebook_opt_1_3b_qa_hf", "pt_opt_facebook_opt_1_3b_seq_cls_hf"], "pcc": 0.99},
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp:102: tt::exception info: ttnn::operations::binary::BinaryDeviceOperation: unsupported broadcast"
-            )
-        ],
+    (
+        Max1,
+        [((1, 16, 32, 32), torch.float32)],
+        {"model_name": ["pt_opt_facebook_opt_350m_seq_cls_hf", "pt_opt_facebook_opt_350m_qa_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Max1,
-            [((1, 16, 32, 32), torch.float32)],
-            {"model_name": ["pt_opt_facebook_opt_350m_seq_cls_hf", "pt_opt_facebook_opt_350m_qa_hf"], "pcc": 0.99},
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp:102: tt::exception info: ttnn::operations::binary::BinaryDeviceOperation: unsupported broadcast"
-            )
-        ],
+    (Max1, [((1, 32, 256, 256), torch.float32)], {"model_name": ["pt_opt_facebook_opt_1_3b_clm_hf"], "pcc": 0.99}),
+    (
+        Max1,
+        [((1, 16, 256, 256), torch.float32)],
+        {
+            "model_name": [
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_xglm_facebook_xglm_1_7b_clm_hf",
+                "pt_xglm_facebook_xglm_564m_clm_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
-    pytest.param(
-        (Max1, [((1, 32, 256, 256), torch.float32)], {"model_name": ["pt_opt_facebook_opt_1_3b_clm_hf"], "pcc": 0.99}),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp:102: tt::exception info: ttnn::operations::binary::BinaryDeviceOperation: unsupported broadcast"
-            )
-        ],
+    (
+        Max1,
+        [((1, 12, 32, 32), torch.float32)],
+        {"model_name": ["pt_opt_facebook_opt_125m_qa_hf", "pt_opt_facebook_opt_125m_seq_cls_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Max1,
-            [((1, 16, 256, 256), torch.float32)],
-            {
-                "model_name": [
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_xglm_facebook_xglm_1_7b_clm_hf",
-                    "pt_xglm_facebook_xglm_564m_clm_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp:102: tt::exception info: ttnn::operations::binary::BinaryDeviceOperation: unsupported broadcast"
-            )
-        ],
-    ),
-    pytest.param(
-        (
-            Max1,
-            [((1, 12, 32, 32), torch.float32)],
-            {"model_name": ["pt_opt_facebook_opt_125m_qa_hf", "pt_opt_facebook_opt_125m_seq_cls_hf"], "pcc": 0.99},
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp:102: tt::exception info: ttnn::operations::binary::BinaryDeviceOperation: unsupported broadcast"
-            )
-        ],
-    ),
-    pytest.param(
-        (Max1, [((1, 12, 256, 256), torch.float32)], {"model_name": ["pt_opt_facebook_opt_125m_clm_hf"], "pcc": 0.99}),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp:102: tt::exception info: ttnn::operations::binary::BinaryDeviceOperation: unsupported broadcast"
-            )
-        ],
-    ),
+    (Max1, [((1, 12, 256, 256), torch.float32)], {"model_name": ["pt_opt_facebook_opt_125m_clm_hf"], "pcc": 0.99}),
 ]
 
 

--- a/forge/test/models_ops/test_reshape.py
+++ b/forge/test/models_ops/test_reshape.py
@@ -17264,21 +17264,14 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"shape": "(1, 39, 11008)"},
         },
     ),
-    pytest.param(
-        (
-            Reshape316,
-            [((1, 596, 4096), torch.float32)],
-            {
-                "model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"],
-                "pcc": 0.99,
-                "op_params": {"shape": "(2441216,)"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=0,y=0) - (x=7,y=7)] grow to 9895024 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+    (
+        Reshape316,
+        [((1, 596, 4096), torch.float32)],
+        {
+            "model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"],
+            "pcc": 0.99,
+            "op_params": {"shape": "(2441216,)"},
+        },
     ),
     (
         Reshape317,
@@ -17352,21 +17345,14 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"shape": "(577, 1024)"},
         },
     ),
-    pytest.param(
-        (
-            Reshape324,
-            [((1, 576, 4096), torch.float32)],
-            {
-                "model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"],
-                "pcc": 0.99,
-                "op_params": {"shape": "(2359296,)"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=0,y=0) - (x=7,y=7)] grow to 9567344 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+    (
+        Reshape324,
+        [((1, 576, 4096), torch.float32)],
+        {
+            "model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"],
+            "pcc": 0.99,
+            "op_params": {"shape": "(2359296,)"},
+        },
     ),
     (
         Reshape316,
@@ -17386,21 +17372,14 @@ forge_modules_and_shapes_dtypes_list = [
             "op_params": {"shape": "(2441216,)"},
         },
     ),
-    pytest.param(
-        (
-            Reshape325,
-            [((2441216,), torch.float32)],
-            {
-                "model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"],
-                "pcc": 0.99,
-                "op_params": {"shape": "(1, 596, 4096)"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range [(x=6,y=7) - (x=6,y=7)] grow to 9976800 B which is beyond max L1 size of 1499136 B"
-            )
-        ],
+    (
+        Reshape325,
+        [((2441216,), torch.float32)],
+        {
+            "model_name": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"],
+            "pcc": 0.99,
+            "op_params": {"shape": "(1, 596, 4096)"},
+        },
     ),
     (
         Reshape326,


### PR DESCRIPTION
In the [latest models ops pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/14653932373/job/41135717160), below issues was resolved in advindex, conv2dtranspose, cimsum, max and reshape models ops tests. so removed xfail marker for the above mentioned models ops tests

Resolved issues:
1. RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:971: tt::exception info: Statically allocated circular buffers on core range
2. RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:980: tt::exception info: Statically allocated circular buffers in program
3. Data mismatch between framework output and compiled model output
4. RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/binary_device_operation.cpp:102: tt::exception info: ttnn::operations::binary::BinaryDeviceOperation: unsupported broadcast
5. RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:140: tt::exception info: Out of Memory: Not enough space to allocate
6. RuntimeError: circular buffers grow beyond max L1 size

Models Ops Test Report: 
[Models Ops Test Report (25-April-2025).xlsx](https://github.com/user-attachments/files/19904802/Models.Ops.Test.Report.25-April-2025.xlsx)

