### PR TITLE
Remove xfail markers in transpose op test

### DIFF
--- a/forge/test/models_ops/test_transpose.py
+++ b/forge/test/models_ops/test_transpose.py
@@ -7833,17 +7833,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((40, 128, 6), torch.float32)],
         {"model_names": ["pt_phi4_microsoft_phi_4_clm_hf"], "pcc": 0.99, "args": {"dim0": "-2", "dim1": "-1"}},
     ),
-    pytest.param(
-        (
-            Transpose1,
-            [((100352, 5120), torch.float32)],
-            {"model_names": ["pt_phi4_microsoft_phi_4_clm_hf"], "pcc": 0.99, "args": {"dim0": "-2", "dim1": "-1"}},
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:140: tt::exception info: Out of Memory: Not enough space to allocate 2055208960 B DRAM buffer across 12 banks, where each bank needs to store 171270144 B"
-            )
-        ],
+    (
+        Transpose1,
+        [((100352, 5120), torch.float32)],
+        {"model_names": ["pt_phi4_microsoft_phi_4_clm_hf"], "pcc": 0.99, "args": {"dim0": "-2", "dim1": "-1"}},
     ),
     (
         Transpose0,


### PR DESCRIPTION
In the [latest nightly models ops pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/14872043835/job/41785401648), `RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:140: tt::exception info: Out of Memory: Not enough space to allocate 2055208960 B DRAM buffer across 12 banks, where each bank needs to store 171270144 B` issues was resolved in transpose op test. so removed xfail markers for below test cases.

Test Case:
`forge/test/models_ops/test_transpose.py::test_module[Transpose1-[((100352, 5120), torch.float32)]]`
