### PR TITLE
[mlir] construct hierarchical locations

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <stdexcept>
 #include <string>
+#include <string_view>
 #include <utils/assert.hpp>
 #include <variant>
 
@@ -657,30 +658,55 @@ class MLIRGenerator
         return mlir::FileLineColLoc::get(builder_.getContext(), module.name(), 0, 0);
     }
 
-    /// Get the node location in format "source_location", (graph_id), (node_id)
-    mlir::Location get_node_location(tt::graphlib::Graph *graph, tt::graphlib::Node *node)
+    /// Recursively parses the layer tag by separing on '/', creating a NameLoc for each part and chaining them
+    /// together.
+    ///
+    /// Example desired behaviour (layer -> NameLoc):
+    /// - "module_name/layer_1/layer_2" -> NameLoc("layer_2", NameLoc("layer_1", NameLoc("module_name")))
+    ///
+    mlir::Location parse_layer_tag(std::string_view layer_tag)
+    {
+        auto pos = layer_tag.rfind('/');
+        if (pos != std::string_view::npos)
+        {
+            std::string_view name = layer_tag.substr(pos + 1);
+
+            mlir::StringAttr name_attr = builder_.getStringAttr(name);
+            return mlir::NameLoc::get(name_attr, parse_layer_tag(layer_tag.substr(0, pos)));
+        }
+        else
+        {
+            mlir::StringAttr name_attr = builder_.getStringAttr(layer_tag);
+            return mlir::NameLoc::get(name_attr);
+        }
+    }
+
+    /// Construct hierarchical `Location` for tt-forge operation.
+    ///
+    /// If the node has a `<layer>` tag, then the `Location` is constructed from the tag value and the node name (tag
+    /// value is used to generate the hierarchy of locations). Otherwise, the `Location` is constructed from the node
+    /// name only.
+    mlir::Location get_tt_forge_operation_location(tt::graphlib::Graph *graph, tt::graphlib::Node *node)
     {
         TT_ASSERT(graph != nullptr);
         TT_ASSERT(node != nullptr);
 
-        const graphlib::TaggedNode *tagged_node = node->as<graphlib::TaggedNode>();
+        std::string_view source_location = node->name();
+        mlir::NameLoc name_loc = mlir::NameLoc::get(builder_.getStringAttr(source_location));
 
-        // Get source location from layer tag if available, otherwise use node name
-        std::string source_location = node->name();
-        if (tagged_node && tagged_node->has_tag("layer"))
+        const graphlib::TaggedNode *tagged_node = node->as<graphlib::TaggedNode>();
+        constexpr auto tag_name = "layer";
+
+        if (tagged_node && tagged_node->has_tag(tag_name))
         {
-            source_location = std::get<std::string>(tagged_node->tag_value("layer")) + "/" + node->name();
+            // We have a layer tag - create a NameLoc chain describing the layers.
+            auto layer_loc = parse_layer_tag(std::get<std::string>(tagged_node->tag_value(tag_name)));
+
+            // Merge the layer locations with the node name location.
+            name_loc = mlir::NameLoc::get(name_loc.getName(), layer_loc);
         }
 
-        // Create and return FileLineColLoc with the collected information
-        return mlir::FileLineColLoc::get(builder_.getContext(), source_location, graph->id(), node->id());
-    }
-
-    /// Get the location for a TTForge operation. The location is a combination of the operation name and the node
-    /// location.
-    mlir::Location get_tt_forge_operation_location(tt::graphlib::Graph *graph, tt::graphlib::Node *node)
-    {
-        return mlir::NameLoc::get(builder_.getStringAttr(graph->name()), get_node_location(graph, node));
+        return name_loc;
     }
 
     /// Convert an MLIR value to a string.

--- a/forge/csrc/reportify/reportify.cpp
+++ b/forge/csrc/reportify/reportify.cpp
@@ -416,8 +416,12 @@ json create_json_for_mlir(const std::string& module_name, mlir::Operation* opera
     std::string outputString;
     llvm::raw_string_ostream outStream(outputString);
 
+    // Print the MLIR module
+    mlir::OpPrintingFlags printFlags;
+    printFlags.enableDebugInfo();
+
     // Put data into string
-    operation->print(outStream);
+    operation->print(outStream, printFlags);
     outStream.flush();
     this_json["content"] = outputString;
 


### PR DESCRIPTION
The current logic for creating locations, forms them in the following way:

`NameLoc(graph_name, child_loc)` - where graph_name is in most cases `"forward"` and `child_loc` contains the actual location: `module/layer1/layer2/node_name`.

There are two problems with this:
 1. `NameLoc` contains only value `"forward"` as its value, so we cannot discern between nodes by looking at it (we would need to get the child location instead)
 2. even if the direct location would contain the layer information, the string is far too large

Since MLIR supports nesting of locations, logic for creating the locations is modified so that it parses the location string and creates nested instances of `NameLoc`. In this way, we have the `NameLoc` attached to a particular op containing its name. If we wish to see more details about where this particular op belongs, we can go through the chain of locations and reconstruct everything.

Example (location string -> `NameLoc`):

`"module_name/layer/op_name"` ->
`NameLoc("op_name", NameLoc("layer", NameLoc("module_name")))`

Also, modify the way we dump the module for `reportify` so that the locations are included in the dump.