### PR TITLE
Use compiled outputs from verify functions for post processing steps in e2e passing Pytorch & ONNX model tests

### DIFF
--- a/forge/test/models/onnx/vision/segformer/test_segformer.py
+++ b/forge/test/models/onnx/vision/segformer/test_segformer.py
@@ -64,13 +64,18 @@ def test_segformer_image_classification_onnx(forge_property_recorder, variant, t
         onnx_model, inputs, forge_property_handler=forge_property_recorder, module_name=module_name
     )
 
-    # Model Verification
-    verify(
+    # Model Verification and Inference
+    _, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
         forge_property_handler=forge_property_recorder,
     )
+
+    # Post processing
+    logits = co_out[0]
+    predicted_label = logits.argmax(-1).item()
+    print("Predicted class: ", torch_model.config.id2label[predicted_label])
 
 
 variants_semseg = [

--- a/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
+++ b/forge/test/models/pytorch/multimodal/vilt/test_vilt.py
@@ -74,14 +74,11 @@ def test_vilt_question_answering_hf_pytorch(forge_property_recorder, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-    # Inference
-    output = compiled_model(*inputs)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
     # Post processing
-    logits = output[0]
+    logits = co_out[0]
     idx = logits.argmax(-1).item()
     print("Predicted answer:", model.config.id2label[idx])
 

--- a/forge/test/models/pytorch/text/albert/test_albert.py
+++ b/forge/test/models/pytorch/text/albert/test_albert.py
@@ -75,8 +75,8 @@ def test_albert_masked_lm_pytorch(forge_property_recorder, size, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(
+    # Model Verification and Inference
+    _, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
@@ -84,11 +84,8 @@ def test_albert_masked_lm_pytorch(forge_property_recorder, size, variant):
         forge_property_handler=forge_property_recorder,
     )
 
-    # Inference
-    output = compiled_model(*inputs)
-
     # post processing
-    logits = output[0]
+    logits = co_out[0]
     mask_token_index = (input_tokens.input_ids == tokenizer.mask_token_id)[0].nonzero(as_tuple=True)[0]
     predicted_token_id = logits[0, mask_token_index].argmax(axis=-1)
     print("The predicted token for the [MASK] is: ", tokenizer.decode(predicted_token_id))
@@ -165,17 +162,14 @@ def test_albert_token_classification_pytorch(forge_property_recorder, size, vari
     else:
         pcc = 0.95
 
-    # Model Verification
-    verify(
+    # Model Verification and Inference
+    _, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
         verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)),
         forge_property_handler=forge_property_recorder,
     )
-
-    # Inference
-    co_out = compiled_model(*inputs)
 
     # post processing
     predicted_token_class_ids = co_out[0].argmax(-1)
@@ -257,11 +251,8 @@ def test_albert_sequence_classification_pytorch(forge_property_recorder, variant
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-    # Inference
-    co_out = compiled_model(*inputs)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
     # post processing
     predicted_class_id = co_out[0].argmax().item()

--- a/forge/test/models/pytorch/text/bert/test_bert.py
+++ b/forge/test/models/pytorch/text/bert/test_bert.py
@@ -55,19 +55,16 @@ def test_bert_masked_lm_pytorch(forge_property_recorder, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(
+    # Model Verification and Inference
+    _, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
         forge_property_handler=forge_property_recorder,
     )
 
-    # Inference
-    output = compiled_model(*inputs)
-
     # post processing
-    logits = output[0]
+    logits = co_out[0]
     mask_token_index = (input_tokens.input_ids == tokenizer.mask_token_id)[0].nonzero(as_tuple=True)[0]
     predicted_token_id = logits[0, mask_token_index].argmax(axis=-1)
     print("The predicted token for the [MASK] is: ", tokenizer.decode(predicted_token_id))
@@ -129,20 +126,17 @@ def test_bert_question_answering_pytorch(forge_property_recorder, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(
+    # Model Verification and Inference
+    _, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
         forge_property_handler=forge_property_recorder,
     )
 
-    # Inference
-    output = compiled_model(*inputs)
-
     # post processing
-    start_logits = output[0]
-    end_logits = output[1]
+    start_logits = co_out[0]
+    end_logits = co_out[1]
 
     answer_start_index = start_logits.argmax()
     answer_end_index = end_logits.argmax()
@@ -196,10 +190,10 @@ def test_bert_sequence_classification_pytorch(forge_property_recorder, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
-    co_out = compiled_model(*inputs)
+    # post processing
     predicted_value = co_out[0].argmax(-1).item()
 
     # Answer - "positive"

--- a/forge/test/models/pytorch/text/dpr/test_dpr.py
+++ b/forge/test/models/pytorch/text/dpr/test_dpr.py
@@ -69,19 +69,16 @@ def test_dpr_context_encoder_pytorch(forge_property_recorder, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(
+    # Model Verification and Inference
+    _, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
         forge_property_handler=forge_property_recorder,
     )
 
-    # Inference
-    embeddings = compiled_model(*inputs)
-
     # Results
-    print("embeddings", embeddings)
+    print("embeddings", co_out)
 
 
 variants = ["facebook/dpr-question_encoder-single-nq-base", "facebook/dpr-question_encoder-multiset-base"]

--- a/forge/test/models/pytorch/text/perceiverio/test_perceiverio.py
+++ b/forge/test/models/pytorch/text/perceiverio/test_perceiverio.py
@@ -48,13 +48,10 @@ def test_perceiverio_masked_lm_pytorch(forge_property_recorder, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-    # Inference
-    output = compiled_model(*inputs)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
     # post processing
-    logits = output[0]
+    logits = co_out[0]
     masked_tokens_predictions = logits[0, 51:61].argmax(dim=-1)
     print("The predicted token for the [MASK] is: ", tokenizer.decode(masked_tokens_predictions))

--- a/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
+++ b/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
@@ -102,14 +102,11 @@ def test_linear_ae_pytorch(forge_property_recorder):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-    # Inference
-    output = compiled_model(sample_tensor)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
     # Post processing
-    output_image = output[0].view(1, 28, 28).detach().numpy()
+    output_image = co_out[0].view(1, 28, 28).detach().numpy()
     save_path = "forge/test/models/pytorch/vision/autoencoder/results"
     os.makedirs(save_path, exist_ok=True)
     reconstructed_image_path = f"{save_path}/reconstructed_image.png"

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
@@ -41,14 +41,11 @@ def test_mobilenetv1_basic(forge_property_recorder):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    #  Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-    # Inference
-    output = compiled_model(*inputs)
+    #  Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
     # Post processing
-    post_processing(output)
+    post_processing(co_out)
 
 
 def generate_model_mobilenetv1_imgcls_hf_pytorch(variant):

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -53,14 +53,11 @@ def test_mobilenetv2_basic(forge_property_recorder):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-    # Inference
-    output = compiled_model(*inputs)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
     # Post processing
-    post_processing(output)
+    post_processing(co_out)
 
 
 def generate_model_mobilenetV2I96_imgcls_hf_pytorch(variant):

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
@@ -51,14 +51,11 @@ def test_mobilenetv3_basic(forge_property_recorder, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-    # Inference
-    output = compiled_model(*inputs)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
     # Post processing
-    post_processing(output)
+    post_processing(co_out)
 
 
 def generate_model_mobilenetV3_imgcls_timm_pytorch(variant):

--- a/forge/test/models/pytorch/vision/resnext/test_resnext.py
+++ b/forge/test/models/pytorch/vision/resnext/test_resnext.py
@@ -42,14 +42,11 @@ def test_resnext_50_torchhub_pytorch(forge_property_recorder, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-    # Inference
-    output = compiled_model(*inputs)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
     # Post processing
-    post_processing(output)
+    post_processing(co_out)
 
 
 @pytest.mark.push
@@ -76,14 +73,11 @@ def test_resnext_101_torchhub_pytorch(forge_property_recorder, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-    # Inference
-    output = compiled_model(*inputs)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
     # Post processing
-    post_processing(output)
+    post_processing(co_out)
 
 
 @pytest.mark.nightly

--- a/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
+++ b/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
@@ -51,14 +51,11 @@ def test_wideresnet_pytorch(forge_property_recorder, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-    # Inference
-    output = compiled_model(*inputs)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
     # Post processing
-    post_processing(output)
+    post_processing(co_out)
 
 
 def generate_model_wideresnet_imgcls_timm(variant):


### PR DESCRIPTION
### Ticket

- This PR fixes https://github.com/tenstorrent/tt-forge-fe/issues/1424

### What's changed

- This PR removes redundant inference and uses compiled output from verify function for post processing steps in e2e passing  Pytorch & ONNX model tests.

### Logs

- [may7_albert.log](https://github.com/user-attachments/files/20081505/may7_albert.log)
- [may7_dpr.log](https://github.com/user-attachments/files/20081554/may7_dpr.log)
- [may7_wideresnet.log](https://github.com/user-attachments/files/20081590/may7_wideresnet.log)
- [may7_mobv2.log](https://github.com/user-attachments/files/20081557/may7_mobv2.log)
- [may7_mobv3.log](https://github.com/user-attachments/files/20081559/may7_mobv3.log)
- [may7_perceiverio.log](https://github.com/user-attachments/files/20081561/may7_perceiverio.log)
- [may7_resnext.log](https://github.com/user-attachments/files/20081562/may7_resnext.log)
- [may7_segformer.log](https://github.com/user-attachments/files/20081564/may7_segformer.log)
- [may7_autoenc.log](https://github.com/user-attachments/files/20081518/may7_autoenc.log)
- [may7_bert.log](https://github.com/user-attachments/files/20081519/may7_bert.log)
- [may7_mobv1.log](https://github.com/user-attachments/files/20081555/may7_mobv1.log)
- [may7_vilt_qa.log](https://github.com/user-attachments/files/20081572/may7_vilt_qa.log)






