### PR TITLE
Fix model loading for microsoft/phi-4 by using AutoModelForCausalLM and add falcon3-10B

### DIFF
--- a/forge/test/models/pytorch/text/falcon/test_falcon.py
+++ b/forge/test/models/pytorch/text/falcon/test_falcon.py
@@ -64,6 +64,10 @@ variants = [
         marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 36 GB)"),
     ),
     pytest.param(
+        "tiiuae/Falcon3-10B-Base",
+        marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB)"),
+    ),
+    pytest.param(
         "tiiuae/Falcon3-Mamba-7B-Base",
         marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 36 GB)"),
     ),
@@ -80,7 +84,12 @@ def test_falcon_3(forge_property_recorder, variant):
     )
 
     # Record Forge Property
-    if variant in ["tiiuae/Falcon3-1B-Base", "tiiuae/Falcon3-3B-Base", "tiiuae/Falcon3-7B-Base"]:
+    if variant in [
+        "tiiuae/Falcon3-1B-Base",
+        "tiiuae/Falcon3-3B-Base",
+        "tiiuae/Falcon3-7B-Base",
+        "tiiuae/Falcon3-10B-Base",
+    ]:
         forge_property_recorder.record_group("red")
     else:
         forge_property_recorder.record_group("generality")

--- a/forge/test/models/pytorch/text/phi4/test_phi4.py
+++ b/forge/test/models/pytorch/text/phi4/test_phi4.py
@@ -2,10 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-from transformers import AutoTokenizer, PhiForCausalLM, PhiForTokenClassification
+from transformers import (
+    AutoModelForCausalLM,
+    AutoModelForSequenceClassification,
+    AutoModelForTokenClassification,
+    AutoTokenizer,
+)
 
 import forge
 from forge.forge_property_utils import Framework, Source, Task
+from forge.verify.verify import verify
 
 from test.utils import download_model
 
@@ -14,9 +20,7 @@ variants = ["microsoft/phi-4"]
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
-@pytest.mark.skip(
-    reason="Insufficient host DRAM to run this model (requires a bit more than 22 GB during compile time)"
-)
+@pytest.mark.skip(reason="Skipped due to kill at consteval compilation stage")
 def test_phi_4_causal_lm_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
@@ -32,7 +36,7 @@ def test_phi_4_causal_lm_pytorch(forge_property_recorder, variant):
     forge_property_recorder.record_priority("P1")
 
     # Load tokenizer and model from HuggingFace
-    framework_model = download_model(PhiForCausalLM.from_pretrained, variant, return_dict=False, use_cache=False)
+    framework_model = download_model(AutoModelForCausalLM.from_pretrained, variant, return_dict=False, use_cache=False)
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
     framework_model.eval()
 
@@ -52,9 +56,7 @@ def test_phi_4_causal_lm_pytorch(forge_property_recorder, variant):
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
-@pytest.mark.skip(
-    reason="Insufficient host DRAM to run this model (requires a bit more than 22 GB during compile time)"
-)
+@pytest.mark.skip(reason="Skipped due to kill at consteval compilation stage")
 def test_phi_4_token_classification_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
@@ -70,7 +72,7 @@ def test_phi_4_token_classification_pytorch(forge_property_recorder, variant):
 
     # Load tokenizer and model from HuggingFace
     framework_model = download_model(
-        PhiForTokenClassification.from_pretrained, variant, return_dict=False, use_cache=False
+        AutoModelForTokenClassification.from_pretrained, variant, return_dict=False, use_cache=False
     )
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
     framework_model.eval()
@@ -89,9 +91,7 @@ def test_phi_4_token_classification_pytorch(forge_property_recorder, variant):
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
-@pytest.mark.skip(
-    reason="Insufficient host DRAM to run this model (requires a bit more than 22 GB during compile time)"
-)
+@pytest.mark.skip(reason="Skipped due to kill at consteval compilation stage")
 def test_phi_4_sequence_classification_pytorch(forge_property_recorder, variant):
 
     # Record Forge Property
@@ -109,7 +109,7 @@ def test_phi_4_sequence_classification_pytorch(forge_property_recorder, variant)
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
     tokenizer.pad_token = tokenizer.eos_token
     framework_model = download_model(
-        PhiForTokenClassification.from_pretrained, variant, return_dict=False, use_cache=False
+        AutoModelForSequenceClassification.from_pretrained, variant, return_dict=False, use_cache=False
     )
     framework_model.eval()
 


### PR DESCRIPTION
### Problem description

- The initial implementation used a specific model class (PhiForCausalLM), which did not align with the architecture of the `microsoft/phi-4` checkpoint, leading to partially initialized weights.

### What's changed

- The above issue was resolved by switching to AutoModelForCausalLM, which dynamically selects the appropriate model class based on the checkpoint’s configuration.
- Adds test for falcon3-10B pytorch model

### Logs

- [Logs.zip](https://github.com/user-attachments/files/20096541/LOGS.zip)








