### PR TITLE
Fix ONNX ModelProto size exceeds via onnx path

### DIFF
--- a/forge/test/models/onnx/text/ministral/test_ministral.py
+++ b/forge/test/models/onnx/text/ministral/test_ministral.py
@@ -41,7 +41,7 @@ def test_ministral(forge_property_recorder, variant, tmp_path):
     # prepare input
     prompt = "What are the benefits of AI in healthcare?"
     input_tokens = tokenizer(prompt, return_tensors="pt")
-    inputs = [input_tokens["input_ids"]]
+    inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
 
     # Export model to ONNX
     onnx_path = f"{tmp_path}/model.onnx"
@@ -53,11 +53,11 @@ def test_ministral(forge_property_recorder, variant, tmp_path):
 
     # passing model file instead of model proto due to size of the model(>2GB) - #https://github.com/onnx/onnx/issues/3775#issuecomment-943416925
     onnx.checker.check_model(onnx_path)
-    framework_model = forge.OnnxModule(module_name, onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model, onnx_path)
 
     # Compile model
     compiled_model = forge.compile(
-        onnx_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
+        framework_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
     )
 
     # Model Verification

--- a/forge/test/models/onnx/text/phi1/test_phi1_5_onnx.py
+++ b/forge/test/models/onnx/text/phi1/test_phi1_5_onnx.py
@@ -63,12 +63,12 @@ def test_phi1_5_clm_onnx(forge_property_recorder, variant, tmp_path):
 
     # passing model file instead of model proto due to size of the model(>2GB) - #https://github.com/onnx/onnx/issues/3775#issuecomment-943416925
     onnx.checker.check_model(onnx_path)
-    framework_model = forge.OnnxModule(module_name, onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model, onnx_path)
 
     # Compile model
     inputs = [input_ids, attn_mask]
     compiled_model = forge.compile(
-        onnx_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
+        framework_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
     )
 
     # Model Verification

--- a/forge/test/models/onnx/text/phi3/test_phi3.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3.py
@@ -65,12 +65,12 @@ def test_phi3_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
 
     # passing model file instead of model proto due to size of the model(>2GB) - #https://github.com/onnx/onnx/issues/3775#issuecomment-943416925
     onnx.checker.check_model(onnx_path)
-    framework_model = forge.OnnxModule(module_name, onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model, onnx_path)
 
     # Compile model
     inputs = [input_ids, attn_mask]
     compiled_model = forge.compile(
-        onnx_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
+        framework_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
     )
 
     # Model Verification


### PR DESCRIPTION
Listed onnx models were facing `ValueError: Message onnx.ModelProto exceeds maximum protobuf size of 2GB: 13263488184`

After passing onnxmodule and onnx_path, this issue was solved

Logs:
[ministral_after_fix1.log](https://github.com/user-attachments/files/20081798/ministral_after_fix1.log)
[phi3_causal_lm_after_fix.log](https://github.com/user-attachments/files/20053278/phi3_causal_lm_after_fix.log)
[phi1_5_onnx_after_fix.log](https://github.com/user-attachments/files/20053437/phi1_5_onnx_after_fix.log)

