### PR TITLE
Remove xfail marker in conv2d models ops test

### DIFF
--- a/forge/test/models_ops/test_conv2d.py
+++ b/forge/test/models_ops/test_conv2d.py
@@ -37404,23 +37404,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D193,
-            [((1, 3072, 1, 128), torch.float32), ((768, 768, 1, 1), torch.float32)],
-            {
-                "model_names": ["pt_squeezebert_squeezebert_squeezebert_mnli_seq_cls_hf"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[1, 1]",
-                    "padding": "[0, 0, 0, 0]",
-                    "dilation": "1",
-                    "groups": "4",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D193,
+        [((1, 3072, 1, 128), torch.float32), ((768, 768, 1, 1), torch.float32)],
+        {
+            "model_names": ["pt_squeezebert_squeezebert_squeezebert_mnli_seq_cls_hf"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "4",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     pytest.param(
         (


### PR DESCRIPTION
In the [latest nightly models ops pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/14895565090/job/41846900037), `Data mismatch between framework output and compiled model output ` issues was resolved in conv2d op test. so removed xfail markers for below test cases.

Test Case:
`forge/test/models_ops/test_conv2d.py::test_module[Conv2D193-[((1, 3072, 1, 128), torch.float32), ((768, 768, 1, 1), torch.float32)]]`