### PR TITLE
Remove xfail markers from cast and where models ops tests

### DIFF
--- a/forge/test/models_ops/test_cast.py
+++ b/forge/test/models_ops/test_cast.py
@@ -142,29 +142,20 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 11), torch.bool)],
         {"model_names": ["pd_roberta_rbt4_ch_clm_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.int32"}},
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 11), torch.bool)],
-            {"model_names": ["pd_roberta_rbt4_ch_clm_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.float32"}},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((1, 11), torch.bool)],
+        {"model_names": ["pd_roberta_rbt4_ch_clm_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.float32"}},
     ),
-    pytest.param(
-        (
-            Cast3,
-            [((1, 11), torch.int64)],
-            {"model_names": ["pd_roberta_rbt4_ch_clm_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.bool"}},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast3,
+        [((1, 11), torch.int64)],
+        {"model_names": ["pd_roberta_rbt4_ch_clm_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.bool"}},
     ),
-    pytest.param(
-        (
-            Cast3,
-            [((1, 11), torch.int32)],
-            {"model_names": ["pd_roberta_rbt4_ch_clm_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.bool"}},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast3,
+        [((1, 11), torch.int32)],
+        {"model_names": ["pd_roberta_rbt4_ch_clm_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.bool"}},
     ),
     (
         Cast1,
@@ -176,29 +167,20 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 9), torch.bool)],
         {"model_names": ["pd_roberta_rbt4_ch_seq_cls_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.int32"}},
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 9), torch.bool)],
-            {"model_names": ["pd_roberta_rbt4_ch_seq_cls_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.float32"}},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((1, 9), torch.bool)],
+        {"model_names": ["pd_roberta_rbt4_ch_seq_cls_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.float32"}},
     ),
-    pytest.param(
-        (
-            Cast3,
-            [((1, 9), torch.int64)],
-            {"model_names": ["pd_roberta_rbt4_ch_seq_cls_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.bool"}},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast3,
+        [((1, 9), torch.int64)],
+        {"model_names": ["pd_roberta_rbt4_ch_seq_cls_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.bool"}},
     ),
-    pytest.param(
-        (
-            Cast3,
-            [((1, 9), torch.int32)],
-            {"model_names": ["pd_roberta_rbt4_ch_seq_cls_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.bool"}},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast3,
+        [((1, 9), torch.int32)],
+        {"model_names": ["pd_roberta_rbt4_ch_seq_cls_padlenlp"], "pcc": 0.99, "args": {"dtype": "torch.bool"}},
     ),
     (
         Cast0,
@@ -224,20 +206,17 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"dtype": "torch.float32"},
         },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((2, 1, 1, 13), torch.bool)],
-            {
-                "model_names": [
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((2, 1, 1, 13), torch.bool)],
+        {
+            "model_names": [
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+            ],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.float32"},
+        },
     ),
     (
         Cast0,
@@ -248,29 +227,23 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"dtype": "torch.float32"},
         },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((2, 1, 7, 7), torch.bool)],
-            {
-                "model_names": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((2, 1, 7, 7), torch.bool)],
+        {
+            "model_names": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.float32"},
+        },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 596, 4096), torch.bool)],
-            {
-                "model_names": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((1, 596, 4096), torch.bool)],
+        {
+            "model_names": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.float32"},
+        },
     ),
     (
         Cast3,
@@ -340,35 +313,32 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"dtype": "torch.float32"},
         },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 1, 256, 256), torch.bool)],
-            {
-                "model_names": [
-                    "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
-                    "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_3b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                    "pt_phi2_microsoft_phi_2_clm_hf",
-                    "pt_phi2_microsoft_phi_2_pytdml_clm_hf",
-                    "pt_phi3_microsoft_phi_3_mini_4k_instruct_clm_hf",
-                    "pt_phi3_5_microsoft_phi_3_5_mini_instruct_clm_hf",
-                    "pt_xglm_facebook_xglm_564m_clm_hf",
-                    "pt_xglm_facebook_xglm_1_7b_clm_hf",
-                ],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((1, 1, 256, 256), torch.bool)],
+        {
+            "model_names": [
+                "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
+                "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_3b_instruct_clm_hf",
+                "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+                "pt_phi2_microsoft_phi_2_clm_hf",
+                "pt_phi2_microsoft_phi_2_pytdml_clm_hf",
+                "pt_phi3_microsoft_phi_3_mini_4k_instruct_clm_hf",
+                "pt_phi3_5_microsoft_phi_3_5_mini_instruct_clm_hf",
+                "pt_xglm_facebook_xglm_564m_clm_hf",
+                "pt_xglm_facebook_xglm_1_7b_clm_hf",
+            ],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.float32"},
+        },
     ),
     (
         Cast3,
@@ -409,22 +379,19 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 1, 32), torch.int64)],
         {"model_names": ["pt_bloom_bigscience_bloom_1b1_clm_hf"], "pcc": 0.99, "args": {"dtype": "torch.float32"}},
     ),
-    pytest.param(
-        (
-            Cast3,
-            [((1, 128), torch.int64)],
-            {
-                "model_names": [
-                    "pt_distilbert_distilbert_base_uncased_mlm_hf",
-                    "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
-                    "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
-                    "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
-                ],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.bool"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast3,
+        [((1, 128), torch.int64)],
+        {
+            "model_names": [
+                "pt_distilbert_distilbert_base_uncased_mlm_hf",
+                "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
+                "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
+                "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
+            ],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.bool"},
+        },
     ),
     (
         Cast2,
@@ -442,22 +409,19 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"dtype": "torch.int32"},
         },
     ),
-    pytest.param(
-        (
-            Cast3,
-            [((1, 128), torch.int32)],
-            {
-                "model_names": [
-                    "pt_distilbert_distilbert_base_uncased_mlm_hf",
-                    "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
-                    "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
-                    "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
-                ],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.bool"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast3,
+        [((1, 128), torch.int32)],
+        {
+            "model_names": [
+                "pt_distilbert_distilbert_base_uncased_mlm_hf",
+                "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
+                "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
+                "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
+            ],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.bool"},
+        },
     ),
     (
         Cast1,
@@ -471,34 +435,28 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"dtype": "torch.int64"},
         },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 12, 128, 128), torch.bool)],
-            {
-                "model_names": [
-                    "pt_distilbert_distilbert_base_uncased_mlm_hf",
-                    "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
-                    "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
-                    "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
-                ],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((1, 12, 128, 128), torch.bool)],
+        {
+            "model_names": [
+                "pt_distilbert_distilbert_base_uncased_mlm_hf",
+                "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
+                "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
+                "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
+            ],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.float32"},
+        },
     ),
-    pytest.param(
-        (
-            Cast3,
-            [((1, 384), torch.int64)],
-            {
-                "model_names": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.bool"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast3,
+        [((1, 384), torch.int64)],
+        {
+            "model_names": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.bool"},
+        },
     ),
     (
         Cast2,
@@ -509,29 +467,23 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"dtype": "torch.int32"},
         },
     ),
-    pytest.param(
-        (
-            Cast3,
-            [((1, 384), torch.int32)],
-            {
-                "model_names": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.bool"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast3,
+        [((1, 384), torch.int32)],
+        {
+            "model_names": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.bool"},
+        },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 12, 384, 384), torch.bool)],
-            {
-                "model_names": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((1, 12, 384, 384), torch.bool)],
+        {
+            "model_names": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.float32"},
+        },
     ),
     (
         Cast3,
@@ -603,26 +555,23 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"dtype": "torch.int32"},
         },
     ),
-    pytest.param(
-        (
-            Cast0,
-            [((1, 1, 32, 32), torch.bool)],
-            {
-                "model_names": [
-                    "pt_llama3_huggyllama_llama_7b_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_3b_clm_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                ],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.float32"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast0,
+        [((1, 1, 32, 32), torch.bool)],
+        {
+            "model_names": [
+                "pt_llama3_huggyllama_llama_7b_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_3b_clm_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+            ],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.float32"},
+        },
     ),
     (
         Cast3,
@@ -633,38 +582,29 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"dtype": "torch.bool"},
         },
     ),
-    pytest.param(
-        (
-            Cast3,
-            [((1, 1, 32, 32), torch.int32)],
-            {
-                "model_names": ["pt_llama3_huggyllama_llama_7b_clm_hf", "pt_llama3_meta_llama_llama_3_2_3b_clm_hf"],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.bool"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast3,
+        [((1, 1, 32, 32), torch.int32)],
+        {
+            "model_names": ["pt_llama3_huggyllama_llama_7b_clm_hf", "pt_llama3_meta_llama_llama_3_2_3b_clm_hf"],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.bool"},
+        },
     ),
-    pytest.param(
-        (
-            Cast3,
-            [((1, 4), torch.int64)],
-            {"model_names": ["pt_llama3_huggyllama_llama_7b_seq_cls_hf"], "pcc": 0.99, "args": {"dtype": "torch.bool"}},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast3,
+        [((1, 4), torch.int64)],
+        {"model_names": ["pt_llama3_huggyllama_llama_7b_seq_cls_hf"], "pcc": 0.99, "args": {"dtype": "torch.bool"}},
     ),
     (
         Cast2,
         [((1, 4), torch.bool)],
         {"model_names": ["pt_llama3_huggyllama_llama_7b_seq_cls_hf"], "pcc": 0.99, "args": {"dtype": "torch.int32"}},
     ),
-    pytest.param(
-        (
-            Cast3,
-            [((1, 4), torch.int32)],
-            {"model_names": ["pt_llama3_huggyllama_llama_7b_seq_cls_hf"], "pcc": 0.99, "args": {"dtype": "torch.bool"}},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast3,
+        [((1, 4), torch.int32)],
+        {"model_names": ["pt_llama3_huggyllama_llama_7b_seq_cls_hf"], "pcc": 0.99, "args": {"dtype": "torch.bool"}},
     ),
     (
         Cast3,
@@ -686,28 +626,25 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"dtype": "torch.bool"},
         },
     ),
-    pytest.param(
-        (
-            Cast3,
-            [((1, 1, 256, 256), torch.int32)],
-            {
-                "model_names": [
-                    "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_3b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
-                    "pt_phi2_microsoft_phi_2_clm_hf",
-                    "pt_phi2_microsoft_phi_2_pytdml_clm_hf",
-                    "pt_phi3_microsoft_phi_3_mini_4k_instruct_clm_hf",
-                ],
-                "pcc": 0.99,
-                "args": {"dtype": "torch.bool"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Cast3,
+        [((1, 1, 256, 256), torch.int32)],
+        {
+            "model_names": [
+                "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_3b_instruct_clm_hf",
+                "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
+                "pt_phi2_microsoft_phi_2_clm_hf",
+                "pt_phi2_microsoft_phi_2_pytdml_clm_hf",
+                "pt_phi3_microsoft_phi_3_mini_4k_instruct_clm_hf",
+            ],
+            "pcc": 0.99,
+            "args": {"dtype": "torch.bool"},
+        },
     ),
     (
         Cast0,

--- a/forge/test/models_ops/test_where.py
+++ b/forge/test/models_ops/test_where.py
@@ -300,20 +300,17 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
     ),
-    pytest.param(
-        (
-            Where2,
-            [((1, 1, 32, 32), torch.bool)],
-            {
-                "model_names": [
-                    "pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="AssertionError: PCC is nan, but tensors are not equal")],
+    (
+        Where2,
+        [((1, 1, 32, 32), torch.bool)],
+        {
+            "model_names": [
+                "pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf",
+                "pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf",
+                "pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     pytest.param(
         (


### PR DESCRIPTION
In the [latest models ops nightly pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/14985048674/job/42129583566), **Data mismatch between framework output and compiled model output** issues was resolved in **cast** op tests and `AssertionError: PCC is nan, but tensors are not equal `issue was resolved in the **where** op tests. so removed xfail markers for below test cases. 

Test Cases:
```
forge/test/models_ops/test_cast.py::test_module[Cast0-[((1, 11), torch.bool)]]
forge/test/models_ops/test_cast.py::test_module[Cast3-[((1, 4), torch.int64)]]
forge/test/models_ops/test_cast.py::test_module[Cast3-[((1, 11), torch.int32)]]
forge/test/models_ops/test_cast.py::test_module[Cast3-[((1, 9), torch.int32)]]
forge/test/models_ops/test_cast.py::test_module[Cast0-[((1, 12, 128, 128), torch.bool)]]
forge/test/models_ops/test_where.py::test_module[Where2-[((1, 1, 32, 32), torch.bool)]]
forge/test/models_ops/test_cast.py::test_module[Cast3-[((1, 11), torch.int64)]]
forge/test/models_ops/test_cast.py::test_module[Cast3-[((1, 9), torch.int64)]]
forge/test/models_ops/test_cast.py::test_module[Cast0-[((1, 12, 384, 384), torch.bool)]]
forge/test/models_ops/test_cast.py::test_module[Cast0-[((1, 596, 4096), torch.bool)]]
forge/test/models_ops/test_cast.py::test_module[Cast3-[((1, 128), torch.int32)]]
forge/test/models_ops/test_cast.py::test_module[Cast0-[((1, 9), torch.bool)]]
forge/test/models_ops/test_cast.py::test_module[Cast3-[((1, 128), torch.int64)]]
forge/test/models_ops/test_cast.py::test_module[Cast0-[((2, 1, 1, 13), torch.bool)]]
forge/test/models_ops/test_cast.py::test_module[Cast0-[((1, 1, 256, 256), torch.bool)]]
forge/test/models_ops/test_cast.py::test_module[Cast3-[((1, 1, 256, 256), torch.int32)]]
forge/test/models_ops/test_cast.py::test_module[Cast0-[((2, 1, 7, 7), torch.bool)]]
forge/test/models_ops/test_cast.py::test_module[Cast3-[((1, 384), torch.int32)]]
forge/test/models_ops/test_cast.py::test_module[Cast3-[((1, 384), torch.int64)]]
forge/test/models_ops/test_cast.py::test_module[Cast0-[((1, 1, 32, 32), torch.bool)]]
forge/test/models_ops/test_cast.py::test_module[Cast3-[((1, 1, 32, 32), torch.int32)]]
forge/test/models_ops/test_cast.py::test_module[Cast3-[((1, 4), torch.int32)]]
```


Generated models ops tests reports: 
[model_ops_tests_report.xlsx](https://github.com/user-attachments/files/20188544/model_ops_tests_report.xlsx)
