### PR TITLE
Regenerate models ops tests for Pad Op

### DIFF
--- a/forge/test/models_ops/test_pad.py
+++ b/forge/test/models_ops/test_pad.py
@@ -20,7 +20,7 @@ class Pad0(ForgeModule):
         super().__init__(name)
 
     def forward(self, pad_input_0):
-        pad_output_1 = forge.op.Pad("", pad_input_0, pad=(0, 0, 0, 0, 2, 2, 0, 0, 0, 0), mode="constant", pad_len=10)
+        pad_output_1 = forge.op.Pad("", pad_input_0, pad=(0, 0, 2, 2), mode="constant", channel_last=True, value=0.0)
         return pad_output_1
 
 
@@ -29,7 +29,7 @@ class Pad1(ForgeModule):
         super().__init__(name)
 
     def forward(self, pad_input_0):
-        pad_output_1 = forge.op.Pad("", pad_input_0, pad=(0, 0, 0, 0, 1, 1, 1, 1), mode="reflect", pad_len=8)
+        pad_output_1 = forge.op.Pad("", pad_input_0, pad=(1, 1, 1, 1), mode="reflect", channel_last=False, value=0.0)
         return pad_output_1
 
 
@@ -40,49 +40,35 @@ def ids_func(param):
 
 
 forge_modules_and_shapes_dtypes_list = [
-    pytest.param(
-        (
-            Pad0,
-            [((1, 1, 96, 54, 54), torch.float32)],
-            {
-                "model_names": ["pt_alexnet_base_img_cls_osmr"],
-                "pcc": 0.99,
-                "args": {"pad": "(0, 0, 0, 0, 2, 2, 0, 0, 0, 0)", "mode": '"constant"', "pad_len": "10"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_FATAL @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp:40: input_tensor.get_padded_shape()[2] + this->input_tensor_start[2] <= this->output_padded_shape[2] info: Output size cannot fit input with offset"
-            )
-        ],
+    (
+        Pad0,
+        [((1, 1, 96, 54, 54), torch.float32)],
+        {
+            "model_names": ["pt_alexnet_base_img_cls_osmr"],
+            "pcc": 0.99,
+            "args": {"pad": "(0, 0, 2, 2)", "mode": '"constant"', "channel_last": "True", "value": "0.0"},
+        },
     ),
-    pytest.param(
-        (
-            Pad0,
-            [((1, 1, 256, 27, 27), torch.float32)],
-            {
-                "model_names": ["pt_alexnet_base_img_cls_osmr"],
-                "pcc": 0.99,
-                "args": {"pad": "(0, 0, 0, 0, 2, 2, 0, 0, 0, 0)", "mode": '"constant"', "pad_len": "10"},
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_FATAL @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_op.cpp:40: input_tensor.get_padded_shape()[2] + this->input_tensor_start[2] <= this->output_padded_shape[2] info: Output size cannot fit input with offset"
-            )
-        ],
+    (
+        Pad0,
+        [((1, 1, 256, 27, 27), torch.float32)],
+        {
+            "model_names": ["pt_alexnet_base_img_cls_osmr"],
+            "pcc": 0.99,
+            "args": {"pad": "(0, 0, 2, 2)", "mode": '"constant"', "channel_last": "True", "value": "0.0"},
+        },
     ),
     (
         Pad1,
         [((1, 512, 10, 32), torch.float32)],
         {
             "model_names": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -90,12 +76,12 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 512, 20, 64), torch.float32)],
         {
             "model_names": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -103,12 +89,12 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 256, 20, 64), torch.float32)],
         {
             "model_names": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -116,12 +102,12 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 256, 40, 128), torch.float32)],
         {
             "model_names": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -129,12 +115,12 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 128, 40, 128), torch.float32)],
         {
             "model_names": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -142,12 +128,12 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 128, 80, 256), torch.float32)],
         {
             "model_names": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -155,61 +141,52 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 64, 80, 256), torch.float32)],
         {
             "model_names": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
-    pytest.param(
-        (
-            Pad1,
-            [((1, 96, 160, 512), torch.float32)],
-            {
-                "model_names": [
-                    "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
-            },
-        ),
-        marks=[pytest.mark.skip(reason="Segmentation fault occurs while executing ttnn binary")],
+    (
+        Pad1,
+        [((1, 96, 160, 512), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
+        },
     ),
-    pytest.param(
-        (
-            Pad1,
-            [((1, 32, 160, 512), torch.float32)],
-            {
-                "model_names": [
-                    "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
-            },
-        ),
-        marks=[pytest.mark.skip(reason="Segmentation fault occurs while executing ttnn binary")],
+    (
+        Pad1,
+        [((1, 32, 160, 512), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
+        },
     ),
-    pytest.param(
-        (
-            Pad1,
-            [((1, 16, 320, 1024), torch.float32)],
-            {
-                "model_names": [
-                    "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
-            },
-        ),
-        marks=[pytest.mark.skip(reason="Killed while executing post_initial_graph_pass")],
+    (
+        Pad1,
+        [((1, 16, 320, 1024), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
+        },
     ),
     (
         Pad1,
@@ -218,13 +195,13 @@ forge_modules_and_shapes_dtypes_list = [
             "model_names": [
                 "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -234,13 +211,13 @@ forge_modules_and_shapes_dtypes_list = [
             "model_names": [
                 "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -250,13 +227,13 @@ forge_modules_and_shapes_dtypes_list = [
             "model_names": [
                 "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -266,13 +243,13 @@ forge_modules_and_shapes_dtypes_list = [
             "model_names": [
                 "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -282,13 +259,13 @@ forge_modules_and_shapes_dtypes_list = [
             "model_names": [
                 "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -298,13 +275,13 @@ forge_modules_and_shapes_dtypes_list = [
             "model_names": [
                 "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -314,13 +291,13 @@ forge_modules_and_shapes_dtypes_list = [
             "model_names": [
                 "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -330,13 +307,13 @@ forge_modules_and_shapes_dtypes_list = [
             "model_names": [
                 "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
     (
@@ -346,33 +323,30 @@ forge_modules_and_shapes_dtypes_list = [
             "model_names": [
                 "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
                 "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
             ],
             "pcc": 0.99,
-            "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
         },
     ),
-    pytest.param(
-        (
-            Pad1,
-            [((1, 16, 192, 640), torch.float32)],
-            {
-                "model_names": [
-                    "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "args": {"pad": "(0, 0, 0, 0, 1, 1, 1, 1)", "mode": '"reflect"', "pad_len": "8"},
-            },
-        ),
-        marks=[pytest.mark.skip(reason="Segmentation fault occurs while executing ttnn binary")],
+    (
+        Pad1,
+        [((1, 16, 192, 640), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_no_pt_640x192_depth_prediction_torchvision",
+                "pt_monodepth2_mono_640x192_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {"pad": "(1, 1, 1, 1)", "mode": '"reflect"', "channel_last": "False", "value": "0.0"},
+        },
     ),
 ]
 


### PR DESCRIPTION
The PR regenerated models ops tests for pad op on top of the [vkovinic/pad_op_fix PR branch](https://github.com/tenstorrent/tt-forge-fe/pull/1892) by utilizing the `scripts/model_analysis/generate_models_ops_test.py `script. All the pad ops tests are passed.

Pad Op tests log: 
[test_pad.log](https://github.com/user-attachments/files/20034590/test_pad.log)

Note:
The PR will be merged once the [vkovinic/pad_op_fix](https://github.com/tenstorrent/tt-forge-fe/pull/1892) branch is uplifted into main
