### PR TITLE
[data collection] skip recording details from fb

### DIFF
--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -569,6 +569,12 @@ class ForgePropertyHandler:
         Args:
             binary_json_str (str): The JSON string representation of the flatbuffer binary.
         """
+
+        if self.get("tags.model_name") is not None:
+            # For model tests, we don't want to record the flatbuffer details, since this
+            # results in a lot of data being recorded.
+            return
+
         binary_json_str = re.sub(r":\s*-inf\s*([,}])", r': "-inf"\1', binary_json_str)
         binary_json_str = re.sub(r":\s*inf\s*([,}])", r': "inf"\1', binary_json_str)
         binary_json = json.loads(binary_json_str)


### PR DESCRIPTION
When executing model tests, skip recording details from the flatbuffer, since this results in large amount of data being collected.