### PR TITLE
Skip transpose models ops tests

### DIFF
--- a/forge/test/models_ops/test_transpose.py
+++ b/forge/test/models_ops/test_transpose.py
@@ -681,11 +681,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "args": {"dim0": "-2", "dim1": "-1"},
             },
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:140: tt::exception info: Out of Memory: Not enough space to allocate 4294967296 B DRAM buffer across 12 banks, where each bank needs to store 357916672 B"
-            )
-        ],
+        marks=[pytest.mark.skip(reason="Segmentation fault occurs while executing ttnn binary")],
     ),
     (
         Transpose3,


### PR DESCRIPTION
In the [latest models ops pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/14826441692/job/41628909323), the below tranpose ops test cases is failling with segmentation fault, so skipping the below test cases.

The segmentation fault error was not present in the [Saturday scheduled nightly models ops pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/14805293532), so @pdeviTT is working on bisecting the test.

Test cases:
`pytest "forge/test/models_ops/test_transpose.py::test_module[Transpose1-[((512, 2048, 1, 1), torch.float32)]]" -vss`

Failure log:
[test_transpose.log](https://github.com/user-attachments/files/20034131/test_transpose.log)

