### PR TITLE
Disable internal post processing steps in YOLOV10 ONNX model

### DIFF
--- a/forge/test/models/onnx/vision/yolo/test_yolo_v10.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v10.py
@@ -13,7 +13,7 @@ from test.models.onnx.vision.yolo.utils.yolo_utils import load_yolo_model_and_im
 from forge.forge_property_utils import Framework, Source, Task
 
 
-@pytest.mark.xfail()
+@pytest.mark.xfail
 @pytest.mark.nightly
 def test_yolov10(forge_property_recorder, tmp_path):
     # Record Forge Property

--- a/forge/test/models/onnx/vision/yolo/utils/yolo_utils.py
+++ b/forge/test/models/onnx/vision/yolo/utils/yolo_utils.py
@@ -12,9 +12,11 @@ class YoloWrapper(torch.nn.Module):
     def __init__(self, model):
         super().__init__()
         self.model = model
+        self.model.model[-1].end2end = False  # Disable internal post processing steps
 
     def forward(self, image: torch.Tensor):
-        return self.model(image)
+        y, x = self.model(image)
+        return (y, *x)
 
 
 def load_yolo_model_and_image(url):


### PR DESCRIPTION
### Problem description

- Yolov10 ONNX model encountered below error on latest main.

```
2025-05-06 12:25:16.561 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2205 - Encountered unsupported op node type: topk, on device: tt
2025-05-06 12:25:16.561 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2205 - Encountered unsupported op node type: gather, on device: tt
2025-05-06 12:25:16.561 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2205 - Encountered unsupported op node type: gather, on device: tt
2025-05-06 12:25:16.561 | ERROR    | forge.tvm_to_python:compile_tvm_to_python:2205 - Encountered unsupported op node type: topk, on device: tt


E AssertionError: Encountered unsupported op types. Check error logs for more details
```
- The root cause is this [post processing block](https://github.com/ultralytics/ultralytics/blob/d3d523bcbd528e2d11c6c273ec8919291abe3477/ultralytics/nn/modules/head.py#L151C1-L172C110), which introduces above mentioned unsupported ops.

### What's changed


- This [post processing block](https://github.com/ultralytics/ultralytics/blob/d3d523bcbd528e2d11c6c273ec8919291abe3477/ultralytics/nn/modules/head.py#L151C1-L172C110) can be disabled which eliminates the need of adding support for those ops

### Logs

- [yolov10_onnx_before_fix.log](https://github.com/user-attachments/files/20062069/may6_yolov10_onnx_before_fix.log)
- [yolov10_onnx_after_fix.log](https://github.com/user-attachments/files/20062067/may6_yolov10_onnx_after_fix.log)


