### PR TITLE
[OP] Unsqueeze op fix - torch.bool -> DataFormat.Int32

### DIFF
--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -669,7 +669,8 @@ def pytorch_dtype_to_forge_dataformat(dtype: torch.dtype, fp32_fallback: Optiona
         return DataFormat.Float32
 
     if dtype == torch.uint8:
-        return DataFormat.RawUInt8
+        logger.warning("Parameter is uint8. Setting to Int32, since uint8 is not supported.")
+        return DataFormat.Int32
 
     if dtype == torch.int8:
         logger.warning("Parameter is int8. Setting to Int32, since int8 is not supported.")
@@ -680,8 +681,8 @@ def pytorch_dtype_to_forge_dataformat(dtype: torch.dtype, fp32_fallback: Optiona
     #     return DataFormat.UInt16
 
     if dtype == torch.bool:
-        logger.warning("Parameter is bool. Setting to uint8, since bool is not supported.")
-        return DataFormat.RawUInt8
+        logger.warning("Parameter is bool. Setting to Int32, since bool is not supported.")
+        return DataFormat.Int32
 
     if dtype == torch.int32:
         return DataFormat.Int32

--- a/forge/test/models_ops/test_unsqueeze.py
+++ b/forge/test/models_ops/test_unsqueeze.py
@@ -4312,11 +4312,6 @@ forge_modules_and_shapes_dtypes_list = [
             [((1, 596), torch.bool)],
             {"model_names": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"], "pcc": 0.99, "args": {"dim": "-1"}},
         ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_FATAL @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp:22: input_tensor_a.get_dtype() == DataType::BFLOAT16 or input_tensor_a.get_dtype() == DataType::UINT32 or input_tensor_a.get_dtype() == DataType::FLOAT32 info: Can only work with bfloat16/float32 or uint32 tensors"
-            )
-        ],
     ),
     (
         Unsqueeze2,


### PR DESCRIPTION
### Ticket
Fix #1662

### Problem description
Previously we mapped `torch.bool` tensors to the `DataFormat.RawUInt8` which is not supported in metal where we get this error:
```
E       RuntimeError: TT_FATAL @ /proj_sw/user_dev/vkovinic/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/reshape_device_operation.cpp:22: input_tensor_a.get_dtype() == DataType::BFLOAT16 or input_tensor_a.get_dtype() == DataType::UINT32 or input_tensor_a.get_dtype() == DataType::FLOAT32
E       info:
E       Can only work with bfloat16/float32 or uint32 tensors
```

### What's changed
Now `torch.uint8` and `torch.bool` ->  `DataFormat.Int32`
