### PR TITLE
Nightly Fail Inspector: use action implemented in tt-forge

### DIFF
--- a/.github/workflows/fail-inspector.yml
+++ b/.github/workflows/fail-inspector.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Perform inspection
         id: inspect
-        uses: tenstorrent/tt-forge/.github/actions/fail-inspector-inspect@nsumrak/fail-inspector-debug-2
+        uses: tenstorrent/tt-forge/.github/actions/fail-inspector-inspect@main
         with:
           workflow: "on-nightly.yml"
           token: ${{ secrets.GH_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
             FORGE_MODELS_CACHE: /mnt/dockercache/forge_models_cache
             HF_HUB_DISABLE_PROGRESS_BARS: 1
             FORGE_DISABLE_REPORTIFY_DUMP: 1
-          uses: tenstorrent/tt-forge/.github/actions/fail-inspector-test@nsumrak/fail-inspector-debug-2
+          uses: tenstorrent/tt-forge/.github/actions/fail-inspector-test@main
           with:
             runs-on: ${{ matrix.build.runs-on }}
             c: ${{ matrix.build.c }}
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find all test runs
-        uses: tenstorrent/tt-forge/.github/actions/fail-inspector-deduct@nsumrak/fail-inspector-debug-2
+        uses: tenstorrent/tt-forge/.github/actions/fail-inspector-deduct@main
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         with:

--- a/.github/workflows/fail-inspector.yml
+++ b/.github/workflows/fail-inspector.yml
@@ -166,8 +166,8 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           repo="${{ github.repository }}"
-          test_step_name="Run Tests"
-          test_job_name=" run-tests "
+          test_job_names=(" run-tests ")
+          test_step_names=("Run Test")
 
           curr_wf_id="${{ steps.success-failed.outputs.curr_wf_id }}"
           curr_wf_attempt="${{ steps.success-failed.outputs.curr_wf_attempt }}"
@@ -175,19 +175,33 @@ jobs:
 
           gh run view $curr_wf_id --attempt $curr_wf_attempt --json jobs >workflow_jobs.json
 
-          # Iterate through jobs using index and echo job name
+          # Iterate through jobs using index
           job_count=$(jq '.jobs | length' workflow_jobs.json)
           for ((i=0; i<job_count; i++)); do
             job_name=$(jq -r ".jobs[$i].name" workflow_jobs.json)
-            if [[ "$job_name" == *"$test_job_name"* ]]; then
+            job_conclusion=$(jq -r ".jobs[$i].conclusion" workflow_jobs.json)
+            if [[ "$job_conclusion" == "success" ]]; then
+                continue
+            fi
+
+            is_job_test=0
+            for test_job_name in "${test_job_names[@]}"; do
+              if [[ "$job_name" == *"$test_job_name"* ]]; then
+                is_job_test=1
+                break
+              fi
+            done
+            if [[ "$is_job_test" -eq 1 ]]; then
               echo "Job $i: $job_name"
               steps_count=$(jq ".jobs[$i].steps | length" workflow_jobs.json)
               for ((j=0; j<steps_count; j++)); do
                 step_name=$(jq -r ".jobs[$i].steps[$j].name" workflow_jobs.json)
                 step_conclusion=$(jq -r ".jobs[$i].steps[$j].conclusion" workflow_jobs.json)
-                if [[ "$step_name" == $test_step_name ]]; then
-                  break
-                fi
+                for test_step_name in "${test_step_names[@]}"; do
+                  if [[ "$step_name" == $test_step_name ]]; then
+                    break 2
+                  fi
+                done
                 if [[ "$step_conclusion" == "failure" ]]; then
                   job_id=$(jq -r ".jobs[$i].databaseId" workflow_jobs.json)
                   echo "- Failure detected in step '$step_name' before tests are run in job: [$job_name](<https://github.com/$repo/actions/runs/$curr_wf_id/job/$job_id>)" >>report.txt

--- a/.github/workflows/fail-inspector.yml
+++ b/.github/workflows/fail-inspector.yml
@@ -40,15 +40,18 @@ jobs:
           jq '[.[] | select(.conclusion == "failure" or .conclusion == "success")]' runs.json >filtered_runs.json
           mv filtered_runs.json runs.json
           echo "Extracted runs: $(cat runs.json)"
-          DATABASE_ID_1=$(jq -r '.[0].databaseId' runs.json)
-          HEAD_SHA_1=$(jq -r '.[0].headSha' runs.json)
-          DATABASE_ID_2=$(jq -r '.[1].databaseId' runs.json)
-          HEAD_SHA_2=$(jq -r '.[1].headSha' runs.json)
+          curr_wf_id=$(jq -r '.[0].databaseId' runs.json)
+          curr_head_sha=$(jq -r '.[0].headSha' runs.json)
+          prev_wf_id=$(jq -r '.[1].databaseId' runs.json)
+          prev_head_sha=$(jq -r '.[1].headSha' runs.json)
+          echo "curr_wf_id=$curr_wf_id" >> $GITHUB_OUTPUT
+          echo "curr_wf_attempt=$(jq -r '.[0].attempt' runs.json)" >> $GITHUB_OUTPUT
+
           # get list of commits between last 2 workflow runs
-          echo "Get list of commits between last $DATABASE_ID_2 and $DATABASE_ID_1 workflow runs"
+          echo "Get list of commits between last $prev_wf_id and $curr_wf_id workflow runs"
           git fetch --all
           git switch main
-          git checkout $HEAD_SHA_2
+          git checkout $prev_head_sha
           git submodule update --init --recursive
           if git show-ref --verify --quiet refs/remotes/origin/main; then
             git rev-list --reverse HEAD..origin/main >commits.txt
@@ -56,13 +59,13 @@ jobs:
             echo "ERROR: The main branch is not available in the repository."
             exit 1
           fi
-          # Remove all lines after $HEAD_SHA_1 in commits.txt
-          if ! grep -q "$HEAD_SHA_1" commits.txt; then
-            echo "WARNING: $HEAD_SHA_1 not found in commits"
+          # Remove all lines after $curr_head_sha in commits.txt
+          if ! grep -q "$curr_head_sha" commits.txt; then
+            echo "WARNING: $curr_head_sha not found in commits"
             exit 1
           else
-            echo "$HEAD_SHA_1 found in commits, setting as last commit"
-            sed -n "/$HEAD_SHA_1/ {p;q;}; p" commits.txt >filtered_commits.txt
+            echo "$curr_head_sha found in commits, setting as last commit"
+            sed -n "/$curr_head_sha/ {p;q;}; p" commits.txt >filtered_commits.txt
             mv filtered_commits.txt commits.txt
             echo "Commits: $(cat commits.txt)"
           fi
@@ -75,8 +78,8 @@ jobs:
           rm -rf log-a
           rm -rf log-b
           # get list of failed tests from the last two workflow runs
-          gh run download $DATABASE_ID_2 --pattern "test-log*" -R $repo -D log-a || true
-          gh run download $DATABASE_ID_1 --pattern "test-log*" -R $repo -D log-b
+          gh run download $prev_wf_id --pattern "test-log*" -R $repo -D log-a || true
+          gh run download $curr_wf_id --pattern "test-log*" -R $repo -D log-b
           # get machine names
           find log-a -type d -name 'test-log-*' | sed -E 's|.*/test-log-([^/-]+)-.*|\1|' | sort -u >machines-a.log
           find log-b -type d -name 'test-log-*' | sed -E 's|.*/test-log-([^/-]+)-.*|\1|' | sort -u >machines-b.log
@@ -155,6 +158,67 @@ jobs:
           name: tests-to-run
           path: tests-*.log
           if-no-files-found: ignore
+
+      # Test sanity of last failed nightly, eg. if tests are run
+      - name: Nightly sanity check
+        id: sanity-check
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        run: |
+          repo="${{ github.repository }}"
+          test_step_name="Run Tests"
+          test_job_name=" run-tests "
+
+          curr_wf_id="${{ steps.success-failed.outputs.curr_wf_id }}"
+          curr_wf_attempt="${{ steps.success-failed.outputs.curr_wf_attempt }}"
+          rm -f report.txt
+
+          gh run view $curr_wf_id --attempt $curr_wf_attempt --json jobs >workflow_jobs.json
+
+          # Iterate through jobs using index and echo job name
+          job_count=$(jq '.jobs | length' workflow_jobs.json)
+          for ((i=0; i<job_count; i++)); do
+            job_name=$(jq -r ".jobs[$i].name" workflow_jobs.json)
+            if [[ "$job_name" == *"$test_job_name"* ]]; then
+              echo "Job $i: $job_name"
+              steps_count=$(jq ".jobs[$i].steps | length" workflow_jobs.json)
+              for ((j=0; j<steps_count; j++)); do
+                step_name=$(jq -r ".jobs[$i].steps[$j].name" workflow_jobs.json)
+                step_conclusion=$(jq -r ".jobs[$i].steps[$j].conclusion" workflow_jobs.json)
+                if [[ "$step_name" == $test_step_name ]]; then
+                  break
+                fi
+                if [[ "$step_conclusion" == "failure" ]]; then
+                  job_id=$(jq -r ".jobs[$i].databaseId" workflow_jobs.json)
+                  echo "- Failure detected in step '$step_name' before tests are run in job: [$job_name](<https://github.com/$repo/actions/runs/$curr_wf_id/job/$job_id>)" >>report.txt
+                fi
+              done
+            fi
+          done
+
+          if [ ! -s report.txt ]; then
+            echo "No failed tests to report."
+            echo "send_msg=" >>$GITHUB_OUTPUT
+            exit 0
+          else
+            echo "Report: $(cat report.txt)"
+            echo "## Inspection report :rocket: for [Nightly](<https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_attempt>)" >> $GITHUB_STEP_SUMMARY
+            cat report.txt >> $GITHUB_STEP_SUMMARY
+            echo "send_msg={\"text\": \"Nightly failure caused by machine failures. Test inspection skipped.\", \"job_link\": \"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_attempt\", \"unfurl_links\": false, \"unfurl_media\": false }" >>$GITHUB_OUTPUT
+          fi
+
+      - name: Send Fail Notification
+        if: ${{ steps.sanity-check.outputs.send_msg }}
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          payload: ${{ steps.sanity-check.outputs.send_msg }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NIGHTLY_INSPECT }}
+      - name: Bad Nightly run detected
+        if: ${{ steps.sanity-check.outputs.send_msg }}
+        run: |
+          echo "Bad nightly run detected. Exiting."
+          exit 1
 
   test:
     needs: inspect

--- a/.github/workflows/fail-inspector.yml
+++ b/.github/workflows/fail-inspector.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Perform inspection
         id: inspect
-        uses: tenstorrent/tt-forge/.github/actions/fail-inspector-inspect@main
+        uses: tenstorrent/tt-forge/.github/actions/fail-inspector-inspect@nsumrak/fail-inspector-debug-2
         with:
           workflow: "on-nightly.yml"
           token: ${{ secrets.GH_TOKEN }}
@@ -89,7 +89,7 @@ jobs:
             FORGE_MODELS_CACHE: /mnt/dockercache/forge_models_cache
             HF_HUB_DISABLE_PROGRESS_BARS: 1
             FORGE_DISABLE_REPORTIFY_DUMP: 1
-          uses: tenstorrent/tt-forge/.github/actions/fail-inspector-test@main
+          uses: tenstorrent/tt-forge/.github/actions/fail-inspector-test@nsumrak/fail-inspector-debug-2
           with:
             runs-on: ${{ matrix.build.runs-on }}
             c: ${{ matrix.build.c }}
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Find all test runs
-        uses: tenstorrent/tt-forge/.github/actions/fail-inspector-deduct@main
+        uses: tenstorrent/tt-forge/.github/actions/fail-inspector-deduct@nsumrak/fail-inspector-debug-2
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         with:

--- a/.github/workflows/fail-inspector.yml
+++ b/.github/workflows/fail-inspector.yml
@@ -85,11 +85,11 @@ jobs:
           while read -r machine; do
             for dir in log-a/test-log-"$machine"-*/; do
               sed -n '/=========================== short test summary info ============================/,$p' "$dir/pytest.log" >temp.log
-              grep '^FAILED ' "temp.log" | sed 's/^FAILED //; s/\(.*\]\).*/\1/' >>a-"$machine".log
+              grep '^FAILED ' "temp.log" | sed 's/^FAILED //; s/^\(.*\) - .*/\1/; s/^\(.*\]\).*/\1/' >>a-"$machine".log
             done
             for dir in log-b/test-log-"$machine"-*/; do
               sed -n '/=========================== short test summary info ============================/,$p' "$dir/pytest.log" >temp.log
-              grep '^FAILED ' "temp.log" | sed 's/^FAILED //; s/\(.*\]\).*/\1/' >>b-"$machine".log
+              grep '^FAILED ' "temp.log" | sed 's/^FAILED //; s/^\(.*\) - .*/\1/; s/^\(.*\]\).*/\1/' >>b-"$machine".log
             done
             # get only the lines that are in b.log but not in a.log
             if [ ! -s a-"$machine".log ]; then
@@ -287,8 +287,15 @@ jobs:
             # Get commit
             no_failed_tests=$(wc -l <a.log)
             commit=$(echo "$test" | sed 's/.*-//')
-            echo "- In <https://github.com/$repo/commit/$commit|$commit> $no_failed_tests test(s) failed\n" >>short_report.txt
-            echo "- In [$commit](<https://github.com/$repo/commit/$commit>) $no_failed_tests test(s) failed:" >>report.txt
+
+            # get commit image link
+            html=$(curl -s "https://github.com/$repo/commit/$commit")
+            commitimg=$(echo "$html" | grep -oP '(?<=<meta name="twitter:image" content=")[^"]*')
+
+            # create commit/summary message
+            echo "* $no_failed_tests test(s) failed in $commit." >>short_report.txt
+            echo "  <https://github.com/$repo/commit/$commit>" >>short_report.txt
+            echo "- In commit [$commit](<https://github.com/$repo/commit/$commit>) $no_failed_tests test(s) failed: <img src=\"$commitimg\" width=\"25%\" align=\"right\"/>" >>report.txt
             sed 's/^/> /' a.log >>report.txt
           done <test_jobs.txt
 
@@ -298,12 +305,11 @@ jobs:
             exit 0
           else
             echo "Report: $(cat report.txt)"
-            echo "<https://github.com/$repo/actions/runs/$workflow_id|More details>" >>short_report.txt
             echo "## Inspection report :rocket:" >> $GITHUB_STEP_SUMMARY
             cat report.txt >> $GITHUB_STEP_SUMMARY
             # Escape special characters in the short report for JSON compatibility
             escaped_report=$(cat short_report.txt | jq -Rs .)
-            echo "send_msg={\"text\": $escaped_report}" >>$GITHUB_OUTPUT
+            echo "send_msg={\"text\": $escaped_report, \"job_link\": \"https://github.com/$repo/actions/runs/$workflow_id\", \"unfurl_links\": false, \"unfurl_media\": false }" >>$GITHUB_OUTPUT
           fi
 
       - name: Send Fail Notification

--- a/.github/workflows/fail-inspector.yml
+++ b/.github/workflows/fail-inspector.yml
@@ -13,137 +13,20 @@ jobs:
   inspect:
     runs-on: ubuntu-latest
     outputs:
-      should-test: ${{ steps.success-failed.outputs.should-test }}
-      matrix: ${{ steps.success-failed.outputs.matrix }}
+      matrix: ${{ steps.inspect.outputs.matrix }}
+      nightly_workflow_id: ${{ steps.inspect.outputs.nightly_workflow_id }}
+      nightly_attempt: ${{ steps.inspect.outputs.nightly_attempt }}
       docker-tag: ${{ steps.get-docker-tag.outputs.docker-tag }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - name: Perform inspection
+        id: inspect
+        uses: tenstorrent/tt-forge/.github/actions/fail-inspector-inspect@main
         with:
-          fetch-depth: 0
-          submodules: recursive
-      - name: Get success-failed workflow
-        id: success-failed
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          repo="${{ github.repository }}"
-          wf_name="on-nightly.yml"
-
-          # get json of the last 10 workflow runs
-          gh run list --workflow $wf_name -R $repo -b main -L 10 --status completed --json attempt,conclusion,databaseId,headSha >runs.json
-          if [ "$(jq -r '.[0].conclusion' runs.json)" != "failure" ]; then
-            echo "The latest workflow run did not fail. Exiting."
-            exit 0
-          fi
-          # Filter runs.json to include only entries where "conclusion" is "failure" or "success"
-          jq '[.[] | select(.conclusion == "failure" or .conclusion == "success")]' runs.json >filtered_runs.json
-          mv filtered_runs.json runs.json
-          echo "Extracted runs: $(cat runs.json)"
-          curr_wf_id=$(jq -r '.[0].databaseId' runs.json)
-          curr_head_sha=$(jq -r '.[0].headSha' runs.json)
-          prev_wf_id=$(jq -r '.[1].databaseId' runs.json)
-          prev_head_sha=$(jq -r '.[1].headSha' runs.json)
-          echo "curr_wf_id=$curr_wf_id" >> $GITHUB_OUTPUT
-          echo "curr_wf_attempt=$(jq -r '.[0].attempt' runs.json)" >> $GITHUB_OUTPUT
-
-          # get list of commits between last 2 workflow runs
-          echo "Get list of commits between last $prev_wf_id and $curr_wf_id workflow runs"
-          git fetch --all
-          git switch main
-          git checkout $prev_head_sha
-          git submodule update --init --recursive
-          if git show-ref --verify --quiet refs/remotes/origin/main; then
-            git rev-list --reverse HEAD..origin/main >commits.txt
-          else
-            echo "ERROR: The main branch is not available in the repository."
-            exit 1
-          fi
-          # Remove all lines after $curr_head_sha in commits.txt
-          if ! grep -q "$curr_head_sha" commits.txt; then
-            echo "WARNING: $curr_head_sha not found in commits"
-            exit 1
-          else
-            echo "$curr_head_sha found in commits, setting as last commit"
-            sed -n "/$curr_head_sha/ {p;q;}; p" commits.txt >filtered_commits.txt
-            mv filtered_commits.txt commits.txt
-            echo "Commits: $(cat commits.txt)"
-          fi
-          if [ ! -s commits.txt ]; then
-            echo "No commits found between the last two workflow runs."
-            echo "matrix=\"[]\"" >>$GITHUB_OUTPUT
-            exit 0
-          fi
-          # cleanup before processing
-          rm -rf log-a
-          rm -rf log-b
-          # get list of failed tests from the last two workflow runs
-          gh run download $prev_wf_id --pattern "test-log*" -R $repo -D log-a || true
-          gh run download $curr_wf_id --pattern "test-log*" -R $repo -D log-b
-          # get machine names
-          find log-a -type d -name 'test-log-*' | sed -E 's|.*/test-log-([^/-]+)-.*|\1|' | sort -u >machines-a.log
-          find log-b -type d -name 'test-log-*' | sed -E 's|.*/test-log-([^/-]+)-.*|\1|' | sort -u >machines-b.log
-          cat machines-a.log machines-b.log | sort -u >machines.log
-          echo "Machines: $(cat machines.log)"
-          while read -r machine; do
-            for dir in log-a/test-log-"$machine"-*/; do
-              sed -n '/=========================== short test summary info ============================/,$p' "$dir/pytest.log" >temp.log
-              grep '^FAILED ' "temp.log" | sed 's/^FAILED //; s/^\(.*\) - .*/\1/; s/^\(.*\]\).*/\1/' >>a-"$machine".log
-            done
-            for dir in log-b/test-log-"$machine"-*/; do
-              sed -n '/=========================== short test summary info ============================/,$p' "$dir/pytest.log" >temp.log
-              grep '^FAILED ' "temp.log" | sed 's/^FAILED //; s/^\(.*\) - .*/\1/; s/^\(.*\]\).*/\1/' >>b-"$machine".log
-            done
-            # get only the lines that are in b.log but not in a.log
-            if [ ! -s a-"$machine".log ]; then
-              cp b-"$machine".log tests-"$machine".log
-            fi
-            if [ ! -s b-"$machine".log ]; then
-              echo "List of failed tests for machine '$machine' is empty, nothing to do."
-            else
-              grep -Fxv -f a-"$machine".log b-"$machine".log >tests-"$machine".log
-              echo "----Tests for machine $machine: $(cat tests-"$machine".log)"
-            fi
-          done <machines.log
-          # Filter out machines with empty test logs
-          cp machines.log filtered_machines.log
-          while read -r machine; do
-            if [ ! -s tests-"$machine".log ]; then
-              echo "No failed tests for machine $machine, removing from list."
-              sed -i "/^$machine$/d" filtered_machines.log
-              rm -f tests-"$machine".log
-            fi
-          done <machines.log
-          if [ ! -s filtered_machines.log ]; then
-            echo "No new failed tests found."
-            exit 0
-          fi
-          # cleanup
-          rm -rf log-a
-          rm -rf log-b
-          rm -f a-*.log
-          rm -f b-*.log
-          rm -f machines-*.log
-          mv filtered_machines.log machines.log
-          # prepare build-test matrix
-          rm -rf matrix.log
-          c=1
-          while read -r commit; do
-            while read -r machine; do
-              echo "{\"runs-on\": \"$machine\", \"commit\": \"$commit\", \"c\": \"$c\"}," >>matrix.log
-            done <machines.log
-            c=$((c+1))
-          done <commits.txt
-          # Remove trailing comma on the last line of matrix.log
-          sed -i '$ s/,$//' matrix.log
-          # Combine all lines in matrix.log into a single line
-          tr -d '\n' <matrix.log >matrix_single_line.log
-          mv matrix_single_line.log matrix.log
-          echo "Extracted matrix: $(cat matrix.log)"
-          echo "matrix=[$(cat matrix.log)]" >>$GITHUB_OUTPUT
-          rm -f matrix.log
-          # set should-build to true
-          echo "should-test=true" >>$GITHUB_OUTPUT
+          workflow: "on-nightly.yml"
+          token: ${{ secrets.GH_TOKEN }}
+          slack_webhook_url: ${{ secrets.SLACK_NIGHTLY_INSPECT }}
+          test_job_names: " run-tests "
+          test_step_names: "Run Test"
 
       - name: Get docker tag
         id: get-docker-tag
@@ -152,91 +35,8 @@ jobs:
           echo "docker-tag=$dt" >> "$GITHUB_OUTPUT"
           echo "Docker tag: $dt"
 
-      - name: Upload tests.log as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: tests-to-run
-          path: tests-*.log
-          if-no-files-found: ignore
-
-      # Test sanity of last failed nightly, eg. if tests are run
-      - name: Nightly sanity check
-        id: sanity-check
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          repo="${{ github.repository }}"
-          test_job_names=(" run-tests ")
-          test_step_names=("Run Test")
-
-          curr_wf_id="${{ steps.success-failed.outputs.curr_wf_id }}"
-          curr_wf_attempt="${{ steps.success-failed.outputs.curr_wf_attempt }}"
-          rm -f report.txt
-
-          gh run view $curr_wf_id --attempt $curr_wf_attempt --json jobs >workflow_jobs.json
-
-          # Iterate through jobs using index
-          job_count=$(jq '.jobs | length' workflow_jobs.json)
-          for ((i=0; i<job_count; i++)); do
-            job_name=$(jq -r ".jobs[$i].name" workflow_jobs.json)
-            job_conclusion=$(jq -r ".jobs[$i].conclusion" workflow_jobs.json)
-            if [[ "$job_conclusion" == "success" ]]; then
-                continue
-            fi
-
-            is_job_test=0
-            for test_job_name in "${test_job_names[@]}"; do
-              if [[ "$job_name" == *"$test_job_name"* ]]; then
-                is_job_test=1
-                break
-              fi
-            done
-            if [[ "$is_job_test" -eq 1 ]]; then
-              echo "Job $i: $job_name"
-              steps_count=$(jq ".jobs[$i].steps | length" workflow_jobs.json)
-              for ((j=0; j<steps_count; j++)); do
-                step_name=$(jq -r ".jobs[$i].steps[$j].name" workflow_jobs.json)
-                step_conclusion=$(jq -r ".jobs[$i].steps[$j].conclusion" workflow_jobs.json)
-                for test_step_name in "${test_step_names[@]}"; do
-                  if [[ "$step_name" == $test_step_name ]]; then
-                    break 2
-                  fi
-                done
-                if [[ "$step_conclusion" == "failure" ]]; then
-                  job_id=$(jq -r ".jobs[$i].databaseId" workflow_jobs.json)
-                  echo "- Failure detected in step '$step_name' before tests are run in job: [$job_name](<https://github.com/$repo/actions/runs/$curr_wf_id/job/$job_id>)" >>report.txt
-                fi
-              done
-            fi
-          done
-
-          if [ ! -s report.txt ]; then
-            echo "No failed tests to report."
-            echo "send_msg=" >>$GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Report: $(cat report.txt)"
-            echo "## Inspection report :rocket: for [Nightly](<https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_attempt>)" >> $GITHUB_STEP_SUMMARY
-            cat report.txt >> $GITHUB_STEP_SUMMARY
-            echo "send_msg={\"text\": \"Nightly failure caused by machine failures. Test inspection skipped.\", \"job_link\": \"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_attempt\", \"unfurl_links\": false, \"unfurl_media\": false }" >>$GITHUB_OUTPUT
-          fi
-
-      - name: Send Fail Notification
-        if: ${{ steps.sanity-check.outputs.send_msg }}
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: ${{ steps.sanity-check.outputs.send_msg }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NIGHTLY_INSPECT }}
-      - name: Bad Nightly run detected
-        if: ${{ steps.sanity-check.outputs.send_msg }}
-        run: |
-          echo "Bad nightly run detected. Exiting."
-          exit 1
-
   test:
     needs: inspect
-    if: ${{ needs.inspect.outputs.should-test }}
     strategy:
       fail-fast: false
       matrix:
@@ -282,11 +82,6 @@ jobs:
             pip install tvm*.whl --force-reinstall
             pip install forge*.whl --force-reinstall
 
-        - name: Download tests.log
-          uses: actions/download-artifact@v4
-          with:
-            name: tests-to-run
-
         - name: Run Test
           env:
             HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -294,106 +89,23 @@ jobs:
             FORGE_MODELS_CACHE: /mnt/dockercache/forge_models_cache
             HF_HUB_DISABLE_PROGRESS_BARS: 1
             FORGE_DISABLE_REPORTIFY_DUMP: 1
-          shell: bash
-          run: |
-            source env/activate
-            echo "import pytest" >runtest.py
-            echo "import sys" >>runtest.py
-            echo "if __name__ == \"__main__\":" >>runtest.py
-            echo "    with open(sys.argv[1], \"r\") as fd:" >>runtest.py
-            echo "        test_list = [line.strip() for line in fd.readlines()]" >>runtest.py
-            echo "    print(f\"Running tests: {test_list}\")" >>runtest.py
-            echo "    sys.exit(pytest.main(test_list))" >>runtest.py
-            python runtest.py tests-${{matrix.build.runs-on}}.log 2>&1 | tee pytest.log
-
-        - name: Upload Test Log
-          uses: actions/upload-artifact@v4
-          if: failure()
+          uses: tenstorrent/tt-forge/.github/actions/fail-inspector-test@main
           with:
-            name: test-log-${{ matrix.build.runs-on }}-${{ matrix.build.c }}-${{ matrix.build.commit }}
-            path: pytest.log
+            runs-on: ${{ matrix.build.runs-on }}
+            c: ${{ matrix.build.c }}
+            commit: ${{ matrix.build.commit }}
 
   deduct:
-    needs: test
+    needs: [ inspect, test ]
     if: failure()
     runs-on: ubuntu-latest
     steps:
       - name: Find all test runs
-        id: do-deduct
+        uses: tenstorrent/tt-forge/.github/actions/fail-inspector-deduct@main
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          workflow_id="${{ github.run_id }}"
-          repo="${{ github.repository }}"
-          rm -f report.txt
-          rm -f short_report.txt
-          rm -f pytest.log
-          rm -rf mach
-          gh run download $workflow_id --name "tests-to-run" -R $repo -D mach
-          cat mach/* >pytest.log
-          rm -rf mach
-          gh run view -R $repo $workflow_id --json jobs -q '.jobs[] | select(.name | startswith("Test")) | .name' >test_jobs.txt
-          sed -i 's/^Test //' test_jobs.txt
-          echo "Extracted test jobs: $(cat test_jobs.txt)"
-          set +e
-            while read -r test; do
-            rm -f a.log
-            rm -rf log
-            touch a.log
-            echo "Processing test job $test"
-            gh run download $workflow_id --pattern "test-log-${test}*" -R $repo -D log
-            if [ $? -ne 0 ]; then
-              echo "Could not download log for test job $test."
-              continue
-            fi
-            for dir in log/test-log-*/; do
-              grep '^FAILED ' "$dir/pytest.log" | sed 's/^FAILED //' >>a.log
-            done
-            # Remove all of tests that doesn't exist in initial list of tests (failed in previous jobs)
-            grep -Fx -f pytest.log a.log >f_a.log
-            mv f_a.log a.log
-            if [ ! -s a.log ]; then
-              echo "No failed tests found for test job $test."
-              continue
-            fi
-            echo "Failed tests for test job $test:"
-            cat a.log
-            # Remove all of failed tests from initial list of tests
-            grep -Fxv -f a.log pytest.log >filtered_pytest.log
-            mv filtered_pytest.log pytest.log
-
-            # Get commit
-            no_failed_tests=$(wc -l <a.log)
-            commit=$(echo "$test" | sed 's/.*-//')
-
-            # get commit image link
-            html=$(curl -s "https://github.com/$repo/commit/$commit")
-            commitimg=$(echo "$html" | grep -oP '(?<=<meta name="twitter:image" content=")[^"]*')
-
-            # create commit/summary message
-            echo "* $no_failed_tests test(s) failed in $commit." >>short_report.txt
-            echo "  <https://github.com/$repo/commit/$commit>" >>short_report.txt
-            echo "- In commit [$commit](<https://github.com/$repo/commit/$commit>) $no_failed_tests test(s) failed: <img src=\"$commitimg\" width=\"25%\" align=\"right\"/>" >>report.txt
-            sed 's/^/> /' a.log >>report.txt
-          done <test_jobs.txt
-
-          if [ ! -s report.txt ]; then
-            echo "No failed tests to report."
-            echo "send_msg=" >>$GITHUB_OUTPUT
-            exit 0
-          else
-            echo "Report: $(cat report.txt)"
-            echo "## Inspection report :rocket:" >> $GITHUB_STEP_SUMMARY
-            cat report.txt >> $GITHUB_STEP_SUMMARY
-            # Escape special characters in the short report for JSON compatibility
-            escaped_report=$(cat short_report.txt | jq -Rs .)
-            echo "send_msg={\"text\": $escaped_report, \"job_link\": \"https://github.com/$repo/actions/runs/$workflow_id\", \"unfurl_links\": false, \"unfurl_media\": false }" >>$GITHUB_OUTPUT
-          fi
-
-      - name: Send Fail Notification
-        if: ${{ steps.do-deduct.outputs.send_msg }}
-        uses: slackapi/slack-github-action@v1.26.0
         with:
-          payload: ${{ steps.do-deduct.outputs.send_msg }}
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NIGHTLY_INSPECT }}
+          token: ${{ secrets.GH_TOKEN }}
+          slack_webhook_url: ${{ secrets.SLACK_NIGHTLY_INSPECT }}
+          nightly_workflow_id: ${{ needs.inspect.outputs.nightly_workflow_id }}
+          nightly_attempt: ${{ needs.inspect.outputs.nightly_attempt }}


### PR DESCRIPTION
### Ticket
slack

### Problem description
Slack message send by nighty failure inspector is badly formatted.
Machine (non-test) failures are ignored.

### What's changed
Suppress link preview in message (if slack obeys)
Short slack message with better formatting (best it supports)
Slack message button "More details" linking to job summary
Better job summary report with images
Detect machine (non-test) failures and send appropriate report (skip test bisect).
Nightly Fail Inspector uses actions implemented in tt-forge

### Checklist
- [ ] New/Existing tests provide coverage for changes
