### PR TITLE
Add support for downsampl2d in cubic mode in Forge frontend

### DIFF
--- a/forge/forge/op/__init__.py
+++ b/forge/forge/op/__init__.py
@@ -71,7 +71,7 @@ from .tm import (
 from .constant import Constant
 from .nn import Softmax, Layernorm, LogSoftmax, Batchnorm, MaxPool2dModule
 from .eltwise_nary import Concatenate, Where, IndexCopy, Stack, Interleave
-from .resize import Resize2d, Resize3d, Upsample2d
+from .resize import Resize2d, Resize3d, Upsample2d, Downsample2d
 from .embedding import Embedding
 from .dram_queue import DRAMQueue
 from .quantize import Quantize, Dequantize, Requantize, ForgeRequantize

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -124,6 +124,7 @@ op_to_module_map = {
     "resize2d": "resize",
     "resize3d": "resize",
     "upsample2d": "resize",
+    "downsample2d": "resize",
     "dram_queue": "dram_queue",
     "softmax": "nn",
     "log_softmax": "nn",

--- a/forge/forge/op/resize.py
+++ b/forge/forge/op/resize.py
@@ -11,11 +11,13 @@ RESIZE2d_METHOD_TO_INT = {
     "nearest_neighbor": 0,
     "linear": 1,
     "bilinear": 1,
+    "cubic": 2,
 }
 
 INT_TO_RESIZE2d_METHOD = {
     0: "nearest",
     1: "bilinear",
+    2: "cubic",
 }
 
 
@@ -50,8 +52,8 @@ def Resize2d(
     """
     assert len(sizes) == 2
     assert (
-        method == "nearest_neighbor" or method == "linear" or method == "bilinear"
-    ), "Only support nearest_neighbor and linear interpolation for now"
+        method == "nearest_neighbor" or method == "linear" or method == "bilinear" or method == "cubic"
+    ), "Only support nearest_neighbor, linear and cubic interpolation for now"
     result: Tensor = op(
         "resize2d",
         name,
@@ -89,6 +91,47 @@ def Upsample2d(
     """
     result: Tensor = op(
         "upsample2d",
+        name,
+        operandA,
+        attrs=(scale_factor, mode, channel_last),
+        scale_factor=scale_factor,
+        mode=mode,
+        channel_last=channel_last,
+    ).get_tensor()
+
+    return result
+
+
+def Downsample2d(
+    name: str, operandA: Tensor, scale_factor: int, mode: str = "nearest", channel_last: bool = False
+) -> Tensor:
+    """
+    Downsample 2D operation
+
+    Parameters
+    ----------
+    name: str
+        Op name, unique to the module, or leave blank to autoset
+
+    operandA: Tensor
+        Input operand A
+
+    scale_factor: int
+        Divider for spatial size.
+
+    mode: str
+        The downsampling algorithm
+
+    channel_last: bool
+        Whether the input is in channel-last format (NHWC)
+
+    Returns
+    -------
+    Tensor
+        Forge tensor
+    """
+    result: Tensor = op(
+        "downsample2d",
         name,
         operandA,
         attrs=(scale_factor, mode, channel_last),

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1467,8 +1467,8 @@ def populate_resize2d_args(graph, nid, compiler_cfg):
     method = node["attrs"]["method"][0][0]
 
     assert (
-        method == "nearest_neighbor" or method == "linear" or method == "bilinear"
-    ), "Only support nearest neighbor and linear for now"
+        method == "nearest_neighbor" or method == "linear" or method == "bilinear" or method == "cubic"
+    ), "Only support nearest neighbor, linear and cubic for now"
     assert int(node["attrs"]["num_inputs"]) == 1
     input_nid = node["inputs"][0][0]
     input_shape = graph["nodes"][input_nid]["attrs"]["shape"][0][0]

--- a/forge/test/mlir/operators/nn/test_nn.py
+++ b/forge/test/mlir/operators/nn/test_nn.py
@@ -221,6 +221,80 @@ def test_interpolate(forge_property_recorder, shape, mode):
 
 
 @pytest.mark.parametrize(
+    "input_shape, target_height, target_width",
+    [
+        pytest.param(
+            (1, 192, 64, 84),
+            32,
+            42,
+            marks=pytest.mark.xfail(
+                reason="Found Unsupported operations while lowering from TTForge to TTIR in forward graph - downsample2d (https://github.com/tenstorrent/tt-mlir/issues/1440)"
+            ),
+        ),
+        pytest.param(
+            (1, 128, 126, 126),
+            42,
+            42,
+            marks=pytest.mark.xfail(
+                reason="Found Unsupported operations while lowering from TTForge to TTIR in forward graph - downsample2d (https://github.com/tenstorrent/tt-mlir/issues/1440)"
+            ),
+        ),
+        pytest.param(
+            (1, 64, 400, 840),
+            100,
+            210,
+            marks=pytest.mark.xfail(
+                reason="Found Unsupported operations while lowering from TTForge to TTIR in forward graph - downsample2d (https://github.com/tenstorrent/tt-mlir/issues/1440)"
+            ),
+        ),
+        pytest.param(
+            (1, 3, 50, 150),
+            10,
+            30,
+            marks=pytest.mark.xfail(
+                reason="Found Unsupported operations while lowering from TTForge to TTIR in forward graph - downsample2d (https://github.com/tenstorrent/tt-mlir/issues/1440)"
+            ),
+        ),
+        pytest.param(
+            (1, 256, 100, 120),
+            50,
+            60,
+            marks=pytest.mark.xfail(
+                reason="Found Unsupported operations while lowering from TTForge to TTIR in forward graph - downsample2d(https://github.com/tenstorrent/tt-mlir/issues/1440)"
+            ),
+        ),
+        pytest.param(
+            (1, 192, 50, 83),
+            32,
+            42,
+            marks=pytest.mark.xfail(
+                reason="AssertionError: Only support downsample with integer scale factor (https://github.com/tenstorrent/tt-forge-fe/issues/2041) "
+            ),
+        ),
+    ],
+)
+@pytest.mark.push
+def test_downsample(forge_property_recorder, input_shape, target_height, target_width):
+    class Downsample(nn.Module):
+        def __init__(self, height, width):
+            super().__init__()
+            self.height = height
+            self.width = width
+
+        def forward(self, x):
+            return nn.functional.interpolate(x, size=(self.height, self.width), mode="bicubic", align_corners=False)
+
+    framework_model = Downsample(target_height, target_width)
+    framework_model.eval()
+
+    inputs = torch.randn(*input_shape)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, forge_property_handler=forge_property_recorder
+    )
+    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+
+@pytest.mark.parametrize(
     "batch_size, num_channels, height, width",
     [
         (1, 32, 56, 56),


### PR DESCRIPTION

### Summary 

- This PR adds support for downsampl2d in cubic mode in Forge frontend


### Logs

- [downsample_sanities_after_fix.log](https://github.com/user-attachments/files/20211481/may14_downsample_after_fix.log)
