### PR TITLE
Remove xfail markers for add, subtract and transpose ops test

### DIFF
--- a/forge/test/models_ops/test_add.py
+++ b/forge/test/models_ops/test_add.py
@@ -11725,23 +11725,20 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 32, 128, 128), torch.float32)],
         {"model_names": ["pt_mistral_mistralai_mistral_7b_v0_1_clm_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add112,
-            [((1, 32), torch.int64)],
-            {
-                "model_names": [
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add112,
+        [((1, 32), torch.int64)],
+        {
+            "model_names": [
+                "pt_opt_facebook_opt_125m_qa_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add17,
@@ -11810,20 +11807,17 @@ forge_modules_and_shapes_dtypes_list = [
         [((32, 2048), torch.float32), ((32, 2048), torch.float32)],
         {"model_names": ["pt_opt_facebook_opt_1_3b_seq_cls_hf", "pt_opt_facebook_opt_1_3b_qa_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add112,
-            [((1, 256), torch.int64)],
-            {
-                "model_names": [
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add112,
+        [((1, 256), torch.int64)],
+        {
+            "model_names": [
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (Add26, [((256, 4096), torch.float32)], {"model_names": ["pt_opt_facebook_opt_350m_clm_hf"], "pcc": 0.99}),
     (Add54, [((256, 1024), torch.float32)], {"model_names": ["pt_opt_facebook_opt_350m_clm_hf"], "pcc": 0.99}),
@@ -12785,19 +12779,16 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 39, 3584), torch.float32), ((1, 39, 3584), torch.float32)],
         {"model_names": ["pt_qwen_v2_qwen_qwen2_5_7b_instruct_clm_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add112,
-            [((1, 128), torch.int64)],
-            {
-                "model_names": [
-                    "pt_roberta_xlm_roberta_base_mlm_hf",
-                    "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add112,
+        [((1, 128), torch.int64)],
+        {
+            "model_names": [
+                "pt_roberta_xlm_roberta_base_mlm_hf",
+                "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (Add127, [((1, 128, 250002), torch.float32)], {"model_names": ["pt_roberta_xlm_roberta_base_mlm_hf"], "pcc": 0.99}),
     (

--- a/forge/test/models_ops/test_subtract.py
+++ b/forge/test/models_ops/test_subtract.py
@@ -624,24 +624,21 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Subtract5,
-            [((1, 32), torch.int64)],
-            {
-                "model_names": [
-                    "pt_bloom_bigscience_bloom_1b1_clm_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Subtract5,
+        [((1, 32), torch.int64)],
+        {
+            "model_names": [
+                "pt_bloom_bigscience_bloom_1b1_clm_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     pytest.param(
         (
@@ -769,20 +766,17 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
-    pytest.param(
-        (
-            Subtract5,
-            [((1, 256), torch.int64)],
-            {
-                "model_names": [
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Subtract5,
+        [((1, 256), torch.int64)],
+        {
+            "model_names": [
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Subtract1,

--- a/forge/test/models_ops/test_transpose.py
+++ b/forge/test/models_ops/test_transpose.py
@@ -4975,17 +4975,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((3584, 14336), torch.float32)],
         {"model_names": ["pt_gemma_google_gemma_2_9b_it_qa_hf"], "pcc": 0.99, "args": {"dim0": "-2", "dim1": "-1"}},
     ),
-    pytest.param(
-        (
-            Transpose1,
-            [((256000, 3584), torch.float32)],
-            {"model_names": ["pt_gemma_google_gemma_2_9b_it_qa_hf"], "pcc": 0.99, "args": {"dim0": "-2", "dim1": "-1"}},
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:140: tt::exception info: Out of Memory: Not enough space to allocate 3670016000 B DRAM buffer across 12 banks, where each bank needs to store 305836032 B"
-            )
-        ],
+    (
+        Transpose1,
+        [((256000, 3584), torch.float32)],
+        {"model_names": ["pt_gemma_google_gemma_2_9b_it_qa_hf"], "pcc": 0.99, "args": {"dim0": "-2", "dim1": "-1"}},
     ),
     (
         Transpose0,

--- a/forge/test/models_ops/test_unsqueeze.py
+++ b/forge/test/models_ops/test_unsqueeze.py
@@ -5418,11 +5418,7 @@ forge_modules_and_shapes_dtypes_list = [
     (
         Unsqueeze1,
         [((768, 768, 1), torch.float32)],
-        {
-            "model_names": ["pt_squeezebert_squeezebert_squeezebert_mnli_seq_cls_hf"],
-            "pcc": 0.99,
-            "args": {"dim": "2"},
-        },
+        {"model_names": ["pt_squeezebert_squeezebert_squeezebert_mnli_seq_cls_hf"], "pcc": 0.99, "args": {"dim": "2"}},
     ),
     (
         Unsqueeze2,


### PR DESCRIPTION
In the [latest models ops pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/14848697549/job/41704858231), below issues was resolved in add, subtract and transpose models ops tests. so removed xfail markers for above mentioned ops tests. For more insight about failed, xpasses test refer below generated models ops tests report.

Resolved issues:
1. Data mismatch between framework output and compiled model output
2. RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:140: tt::exception info: Out of Memory: Not enough space to allocate 3670016000 B DRAM buffer across 12 banks, where each bank needs to store 305836032 B


Note:
In the generated models ops test report,
1. The pad ops is failling with `TypeError: Pad() got an unexpected keyword argument 'pad_len'` error and this issues was resolved by regenerating models ops tests in the latest main and the [PR](https://github.com/tenstorrent/tt-forge-fe/pull/1923) was also merged.
2. The below softmax and transpose ops is failling with `RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:140: tt::exception info: Out of Memory: Not enough space to allocate 3798663168 B DRAM buffer across 12 banks, where each bank needs to store 316555264 B` error but the issues was not replicated locally so I have not added xfail markers for those below mentioned tests. Let us check the status of below tests in the next nightly models ops nightly 
```
forge/test/models_ops/test_softmax.py::test_module[Softmax1-[((2, 24, 4429, 4429), torch.float32)]]
forge/test/models_ops/test_transpose.py::test_module[Transpose1-[((151936, 896), torch.float32)]]
```

Genenared models ops tests report: 
[model_ops_tests_report.xlsx](https://github.com/user-attachments/files/20060396/model_ops_tests_report.xlsx)
