### PR TITLE
Add pytest fixture to remove tmp_path directory after test execution

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,6 +6,7 @@ import gc
 import time
 import pytest
 import psutil
+import shutil
 from loguru import logger
 from datetime import datetime
 from forge.forge_property_utils import ForgePropertyHandler, ForgePropertyStore, ExecutionStage
@@ -20,6 +21,20 @@ def pytest_addoption(parser):
         default=False,
         help="log per-test memory usage into pytest-memory-usage.csv",
     )
+
+
+@pytest.fixture(scope="function")
+def forge_tmp_path(tmp_path):
+    """
+    Yield a temporary directory path and remove it immediately after the test execution complete.
+
+    This fixture wraps pytest's built-in tmp_path fixture to ensure that
+    the temporary directory is cleaned up as soon as the test finishes,
+    regardless of the test outcome.
+    """
+    yield tmp_path
+    # After the test, delete the entire temporary directory and its contents
+    shutil.rmtree(str(tmp_path), ignore_errors=True)
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/forge/test/models/onnx/multimodal/oft/test_oft_onnx.py
+++ b/forge/test/models/onnx/multimodal/oft/test_oft_onnx.py
@@ -13,7 +13,7 @@ from forge.forge_property_utils import Framework, Source, Task
 @pytest.mark.skip(reason="Segmentation Fault")
 @pytest.mark.parametrize("variant", ["runwayml/stable-diffusion-v1-5"])
 @pytest.mark.nightly
-def test_oft(forge_property_recorder, tmp_path, variant):
+def test_oft(forge_property_recorder, forge_tmp_path, variant):
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
@@ -27,7 +27,7 @@ def test_oft(forge_property_recorder, tmp_path, variant):
 
     # Load model and inputs
     pipe, inputs = get_inputs(model=variant)
-    onnx_model, framework_model = get_models(inputs, tmp_path, pipe)
+    onnx_model, framework_model = get_models(inputs, forge_tmp_path, pipe)
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     compiled_model = forge.compile(

--- a/forge/test/models/onnx/text/bert/test_bert.py
+++ b/forge/test/models/onnx/text/bert/test_bert.py
@@ -27,7 +27,7 @@ opset_versions = [17]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["bert-base-uncased"])
 @pytest.mark.parametrize("opset_version", opset_versions, ids=opset_versions)
-def test_bert_masked_lm_onnx(forge_property_recorder, variant, tmp_path, opset_version):
+def test_bert_masked_lm_onnx(forge_property_recorder, variant, forge_tmp_path, opset_version):
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
@@ -58,7 +58,7 @@ def test_bert_masked_lm_onnx(forge_property_recorder, variant, tmp_path, opset_v
 
     # Export model to ONNX
     # TODO: Replace with pre-generated ONNX model to avoid exporting from scratch.
-    onnx_path = f"{tmp_path}/bert_masked_lm.onnx"
+    onnx_path = f"{forge_tmp_path}/bert_masked_lm.onnx"
     torch.onnx.export(framework_model, inputs[0], onnx_path, opset_version=opset_version)
 
     # Load ONNX model
@@ -78,7 +78,7 @@ def test_bert_masked_lm_onnx(forge_property_recorder, variant, tmp_path, opset_v
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["phiyodr/bert-large-finetuned-squad2"])
 @pytest.mark.parametrize("opset_version", opset_versions, ids=opset_versions)
-def test_bert_question_answering_onnx(forge_property_recorder, variant, tmp_path, opset_version):
+def test_bert_question_answering_onnx(forge_property_recorder, variant, forge_tmp_path, opset_version):
     pytest.skip("Transient failure - Out of memory due to other tests in CI pipeline")
 
     # Record Forge Property
@@ -121,7 +121,7 @@ def test_bert_question_answering_onnx(forge_property_recorder, variant, tmp_path
 
     # Export model to ONNX
     # TODO: Replace with pre-generated ONNX model to avoid exporting from scratch.
-    onnx_path = f"{tmp_path}/bert_qa.onnx"
+    onnx_path = f"{forge_tmp_path}/bert_qa.onnx"
     torch.onnx.export(framework_model, inputs[0], onnx_path, opset_version=opset_version)
 
     # Load ONNX model
@@ -141,7 +141,7 @@ def test_bert_question_answering_onnx(forge_property_recorder, variant, tmp_path
 @pytest.mark.nightly
 @pytest.mark.push
 @pytest.mark.parametrize("variant", ["emrecan/bert-base-turkish-cased-mean-nli-stsb-tr"])
-def test_bert_sentence_embedding_generation_onnx(forge_property_recorder, variant, tmp_path):
+def test_bert_sentence_embedding_generation_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -167,7 +167,7 @@ def test_bert_sentence_embedding_generation_onnx(forge_property_recorder, varian
     inputs = [encoded_input["input_ids"], encoded_input["attention_mask"], encoded_input["token_type_ids"]]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/bert_sentence_emb_gen.onnx"
+    onnx_path = f"{forge_tmp_path}/bert_sentence_emb_gen.onnx"
     torch.onnx.export(framework_model, (inputs[0], inputs[1], inputs[2]), onnx_path, opset_version=17)
 
     # Load ONNX model

--- a/forge/test/models/onnx/text/bi_lstm_crf/test_bilstm_crf.py
+++ b/forge/test/models/onnx/text/bi_lstm_crf/test_bilstm_crf.py
@@ -15,7 +15,7 @@ from forge.forge_property_utils import Framework, Source, Task
 
 @pytest.mark.nightly
 @pytest.mark.xfail()
-def test_birnn_crf(forge_property_recorder, tmp_path):
+def test_birnn_crf(forge_property_recorder, forge_tmp_path):
 
     # Build Module Name
     module_name = forge_property_recorder.record_model_properties(
@@ -35,7 +35,7 @@ def test_birnn_crf(forge_property_recorder, tmp_path):
     model, test_input = get_model(test_sentence)
     model.eval()
 
-    onnx_path = f"{tmp_path}/bilstm_crf.onnx"
+    onnx_path = f"{forge_tmp_path}/bilstm_crf.onnx"
     torch.onnx.export(model, test_input, onnx_path, opset_version=17)
 
     # Load ONNX model

--- a/forge/test/models/onnx/text/deepcogito/test_cogito_v1_onnx.py
+++ b/forge/test/models/onnx/text/deepcogito/test_cogito_v1_onnx.py
@@ -19,7 +19,7 @@ from test.models.pytorch.text.deepcogito.utils.model import get_input_model
 @pytest.mark.skip(reason="Skipping due to CI/CD Limitations")
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["deepcogito/cogito-v1-preview-llama-3B"])
-def test_cogito_generation_onnx(forge_property_recorder, tmp_path, variant):
+def test_cogito_generation_onnx(forge_property_recorder, forge_tmp_path, variant):
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
@@ -34,9 +34,9 @@ def test_cogito_generation_onnx(forge_property_recorder, tmp_path, variant):
     sample_inputs, framework_model = get_input_model(variant)
 
     # Export paths
-    temp_onnx = tmp_path / "temp_model.onnx"
-    final_onnx = tmp_path / "cogito.onnx"
-    external_data_file = tmp_path / "cogito.onnx.data"
+    temp_onnx = forge_tmp_path / "temp_model.onnx"
+    final_onnx = forge_tmp_path / "cogito.onnx"
+    external_data_file = forge_tmp_path / "cogito.onnx.data"
 
     # Export to ONNX
     torch.onnx.export(

--- a/forge/test/models/onnx/text/gemma/test_gemma_v1.py
+++ b/forge/test/models/onnx/text/gemma/test_gemma_v1.py
@@ -29,7 +29,7 @@ import torch
         ),
     ],
 )
-def test_gemma_v1_onnx(forge_property_recorder, variant, tmp_path):
+def test_gemma_v1_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -48,7 +48,7 @@ def test_gemma_v1_onnx(forge_property_recorder, variant, tmp_path):
     inputs = [input["input_ids"]]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/gemma_v1.onnx"
+    onnx_path = f"{forge_tmp_path}/gemma_v1.onnx"
     torch.onnx.export(framework_model, inputs[0], onnx_path, opset_version=17)
 
     # Load framework model

--- a/forge/test/models/onnx/text/gemma/test_gemma_v2.py
+++ b/forge/test/models/onnx/text/gemma/test_gemma_v2.py
@@ -33,7 +33,7 @@ Gemma2DecoderLayer.forward = Gemma2DecoderLayer_patched_forward
         ),
     ],
 )
-def test_gemma_v2_onnx(forge_property_recorder, variant, tmp_path):
+def test_gemma_v2_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -53,7 +53,7 @@ def test_gemma_v2_onnx(forge_property_recorder, variant, tmp_path):
     inputs = [input["input_ids"]]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/gemma_v2.onnx"
+    onnx_path = f"{forge_tmp_path}/gemma_v2.onnx"
     torch.onnx.export(framework_model, inputs[0], onnx_path, opset_version=17)
 
     # Load framework model

--- a/forge/test/models/onnx/text/llama/test_llama3.py
+++ b/forge/test/models/onnx/text/llama/test_llama3.py
@@ -149,7 +149,7 @@ LlamaModel._update_causal_mask = _update_causal_mask
         ),
     ],
 )
-def test_llama3_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
+def test_llama3_causal_lm_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -196,8 +196,8 @@ def test_llama3_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
     inputs = [input_ids, attn_mask]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/model.onnx"
-    command = build_optimum_cli_command(variant, tmp_path)
+    onnx_path = f"{forge_tmp_path}/model.onnx"
+    command = build_optimum_cli_command(variant, forge_tmp_path)
     subprocess.run(command, check=True)
 
     # Load framework model

--- a/forge/test/models/onnx/text/minilm/test_minilm.py
+++ b/forge/test/models/onnx/text/minilm/test_minilm.py
@@ -21,7 +21,7 @@ opset_versions = [9, 17]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["sentence-transformers/all-MiniLM-L6-v2"])
 @pytest.mark.parametrize("opset_version", opset_versions, ids=opset_versions)
-def test_minilm_sequence_classification_onnx(forge_property_recorder, variant, tmp_path, opset_version):
+def test_minilm_sequence_classification_onnx(forge_property_recorder, variant, forge_tmp_path, opset_version):
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
@@ -45,7 +45,7 @@ def test_minilm_sequence_classification_onnx(forge_property_recorder, variant, t
 
     # Export model to ONNX
     # TODO: Replace with pre-generated ONNX model to avoid exporting from scratch.
-    onnx_path = f"{tmp_path}/minilm.onnx"
+    onnx_path = f"{forge_tmp_path}/minilm.onnx"
     torch.onnx.export(framework_model, inputs[0], onnx_path, opset_version=opset_version)
 
     # Load ONNX model

--- a/forge/test/models/onnx/text/ministral/test_ministral.py
+++ b/forge/test/models/onnx/text/ministral/test_ministral.py
@@ -18,7 +18,7 @@ variants = ["ministral/Ministral-3b-instruct"]
 @pytest.mark.nightly
 @pytest.mark.skip(reason="Transient test - Out of memory due to other tests in CI pipeline")
 @pytest.mark.parametrize("variant", variants)
-def test_ministral(forge_property_recorder, variant, tmp_path):
+def test_ministral(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -44,8 +44,8 @@ def test_ministral(forge_property_recorder, variant, tmp_path):
     inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/model.onnx"
-    command = build_optimum_cli_command(variant, tmp_path)
+    onnx_path = f"{forge_tmp_path}/model.onnx"
+    command = build_optimum_cli_command(variant, forge_tmp_path)
     subprocess.run(command, check=True)
 
     # Load framework model

--- a/forge/test/models/onnx/text/mistral/test_mistral.py
+++ b/forge/test/models/onnx/text/mistral/test_mistral.py
@@ -20,7 +20,7 @@ variants = ["mistralai/Mistral-7B-Instruct-v0.3"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.xfail
-def test_mistral_v0_3_onnx(forge_property_recorder, variant, tmp_path):
+def test_mistral_v0_3_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -52,7 +52,7 @@ def test_mistral_v0_3_onnx(forge_property_recorder, variant, tmp_path):
     inputs = [input["input_ids"]]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/mistral_7b_v0_3.onnx"
+    onnx_path = f"{forge_tmp_path}/mistral_7b_v0_3.onnx"
     torch.onnx.export(framework_model, inputs[0], onnx_path, opset_version=17)
 
     # Load framework model

--- a/forge/test/models/onnx/text/phi1/test_phi1_5_onnx.py
+++ b/forge/test/models/onnx/text/phi1/test_phi1_5_onnx.py
@@ -20,7 +20,7 @@ variants = ["microsoft/phi-1_5"]
 @pytest.mark.nightly
 @pytest.mark.skip(reason="Transient test - Out of memory due to other tests in CI pipeline")
 @pytest.mark.parametrize("variant", variants)
-def test_phi1_5_clm_onnx(forge_property_recorder, variant, tmp_path):
+def test_phi1_5_clm_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -54,8 +54,8 @@ def test_phi1_5_clm_onnx(forge_property_recorder, variant, tmp_path):
     attn_mask = inputs["attention_mask"]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/model.onnx"
-    command = build_optimum_cli_command(variant, tmp_path)
+    onnx_path = f"{forge_tmp_path}/model.onnx"
+    command = build_optimum_cli_command(variant, forge_tmp_path)
     subprocess.run(command, check=True)
 
     # Load framework model

--- a/forge/test/models/onnx/text/phi1/test_phi1_onnx.py
+++ b/forge/test/models/onnx/text/phi1/test_phi1_onnx.py
@@ -24,7 +24,7 @@ variants = ["microsoft/phi-1"]
 @pytest.mark.nightly
 @pytest.mark.skip("Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)")
 @pytest.mark.parametrize("variant", variants)
-def test_phi_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
+def test_phi_causal_lm_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -50,8 +50,8 @@ def test_phi_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
     sample_inputs = [input_ids, attn_mask]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/model.onnx"
-    command = build_optimum_cli_command(variant, tmp_path)
+    onnx_path = f"{forge_tmp_path}/model.onnx"
+    command = build_optimum_cli_command(variant, forge_tmp_path)
     subprocess.run(command, check=True)
 
     # Load framework model

--- a/forge/test/models/onnx/text/phi2/test_phi2.py
+++ b/forge/test/models/onnx/text/phi2/test_phi2.py
@@ -19,7 +19,7 @@ variants = ["microsoft/phi-2"]
 @pytest.mark.nightly
 @pytest.mark.skip(reason="Transient test - Out of memory due to other tests in CI pipeline")
 @pytest.mark.parametrize("variant", variants)
-def test_phi2_clm_onnx(forge_property_recorder, variant, tmp_path):
+def test_phi2_clm_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -55,8 +55,8 @@ def test_phi2_clm_onnx(forge_property_recorder, variant, tmp_path):
     attn_mask = inputs["attention_mask"]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/model.onnx"
-    command = build_optimum_cli_command(variant, tmp_path)
+    onnx_path = f"{forge_tmp_path}/model.onnx"
+    command = build_optimum_cli_command(variant, forge_tmp_path)
     subprocess.run(command, check=True)
 
     # Load framework model

--- a/forge/test/models/onnx/text/phi3/test_phi3.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3.py
@@ -21,7 +21,7 @@ variants = ["microsoft/phi-3-mini-4k-instruct", "microsoft/Phi-3-mini-128k-instr
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.skip(reason="Transient test - Out of memory due to other tests in CI pipeline")
-def test_phi3_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
+def test_phi3_causal_lm_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -56,8 +56,8 @@ def test_phi3_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
     attn_mask = inputs["attention_mask"]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/model.onnx"
-    command = build_optimum_cli_command(variant, tmp_path)
+    onnx_path = f"{forge_tmp_path}/model.onnx"
+    command = build_optimum_cli_command(variant, forge_tmp_path)
     subprocess.run(command, check=True)
 
     # Load framework model

--- a/forge/test/models/onnx/text/phi3/test_phi3_5.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3_5.py
@@ -19,7 +19,7 @@ variants = ["microsoft/Phi-3.5-mini-instruct"]
 @pytest.mark.nightly
 @pytest.mark.skip("Transient test - Out of memory due to other tests in CI pipeline")
 @pytest.mark.parametrize("variant", variants)
-def test_phi3_5_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
+def test_phi3_5_causal_lm_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -49,8 +49,8 @@ def test_phi3_5_causal_lm_onnx(forge_property_recorder, variant, tmp_path):
     inputs = [inputs["input_ids"], inputs["attention_mask"]]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/model.onnx"
-    command = build_optimum_cli_command(variant, tmp_path)
+    onnx_path = f"{forge_tmp_path}/model.onnx"
+    command = build_optimum_cli_command(variant, forge_tmp_path)
     subprocess.run(command, check=True)
 
     # Load framework model

--- a/forge/test/models/onnx/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/onnx/text/qwen/test_qwen_v2.py
@@ -44,7 +44,7 @@ import torch
         ),
     ],
 )
-def test_qwen_clm_onnx(forge_property_recorder, variant, tmp_path):
+def test_qwen_clm_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -73,9 +73,9 @@ def test_qwen_clm_onnx(forge_property_recorder, variant, tmp_path):
     inputs = [input_ids, attention_mask]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/model.onnx"
+    onnx_path = f"{forge_tmp_path}/model.onnx"
     if variant not in ["Qwen/Qwen2.5-0.5B", "Qwen/Qwen2.5-0.5B-Instruct"]:
-        command = build_optimum_cli_command(variant, tmp_path)
+        command = build_optimum_cli_command(variant, forge_tmp_path)
         subprocess.run(command, check=True)
     else:
         torch.onnx.export(framework_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)

--- a/forge/test/models/onnx/vision/detr/test_detr.py
+++ b/forge/test/models/onnx/vision/detr/test_detr.py
@@ -19,7 +19,7 @@ from test.models.models_utils import preprocess_input_data
 @pytest.mark.nightly
 @pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["facebook/detr-resnet-50"])
-def test_detr_detection_onnx(forge_property_recorder, variant, tmp_path):
+def test_detr_detection_onnx(forge_property_recorder, variant, forge_tmp_path):
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
@@ -43,7 +43,7 @@ def test_detr_detection_onnx(forge_property_recorder, variant, tmp_path):
     inputs = [input_batch]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/detr_obj_det.onnx"
+    onnx_path = f"{forge_tmp_path}/detr_obj_det.onnx"
     torch.onnx.export(framework_model, (inputs[0]), onnx_path, opset_version=17)
 
     # Load ONNX model
@@ -63,7 +63,7 @@ def test_detr_detection_onnx(forge_property_recorder, variant, tmp_path):
 @pytest.mark.nightly
 @pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["facebook/detr-resnet-50-panoptic"])
-def test_detr_segmentation_onnx(forge_property_recorder, variant, tmp_path):
+def test_detr_segmentation_onnx(forge_property_recorder, variant, forge_tmp_path):
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
@@ -86,7 +86,7 @@ def test_detr_segmentation_onnx(forge_property_recorder, variant, tmp_path):
     inputs = [input_batch]
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/detr_semseg.onnx"
+    onnx_path = f"{forge_tmp_path}/detr_semseg.onnx"
     torch.onnx.export(framework_model, (inputs[0]), onnx_path, opset_version=17)
 
     # Load ONNX model

--- a/forge/test/models/onnx/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/onnx/vision/efficientnet/test_efficientnet.py
@@ -34,7 +34,7 @@ params = [
 
 @pytest.mark.parametrize("variant", params)
 @pytest.mark.nightly
-def test_efficientnet_onnx(variant, forge_property_recorder, tmp_path):
+def test_efficientnet_onnx(variant, forge_property_recorder, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -60,7 +60,7 @@ def test_efficientnet_onnx(variant, forge_property_recorder, tmp_path):
     )
 
     inputs = load_inputs(img, model)
-    onnx_path = f"{tmp_path}/efficientnet.onnx"
+    onnx_path = f"{forge_tmp_path}/efficientnet.onnx"
     torch.onnx.export(model, inputs[0], onnx_path)
 
     # Load onnx model

--- a/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
+++ b/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
@@ -27,7 +27,7 @@ params = [
 
 @pytest.mark.parametrize("variant", params)
 @pytest.mark.nightly
-def test_mobilenetv2_onnx(variant, forge_property_recorder, tmp_path):
+def test_mobilenetv2_onnx(variant, forge_property_recorder, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -54,7 +54,7 @@ def test_mobilenetv2_onnx(variant, forge_property_recorder, tmp_path):
     )
 
     inputs = load_inputs(img, model)
-    onnx_path = f"{tmp_path}/mobilenetv2.onnx"
+    onnx_path = f"{forge_tmp_path}/mobilenetv2.onnx"
     torch.onnx.export(model, inputs[0], onnx_path)
 
     # Load onnx model

--- a/forge/test/models/onnx/vision/resnet/test_resnet.py
+++ b/forge/test/models/onnx/vision/resnet/test_resnet.py
@@ -29,7 +29,7 @@ opset_versions = [7, 17]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.parametrize("opset_version", opset_versions, ids=opset_versions)
-def test_resnet_onnx(forge_property_recorder, variant, tmp_path, opset_version):
+def test_resnet_onnx(forge_property_recorder, variant, forge_tmp_path, opset_version):
     random.seed(0)
 
     # Record model details
@@ -45,7 +45,7 @@ def test_resnet_onnx(forge_property_recorder, variant, tmp_path, opset_version):
     # Export model to ONNX
     torch_model = ResNetForImageClassification.from_pretrained(variant)
     input_sample = torch.randn(1, 3, 224, 224)
-    onnx_path = f"{tmp_path}/resnet50.onnx"
+    onnx_path = f"{forge_tmp_path}/resnet50.onnx"
     torch.onnx.export(torch_model, input_sample, onnx_path, opset_version=opset_version)
 
     # Load framework model

--- a/forge/test/models/onnx/vision/sam/test_sam_onnx.py
+++ b/forge/test/models/onnx/vision/sam/test_sam_onnx.py
@@ -22,7 +22,7 @@ from test.models.pytorch.vision.sam.utils.model import get_model_inputs
     ],
 )
 @pytest.mark.nightly
-def test_sam_onnx(forge_property_recorder, variant, tmp_path):
+def test_sam_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -45,7 +45,7 @@ def test_sam_onnx(forge_property_recorder, variant, tmp_path):
     input_tensor = sample_inputs[0]
     sample_inputs = [input_tensor]
 
-    onnx_path = f"{tmp_path}/sam_" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    onnx_path = f"{forge_tmp_path}/sam_" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
     torch.onnx.export(
         framework_model,
         input_tensor,

--- a/forge/test/models/onnx/vision/segformer/test_segformer.py
+++ b/forge/test/models/onnx/vision/segformer/test_segformer.py
@@ -25,7 +25,7 @@ variants_img_classification = [
 
 @pytest.mark.parametrize("variant", variants_img_classification)
 @pytest.mark.nightly
-def test_segformer_image_classification_onnx(forge_property_recorder, variant, tmp_path):
+def test_segformer_image_classification_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -51,7 +51,7 @@ def test_segformer_image_classification_onnx(forge_property_recorder, variant, t
     inputs = get_sample_data(variant)
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/segformer_" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    onnx_path = f"{forge_tmp_path}/segformer_" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
     torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
 
     # Load framework model
@@ -90,7 +90,7 @@ variants_semseg = [
 @pytest.mark.parametrize("variant", variants_semseg)
 @pytest.mark.nightly
 @pytest.mark.xfail
-def test_segformer_semantic_segmentation_onnx(forge_property_recorder, variant, tmp_path):
+def test_segformer_semantic_segmentation_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -112,7 +112,7 @@ def test_segformer_semantic_segmentation_onnx(forge_property_recorder, variant, 
     inputs = get_sample_data(variant)
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
     torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
 
     # Load framework model

--- a/forge/test/models/onnx/vision/swin/test_swin.py
+++ b/forge/test/models/onnx/vision/swin/test_swin.py
@@ -20,7 +20,7 @@ from forge.forge_property_utils import Framework, Source, Task
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
 @pytest.mark.xfail
-def test_swin_v2_tiny_image_classification_onnx(forge_property_recorder, variant, tmp_path):
+def test_swin_v2_tiny_image_classification_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -43,7 +43,7 @@ def test_swin_v2_tiny_image_classification_onnx(forge_property_recorder, variant
     inputs = load_image(url, feature_extractor)
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/swin_v2_obj_cls.onnx"
+    onnx_path = f"{forge_tmp_path}/swin_v2_obj_cls.onnx"
     torch.onnx.export(
         framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
     )
@@ -62,7 +62,7 @@ def test_swin_v2_tiny_image_classification_onnx(forge_property_recorder, variant
 @pytest.mark.nightly
 @pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
-def test_swin_v2_tiny_masked_onnx(forge_property_recorder, variant, tmp_path):
+def test_swin_v2_tiny_masked_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -84,7 +84,7 @@ def test_swin_v2_tiny_masked_onnx(forge_property_recorder, variant, tmp_path):
     inputs = load_image(url, feature_extractor)
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/swin_v2_tiny_masked.onnx"
+    onnx_path = f"{forge_tmp_path}/swin_v2_tiny_masked.onnx"
     torch.onnx.export(
         framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
     )
@@ -106,7 +106,7 @@ variants_with_weights = {"swin_v2_t": "Swin_V2_T_Weights"}
 @pytest.mark.nightly
 @pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["swin_v2_t"])
-def test_swin_torchvision(forge_property_recorder, variant, tmp_path):
+def test_swin_torchvision(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -123,7 +123,7 @@ def test_swin_torchvision(forge_property_recorder, variant, tmp_path):
     framework_model, inputs = load_vision_model_and_input(variant, "classification", weight_name)
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/swin_v2_torchvision.onnx"
+    onnx_path = f"{forge_tmp_path}/swin_v2_torchvision.onnx"
     torch.onnx.export(
         framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
     )

--- a/forge/test/models/onnx/vision/unet/test_unet.py
+++ b/forge/test/models/onnx/vision/unet/test_unet.py
@@ -13,7 +13,7 @@ from utils import load_inputs
 
 @pytest.mark.nightly
 @pytest.mark.xfail()
-def test_unet_onnx(forge_property_recorder, tmp_path):
+def test_unet_onnx(forge_property_recorder, forge_tmp_path):
 
     # Build Module Name
     module_name = forge_property_recorder.record_model_properties(
@@ -42,7 +42,7 @@ def test_unet_onnx(forge_property_recorder, tmp_path):
     )
     inputs = load_inputs(url, filename)
 
-    onnx_path = f"{tmp_path}/unet.onnx"
+    onnx_path = f"{forge_tmp_path}/unet.onnx"
     torch.onnx.export(torch_model, inputs[0], onnx_path)
     onnx_model = onnx.load(onnx_path)
     onnx.checker.check_model(onnx_model)

--- a/forge/test/models/onnx/vision/vit/test_vit.py
+++ b/forge/test/models/onnx/vision/vit/test_vit.py
@@ -22,7 +22,7 @@ variants = [
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
-def test_vit_classify_224(forge_property_recorder, variant, tmp_path):
+def test_vit_classify_224(forge_property_recorder, variant, forge_tmp_path):
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
@@ -45,7 +45,7 @@ def test_vit_classify_224(forge_property_recorder, variant, tmp_path):
     # Load the inputs
     inputs = [torch.rand(1, 3, 224, 224)]
 
-    onnx_path = f"{tmp_path}/vit.onnx"
+    onnx_path = f"{forge_tmp_path}/vit.onnx"
     torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
     onnx_model = onnx.load(onnx_path)
     onnx.checker.check_model(onnx_model)

--- a/forge/test/models/onnx/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/onnx/vision/vovnet/test_vovnet.py
@@ -30,7 +30,7 @@ def generate_model_vovnet_imgcls_osmr_pytorch(variant):
 @pytest.mark.nightly
 @pytest.mark.skip(reason="Segmentation Fault")
 @pytest.mark.parametrize("variant", ["vovnet27s"])
-def test_vovnet_osmr_pytorch(forge_property_recorder, variant, tmp_path):
+def test_vovnet_osmr_pytorch(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -44,7 +44,7 @@ def test_vovnet_osmr_pytorch(forge_property_recorder, variant, tmp_path):
     framework_model, inputs, _ = generate_model_vovnet_imgcls_osmr_pytorch(variant)
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/vovnet_osmr.onnx"
+    onnx_path = f"{forge_tmp_path}/vovnet_osmr.onnx"
     torch.onnx.export(
         framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
     )
@@ -69,7 +69,7 @@ def generate_model_vovnet39_imgcls_stigma_pytorch():
 @pytest.mark.nightly
 @pytest.mark.skip(reason="Segmentation Fault")
 @pytest.mark.parametrize("variant", ["vovnet39"])
-def test_vovnet_v1_39_stigma_onnx(forge_property_recorder, variant, tmp_path):
+def test_vovnet_v1_39_stigma_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -86,7 +86,7 @@ def test_vovnet_v1_39_stigma_onnx(forge_property_recorder, variant, tmp_path):
     framework_model, inputs, _ = generate_model_vovnet39_imgcls_stigma_pytorch()
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/vovnet_v1_39.onnx"
+    onnx_path = f"{forge_tmp_path}/vovnet_v1_39.onnx"
     torch.onnx.export(
         framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
     )
@@ -112,7 +112,7 @@ def generate_model_vovnet57_imgcls_stigma_pytorch():
 @pytest.mark.nightly
 @pytest.mark.skip(reason="Segmentation Fault")
 @pytest.mark.parametrize("variant", ["vovnet_v1_57"])
-def test_vovnet_v1_57_stigma_onnx(forge_property_recorder, variant, tmp_path):
+def test_vovnet_v1_57_stigma_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -129,7 +129,7 @@ def test_vovnet_v1_57_stigma_onnx(forge_property_recorder, variant, tmp_path):
     framework_model, inputs, _ = generate_model_vovnet57_imgcls_stigma_pytorch()
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/vovnet_v1_57.onnx"
+    onnx_path = f"{forge_tmp_path}/vovnet_v1_57.onnx"
     torch.onnx.export(
         framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
     )
@@ -154,7 +154,7 @@ def generate_model_vovnet_imgcls_timm_pytorch(variant):
 @pytest.mark.nightly
 @pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["ese_vovnet19b_dw.ra_in1k"])
-def test_vovnet_timm_pytorch(forge_property_recorder, variant, tmp_path):
+def test_vovnet_timm_pytorch(forge_property_recorder, variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -173,7 +173,7 @@ def test_vovnet_timm_pytorch(forge_property_recorder, variant, tmp_path):
     )
 
     # Export model to ONNX
-    onnx_path = f"{tmp_path}/vovnet_timm.onnx"
+    onnx_path = f"{forge_tmp_path}/vovnet_timm.onnx"
     torch.onnx.export(
         framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
     )

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v10.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v10.py
@@ -15,7 +15,7 @@ from forge.forge_property_utils import Framework, Source, Task
 
 @pytest.mark.xfail
 @pytest.mark.nightly
-def test_yolov10(forge_property_recorder, tmp_path):
+def test_yolov10(forge_property_recorder, forge_tmp_path):
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
@@ -34,7 +34,7 @@ def test_yolov10(forge_property_recorder, tmp_path):
     torch_model = YoloWrapper(model)
 
     # Export model to ONNX
-    onnx_path = tmp_path / "yolov10.onnx"
+    onnx_path = forge_tmp_path / "yolov10.onnx"
     torch.onnx.export(
         torch_model,
         image_tensor,

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v8.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v8.py
@@ -15,7 +15,7 @@ from forge.forge_property_utils import Framework, Source, Task
 
 @pytest.mark.xfail()
 @pytest.mark.nightly
-def test_yolov8(forge_property_recorder, tmp_path):
+def test_yolov8(forge_property_recorder, forge_tmp_path):
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
         framework=Framework.ONNX,
@@ -34,7 +34,7 @@ def test_yolov8(forge_property_recorder, tmp_path):
     torch_model = YoloWrapper(model)
 
     # Export model to ONNX
-    onnx_path = tmp_path / "yolov8.onnx"
+    onnx_path = forge_tmp_path / "yolov8.onnx"
     torch.onnx.export(
         torch_model,
         image_tensor,


### PR DESCRIPTION
1. Currently pytest built-in **tmp_path** fixture was added to each ONNX models tests to generate a unique temporary directory for saving ONNX files, but [tmp_path fixture](https://github.com/pytest-dev/pytest/blob/017dd1ccd60055bc6a7a41af11b74425da87a696/src/_pytest/tmpdir.py#L239C1-L253C46) leaves these directories intact by default, causing outdated artifacts to pile up. This PR introduces a new `forge_tmp_path` fixture that wraps `tmp_path` and automatically removes its directory (and all contents) immediately after each test completes—ensuring no stale ONNX files remain. 
2. Replaced `tmp_path` with  `forge_tmp_path` pytest fixture in the ONNX models tests.