### PR TITLE
Re-enable the skipped set6 tests in CI

### DIFF
--- a/forge/test/models/pytorch/audio/whisper/test_whisper.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper.py
@@ -20,18 +20,30 @@ variants = [
         "openai/whisper-tiny",
         marks=[pytest.mark.xfail],
     ),
-    "openai/whisper-base",
-    "openai/whisper-small",
-    "openai/whisper-medium",
-    "openai/whisper-large",
+    pytest.param(
+        "openai/whisper-base",
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(
+        "openai/whisper-small",
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(
+        "openai/whisper-medium",
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(
+        "openai/whisper-large",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 21 GB during compile time)"
+        ),
+    ),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_whisper(forge_property_recorder, variant):
-    if variant != "openai/whisper-tiny":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/text/llama/test_llama3.py
+++ b/forge/test/models/pytorch/text/llama/test_llama3.py
@@ -126,11 +126,24 @@ variants = [
     pytest.param("meta-llama/Llama-3.1-8B-Instruct", marks=pytest.mark.skip(reason="Segmentation Fault")),
     pytest.param("meta-llama/Llama-3.2-1B", marks=pytest.mark.xfail),
     pytest.param("meta-llama/Llama-3.2-1B-Instruct", marks=pytest.mark.xfail),
-    pytest.param("meta-llama/Llama-3.2-3B", marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model")),
     pytest.param(
-        "meta-llama/Llama-3.2-3B-Instruct", marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model")
+        "meta-llama/Llama-3.2-3B",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 26 GB during compile time)"
+        ),
     ),
-    pytest.param("huggyllama/llama-7b", marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model")),
+    pytest.param(
+        "meta-llama/Llama-3.2-3B-Instruct",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 40 GB during compile time)"
+        ),
+    ),
+    pytest.param(
+        "huggyllama/llama-7b",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 58 GB during compile time)"
+        ),
+    ),
 ]
 
 
@@ -198,10 +211,62 @@ def test_llama3_causal_lm(forge_property_recorder, variant):
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
 
+variants = [
+    pytest.param(
+        "meta-llama/Meta-Llama-3-8B",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
+        ),
+    ),
+    pytest.param(
+        "meta-llama/Meta-Llama-3-8B-Instruct",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
+        ),
+    ),
+    pytest.param(
+        "meta-llama/Llama-3.1-8B",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
+        ),
+    ),
+    pytest.param(
+        "meta-llama/Llama-3.1-8B-Instruct",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
+        ),
+    ),
+    pytest.param(
+        "meta-llama/Llama-3.2-1B",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
+        ),
+    ),
+    pytest.param("meta-llama/Llama-3.2-1B-Instruct"),
+    pytest.param(
+        "meta-llama/Llama-3.2-3B",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 24 GB during compile time)"
+        ),
+    ),
+    pytest.param(
+        "meta-llama/Llama-3.2-3B-Instruct",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
+        ),
+    ),
+    pytest.param(
+        "huggyllama/llama-7b",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
+        ),
+    ),
+]
+
+
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_llama3_sequence_classification(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/text/opt/test_opt.py
+++ b/forge/test/models/pytorch/text/opt/test_opt.py
@@ -17,20 +17,16 @@ from forge.verify.verify import verify
 from test.utils import download_model
 
 variants = [
-    pytest.param(
-        "facebook/opt-125m",
-        marks=[pytest.mark.xfail],
-    ),
+    "facebook/opt-125m",
     "facebook/opt-350m",
     "facebook/opt-1.3b",
 ]
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_opt_causal_lm(forge_property_recorder, variant):
-    if variant != "facebook/opt-125m":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -79,9 +75,9 @@ def test_opt_causal_lm(forge_property_recorder, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_opt_qa(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -126,9 +122,9 @@ def test_opt_qa(forge_property_recorder, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_opt_sequence_classification(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
@@ -14,20 +14,46 @@ variants = [
         "Qwen/Qwen2.5-Coder-0.5B",
         marks=[pytest.mark.xfail],
     ),
-    "Qwen/Qwen2.5-Coder-1.5B",
-    "Qwen/Qwen2.5-Coder-1.5B-Instruct",
-    "Qwen/Qwen2.5-Coder-3B",
-    "Qwen/Qwen2.5-Coder-3B-Instruct",
-    "Qwen/Qwen2.5-Coder-7B",
-    "Qwen/Qwen2.5-Coder-7B-Instruct",
+    pytest.param(
+        "Qwen/Qwen2.5-Coder-1.5B",
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(
+        "Qwen/Qwen2.5-Coder-1.5B-Instruct",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 23 GB during compile time)"
+        ),
+    ),
+    pytest.param(
+        "Qwen/Qwen2.5-Coder-3B",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 25 GB during compile time)"
+        ),
+    ),
+    pytest.param(
+        "Qwen/Qwen2.5-Coder-3B-Instruct",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
+        ),
+    ),
+    pytest.param(
+        "Qwen/Qwen2.5-Coder-7B",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
+        ),
+    ),
+    pytest.param(
+        "Qwen/Qwen2.5-Coder-7B-Instruct",
+        marks=pytest.mark.skip(
+            reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
+        ),
+    ),
 ]
 
 
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_qwen_clm(forge_property_recorder, variant):
-    if variant != "Qwen/Qwen2.5-Coder-0.5B":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(


### PR DESCRIPTION
 This PR enables the following skipped test cases:

````
pt_whisper_openai_whisper_base_speech_recognition_hf - Maximum: 3368.68 MB
pt_whisper_openai_whisper_small_speech_recognition_hf - Maximum: 6606.34 MB
pt_whisper_openai_whisper_medium_speech_recognition_hf - Maximum: 16050.68 MB
pt_opt_facebook_opt_350m_clm_hf - Maximum: 5977.14 MB
pt_opt_facebook_opt_1_3b_clm_hf - Maximum: 13667.19 MB
pt_opt_facebook_opt_350m_qa_hf - Maximum: 15158.48 MB
pt_opt_facebook_opt_1_3b_qa_hf - Maximum: 13111.44 MB
pt_opt_facebook_opt_350m_seq_cls_hf - Maximum: 8698.81 MB
pt_opt_facebook_opt_1_3b_seq_cls_hf - Maximum: 13176.01 MB
pt_qwen_coder_qwen_qwen2_5_coder_1_5b_clm_hf - Maximum: 14413.74 MB
pt_llama3_meta_llama_llama_3_2_1b_instruct_seq_cls_hf - Maximum: 15246.07 MB
pt_resnext_resnext101_32x8d_wsl_img_cls_torchhub - Maximum: 2430.73 MB
pt_resnext_resnext14_32x4d_img_cls_osmr - Maximum: 2401.26 MB
pt_resnext_resnext26_32x4d_img_cls_osmr - Maximum: 2507.37 MB
pt_resnext_resnext50_32x4d_img_cls_osmr - Maximum: 2548.48 MB
pt_resnext_resnext101_64x4d_img_cls_osmr - Maximum: 2881.03 MB
````
logs:
[whisper.log](https://github.com/user-attachments/files/20217978/whisper.log)
[opt.log](https://github.com/user-attachments/files/20217982/opt.log)
[qwen_coder.log](https://github.com/user-attachments/files/20217983/qwen_coder.log)
[llama_seq_cls.log](https://github.com/user-attachments/files/20217985/llama_seq_cls.log)
[llama3_causal_lm.log](https://github.com/user-attachments/files/20224904/llama3_causal_lm.log)
[resnext.log](https://github.com/user-attachments/files/20218328/resnext.log)
