### PR TITLE
Fix pcc drop in Bloom, Codegen, Gptneo pytorch model

### DIFF
--- a/forge/test/models/models_utils.py
+++ b/forge/test/models/models_utils.py
@@ -151,3 +151,46 @@ def pad_inputs(inputs, max_new_tokens=512):
     padded_inputs = torch.zeros((batch_size, max_seq_len), dtype=inputs.dtype, device=inputs.device)
     padded_inputs[:, :seq_len] = inputs
     return padded_inputs, seq_len
+
+
+def _prepare_4d_causal_attention_mask_with_cache_position(
+    self,
+    attention_mask: torch.Tensor,
+    sequence_length: int,
+    target_length: int,
+    dtype: torch.dtype,
+    device: torch.device,
+    cache_position: torch.Tensor,
+    batch_size: int,
+    **kwargs,
+):
+    if attention_mask is not None and attention_mask.dim() == 4:
+        # In this case we assume that the mask comes already in inverted form and requires no inversion or slicing.
+        causal_mask = attention_mask
+    else:
+        min_dtype = torch.finfo(dtype).min
+        causal_mask = torch.full((sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device)
+        if sequence_length != 1:
+            causal_mask = torch.triu(causal_mask, diagonal=1)
+        causal_mask *= torch.arange(target_length, device=device) > cache_position.reshape(-1, 1)
+        causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)
+        if attention_mask is not None:
+            causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
+            mask_length = attention_mask.shape[-1]
+            padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :]
+            padding_mask = padding_mask == 0
+
+            # Replace Implace Slice Update
+            # causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
+            #     padding_mask, min_dtype
+            # )
+
+            if causal_mask.shape[-1] > mask_length:
+                part_1 = causal_mask[:, :, :, :mask_length]
+                part_2 = causal_mask[:, :, :, mask_length:]
+                part_1 = part_1.masked_fill(padding_mask, min_dtype)
+                causal_mask = torch.cat([part_1, part_2], dim=-1)
+            else:
+                causal_mask = causal_mask.masked_fill(padding_mask, min_dtype)
+
+    return causal_mask

--- a/forge/test/models/pytorch/text/bloom/test_bloom.py
+++ b/forge/test/models/pytorch/text/bloom/test_bloom.py
@@ -3,13 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoModelForCausalLM, AutoTokenizer, BloomModel
 
 import forge
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
+from test.models.models_utils import (
+    _prepare_4d_causal_attention_mask_with_cache_position,
+)
 from test.utils import download_model
+
+BloomModel._prepare_4d_causal_attention_mask_with_cache_position = _prepare_4d_causal_attention_mask_with_cache_position
 
 
 # Wrapper to get around past key values

--- a/forge/test/models/pytorch/text/codegen/test_codegen.py
+++ b/forge/test/models/pytorch/text/codegen/test_codegen.py
@@ -5,13 +5,21 @@
 
 import pytest
 import torch
-from transformers import AutoTokenizer, CodeGenForCausalLM
+from transformers import AutoTokenizer, CodeGenForCausalLM, CodeGenModel
 
 import forge
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
+from test.models.models_utils import (
+    _prepare_4d_causal_attention_mask_with_cache_position,
+)
 from test.utils import download_model
+
+CodeGenModel._prepare_4d_causal_attention_mask_with_cache_position = (
+    _prepare_4d_causal_attention_mask_with_cache_position
+)
+
 
 variants = [
     "Salesforce/codegen-350M-mono",

--- a/forge/test/models/pytorch/text/gptneo/test_gptneo.py
+++ b/forge/test/models/pytorch/text/gptneo/test_gptneo.py
@@ -8,13 +8,21 @@ from transformers import (
     GPTNeoConfig,
     GPTNeoForCausalLM,
     GPTNeoForSequenceClassification,
+    GPTNeoModel,
 )
 
 import forge
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
+from test.models.models_utils import (
+    _prepare_4d_causal_attention_mask_with_cache_position,
+)
 from test.utils import download_model
+
+GPTNeoModel._prepare_4d_causal_attention_mask_with_cache_position = (
+    _prepare_4d_causal_attention_mask_with_cache_position
+)
 
 variants = [
     pytest.param(

--- a/forge/test/models/pytorch/text/phi2/test_phi2.py
+++ b/forge/test/models/pytorch/text/phi2/test_phi2.py
@@ -2,7 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-import torch
 from transformers import (
     AutoTokenizer,
     PhiConfig,
@@ -16,50 +15,9 @@ import forge
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-
-def _prepare_4d_causal_attention_mask_with_cache_position(
-    self,
-    attention_mask: torch.Tensor,
-    sequence_length: int,
-    target_length: int,
-    dtype: torch.dtype,
-    device: torch.device,
-    cache_position: torch.Tensor,
-    batch_size: int,
-    **kwargs,
-):
-
-    if attention_mask is not None and attention_mask.dim() == 4:
-        # In this case we assume that the mask comes already in inverted form and requires no inversion or slicing.
-        causal_mask = attention_mask
-    else:
-        min_dtype = torch.finfo(dtype).min
-        causal_mask = torch.full((sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device)
-        if sequence_length != 1:
-            causal_mask = torch.triu(causal_mask, diagonal=1)
-        causal_mask *= torch.arange(target_length, device=device) > cache_position.reshape(-1, 1)
-        causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)
-        if attention_mask is not None:
-            causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
-            mask_length = attention_mask.shape[-1]
-            padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :]
-            padding_mask = padding_mask == 0
-
-            # Replace Implace Slice Update
-            # causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
-            #     padding_mask, min_dtype
-            # )
-
-            if causal_mask.shape[-1] > mask_length:
-                part_1 = causal_mask[:, :, :, :mask_length]
-                part_2 = causal_mask[:, :, :, mask_length:]
-                part_1 = part_1.masked_fill(padding_mask, min_dtype)
-                causal_mask = torch.cat([part_1, part_2], dim=-1)
-            else:
-                causal_mask = causal_mask.masked_fill(padding_mask, min_dtype)
-
-    return causal_mask
-
+from test.models.models_utils import (
+    _prepare_4d_causal_attention_mask_with_cache_position,
+)
 
 PhiModel._prepare_4d_causal_attention_mask_with_cache_position = _prepare_4d_causal_attention_mask_with_cache_position
 


### PR DESCRIPTION
### Ticket

- N/A

### Problem description

- A  PCC drop was observed in Bloom, Codegen, Gptneo models due to inplace update operation

### What's changed

- The problematic in-place update in the attention mask update logic has been monkey patched to avoid in-place modifications.

### Logs

- [apr28_bloom_before_fix.log](https://github.com/user-attachments/files/19941800/apr28_bloom.log)
- [apr28_bloom_after_fix.log](https://github.com/user-attachments/files/19941799/apr28_bloom_after_fix.log)
- [apr28_codegen_before_fix.log](https://github.com/user-attachments/files/19941817/apr28_codegen_before_fix.log)
- [apr28_codegen_after_fix.log](https://github.com/user-attachments/files/19941801/apr28_codegen_after_fix.log)
- [apr28_gpt_neo_before_fix.log](https://github.com/user-attachments/files/19941823/apr28_gpt_neo.log)
- [apr28_gpt_neo_after_fix.log](https://github.com/user-attachments/files/19941818/apr28_gpt_neo_after_fix.log)




