### PR TITLE
Fix model_name recording in models tests and remove swin and regnet models tests

### DIFF
--- a/forge/test/models/onnx/multimodal/oft/test_oft_onnx.py
+++ b/forge/test/models/onnx/multimodal/oft/test_oft_onnx.py
@@ -18,12 +18,12 @@ def test_oft(forge_property_recorder, tmp_path, variant):
     module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
         model="oft",
+        variant=variant.split("/")[-1],
         task=Task.CONDITIONAL_GENERATION,
         source=Source.HUGGINGFACE,
     )
     forge_property_recorder.record_group("generality")
     forge_property_recorder.record_priority("P1")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and inputs
     pipe, inputs = get_inputs(model=variant)

--- a/forge/test/models/onnx/text/bi_lstm_crf/test_bilstm_crf.py
+++ b/forge/test/models/onnx/text/bi_lstm_crf/test_bilstm_crf.py
@@ -19,7 +19,7 @@ def test_birnn_crf(forge_property_recorder, tmp_path):
 
     # Build Module Name
     module_name = forge_property_recorder.record_model_properties(
-        framework=Framework.PYTORCH,
+        framework=Framework.ONNX,
         model="BiRnnCrf",
         task=Task.TOKEN_CLASSIFICATION,
         source=Source.GITHUB,

--- a/forge/test/models/onnx/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/onnx/vision/efficientnet/test_efficientnet.py
@@ -69,7 +69,9 @@ def test_efficientnet_onnx(variant, forge_property_recorder, tmp_path):
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Compile model
-    compiled_model = forge.compile(onnx_model, inputs, forge_property_handler=forge_property_recorder)
+    compiled_model = forge.compile(
+        onnx_model, inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+    )
 
     pcc = 0.99
 

--- a/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
+++ b/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
@@ -63,7 +63,9 @@ def test_mobilenetv2_onnx(variant, forge_property_recorder, tmp_path):
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Compile model
-    compiled_model = forge.compile(onnx_model, inputs, forge_property_handler=forge_property_recorder)
+    compiled_model = forge.compile(
+        onnx_model, inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+    )
 
     pcc = 0.99
     if variant == "mobilenetv2_050":

--- a/forge/test/models/onnx/vision/sam/test_sam_onnx.py
+++ b/forge/test/models/onnx/vision/sam/test_sam_onnx.py
@@ -39,8 +39,6 @@ def test_sam_onnx(forge_property_recorder, variant, tmp_path):
     else:
         forge_property_recorder.record_group("generality")
 
-    forge_property_recorder.record_model_name(module_name)
-
     # Load  model and input
 
     framework_model, sample_inputs = get_model_inputs(variant)

--- a/forge/test/models/onnx/vision/swin/test_swin.py
+++ b/forge/test/models/onnx/vision/swin/test_swin.py
@@ -62,47 +62,6 @@ def test_swin_v2_tiny_image_classification_onnx(forge_property_recorder, variant
 @pytest.mark.nightly
 @pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
-def test_swin_v2_tiny_4_256_hf_pytorch(forge_property_recorder, variant, tmp_path):
-
-    # Record Forge Property
-    module_name = forge_property_recorder.record_model_properties(
-        framework=Framework.ONNX,
-        model="swin",
-        variant=variant,
-        source=Source.HUGGINGFACE,
-        task=Task.IMAGE_CLASSIFICATION,
-    )
-    forge_property_recorder.record_group("generality")
-
-    # Load the model
-    framework_model = Swinv2Model.from_pretrained(variant)
-    framework_model.eval()
-
-    # Prepare input data
-    feature_extractor = ViTImageProcessor.from_pretrained(variant)
-    url = "http://images.cocodataset.org/val2017/000000039769.jpg"
-    inputs = load_image(url, feature_extractor)
-
-    # Export model to ONNX
-    onnx_path = f"{tmp_path}/swin_v2_tiny_4_256.onnx"
-    torch.onnx.export(
-        framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
-    )
-
-    # Load ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
-    framework_model = forge.OnnxModule(module_name, onnx_model)
-
-    # Forge compile framework model
-    compiled_model = forge.compile(
-        onnx_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
-    )
-
-
-@pytest.mark.nightly
-@pytest.mark.xfail
-@pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
 def test_swin_v2_tiny_masked_onnx(forge_property_recorder, variant, tmp_path):
 
     # Record Forge Property

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v8.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v8.py
@@ -18,7 +18,7 @@ from forge.forge_property_utils import Framework, Source, Task
 def test_yolov8(forge_property_recorder, tmp_path):
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
-        framework=Framework.PYTORCH,
+        framework=Framework.ONNX,
         model="Yolov8",
         variant="default",
         task=Task.OBJECT_DETECTION,

--- a/forge/test/models/pytorch/multimodal/oft/test_oft.py
+++ b/forge/test/models/pytorch/multimodal/oft/test_oft.py
@@ -21,13 +21,13 @@ def test_oft(forge_property_recorder, variant):
     module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="oft",
+        variant=variant.split("/")[-1],
         task=Task.CONDITIONAL_GENERATION,
         source=Source.HUGGINGFACE,
     )
 
     forge_property_recorder.record_group("red")
     forger_proprty_recorder.record_priority("P1")
-    forge_property_recorder.record_model_name(module_name)
 
     # Load model and inputs
     pipe, inputs = get_inputs(model=variant)

--- a/forge/test/models/pytorch/text/gliner/test_gliner.py
+++ b/forge/test/models/pytorch/text/gliner/test_gliner.py
@@ -50,7 +50,7 @@ def test_gliner(forge_property_recorder, variant):
     framework_model = GlinerWrapper(model)
     framework_model.eval()
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder
+        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
+++ b/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
@@ -22,7 +22,6 @@ def test_alexnet_torchhub(forge_property_recorder):
     module_name = forge_property_recorder.record_model_properties(
         framework=Framework.PYTORCH,
         model="alexnet",
-        variant="alexnet",
         source=Source.TORCH_HUB,
         task=Task.IMAGE_CLASSIFICATION,
     )

--- a/forge/test/models/pytorch/vision/efficientnet/test_efficientnet_lite.py
+++ b/forge/test/models/pytorch/vision/efficientnet/test_efficientnet_lite.py
@@ -212,7 +212,9 @@ def test_efficientnet_lite_timm(forge_property_recorder, variant):
     framework_model, inputs = load_timm_model_and_input(variant)
 
     # Forge compile framework model
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+    )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)

--- a/forge/test/models/pytorch/vision/regnet/test_regnet.py
+++ b/forge/test/models/pytorch/vision/regnet/test_regnet.py
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-from transformers import RegNetForImageClassification, RegNetModel
+from transformers import RegNetForImageClassification
 
 import forge
 from forge.forge_property_utils import Framework, Source, Task
@@ -10,37 +10,6 @@ from forge.verify.verify import verify
 
 from test.models.pytorch.vision.regnet.utils.image_utils import preprocess_input_data
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
-
-
-@pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["facebook/regnet-y-040"])
-def test_regnet(forge_property_recorder, variant):
-    # Record Forge Property
-    module_name = forge_property_recorder.record_model_properties(
-        framework=Framework.PYTORCH,
-        model="regnet",
-        variant=variant,
-        source=Source.HUGGINGFACE,
-        task=Task.IMAGE_CLASSIFICATION,
-    )
-
-    # Record Forge Property
-    forge_property_recorder.record_group("generality")
-
-    # Load RegNet model
-    framework_model = RegNetModel.from_pretrained("facebook/regnet-y-040", return_dict=False)
-
-    # Preprocess the image
-    image_url = "http://images.cocodataset.org/val2017/000000039769.jpg"
-    inputs = preprocess_input_data(image_url, variant)
-
-    # Forge compile framework model
-    compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
-    )
-
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
 
 @pytest.mark.nightly

--- a/forge/test/models/pytorch/vision/sam/test_sam.py
+++ b/forge/test/models/pytorch/vision/sam/test_sam.py
@@ -37,8 +37,6 @@ def test_sam(forge_property_recorder, variant):
     else:
         forge_property_recorder.record_group("generality")
 
-    forge_property_recorder.record_model_name(module_name)
-
     # Load  model and input
 
     framework_model, sample_inputs = get_model_inputs(variant)

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_world.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_world.py
@@ -48,7 +48,9 @@ def test_yolo_world_inference(forge_property_recorder):
     inputs = [get_test_input()]
 
     # Compile with Forge
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+    )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)


### PR DESCRIPTION
This PR addresses two key changes in the ONNX and PyTorch model ops tests:

1. **Fixes `model_names` Property Recording**  
   - Passing `module_name=module_name`  and  `forge_property_handler=forge_property_recorder` into `forge.compile()` and `forge.verify` function for both ONNX and PyTorch model tests.
   - Correcting the Framework name and passing variant name in `record_model_properties` method

2. **Removes Redundant Model Tests: `Swinv2` and `RegNet`**  
   The following tests have been removed due to redundancy,

   - **Swinv2**
     - **Removed Test**: `test_swin_v2_tiny_4_256_hf_pytorch` (compiling `Swinv2Model`)
     - **Reason**: This test targets the base `Swinv2Model`, which is already validated through its downstream modules:
       - `Swinv2ForImageClassification`: tested in `test_swin_v2_tiny_image_classification_onnx`
       - `Swinv2ForMaskedImageModeling`: tested in `test_swin_v2_tiny_masked_onnx`  
       📄 [Reference – Swinv2Model Source](https://github.com/huggingface/transformers/blob/5d7739f15a6e50de416977fe2cc9cb516d67edda/src/transformers/models/swinv2/modeling_swinv2.py#L1281)

   - **RegNet**
     - **Removed Test**: `test_regnet` (compiling `RegNetModel`)
     - **Reason**: This base model is already validated through the `RegNetForImageClassification` module in `test_regnet_img_classification`  
       📄 [Reference – RegNetModel Source](https://github.com/huggingface/transformers/blob/5d7739f15a6e50de416977fe2cc9cb516d67edda/src/transformers/models/regnet/modeling_regnet.py#L384C1-L388C42)
