### PR TITLE
Remove skip mark from Jax ops test

### DIFF
--- a/forge/test/mlir/test_ops_jax.py
+++ b/forge/test/mlir/test_ops_jax.py
@@ -158,7 +158,6 @@ def test_multiple_layers(forge_property_recorder):
 
 
 @pytest.mark.push
-@pytest.mark.skip(reason="Conversion for ttnn::relu is missing and the maximum operation is incorrect")
 def test_mnist_linear(forge_property_recorder):
     class MNISTLinear(nn.Module):
         @nn.compact


### PR DESCRIPTION
### Ticket
N/A

### Problem description
N/A

### What's changed
Remove skip marks from JAX ops tests now that tt-mlir issue is resolved

### Checklist
- [ ] New/Existing tests provide coverage for changes
