### PR TITLE
Enhance models ops tests generation

### DIFF
--- a/forge/forge/python_codegen.py
+++ b/forge/forge/python_codegen.py
@@ -13,86 +13,79 @@ from forge.tensor import forge_dataformat_to_pytorch_dtype
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 
-def forge_df_from_str(df: str, name: str, return_as_str: bool = True):
-    df = df.lower()
+def forge_df_from_str(df: Union[str, forge.DataFormat], name: str, return_as_str: bool = True):
 
-    if df == "bfp2":
-        dev_data_format = forge.DataFormat.Bfp2
-    elif df == "bfp2_b":
-        dev_data_format = forge.DataFormat.Bfp2_b
-    elif df == "bfp4":
-        dev_data_format = forge.DataFormat.Bfp4
-    elif df == "bfp4_b":
-        dev_data_format = forge.DataFormat.Bfp4_b
-    elif df == "bfp8":
-        dev_data_format = forge.DataFormat.Bfp8
-    elif df == "bfp8_b":
-        dev_data_format = forge.DataFormat.Bfp8_b
-    elif df == "float16":
-        dev_data_format = forge.DataFormat.Float16
-    elif df in ["float16_b", "bfloat16"]:
-        dev_data_format = forge.DataFormat.Float16_b
-    elif df == "float32":
-        dev_data_format = forge.DataFormat.Float32
-    elif df == "int8":
-        dev_data_format = forge.DataFormat.Int8
-    elif df == "invalid":
-        dev_data_format = forge.DataFormat.Invalid
-    elif df == "lf8":
-        dev_data_format = forge.DataFormat.Lf8
-    elif df == "raw_uint16":
-        dev_data_format = forge.DataFormat.RawUInt16
-    elif df == "raw_uint32":
-        dev_data_format = forge.DataFormat.RawUInt32
-    elif df == "raw_uint8":
-        dev_data_format = forge.DataFormat.RawUInt8
-    elif df == "uint16":
-        dev_data_format = forge.DataFormat.UInt16
-    elif df == "uint8":
-        dev_data_format = forge.DataFormat.UInt8
-    elif df == "int8":
-        dev_data_format = forge.DataFormat.Int8
-    elif df == "int32":
-        dev_data_format = forge.DataFormat.Int32
-    else:
-        logger.warning(f"Invalid data format: {df} for constant/parameter '{name}', defaulting to float32")
-        dev_data_format = forge.DataFormat.Float32
+    dtype_str_to_forge_df = {
+        "bfp2": forge.DataFormat.Bfp2,
+        "bfp2_b": forge.DataFormat.Bfp2_b,
+        "bfp4": forge.DataFormat.Bfp4,
+        "bfp4_b": forge.DataFormat.Bfp4_b,
+        "bfp8": forge.DataFormat.Bfp8,
+        "bfp8_b": forge.DataFormat.Bfp8_b,
+        "float16": forge.DataFormat.Float16,
+        "float16_b": forge.DataFormat.Float16_b,
+        "bfloat16": forge.DataFormat.Float16_b,
+        "float32": forge.DataFormat.Float32,
+        "int8": forge.DataFormat.Int8,
+        "int32": forge.DataFormat.Int32,
+        "invalid": forge.DataFormat.Invalid,
+        "lf8": forge.DataFormat.Lf8,
+        "raw_uint16": forge.DataFormat.RawUInt16,
+        "raw_uint32": forge.DataFormat.RawUInt32,
+        "raw_uint8": forge.DataFormat.RawUInt8,
+        "uint16": forge.DataFormat.UInt16,
+    }
 
-    if return_as_str:
-        return "forge." + str(dev_data_format)
+    if isinstance(df, str):
+        df = df.lower()
+        dev_data_format = dtype_str_to_forge_df.get(df, forge.DataFormat.Float32)
+        if df not in dtype_str_to_forge_df:
+            logger.warning(f"Invalid data format: {df} for constant/parameter '{name}', defaulting to float32")
+        if return_as_str:
+            dev_data_format = "forge." + str(dev_data_format)
+
+    elif isinstance(df, forge.DataFormat):
+        forge_df_to_dtype_str = {}
+        for dtype_str, forge_df in dtype_str_to_forge_df.items():
+            forge_df_to_dtype_str.setdefault(forge_df, dtype_str)
+        dev_data_format = forge_df_to_dtype_str.get(df, "float32")
+        if df not in forge_df_to_dtype_str:
+            logger.warning(f"Invalid data format: {df} for constant/parameter '{name}', defaulting to float32")
 
     return dev_data_format
 
 
-def pytorch_df_from_str(df: str, name: str, return_as_str: bool = True):
-    df = df.lower()
+def pytorch_df_from_str(df: Union[str, torch.dtype], name: str, return_as_str: bool = True):
 
-    if df == "float16":
-        torch_dtype = torch.float16
-    elif df in ["float16_b", "bfloat16"]:
-        torch_dtype = torch.bfloat16
-    elif df == "float32":
-        torch_dtype = torch.float32
-    elif df == "float64":
-        torch_dtype = torch.float64
-    elif df == "uint8":
-        torch_dtype = torch.uint8
-    elif df == "int8":
-        torch_dtype = torch.int8
-    elif df == "int32":
-        torch_dtype = torch.int32
-    elif df == "int16":
-        torch_dtype = torch.int16
-    elif df == "int64":
-        torch_dtype = torch.int64
-    elif df == "uint1":
-        torch_dtype = torch.bool
-    else:
-        logger.warning(f"Invalid data format: {df} for constant/parameter '{name}', defaulting to float32")
-        torch_dtype = torch.float32
+    dtype_str_to_torch_dtype = {
+        "float16": torch.float16,
+        "float16_b": torch.bfloat16,
+        "bfloat16": torch.bfloat16,
+        "float32": torch.float32,
+        "float64": torch.float64,
+        "uint8": torch.uint8,
+        "int8": torch.int8,
+        "int32": torch.int32,
+        "int16": torch.int16,
+        "int64": torch.int64,
+        "uint1": torch.bool,
+    }
 
-    if return_as_str:
-        return str(torch_dtype)
+    if isinstance(df, str):
+        df = df.lower()
+        torch_dtype = dtype_str_to_torch_dtype.get(df, torch.float32)
+        if df not in dtype_str_to_torch_dtype:
+            logger.warning(f"Invalid data format: {df} for constant/parameter '{name}', defaulting to float32")
+        if return_as_str:
+            torch_dtype = str(torch_dtype)
+
+    elif isinstance(df, torch.dtype):
+        torch_dtype_to_dtype_str = {}
+        for dtype_str, torch_dtype in dtype_str_to_torch_dtype.items():
+            torch_dtype_to_dtype_str.setdefault(torch_dtype, dtype_str)
+        torch_dtype = torch_dtype_to_dtype_str.get(df, "float32")
+        if df not in torch_dtype_to_dtype_str:
+            logger.warning(f"Invalid data format: {df} for constant/parameter '{name}', defaulting to float32")
 
     return torch_dtype
 
@@ -917,6 +910,7 @@ class ForgeWriter(PythonWriter):
         use_ids_function: bool = False,
         include_random_parameter_constant_gen: bool = False,
         exclude_record_property: Optional[List[str]] = None,
+        pytest_markers_with_reasons: Optional[List[List[Dict[str, Any]]]] = None,
     ):
         """
         Generates a pytest function that tests modules with input shapes and data types.
@@ -940,6 +934,7 @@ class ForgeWriter(PythonWriter):
             use_ids_function(bool): If set, the forge module name and shapes and dtyes will used as id for the pytest parameter.
             include_random_parameter_constant_gen(bool): If set, it will include the code for generating and assigning of random tensor for forge module parameters and constants
             exclude_record_property(Optional[List[str]]): A list of pytest metadata property which will be excluded in forge_property_recorder fixtures(i.e pcc)
+            pytest_markers_with_reasons(Optional[List[List[Dict[str, Any]]]]): A list of pytest markers with reason to add in the tests parameter in the forge_modules_and_shapes_dtypes_list.
         """
         self.wl("")
         self.wl("")
@@ -957,17 +952,33 @@ class ForgeWriter(PythonWriter):
         if pytest_metadata_list is None or len(pytest_metadata_list) == 0:
             pytest_metadata_list = [None] * len(pytest_input_shapes_and_dtypes_list)
             is_pytest_metadata_list_empty = True
-        for forge_module_name, pytest_input_shapes_and_dtypes, pytest_metadata in zip(
-            forge_module_names, pytest_input_shapes_and_dtypes_list, pytest_metadata_list
+        if pytest_markers_with_reasons is None:
+            pytest_markers_with_reasons = [None] * len(pytest_input_shapes_and_dtypes_list)
+        for forge_module_name, pytest_input_shapes_and_dtypes, pytest_metadata, markers_with_reasons in zip(
+            forge_module_names, pytest_input_shapes_and_dtypes_list, pytest_metadata_list, pytest_markers_with_reasons
         ):
             pytest_input_shapes_and_dtypes = [
                 (shape, pytorch_df_from_str(dtype, "", return_as_str=False))
                 for shape, dtype in pytest_input_shapes_and_dtypes
             ]
             if pytest_metadata is None:
-                self.wl(f"({forge_module_name}, {pytest_input_shapes_and_dtypes}), ")
+                test_param = f"({forge_module_name}, {pytest_input_shapes_and_dtypes})"
             else:
-                self.wl(f"({forge_module_name}, {pytest_input_shapes_and_dtypes}, {pytest_metadata}), ")
+                test_param = f"({forge_module_name}, {pytest_input_shapes_and_dtypes}, {pytest_metadata})"
+
+            if markers_with_reasons is not None:
+                marker_str_list = []
+                for marker_with_reason in markers_with_reasons:
+                    marker_str = f'pytest.mark.{marker_with_reason["maker_name"]}'
+                    marker_reason = marker_with_reason["reason"]
+                    if marker_reason is not None:
+                        marker_str += f'(reason="{marker_reason}")'
+                    marker_str_list.append(marker_str)
+                marker_str = ", ".join(marker_str_list)
+                self.wl(f"pytest.param({test_param}, marks=[{marker_str}]), ")
+            else:
+                self.wl(f"{test_param}, ")
+
         self.indent -= 1
         self.wl("]")
         if markers is not None:

--- a/forge/forge/tvm_unique_op_generation.py
+++ b/forge/forge/tvm_unique_op_generation.py
@@ -7,6 +7,7 @@ from enum import Enum
 from loguru import logger
 from typing import Any, Dict, List, Optional
 from collections.abc import MutableMapping
+from collections import Counter
 
 import torch
 import onnx
@@ -378,6 +379,8 @@ class UniqueOperations(dict):
         named_parameters: Dict[str, torch.Tensor],
         node_name_to_node_type: Optional[Dict[str, NodeType]] = None,
         use_constant_value: bool = True,
+        convert_param_and_const_to_activation: bool = False,
+        existing_unique_operations: Optional["UniqueOperations"] = None,
     ):
         """
         Creates unique operations by mapping operand and argument information to forge op names.
@@ -391,11 +394,29 @@ class UniqueOperations(dict):
         Returns:
             UniqueOperations: Populated UniqueOperations dictionary.
         """
-        unique_operations = UniqueOperations()
+        if existing_unique_operations is not None:
+            unique_operations = existing_unique_operations
+        else:
+            unique_operations = UniqueOperations()
         for nid in sorted(ops):
             forge_op_function_name = ops[nid].function_name
             operand_names = ops[nid].input_names
             operand_types = ops[nid].input_node_types
+            if convert_param_and_const_to_activation:
+                assert (
+                    node_name_to_node_type is None
+                ), "node_name_to_node_type shouldn't be provided when convert_param_and_const_to_activation is set to True"
+                # Check if all operands types are parameters or constants and change the operand type from
+                # parameters or constants to activation and pass it as activation to forge module forward function
+                all_params_const = all(
+                    [
+                        True if (operand_type == NodeType.Parameter or operand_type == NodeType.Constant) else False
+                        for operand_type in operand_types
+                    ]
+                )
+                if all_params_const:
+                    operand_types = [NodeType.Activation] * len(operand_types)
+
             if node_name_to_node_type is not None:
                 assert UniqueOperations.validate_node_types(
                     operand_names, operand_types, node_name_to_node_type
@@ -956,6 +977,7 @@ def generate_models_ops_test(unique_operations: UniqueOperations, models_ops_tes
         ].get_unique_operands_and_opargs_opmetadata()
 
         pytest_input_shapes_and_dtypes_list = []
+        pytest_markers_with_reasons = []
         forge_module_names = []
         module_idx = 0
         forge_module_list = []
@@ -968,17 +990,6 @@ def generate_models_ops_test(unique_operations: UniqueOperations, models_ops_tes
                 operand_types = operands.get_operand_types()
                 operand_dtypes = operands.get_operand_dtypes()
                 model_variant_info_list = operation_metadata["model_variant_info"]
-
-                # Check if all operands types are parameters or constants and change the operand type from
-                # parameters or constants to activation and pass it as activation to forge module forward function
-                all_params_const = all(
-                    [
-                        True if (operand_type == NodeType.Parameter or operand_type == NodeType.Constant) else False
-                        for operand_type in operand_types
-                    ]
-                )
-                if all_params_const:
-                    operand_types = [NodeType.Activation] * len(operand_types)
 
                 # Check if an existing Forge module matches the current operation configuration.
                 # This involves comparing the number of inputs, operand types, activation operand count,
@@ -1049,7 +1060,6 @@ def generate_models_ops_test(unique_operations: UniqueOperations, models_ops_tes
 
                 # If no matching Forge module was found, create a new one for the current operation configuration
                 if need_to_create_forge_module:
-
                     # Generate class name and append it forge_module_names list for using it as pytest parameter.
                     class_name = op_name + str(module_idx)
                     class_name = class_name.title().replace("_", "")
@@ -1125,24 +1135,52 @@ def generate_models_ops_test(unique_operations: UniqueOperations, models_ops_tes
                 pytest_input_shapes_and_dtypes_list.append(pytest_input_shapes_dtypes)
 
                 # A dictonary contain metadata info for the specific operation configuration which will be recorded in record_property fixture
-                pytest_metadata = {
-                    "model_names": [
-                        model_variant_info["variant_name"] for model_variant_info in model_variant_info_list
-                    ],
-                    "pcc": 0.99,
-                }
+                model_names = [model_variant_info["variant_name"] for model_variant_info in model_variant_info_list]
+                non_duplicate_model_names = list(dict.fromkeys(model_names))
+                model_names_cnt = Counter(model_names)
+                duplicate_model_names = [
+                    model_name for model_name in non_duplicate_model_names if model_names_cnt[model_name] > 1
+                ]
+                if duplicate_model_names:
+                    logger.warning(
+                        f"There are duplicate model names(i.e {duplicate_model_names}) present inside the operation_metadata"
+                    )
+                pytest_metadata = {"model_names": non_duplicate_model_names}
+                if "pcc" in operation_metadata.keys():
+                    assert (
+                        len(operation_metadata["pcc"]) == 1
+                    ), "There should be only one pcc value in operation metadata"
+                    pytest_metadata["pcc"] = operation_metadata["pcc"][0]
+                else:
+                    pytest_metadata["pcc"] = 0.99
 
                 if len(args) != 0:
                     pytest_metadata["args"] = dict(args)
 
-                if op_name == "embedding":
-                    # Calculate embedding op indicies tensor maximum value based upon the num_embeddings of the weight tensor.
-                    pytest_metadata["max_int"] = int(operand_shapes[1][0]) - 1
-                elif op_name == "advindex":
-                    # Calculate advindex op indicies tensor maximum value based upon the reference tensor along the specified dimension (default is 0).
-                    advindex_dim = args["dim"] if not args.is_empty() and "dim" in args else 0
-                    pytest_metadata["max_int"] = int(operand_shapes[0][advindex_dim]) - 1
+                if (
+                    "max_int" in operation_metadata.keys()
+                    and len(operation_metadata["max_int"]) == 1
+                    and operation_metadata["max_int"][0] is not None
+                ):
+                    pytest_metadata["max_int"] = operation_metadata["max_int"][0]
+                else:
+                    if op_name == "embedding":
+                        # Calculate embedding op indicies tensor maximum value based upon the num_embeddings of the weight tensor.
+                        pytest_metadata["max_int"] = int(operand_shapes[1][0]) - 1
+                    elif op_name == "advindex":
+                        # Calculate advindex op indicies tensor maximum value based upon the reference tensor along the specified dimension (default is 0).
+                        advindex_dim = args["dim"] if not args.is_empty() and "dim" in args else 0
+                        pytest_metadata["max_int"] = int(operand_shapes[0][advindex_dim]) - 1
 
+                markers_with_reasons = None
+                if (
+                    "markers" in operation_metadata.keys()
+                    and operation_metadata["markers"]
+                    and len(operation_metadata["markers"]) == 1
+                ):
+                    markers_with_reasons = operation_metadata["markers"][0]
+
+                pytest_markers_with_reasons.append(markers_with_reasons)
                 pytest_metadata_list.append(pytest_metadata)
 
         # List of marker that will added at the top of the test function
@@ -1164,6 +1202,7 @@ def generate_models_ops_test(unique_operations: UniqueOperations, models_ops_tes
             use_ids_function=True,
             include_random_parameter_constant_gen=True,
             exclude_record_property=exclude_record_property,
+            pytest_markers_with_reasons=pytest_markers_with_reasons,
         )
 
         writer.close_file()

--- a/scripts/model_analysis/generate_models_ops_test.py
+++ b/scripts/model_analysis/generate_models_ops_test.py
@@ -4,8 +4,12 @@
 import os
 from loguru import logger
 import argparse
-from utils import create_python_package, run_precommit, remove_directory, filter_unique_operations
-from unique_ops_utils import generate_and_export_unique_ops_tests, extract_unique_op_tests_from_models
+from utils import create_python_package, run_precommit, remove_directory, filter_unique_operations, check_path
+from unique_ops_utils import (
+    generate_and_export_unique_ops_tests,
+    extract_unique_op_tests_from_models,
+    extract_existing_unique_ops_config,
+)
 from forge.tvm_unique_op_generation import generate_models_ops_test
 
 
@@ -62,8 +66,25 @@ def main():
             "By default, every operator extracted across all the models will have tests generated."
         ),
     )
+    parser.add_argument(
+        "--override_existing_ops",
+        action="store_true",
+        help=(
+            "If set, it will extract unique ops configurations from existing generated models ops tests directory path(i.e forge/test/models_ops)"
+            "and then combine it with unique ops configuration extracted for the list of models tests specified in the tests_to_filter and then generate models ops tests"
+        ),
+    )
 
     args = parser.parse_args()
+
+    if args.override_existing_ops:
+        assert (
+            args.tests_to_filter is not None and args.tests_to_filter
+        ), "List of models tests must be provided in tests_to_filter when override_existing_ops is enabled"
+
+    models_ops_tests_directory_path = os.path.join(
+        args.models_ops_test_output_directory_path, args.models_ops_test_package_name
+    )
 
     model_output_dir_paths = generate_and_export_unique_ops_tests(
         test_directory_or_file_path=args.test_directory_or_file_path,
@@ -72,30 +93,42 @@ def main():
         tests_to_filter=args.tests_to_filter,
     )
 
-    unique_ops_config_across_all_models_ops_test_file_path = os.path.join(
-        args.unique_ops_output_directory_path, "extracted_unique_ops_config_across_all_models_ops_test.log"
+    existing_unique_ops_config = None
+    if args.override_existing_ops:
+        existing_unique_ops_config_file_path = os.path.join(
+            args.unique_ops_output_directory_path, "existing_unique_ops_config_across_all_models_ops_tests.log"
+        )
+        existing_unique_ops_config = extract_existing_unique_ops_config(
+            models_ops_tests_directory_path=models_ops_tests_directory_path,
+            existing_unique_ops_config_file_path=existing_unique_ops_config_file_path,
+            ops_to_filter=args.ops_to_filter,
+        )
+
+    unique_ops_config_file_path = os.path.join(
+        args.unique_ops_output_directory_path, "extracted_unique_ops_config_across_all_models_ops_tests.log"
     )
     unique_operations_across_all_models_ops_test = extract_unique_op_tests_from_models(
         model_output_dir_paths=model_output_dir_paths,
-        unique_ops_config_file_path=unique_ops_config_across_all_models_ops_test_file_path,
+        unique_ops_config_file_path=unique_ops_config_file_path,
         use_constant_value=False,
+        convert_param_and_const_to_activation=True,
+        existing_unique_ops_config=existing_unique_ops_config,
     )
     unique_operations_across_all_models_ops_test = filter_unique_operations(
         unique_operations=unique_operations_across_all_models_ops_test, ops_to_filter=args.ops_to_filter
     )
-    remove_directory(
-        directory_path=os.path.join(args.models_ops_test_output_directory_path, args.models_ops_test_package_name)
-    )
-    create_python_package(
-        package_path=args.models_ops_test_output_directory_path, package_name=args.models_ops_test_package_name
-    )
+    if (check_path(models_ops_tests_directory_path) and not args.override_existing_ops) or (
+        not check_path(models_ops_tests_directory_path)
+    ):
+        remove_directory(directory_path=models_ops_tests_directory_path)
+        create_python_package(
+            package_path=args.models_ops_test_output_directory_path, package_name=args.models_ops_test_package_name
+        )
     generate_models_ops_test(
         unique_operations_across_all_models_ops_test,
-        os.path.join(args.models_ops_test_output_directory_path, args.models_ops_test_package_name),
+        models_ops_tests_directory_path,
     )
-    run_precommit(
-        directory_path=os.path.join(args.models_ops_test_output_directory_path, args.models_ops_test_package_name)
-    )
+    run_precommit(directory_path=models_ops_tests_directory_path)
 
 
 if __name__ == "__main__":

--- a/scripts/model_analysis/utils.py
+++ b/scripts/model_analysis/utils.py
@@ -8,6 +8,7 @@ from enum import IntEnum
 from typing import Union, Dict, List, Tuple, Optional, Callable
 import shutil
 from git import Repo
+import ast
 
 import torch
 from forge.tvm_unique_op_generation import UniqueOperations
@@ -407,3 +408,224 @@ def filter_tests(tests: List[str], tests_to_filter: Optional[List[str]] = None) 
     filtered_tests.sort()
 
     return filtered_tests
+
+
+def extract_models_ops_test_params(pytest_file_path: str):
+    """
+    Parse a pytest file to extract test parameters for Forge modules and their operations.
+
+    For each entry in 'forge_modules_and_shapes_dtypes_list', returns a dict containing:
+      - module_name: Name of the ForgeModule subclass
+      - forge_op_name: The fully-qualified forge.op.* call string
+      - operand_names: Names of operands (variable or constant/parameter key)
+      - operand_shapes: List of tuple shapes passed to each operand
+      - operand_types: Classification: 'Activation', 'Constant', or 'Parameter'
+      - operand_dtypes: Corresponding dtype expressions or strings
+      - op_args: Keyword arguments passed to the operation call
+      - model_names: List of model names from test metadata
+      - pcc: Allowed post-conversion change threshold from metadata
+      - max_int: Maximum integer value from metadata
+      - markers: pytest.mark annotations with name and optional reason
+
+    Args:
+        pytest_file_path (str): Path to the pytest file (.py) to parse.
+
+    Returns:
+        List[dict]: Each dict contains all extracted fields for one test parameter.
+    """
+
+    # Read file content and parse into an AST for static analysis
+    with open(pytest_file_path, "r") as f:
+        file_content = f.read()
+    ast_tree = ast.parse(file_content)
+
+    # Build a mapping from class names to their AST.ClassDef nodes
+    class_defs = {node.name: node for node in ast_tree.body if isinstance(node, ast.ClassDef)}
+
+    # Pre-extract constants and parameters from each class's __init__ method
+    init_data = {}
+    for class_name, class_node in class_defs.items():
+        constants_map = {}
+        parameters_map = {}
+
+        # Locate the __init__ FunctionDef inside the class
+        for stmt in class_node.body:
+            if not (isinstance(stmt, ast.FunctionDef) and stmt.name == "__init__"):
+                continue
+            # Iterate over statements in __init__ to find add_constant / add_parameter calls
+            for init_call in stmt.body:
+                if not (isinstance(init_call, ast.Expr) and isinstance(init_call.value, ast.Call)):
+                    continue
+                call_node = init_call.value
+
+                # Handle add_constant(...) calls
+                if isinstance(call_node.func, ast.Attribute) and call_node.func.attr == "add_constant":
+                    const_name = ast.literal_eval(call_node.args[0])
+                    # Extract 'shape' keyword argument
+                    const_shape = next(
+                        (ast.literal_eval(kw.value) for kw in call_node.keywords if kw.arg == "shape"), None
+                    )
+                    # Extract 'dtype' keyword argument as source code string
+                    const_dtype = next((ast.unparse(kw.value) for kw in call_node.keywords if kw.arg == "dtype"), None)
+                    constants_map[const_name] = (const_shape, const_dtype)
+
+                # Handle add_parameter(name, forge.Parameter(*shape, dev_data_format=...))
+                elif isinstance(call_node.func, ast.Attribute) and call_node.func.attr == "add_parameter":
+                    param_name = ast.literal_eval(call_node.args[0])
+                    parameter_ctor = call_node.args[1]
+                    # Starred args hold the shape tuple
+                    param_shape = next(
+                        (ast.literal_eval(arg.value) for arg in parameter_ctor.args if isinstance(arg, ast.Starred)),
+                        None,
+                    )
+                    # Extract 'dev_data_format' keyword from Parameter constructor
+                    param_dtype = next(
+                        (ast.unparse(kw.value) for kw in parameter_ctor.keywords if kw.arg == "dev_data_format"), None
+                    )
+                    parameters_map[param_name] = (param_shape, param_dtype)
+
+        # Store extracted init data per class
+        init_data[class_name] = {
+            "constants": constants_map,
+            "parameters": parameters_map,
+        }
+
+    # List to collect extracted parameter info
+    results = []
+
+    # Find the assignment to forge_modules_and_shapes_dtypes_list
+    for node in ast_tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        for target in node.targets:
+            if not (isinstance(target, ast.Name) and target.id == "forge_modules_and_shapes_dtypes_list"):
+                continue
+
+            # node.value should be a List of tuples or pytest.param() calls
+            for list_element in node.value.elts:
+                # Collect pytest.mark decorators
+                marker_list = []
+
+                # Unwrap pytest.param(...) if used
+                if (
+                    isinstance(list_element, ast.Call)
+                    and isinstance(list_element.func, ast.Attribute)
+                    and list_element.func.attr == "param"
+                ):
+                    param_call = list_element
+                    # Extract any marks kwarg
+                    for kw in param_call.keywords:
+                        if kw.arg == "marks":
+                            mark_nodes = kw.value.elts if isinstance(kw.value, (ast.List, ast.Tuple)) else [kw.value]
+                            for mark_node in mark_nodes:
+                                # Handle mark with reason arg
+                                if isinstance(mark_node, ast.Call) and isinstance(mark_node.func, ast.Attribute):
+                                    mark_name = mark_node.func.attr
+                                    mark_reason = None
+                                    # Check for reason=...
+                                    for mk_kw in mark_node.keywords:
+                                        if mk_kw.arg == "reason":
+                                            mark_reason = ast.literal_eval(mk_kw.value)
+                                    marker_list.append(
+                                        {
+                                            "maker_name": mark_name,
+                                            "reason": mark_reason,
+                                        }
+                                    )
+                                elif isinstance(mark_node, ast.Attribute):
+                                    mark_name = mark_node.attr
+                                    marker_list.append({"maker_name": mark_name, "reason": None})
+
+                    # The test tuple is the first argument to param()
+                    param_tuple = param_call.args[0]
+                elif isinstance(list_element, ast.Tuple):
+                    param_tuple = list_element
+                else:
+                    # Skip unexpected elements
+                    continue
+
+                # Unpack the tuple: (ModuleClass, [ (shape,dtype)... ], metadata_dict)
+                module_class_name = ast.unparse(param_tuple.elts[0])
+                shapes_and_dtypes = [
+                    (ast.literal_eval(s.elts[0]), ast.unparse(s.elts[1])) for s in param_tuple.elts[1].elts
+                ]
+                metadata = ast.literal_eval(param_tuple.elts[2])
+
+                # Extract common metadata fields
+                model_names = metadata.get("model_names", [])
+                pcc_value = metadata.get("pcc", None)
+                max_int_value = metadata.get("max_int", None)
+                op_args = metadata.get("args", {})
+
+                # Locate the forward() method to find the forge.op.* call
+                class_node = class_defs.get(module_class_name)
+                op_call_node = None
+                for fn in class_node.body:
+                    if isinstance(fn, ast.FunctionDef) and fn.name == "forward":
+                        # Walk AST under forward() to find the op invocation
+                        for stmt in ast.walk(fn):
+                            if (
+                                isinstance(stmt, ast.Call)
+                                and isinstance(stmt.func, ast.Attribute)
+                                and isinstance(stmt.func.value, ast.Attribute)
+                                and isinstance(stmt.func.value.value, ast.Name)
+                                and stmt.func.value.value.id == "forge"
+                                and stmt.func.value.attr == "op"
+                            ):
+                                op_call_node = stmt
+                                break
+                        break
+
+                # Prepare to extract operand details from the op call
+                shape_iter = iter(shapes_and_dtypes)
+                operand_shapes = []
+                operand_types = []
+                operand_dtypes = []
+                operand_names = []
+                const_map = init_data[module_class_name]["constants"]
+                param_map = init_data[module_class_name]["parameters"]
+
+                for operand in op_call_node.args[1:]:
+                    # Activation inputs are plain variables
+                    if isinstance(operand, ast.Name):
+                        operand_types.append("Activation")
+                        operand_names.append(operand.id)
+                        shape, dtype = next(shape_iter)
+                        operand_shapes.append(tuple(shape))
+                        operand_dtypes.append(dtype)
+
+                    # Constants or Parameters fetched via self.get_*()
+                    elif isinstance(operand, ast.Call) and isinstance(operand.func, ast.Attribute):
+                        if operand.func.attr == "get_constant":
+                            operand_types.append("Constant")
+                            const_key = ast.literal_eval(operand.args[0])
+                            operand_names.append(const_key)
+                            shape, dtype = const_map.get(const_key, (None, None))
+                            operand_shapes.append(tuple(shape))
+                            operand_dtypes.append(dtype)
+                        elif operand.func.attr == "get_parameter":
+                            operand_types.append("Parameter")
+                            param_key = ast.literal_eval(operand.args[0])
+                            operand_names.append(param_key)
+                            shape, dtype = param_map.get(param_key, (None, None))
+                            operand_shapes.append(tuple(shape))
+                            operand_dtypes.append(dtype)
+
+                # Aggregate all extracted details
+                results.append(
+                    {
+                        "module_name": module_class_name,
+                        "forge_op_name": ast.unparse(op_call_node.func),
+                        "operand_types": operand_types,
+                        "operand_shapes": operand_shapes,
+                        "operand_dtypes": operand_dtypes,
+                        "operand_names": operand_names,
+                        "op_args": op_args,
+                        "model_names": model_names,
+                        "pcc": pcc_value,
+                        "max_int": max_int_value,
+                        "markers": marker_list,
+                    }
+                )
+
+    return results


### PR DESCRIPTION
1. Added a feature in the model analysis ops test generation to regenerate model-ops tests for list of models whose unique-ops extraction previously failed. It first parses all existing pytest files in `forge/test/models_ops`  directory path to collect each operation configuration (Module name(i.e Add1), operand names, types, shapes, dtypes, arguments, metadata and markers with reason if any). Models that failed unique ops extraction are passed via the test_to_filters list, and only those specific tests are executed to retrieve their missing unique ops configs. Finally, the newly extracted data is merged with the parsed configurations to generate additional model-ops tests—eliminating gaps without reprocessing models that already succeeded.
2. Found duplicate pytest params in the `forge_modules_and_shapes_dtypes_list` in the generated models ops tests, the duplicate is generated when all the operands is either parameter or constant, we will convert it to activation because we need to pass at atleast one activation input to forgemodule subclass. Fixed it by moving operands type conversion while extracting unique ops configuration.
3. Updated the `forge_df_from_str` and `pytorch_df_from_str` function to convert **dtype str** to **forge dataformat** and **torch dtype** and vice versa which will utilised for extracting unique ops configs from existing pytest files in `forge/test/models_ops`  directory path for converting parameter forge dataformat and activation and constant operand torch dtype to dtype str for combining the unique ops config between newly extracted and parsed configurations