### PR TITLE
Disable device perf because of troubles with TTRT.

### DIFF
--- a/.github/workflows/perf-benchmark-sub.yml
+++ b/.github/workflows/perf-benchmark-sub.yml
@@ -18,13 +18,13 @@ jobs:
       fail-fast: false
       matrix:
         build: [
-          { runs-on: "n150", name: "mnist_linear",             dir: "MNISTLinear",                  bs: 32, lp: 32, df: 'float32' , allow-fail: true },
+          { runs-on: "n150", name: "mnist_linear",             dir: "MNISTLinear",                  bs: 32, lp: 32, df: 'float32' },
           { runs-on: "n150", name: "resnet50_hf",              dir: "ResNetForImageClassification", bs: 8,  lp: 32, df: 'bfloat16', allow-fail: true },
-          { runs-on: "n150", name: "llama",                    dir: "LlamaModel",                   bs: 1,  lp: 32, df: 'float32' , allow-fail: true },
-          { runs-on: "n150", name: "mobilenetv2_basic",        dir: "MobileNetv2Basic",             bs: 1,  lp: 32, df: 'float32' , allow-fail: true },
+          { runs-on: "n150", name: "llama",                    dir: "LlamaModel",                   bs: 1,  lp: 32, df: 'float32' },
+          { runs-on: "n150", name: "mobilenetv2_basic",        dir: "MobileNetv2Basic",             bs: 1,  lp: 32, df: 'float32' },
           { runs-on: "n150", name: "efficientnet_timm",        dir: "EfficientNetTimmB0",           bs: 1,  lp: 32, df: 'float32' , allow-fail: true },
-          { runs-on: "n150", name: "segformer_classification", dir: "SegformerClassification",      bs: 1,  lp: 32, df: 'float32' , allow-fail: true },
-          { runs-on: "n150", name: "vit_base",                 dir: "ViTBase",                      bs: 1,  lp: 32, df: 'float32' , allow-fail: true },
+          { runs-on: "n150", name: "segformer_classification", dir: "SegformerClassification",      bs: 1,  lp: 32, df: 'float32' },
+          { runs-on: "n150", name: "vit_base",                 dir: "ViTBase",                      bs: 1,  lp: 32, df: 'float32' },
           { runs-on: "n150", name: "vovnet_osmr",              dir: "VovnetOSMR",                   bs: 1,  lp: 32, df: 'float32' , allow-fail: true }
         ]
     runs-on:

--- a/.github/workflows/perf-benchmark-sub.yml
+++ b/.github/workflows/perf-benchmark-sub.yml
@@ -18,14 +18,14 @@ jobs:
       fail-fast: false
       matrix:
         build: [
-          { runs-on: "n150", name: "mnist_linear",             dir: "MNISTLinear",                  bs: 32, lp: 32, df: 'float32'  },
-          { runs-on: "n150", name: "resnet50_hf",              dir: "ResNetForImageClassification", bs: 8,  lp: 32, df: 'bfloat16' },
-          { runs-on: "n150", name: "llama",                    dir: "LlamaModel",                   bs: 1,  lp: 32, df: 'float32'  },
-          { runs-on: "n150", name: "mobilenetv2_basic",        dir: "MobileNetv2Basic",             bs: 1,  lp: 32, df: 'float32'  },
-          { runs-on: "n150", name: "efficientnet_timm",        dir: "EfficientNetTimmB0",           bs: 1,  lp: 32, df: 'float32'  },
-          { runs-on: "n150", name: "segformer_classification", dir: "SegformerClassification",      bs: 1,  lp: 32, df: 'float32'  },
-          { runs-on: "n150", name: "vit_base",                 dir: "ViTBase",                      bs: 1,  lp: 32, df: 'float32'  },
-          { runs-on: "n150", name: "vovnet_osmr",              dir: "VovnetOSMR",                   bs: 1,  lp: 32, df: 'float32'  }
+          { runs-on: "n150", name: "mnist_linear",             dir: "MNISTLinear",                  bs: 32, lp: 32, df: 'float32' , allow-fail: true },
+          { runs-on: "n150", name: "resnet50_hf",              dir: "ResNetForImageClassification", bs: 8,  lp: 32, df: 'bfloat16', allow-fail: true },
+          { runs-on: "n150", name: "llama",                    dir: "LlamaModel",                   bs: 1,  lp: 32, df: 'float32' , allow-fail: true },
+          { runs-on: "n150", name: "mobilenetv2_basic",        dir: "MobileNetv2Basic",             bs: 1,  lp: 32, df: 'float32' , allow-fail: true },
+          { runs-on: "n150", name: "efficientnet_timm",        dir: "EfficientNetTimmB0",           bs: 1,  lp: 32, df: 'float32' , allow-fail: true },
+          { runs-on: "n150", name: "segformer_classification", dir: "SegformerClassification",      bs: 1,  lp: 32, df: 'float32' , allow-fail: true },
+          { runs-on: "n150", name: "vit_base",                 dir: "ViTBase",                      bs: 1,  lp: 32, df: 'float32' , allow-fail: true },
+          { runs-on: "n150", name: "vovnet_osmr",              dir: "VovnetOSMR",                   bs: 1,  lp: 32, df: 'float32' , allow-fail: true }
         ]
     runs-on:
       - ${{ matrix.build.runs-on }}-perf


### PR DESCRIPTION
TTRT causes troubles with performance benchmark tests. Until we solve the problems, we disable preserving device perf, because without disabling we can't preserve even end-to-end perf into the database.