### PR TITLE
Record refined_error_message and failure_category forge property for all failed tests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -64,11 +64,8 @@ def forge_property_recorder(request, record_property):
         # Retrieve any refined error message that might have been set during the test execution
         refined_error_message = getattr(request.node, "refined_error_message", None)
 
-        # Check if:
-        # 1. The refined error message exists.
-        # 2. The handler is configured to record single operation details (record_single_op_details flag is True).
-        # If either of these checks fail, exit without further recording.
-        if refined_error_message is None or not forge_property_handler.record_single_op_details:
+        # If refined error message doesn't exists, exit without further recording.
+        if refined_error_message is None:
             return
 
         # Record the refined error message in the handler's property store.

--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -674,23 +674,21 @@ class ForgePropertyHandler:
 
     def record_refined_error_message(self, refined_error_message: str):
         """
-        Records the refined error message in the tags if single op details recording is enabled.
+        Records the refined error message in the tags.
 
         Args:
             refined_error_message (str): The refined error message string.
         """
-        if self.record_single_op_details:
-            self.add("tags.refined_error_message", refined_error_message)
+        self.add("tags.refined_error_message", refined_error_message)
 
     def record_failure_category(self, failure_category: str):
         """
-        Records the failure category in the tags if single op details recording is enabled.
+        Records the failure category in the tags.
 
         Args:
             failure_category (str): The failure category string.
         """
-        if self.record_single_op_details:
-            self.add("tags.failure_category", failure_category)
+        self.add("tags.failure_category", failure_category)
 
     def to_dict(self):
         """


### PR DESCRIPTION
Currently we are recording `refined_error_message` and `failure_category` forge property for **nightly models ops tests** present in the `forge/test/models_ops` directory path.
Extending the refined_error_message and failure_category property recording for the all the pytest present in the tt-forge-fe repository. 
The refined_error_message property contain latest error message for both standard failing tests and tests expected to fail (xfailed) and failure_category property is extracted from the refined_error_message which will used for grouping failure in superset.


Tested it for xfailed models tests and below is test cases and generated xml report,

`pytest forge/test/models/pytorch/text/bart/test_bart.py::test_pt_bart_classifier -vss --junit-xml=report.xml`

[report.xml.zip](https://github.com/user-attachments/files/20189636/report.xml.zip)

