### PR TITLE
Enable optimizer on performance benchmark models.

### DIFF
--- a/forge/test/benchmark/benchmark/models/efficientnet_timm.py
+++ b/forge/test/benchmark/benchmark/models/efficientnet_timm.py
@@ -19,6 +19,7 @@ import forge
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 from forge._C.runtime.experimental import configure_devices, DeviceSettings
+from forge.config import CompilerConfig, MLIRConfig
 
 from test.utils import download_model
 
@@ -67,8 +68,15 @@ def test_efficientnet_timm(training, batch_size, input_size, channel_size, loop_
     framework_model.eval()
     fw_out = framework_model(*input_sample)
 
+    # Compiler configuration
+    compiler_config = CompilerConfig()
+    # Turn on MLIR optimizations.
+    compiler_config.mlir_config = MLIRConfig().set_enable_consteval(True).set_enable_optimizer(True)
+
     # Forge compile framework model
-    compiled_model = forge.compile(framework_model, sample_inputs=input_sample, module_name=module_name)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=input_sample, module_name=module_name, compiler_cfg=compiler_config
+    )
 
     # Enable program cache on all devices
     settings = DeviceSettings()

--- a/forge/test/benchmark/benchmark/models/llama.py
+++ b/forge/test/benchmark/benchmark/models/llama.py
@@ -21,6 +21,7 @@ import forge
 from forge._C.runtime.experimental import configure_devices, DeviceSettings
 from test.mlir.llama.utils.utils import load_model
 from forge.verify.compare import compare_with_golden
+from forge.config import CompilerConfig, MLIRConfig
 
 
 # Common constants
@@ -66,9 +67,15 @@ def test_llama_prefill(
     prompt = "Q: What is the largest animal?\nA:"
     input_ids = tokenizer(prompt, return_tensors="pt").input_ids
 
+    # Compiler configuration
+    compiler_config = CompilerConfig()
+    # @TODO - For now, we are skipping enabling MLIR optimizations, because it is not working with the current version of the model.
+    # Turn on MLIR optimizations.
+    # compiler_config.mlir_config = MLIRConfig().set_enable_consteval(True).set_enable_optimizer(True)
+
     # This is the part of the model needed for prefill; model without the last Linear layer (lm_head)
     model_decoder = model.get_decoder()
-    compiled_decoder = forge.compile(model_decoder, sample_inputs=input_ids)
+    compiled_decoder = forge.compile(model_decoder, sample_inputs=input_ids, compiler_cfg=compiler_config)
 
     # Enable program cache on all devices
     settings = DeviceSettings()

--- a/forge/test/benchmark/benchmark/models/mobilenetv2_basic.py
+++ b/forge/test/benchmark/benchmark/models/mobilenetv2_basic.py
@@ -17,6 +17,7 @@ import forge
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 from forge._C.runtime.experimental import configure_devices, DeviceSettings
+from forge.config import CompilerConfig, MLIRConfig
 
 from test.utils import download_model
 
@@ -72,8 +73,15 @@ def test_mobilenetv2_basic(training, batch_size, input_size, channel_size, loop_
     framework_model.eval()
     fw_out = framework_model(*input_sample)
 
+    # Compiler configuration
+    compiler_config = CompilerConfig()
+    # Turn on MLIR optimizations.
+    compiler_config.mlir_config = MLIRConfig().set_enable_consteval(True).set_enable_optimizer(True)
+
     # Forge compile framework model
-    compiled_model = forge.compile(framework_model, sample_inputs=input_sample, module_name=module_name)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=input_sample, module_name=module_name, compiler_cfg=compiler_config
+    )
 
     # Enable program cache on all devices
     settings = DeviceSettings()

--- a/forge/test/benchmark/benchmark/models/segformer.py
+++ b/forge/test/benchmark/benchmark/models/segformer.py
@@ -19,6 +19,7 @@ import forge
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 from forge._C.runtime.experimental import configure_devices, DeviceSettings
+from forge.config import CompilerConfig, MLIRConfig
 
 
 # Common constants
@@ -91,8 +92,15 @@ def test_segformer_classification(
     framework_model.eval()
     fw_out = framework_model(*input_sample)
 
+    # Compiler configuration
+    compiler_config = CompilerConfig()
+    # Turn on MLIR optimizations.
+    compiler_config.mlir_config = MLIRConfig().set_enable_consteval(True).set_enable_optimizer(True)
+
     # Forge compile framework model
-    compiled_model = forge.compile(framework_model, sample_inputs=input_sample, module_name=module_name)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=input_sample, module_name=module_name, compiler_cfg=compiler_config
+    )
 
     # Enable program cache on all devices
     settings = DeviceSettings()

--- a/forge/test/benchmark/benchmark/models/vit.py
+++ b/forge/test/benchmark/benchmark/models/vit.py
@@ -19,6 +19,7 @@ from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 from forge._C.runtime.experimental import configure_devices, DeviceSettings
 from test.utils import download_model
+from forge.config import CompilerConfig, MLIRConfig
 
 
 # Common constants
@@ -85,8 +86,16 @@ def test_vit_base(
     framework_model.eval()
     fw_out = framework_model(*input_sample)
 
+    # Compiler configuration
+    compiler_config = CompilerConfig()
+    # @TODO - For now, we are skipping enabling MLIR optimizations, because it is not working with the current version of the model.
+    # # Turn on MLIR optimizations.
+    # compiler_config.mlir_config = MLIRConfig().set_enable_consteval(True).set_enable_optimizer(True)
+
     # Forge compile framework model
-    compiled_model = forge.compile(framework_model, sample_inputs=input_sample, module_name=module_name)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=input_sample, module_name=module_name, compiler_cfg=compiler_config
+    )
 
     # Enable program cache on all devices
     settings = DeviceSettings()

--- a/forge/test/benchmark/benchmark/models/vovnet.py
+++ b/forge/test/benchmark/benchmark/models/vovnet.py
@@ -19,6 +19,7 @@ from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 from forge._C.runtime.experimental import configure_devices, DeviceSettings
 from test.utils import download_model
+from forge.config import CompilerConfig, MLIRConfig
 
 
 # Common constants
@@ -80,8 +81,16 @@ def test_vovnet_osmr(
     framework_model.eval()
     fw_out = framework_model(*input_sample)
 
+    # Compiler configuration
+    compiler_config = CompilerConfig()
+    # @TODO - For now, we are skipping enabling MLIR optimizations, because it is not working with the current version of the model.
+    # # Turn on MLIR optimizations.
+    # compiler_config.mlir_config = MLIRConfig().set_enable_consteval(True).set_enable_optimizer(True)
+
     # Forge compile framework model
-    compiled_model = forge.compile(framework_model, sample_inputs=input_sample, module_name=module_name)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=input_sample, module_name=module_name, compiler_cfg=compiler_config
+    )
 
     # Enable program cache on all devices
     settings = DeviceSettings()
@@ -111,7 +120,7 @@ def test_vovnet_osmr(
     num_layers = 27  # Number of layers in the model, in this case number of convolutional layers
 
     print("====================================================================")
-    print("| Vovnet OSMR Benchmark Results:                                           |")
+    print("| Vovnet OSMR Benchmark Results:                                   |")
     print("--------------------------------------------------------------------")
     print(f"| Model: {model_name}")
     print(f"| Model type: {model_type}")


### PR DESCRIPTION
Some of perfomance benchmark tests/models can be run with MLIR optimizer, so we enable it.
