### PR TITLE
Update forge-fe requirements

### DIFF
--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -1,22 +1,17 @@
 setuptools>=61
-# This is needed to avoid issue https://yyz-gitlab.local.tenstorrent.com/devops/devops/-/issues/95
-# jax requires any version of optax which requires any version of chex which in turn
-# requires jax>=0.4.6 which conflicts with our jax == 0.3.16
-# TODO: Remove when jax library is upgraded
-chex==0.1.6
 dataclasses-json==0.5.7
 datasets==2.14.6
 decorator==5.1.1
-flatbuffers==23.5.26
+flatbuffers==24.3.25
 # This is needed to prevent AttributeError: module 'ml_dtypes' has no attribute 'float8_e4m3b11'
-ml-dtypes==0.2.0
-flax==0.9.0
-jax==0.4.30
-jaxlib==0.4.30
+ml-dtypes==0.5.1
+flax==0.10.4
+jax==0.5.0
+jaxlib==0.5.0
 loguru==0.5.3
 matplotlib==3.5.1
 networkx==2.8.5
-numpy==1.23.1
+numpy==2.0.0
 onnx>=1.15.0
 onnxruntime>=1.16.3
 opencv-python-headless==4.10.0.84
@@ -27,8 +22,8 @@ protobuf==3.20.3
 pybind11==2.6.2
 pyinstrument>=4.1.1
 scipy>=1.8.0
-tensorflow==2.13
-tensorboard==2.13
+tensorflow==2.18.1
+tensorboard==2.18
 tf2onnx==1.15.1
 transformers==4.47.0
 # To avoid warning during the import

--- a/env/linux_requirements.txt
+++ b/env/linux_requirements.txt
@@ -28,7 +28,7 @@ yolov5==7.0.9
 # several GB smaller which made a large impact on the performance of CI
 # (through build artifacts and caching)
 torch @ https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.1.0%2Bcpu.cxx11.abi-cp38-cp38-linux_x86_64.whl ; python_version=='3.8'
-torch @ https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.1.0%2Bcpu.cxx11.abi-cp310-cp310-linux_x86_64.whl ; python_version=='3.10'
+torch @ https://download.pytorch.org/whl/cpu-cxx11-abi/torch-2.6.0%2Bcpu.cxx11.abi-cp310-cp310-linux_x86_64.whl ; python_version=='3.10'
 torch==2.3.1 ; python_version=='3.11'
 torchxrayvision==0.0.39
 vgg_pytorch==0.3.0

--- a/forge/csrc/tt_torch_device/torch_device_impl.cpp
+++ b/forge/csrc/tt_torch_device/torch_device_impl.cpp
@@ -113,6 +113,8 @@ struct Mallocator final : public c10::Allocator
         return c10::DataPtr(ptr, nullptr, std::free, c10::Device(TT, 0));
     }
 
+    virtual void copy_data(void* dest, const void* src, std::size_t count) override { std::memcpy(dest, src, count); }
+
     static c10::Allocator* get()
     {
         static std::unique_ptr<Mallocator> mallocator = std::make_unique<Mallocator>();

--- a/forge/csrc/tt_torch_device/torch_device_impl.cpp
+++ b/forge/csrc/tt_torch_device/torch_device_impl.cpp
@@ -107,7 +107,7 @@ std::vector<std::shared_ptr<TTDevice>> get_available_tt_devices() { return Torch
 
 struct Mallocator final : public c10::Allocator
 {
-    virtual c10::DataPtr allocate(size_t n) const override
+    virtual c10::DataPtr allocate(size_t n) override
     {
         void* ptr = std::calloc(n, 1);
         return c10::DataPtr(ptr, nullptr, std::free, c10::Device(TT, 0));

--- a/forge/csrc/tt_torch_device/torch_device_impl.cpp
+++ b/forge/csrc/tt_torch_device/torch_device_impl.cpp
@@ -113,7 +113,10 @@ struct Mallocator final : public c10::Allocator
         return c10::DataPtr(ptr, nullptr, std::free, c10::Device(TT, 0));
     }
 
-    virtual void copy_data(void* dest, const void* src, std::size_t count) override { std::memcpy(dest, src, count); }
+    virtual void copy_data(void* dest, const void* src, std::size_t count) const override
+    {
+        default_copy_data(dest, src, count);
+    }
 
     static c10::Allocator* get()
     {


### PR DESCRIPTION
This commit updates forge-fe core requirements such that they are compatible with the other frontends, tt-torch and tt-xla.  This enables all of their respective wheels to be installed inside of the same venv.
