### PR TITLE
Add support for einsum pattern(...si,...id->...sd)

### DIFF
--- a/forge/forge/tvm_calls/relay/op/forge_passes.py
+++ b/forge/forge/tvm_calls/relay/op/forge_passes.py
@@ -2036,6 +2036,16 @@ class DecomposeEinsum(DFPatternCallback):
 
             return result
 
+        elif match_einsum_pattern("...si,...id->...sd", equation):
+            from tvm.relay.frontend.common import infer_shape
+
+            # Ensure the einsum pattern is matched, and there are two input nodes
+            assert len(node_map[self.act][0]) == 2
+            srcA = node_map[self.act][0][0]
+            srcB = node_map[self.act][0][1]
+            assert infer_shape(srcA)[-1] == infer_shape(srcB)[-2]
+            return tvm.relay.nn.batch_matmul(srcA, srcB, transpose_a=False, transpose_b=False)
+
         else:
             assert False, f"TVM einsum decomposition does not support {equation} yet."
 

--- a/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
+++ b/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
@@ -842,10 +842,14 @@ def test_argmax(forge_property_recorder, shape, dim, keepdim):
 @pytest.mark.parametrize(
     "pattern, input_shape",
     [
-        ("nhwpqc->nchpwq", (2, 64, 64, 2, 2, 16)),
-        ("nhwpqc->nchpwq", (1, 32, 32, 4, 4, 8)),
-        ("nhwpqc->nchpwq", (4, 16, 16, 2, 2, 32)),
-        ("nhwpqc->nchpwq", (3, 8, 8, 1, 1, 64)),
+        ("nhwpqc->nchpwq", [(2, 64, 64, 2, 2, 16)]),
+        ("nhwpqc->nchpwq", [(1, 32, 32, 4, 4, 8)]),
+        ("nhwpqc->nchpwq", [(4, 16, 16, 2, 2, 32)]),
+        ("nhwpqc->nchpwq", [(3, 8, 8, 1, 1, 64)]),
+        ("...si,...id->...sd", [(2, 3, 4), (2, 4, 5)]),
+        ("...si,...id->...sd", [(5, 6, 7), (5, 7, 8)]),
+        ("...si,...id->...sd", [(1, 10, 20), (1, 20, 30)]),
+        ("...si,...id->...sd", [(4, 2, 3), (4, 3, 6)]),
     ],
 )
 @pytest.mark.push
@@ -855,11 +859,10 @@ def test_einsum(forge_property_recorder, pattern, input_shape):
             super().__init__()
             self.pattern = pattern
 
-        def forward(self, x):
-            return torch.einsum(self.pattern, x)
+        def forward(self, *inputs):
+            return torch.einsum(self.pattern, *inputs)
 
-    input_tensor = torch.randn(input_shape)
-    inputs = [input_tensor]
+    inputs = [torch.randn(shape) for shape in input_shape]
 
     model = EinsumModel(pattern)
     model.eval()

--- a/forge/test/models/pytorch/vision/mgp_str_base/test_mgp_str_base.py
+++ b/forge/test/models/pytorch/vision/mgp_str_base/test_mgp_str_base.py
@@ -4,12 +4,22 @@
 
 # From: https://huggingface.co/alibaba-damo/mgp-str-base
 import pytest
+import torch
 
 import forge
 from forge.forge_property_utils import Framework, Source, Task
-from forge.verify.verify import verify
+from forge.verify.verify import DepricatedVerifyConfig, verify
 
 from test.models.pytorch.vision.mgp_str_base.utils.utils import load_input, load_model
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, inputs):
+        return self.model(inputs).logits
 
 
 @pytest.mark.nightly
@@ -35,11 +45,16 @@ def test_mgp_scene_text_recognition(forge_property_recorder, variant):
 
     # Load model and input
     framework_model = load_model(variant)
+    framework_model = Wrapper(framework_model)
     inputs = load_input(variant)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        verify_cfg=DepricatedVerifyConfig(verify_forge_codegen_vs_framework=True),
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
     )
 
     # Model Verification


### PR DESCRIPTION
Added a wrapper to solve _run_jit_passes issue faced by mgp_str_base model
 
post which model was failing in DecomposeEinsum TVM Callback, decomposition for einsum pattern(...si,...id->...sd) has been added.

Logs:
[mgp_before_fix.log](https://github.com/user-attachments/files/20061711/mgp_before_fix.log)
[mgp_after_fix.log](https://github.com/user-attachments/files/20061715/mgp_after_fix.log)
