### PR TITLE
Improve lower data formats logic: Adding less cast ops and some bug fixes

### DIFF
--- a/forge/forge/op/eval/forge/convolution.py
+++ b/forge/forge/op/eval/forge/convolution.py
@@ -59,12 +59,12 @@ class Conv2d(PyOp):
             padding,
         )
         if t_ops[1].dtype == torch.int8:
-            target_dtype = torch.int32
             padded_activations, weights = padded_activations.float(), weights.float()
             if bias is not None:
                 bias = bias.float()
+            cast_result_to_int32 = True
         else:
-            target_dtype = torch.float32
+            cast_result_to_int32 = False
 
         result = torch.nn.functional.conv2d(
             padded_activations,
@@ -79,7 +79,8 @@ class Conv2d(PyOp):
         if channel_last:
             result = result.permute((0, 2, 3, 1))
 
-        result = result.to(target_dtype)
+        if cast_result_to_int32:
+            result = result.to(torch.int32)
         return result
 
     def shape(self, tensor_shapes):
@@ -223,12 +224,12 @@ class Conv2dTranspose(PyOp):
             activations = activations.permute((0, 3, 1, 2))
 
         if t_ops[1].dtype == torch.int8:
-            target_dtype = torch.int32
             activations, weights = activations.float(), weights.float()
             if bias is not None:
                 bias = bias.float()
+            cast_result_to_int32 = True
         else:
-            target_dtype = torch.float32
+            cast_result_to_int32 = False
 
         result = torch.nn.functional.conv_transpose2d(
             activations,
@@ -243,7 +244,8 @@ class Conv2dTranspose(PyOp):
 
         if channel_last:
             result = result.permute((0, 2, 3, 1))
-        result = result.to(target_dtype)
+        if cast_result_to_int32:
+            result = result.to(torch.int32)
         return result
 
     def shape(self, tensor_shapes):

--- a/forge/forge/op/eval/forge/eltwise_binary.py
+++ b/forge/forge/op/eval/forge/eltwise_binary.py
@@ -27,12 +27,6 @@ def eval(type, attr, ops):
 
     t_ops = to_torch_operands(*ops)
 
-    if t_ops[0].dtype != t_ops[1].dtype:
-        if t_ops[0].dtype == torch.bool:
-            t_ops = (t_ops[0].type(t_ops[1].dtype), t_ops[1])
-        else:
-            t_ops = (t_ops[0], t_ops[1].type(t_ops[0].dtype))
-
     f = {
         "add": lambda i: torch.add(t_ops[0], t_ops[1]),
         "divide": lambda i: torch.divide(t_ops[0], t_ops[1]),

--- a/forge/test/mlir/operators/indexing/test_scatter_ops.py
+++ b/forge/test/mlir/operators/indexing/test_scatter_ops.py
@@ -17,7 +17,6 @@ from forge.verify.verify import verify
             torch.tensor([True, False, True, False, True, False, True, False, True, False]),  # Mask
             torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0]),  # Source tensor
             id="test_masked_scatter_1",
-            marks=pytest.mark.xfail(reason="RuntimeError: users.size() > 0"),
         ),
         # Less Number of elements in source
         pytest.param(
@@ -25,7 +24,6 @@ from forge.verify.verify import verify
             torch.tensor([True, False, True, False, True], dtype=torch.bool),  # mask shape = (5,)
             torch.tensor([10, 20, 30], dtype=torch.float32),  # source shape = (3,)
             id="test_masked_scatter_2",
-            marks=pytest.mark.xfail(reason="RuntimeError: users.size() > 0"),
         ),
         # Broadcasting: 1D input and mask with 2D source tensor
         pytest.param(
@@ -33,7 +31,6 @@ from forge.verify.verify import verify
             torch.tensor([True, False, True, False, True], dtype=torch.bool),  # mask shape = (5,)
             torch.tensor([[10], [20], [30]], dtype=torch.float32),  # source shape = (3, 1)
             id="test_masked_scatter_3",
-            marks=pytest.mark.xfail(reason="RuntimeError: users.size() > 0"),
         ),
         # 2D tensors where mask has a different shape from input tensor but can be broadcasted
         pytest.param(
@@ -41,7 +38,6 @@ from forge.verify.verify import verify
             torch.tensor([[True, False], [False, True], [True, True]], dtype=torch.bool),  # mask shape = (3, 2)
             torch.tensor([10, 20, 30, 40], dtype=torch.float32),  # source shape = (4,)
             id="test_masked_scatter_4",
-            marks=pytest.mark.xfail(reason="RuntimeError: users.size() > 0"),
         ),
         # Test with a mask of all False (nothing should be replaced)
         pytest.param(
@@ -49,7 +45,6 @@ from forge.verify.verify import verify
             torch.tensor([False, False, False, False, False], dtype=torch.bool),  # mask shape = (5,)
             torch.tensor([10, 20, 30], dtype=torch.float32),  # source shape = (3,)
             id="test_masked_scatter_5",
-            marks=pytest.mark.xfail(reason="RuntimeError: users.size() > 0"),
         ),
         # Test with a mask of all True (everything should be replaced)
         pytest.param(
@@ -57,7 +52,6 @@ from forge.verify.verify import verify
             torch.tensor([True, True, True, True, True], dtype=torch.bool),  # mask shape = (5,)
             torch.tensor([10, 20, 30, 40, 50], dtype=torch.float32),  # source shape = (5,)
             id="test_masked_scatter_6",
-            marks=pytest.mark.xfail(reason="RuntimeError: users.size() > 0"),
         ),
         pytest.param(
             torch.zeros((4, 4), dtype=torch.float32),  # 2D input tensor
@@ -71,7 +65,6 @@ from forge.verify.verify import verify
             ),
             torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]),  # Source tensor
             id="test_masked_scatter_7",
-            marks=pytest.mark.xfail(reason="RuntimeError: users.size() > 0"),
         ),
     ],
 )

--- a/forge/test/mlir/test_dataformats.py
+++ b/forge/test/mlir/test_dataformats.py
@@ -13,12 +13,89 @@ import onnx.helper
 import onnx.numpy_helper
 
 import forge
-from forge.verify.verify import verify
+from forge.verify.verify import verify, VerifyConfig
 from forge.config import CompilerConfig
 from forge._C import DataFormat
 
 
-# PyTorch test remains the same
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (2, 32, 32),
+    ],
+)
+@pytest.mark.push
+def test_add_bfloat16_pytorch(forge_property_recorder, shape):
+    class Add(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, a, b):
+            return a + b
+
+    # Generate random tensors of the appropriate shape and dtype
+    a = torch.rand(size=shape).to(torch.bfloat16)
+    b = torch.rand(size=shape).to(torch.bfloat16)
+    inputs = [a, b]
+
+    framework_model = Add()
+    framework_model = framework_model.to(torch.bfloat16)
+
+    data_format_override = DataFormat.Float16_b
+
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder, compiler_cfg=compiler_cfg
+    )
+
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        forge_property_handler=forge_property_recorder,
+    )
+
+
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (2, 32, 32),
+    ],
+)
+@pytest.mark.push
+def test_add_constant_bfloat16_pytorch(forge_property_recorder, shape):
+    class Add(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.register_buffer("constant_b", torch.rand(size=shape))
+
+        def forward(self, a):
+            return a + self.constant_b
+
+    # Generate random tensors of the appropriate shape and dtype
+    a = torch.rand(size=shape).to(torch.bfloat16)
+    inputs = [
+        a,
+    ]
+
+    framework_model = Add()
+    framework_model = framework_model.to(torch.bfloat16)
+
+    data_format_override = DataFormat.Float16_b
+
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder, compiler_cfg=compiler_cfg
+    )
+
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        forge_property_handler=forge_property_recorder,
+    )
+
+
 @pytest.mark.parametrize("shape", [(1, 3, 8, 8)])
 @pytest.mark.push
 def test_conv2d_bnorm_bfloat16_pytorch(forge_property_recorder, shape):

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v10.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v10.py
@@ -3,8 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+import torch
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -14,7 +17,6 @@ from test.models.pytorch.vision.yolo.utils.yolo_utils import (
 )
 
 
-@pytest.mark.xfail
 @pytest.mark.nightly
 def test_yolov10(forge_property_recorder):
     # Record Forge Property
@@ -32,7 +34,10 @@ def test_yolov10(forge_property_recorder):
     model, image_tensor = load_yolo_model_and_image(
         "https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov10n.pt"
     )
-    framework_model = YoloWrapper(model)
+    framework_model = YoloWrapper(model).to(torch.bfloat16)
+    image_tensor = image_tensor.to(torch.bfloat16)
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
@@ -40,6 +45,7 @@ def test_yolov10(forge_property_recorder):
         sample_inputs=[image_tensor],
         module_name=module_name,
         forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/yolo/utils/yolo_utils.py
+++ b/forge/test/models/pytorch/vision/yolo/utils/yolo_utils.py
@@ -16,7 +16,9 @@ class YoloWrapper(torch.nn.Module):
 
     def forward(self, image: torch.Tensor):
         y, x = self.model(image)
-        return (y, *x)
+        # Post processing inside model casts output to float32, even though raw output is aligned with image.dtype
+        # Therefore we need to cast it back to image.dtype
+        return (y.to(image.dtype), *x)
 
 
 def load_yolo_model_and_image(url):


### PR DESCRIPTION
### Ticket
Closes #1982 

### Problem description
Lower data format logic uses casts to ensure inputs to graph are in desired data format. However, some unnecessary casts were being added. Also, there were some bugs in logic for adding casts. Some data format bugs throughout the stack are also tackled in this PR. 


### What's changed
This PR adds:

    - [Fewer Cast Nodes] Insert a cast node on every constant node whose data format differs from the df_override.
    - [Configure Output Data Formats] Set the output data format of all nodes that need it to match df_override.
    
    Bug Fixes:
    - Improve to_torch_operands: if operands use different floating-point dtypes, cast all to the highest precision.
    - Conv2d.eval: avoid casting the output of the evaluation function to float32.
    - Eltwise Binary: remove unnecessary operand casting.
    
    Tests:
    - Add tests that reproduced the aforementioned bugs in forge/test/mlir/test_dataformats.py.
    - Enable lower data format support in YOLOv8 and YOLOv10, and remove related xfails.

This simplifies specifying lower data formats in tests.

Few side changes are also added:
- bugfix: while iterating through graph nodes and adding constants in loop, there was a segmentation fault hit. This was because we used range based loop `(for (Node* node : graph->nodes()))` where `graph->nodes()` returned a reference to vector of nodes. Inside loop we added new nodes to that vector. If that vector should be reallocated due to expanding, iterators in for loop wouldn't be valid anymore. Solution - iterate using vector size before adding any new nodes. Nodes are added to the back of the vector so this doesn't cause any problem.
