### PR TITLE
Remove xfail maker from Jax Resnet test

### DIFF
--- a/forge/test/models/jax/vision/resnet/test_resnet.py
+++ b/forge/test/models/jax/vision/resnet/test_resnet.py
@@ -8,6 +8,8 @@ import jax.random as random
 
 import forge
 from forge.verify import verify
+from forge.verify.config import VerifyConfig
+from forge.verify.value_checkers import AutomaticValueChecker
 from forge.forge_property_utils import Framework, Source, Task
 
 from test.utils import download_model
@@ -18,8 +20,6 @@ variants = [
 ]
 
 
-# TODO: Remove xfail once the unsupported broadcast operation issue is resolved.
-@pytest.mark.xfail
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_resnet(forge_property_recorder, variant):
@@ -51,5 +51,6 @@ def test_resnet(forge_property_recorder, variant):
         input_sample,
         framework_model,
         compiled_model,
+        VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95)),
         forge_property_handler=forge_property_recorder,
     )


### PR DESCRIPTION
### Ticket
N/A

### Problem description
N/A

### What's changed
Updated tt-mlir to successfully run the ResNet JAX test(with a PCC is 0.989). Since the test now passes, the xfail marker has been removed.

### Checklist
- [ ] New/Existing tests provide coverage for changes
