### PR TITLE
Add benchmark codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,6 @@
 
 # Models
 forge/test/models @nvukobratTT @pilkicTT @dgolubovicTT @vkovinicTT @mstojkovicTT
+
+# Benchmarks
+forge/test/benchmark @vcanicTT @odjuricicTT @pilkicTT @nvukobratTT @dgolubovicTT


### PR DESCRIPTION
### Problem description
I want to be notified on benchmark test changes.

### What's changed
Add @vcanicTT @odjuricicTT to benchmark codeowners.

