### PR TITLE
Set pretrained to False for ese_vovnet99b model variant

### DIFF
--- a/forge/test/models/pytorch/vision/vovnet/utils/model_utils.py
+++ b/forge/test/models/pytorch/vision/vovnet/utils/model_utils.py
@@ -55,7 +55,10 @@ def preprocess_steps(model_type):
 
 
 def preprocess_timm_model(model_name):
-    model = timm.create_model(model_name, pretrained=True)
+    use_pretrained_weights = True
+    if model_name == "ese_vovnet99b":
+        use_pretrained_weights = False
+    model = timm.create_model(model_name, pretrained=use_pretrained_weights)
     model.eval()
     config = resolve_data_config({}, model=model)
     transform = create_transform(**config)


### PR DESCRIPTION
The vovnet model variant(i.e `ese_vovnet99b`) present in the PyTorch framework was failing with `RuntimeError: No pretrained weights exist for ese_vovnet99b. Use `pretrained=False` for random init.` while generating models ops tests because there is no pretrained weights for the ese_vovnet99b variant(i.e [Reference](https://github.com/huggingface/pytorch-image-models/blob/072783331f42dd320e3c6fe890a5c197fc21958f/timm/models/vovnet.py#L411)) so added condition to set pretrained = False for the ese_vovnet99b variant.