### PR TITLE
Monkey patch: fix ONNX Where type error in Gemma2DecoderLayer by matching dtype

### DIFF
--- a/forge/test/models/models_utils.py
+++ b/forge/test/models/models_utils.py
@@ -9,6 +9,8 @@ from transformers import AutoImageProcessor
 import torch
 from tabulate import tabulate
 import json
+from typing import Optional, Tuple
+from transformers import Cache
 
 # Mean Pooling - Take attention mask into account for correct averaging
 def mean_pooling(model_output, attention_mask):
@@ -196,3 +198,65 @@ def _prepare_4d_causal_attention_mask_with_cache_position(
                 causal_mask = causal_mask.masked_fill(padding_mask, min_dtype)
 
     return causal_mask
+
+
+def Gemma2DecoderLayer_patched_forward(
+    self,
+    hidden_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_value: Optional[Cache] = None,
+    output_attentions: Optional[bool] = False,
+    use_cache: Optional[bool] = False,
+    cache_position: Optional[torch.LongTensor] = None,
+) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
+    if self.is_sliding and attention_mask is not None:  # efficient SDPA and no padding
+        # Flash-attn is a 2D tensor
+        if self.config._attn_implementation == "flash_attention_2":
+            if past_key_value is not None:  # when decoding
+                attention_mask = attention_mask[:, -self.sliding_window :]
+        else:
+            # min_dtype = torch.finfo(hidden_states.dtype).min
+
+            # [Monkey patch] Cast scalar to tensor with hidden_states dtype to fix ONNX Where op type mismatch
+            min_dtype = torch.tensor(torch.finfo(hidden_states.dtype).min, dtype=hidden_states.dtype)
+
+            sliding_window_mask = torch.tril(
+                torch.ones_like(attention_mask, dtype=torch.bool), diagonal=-self.sliding_window
+            )
+            attention_mask = torch.where(sliding_window_mask, min_dtype, attention_mask)
+            if attention_mask.shape[-1] <= 1:  # when decoding
+                attention_mask = attention_mask[:, :, :, -self.sliding_window :]
+
+    residual = hidden_states
+
+    hidden_states = self.input_layernorm(hidden_states)
+
+    # Self Attention
+    hidden_states, self_attn_weights, present_key_value = self.self_attn(
+        hidden_states=hidden_states,
+        attention_mask=attention_mask,
+        position_ids=position_ids,
+        past_key_value=past_key_value,
+        output_attentions=output_attentions,
+        use_cache=use_cache,
+        cache_position=cache_position,
+    )
+    hidden_states = self.post_attention_layernorm(hidden_states)
+    hidden_states = residual + hidden_states
+
+    residual = hidden_states
+    hidden_states = self.pre_feedforward_layernorm(hidden_states)
+    hidden_states = self.mlp(hidden_states)
+    hidden_states = self.post_feedforward_layernorm(hidden_states)
+    hidden_states = residual + hidden_states
+
+    outputs = (hidden_states,)
+
+    if output_attentions:
+        outputs += (self_attn_weights,)
+
+    if use_cache:
+        outputs += (present_key_value,)
+
+    return outputs

--- a/forge/test/models/onnx/text/gemma/test_gemma_v2.py
+++ b/forge/test/models/onnx/text/gemma/test_gemma_v2.py
@@ -13,6 +13,10 @@ from forge.verify.verify import verify
 from forge.forge_property_utils import Framework, Source, Task
 from test.utils import download_model
 import onnx
+from transformers.models.gemma2.modeling_gemma2 import Gemma2DecoderLayer
+from test.models.models_utils import Gemma2DecoderLayer_patched_forward
+
+Gemma2DecoderLayer.forward = Gemma2DecoderLayer_patched_forward
 
 
 @pytest.mark.nightly


### PR DESCRIPTION
### Problem description
While running the exported gemma_v2 model in ONNX Runtime, the following type mismatch error was encountered:

```
onnxruntime.capi.onnxruntime_pybind11_state.Fail: [ONNXRuntimeError] : 1 : FAIL : Load model from /tmp/pytest-of-kkannan/pytest-1/test_gemma_v2_onnx_google_gemm1/gemma_v2.onnx failed:Type Error: Type parameter (T) of Optype (Where) bound to different types (tensor(double) and tensor(float) in node (/model/layers.0/Where).
```

This error occurs because [torch.finfo(...).min](https://github.com/huggingface/transformers/blob/5d7739f15a6e50de416977fe2cc9cb516d67edda/src/transformers/models/gemma2/modular_gemma2.py#L510C29-L510C65) returns a Python scalar of type float (i.e., double in ONNX), which causes a type mismatch when used in a [torch.where(...)](https://github.com/huggingface/transformers/blob/5d7739f15a6e50de416977fe2cc9cb516d67edda/src/transformers/models/gemma2/modular_gemma2.py#L514C34-L514C93) operation alongside attention_mask(float32)

### What's changed

To resolve this issue, a monkey patch was applied to Gemma2DecoderLayer.forward. The patch ensures that the scalar is cast to a tensor with the same data type as hidden_states, maintaining type consistency in the torch.where(...) operation and avoiding ONNX type errors.

### Logs

- [gemma2_before_fix.log](https://github.com/user-attachments/files/20014471/may2_gemma_before_fix.log)
- [gemma2_2b_after_fix.log](https://github.com/user-attachments/files/20014482/may2_gemma_2b_after_fix.log)


