### PR TITLE
Add save function for a flatbuffer file of compiled model

### DIFF
--- a/forge/csrc/runtime/python_bindings.cpp
+++ b/forge/csrc/runtime/python_bindings.cpp
@@ -18,8 +18,11 @@ void RuntimeModule(py::module &m_runtime)
     py::class_<runtime::Binary>(m_runtime, "Binary")
         .def("get_program_inputs", &runtime::Binary::getProgramInputs)
         .def("get_program_outputs", &runtime::Binary::getProgramOutputs)
-        .def("store", &runtime::Binary::store);
+        .def("store", &runtime::Binary::store)
+        .def("get_file_identifier", &runtime::Binary::getFileIdentifier);
+
     m_runtime.def("run_program", &tt::run_program);
+    m_runtime.def("load_binary_from_file", &tt::load_binary_from_file);
 
     py::class_<Tensor>(m_runtime, "Tensor")
         .def(py::init<torch::Tensor &>())

--- a/forge/csrc/runtime/python_bindings.cpp
+++ b/forge/csrc/runtime/python_bindings.cpp
@@ -17,7 +17,8 @@ void RuntimeModule(py::module &m_runtime)
     // Main runtime APIs
     py::class_<runtime::Binary>(m_runtime, "Binary")
         .def("get_program_inputs", &runtime::Binary::getProgramInputs)
-        .def("get_program_outputs", &runtime::Binary::getProgramOutputs);
+        .def("get_program_outputs", &runtime::Binary::getProgramOutputs)
+        .def("store", &runtime::Binary::store);
     m_runtime.def("run_program", &tt::run_program);
 
     py::class_<Tensor>(m_runtime, "Tensor")

--- a/forge/csrc/runtime/python_bindings.cpp
+++ b/forge/csrc/runtime/python_bindings.cpp
@@ -18,11 +18,9 @@ void RuntimeModule(py::module &m_runtime)
     py::class_<runtime::Binary>(m_runtime, "Binary")
         .def("get_program_inputs", &runtime::Binary::getProgramInputs)
         .def("get_program_outputs", &runtime::Binary::getProgramOutputs)
-        .def("store", &runtime::Binary::store)
-        .def("get_file_identifier", &runtime::Binary::getFileIdentifier);
+        .def("store", &runtime::Binary::store);
 
     m_runtime.def("run_program", &tt::run_program);
-    m_runtime.def("load_binary_from_file", &tt::load_binary_from_file);
 
     py::class_<Tensor>(m_runtime, "Tensor")
         .def(py::init<torch::Tensor &>())

--- a/forge/csrc/runtime/runtime.hpp
+++ b/forge/csrc/runtime/runtime.hpp
@@ -12,9 +12,6 @@
 namespace tt
 {
 
-// Helper function to load the binary from the file.
-runtime::Binary load_binary_from_file(std::string const& filename);
-
 // Helper function to load the binary from the file and run a program - might be useful for testing/debugging.
 std::vector<tt::Tensor> run_program_from_file(
     std::string const& filename, int program_idx, std::vector<torch::Tensor> const& inputs);

--- a/forge/csrc/runtime/runtime.hpp
+++ b/forge/csrc/runtime/runtime.hpp
@@ -12,6 +12,9 @@
 namespace tt
 {
 
+// Helper function to load the binary from the file.
+runtime::Binary load_binary_from_file(std::string const& filename);
+
 // Helper function to load the binary from the file and run a program - might be useful for testing/debugging.
 std::vector<tt::Tensor> run_program_from_file(
     std::string const& filename, int program_idx, std::vector<torch::Tensor> const& inputs);

--- a/forge/forge/compiled_graph_state.py
+++ b/forge/forge/compiled_graph_state.py
@@ -448,6 +448,20 @@ class CompiledModel:
 
         self.gradient_outputs = []
 
+    def save(self, output_path: str) -> None:
+        """
+        Save the model to a flatbuffer file.
+
+        Parameters
+        ----------
+        output_path: str
+            Path to the file where the flatbuffer will be saved.
+        """
+        if not output_path.endswith(".ttnn"):
+            raise ValueError("The flatbuffer file must have a '.ttnn' extension.")
+        self.compiled_binary.store(output_path)
+        logger.info(f"Saved model as flatbuffer file to {output_path}")
+
     def export_to_cpp(self, export_path: str) -> None:
         """
         Export the model to a cpp file.

--- a/forge/test/test_api.py
+++ b/forge/test/test_api.py
@@ -13,7 +13,6 @@ import forge
 from forge.config import CompilerConfig, MLIRConfig
 from forge.tensor import to_forge_tensors, to_pt_tensors
 from forge.verify.value_checkers import AutomaticValueChecker
-from forge._C.runtime import load_binary_from_file
 
 
 @pytest.mark.push
@@ -114,8 +113,10 @@ def test_save_binary():
     compiled_model.save(file_path)
 
     assert os.path.exists(file_path)
-    load_bin = load_binary_from_file(file_path)
-    assert load_bin.get_file_identifier() == "TTNN"
+    with open(file_path, "rb") as f:
+        f.seek(8)
+        load_identify = f.read(4)
+    assert load_identify == b"TTNN"
     os.remove(file_path)
 
     # Must be *.ttnn extension, it causes an error if it is not


### PR DESCRIPTION
### Ticket
Closes #1788 

### Problem description
There is currently no mechanism to save the compiled FlatBuffer, making it impossible to reuse the generated data with tools such as tt-explorer and ttrt.

### What's changed
Add a mechanism to save the compiled FlatBuffer to a file from CompiledModel.

### Checklist
- [x] New/Existing tests provide coverage for changes
