### PR TITLE
Re-enable the skipped set7 tests in CI

### DIFF
--- a/forge/test/models/pytorch/text/phi2/test_phi2.py
+++ b/forge/test/models/pytorch/text/phi2/test_phi2.py
@@ -27,13 +27,15 @@ variants = [
         "microsoft/phi-2",
         marks=[pytest.mark.xfail],
     ),
-    "microsoft/phi-2-pytdml",
+    pytest.param(
+        "microsoft/phi-2-pytdml",
+        marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 29 GB"),
+    ),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
-@pytest.mark.skip(reason="Skipping due to the current CI/CD pipeline limitations")
 def test_phi2_clm(forge_property_recorder, variant):
 
     # Record Forge Property
@@ -87,10 +89,21 @@ def test_phi2_clm(forge_property_recorder, variant):
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
 
+variants = [
+    pytest.param(
+        "microsoft/phi-2",
+        marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB"),
+    ),
+    pytest.param(
+        "microsoft/phi-2-pytdml",
+        marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 28 GB"),
+    ),
+]
+
+
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_phi2_token_classification(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -133,10 +146,21 @@ def test_phi2_token_classification(forge_property_recorder, variant):
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
 
+variants = [
+    pytest.param(
+        "microsoft/phi-2",
+        marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 27 GB"),
+    ),
+    pytest.param(
+        "microsoft/phi-2-pytdml",
+        marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 28 GB"),
+    ),
+]
+
+
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_phi2_sequence_classification(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/text/phi3/test_phi3.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3.py
@@ -137,7 +137,10 @@ def test_phi3_causal_lm(forge_property_recorder, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_token_classification(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
+    if variant == "microsoft/phi-3-mini-4k-instruct":
+        pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 29 GB)")
+    elif variant == "microsoft/phi-3-mini-128k-instruct":
+        pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 31 GB)")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -180,9 +183,9 @@ def test_phi3_token_classification(forge_property_recorder, variant):
 
 
 @pytest.mark.nightly
+@pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB")
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_sequence_classification(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/resnext/test_resnext.py
+++ b/forge/test/models/pytorch/vision/resnext/test_resnext.py
@@ -83,7 +83,6 @@ def test_resnext_101_torchhub_pytorch(forge_property_recorder, variant):
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["resnext101_32x8d_wsl"])
 def test_resnext_101_32x8d_fb_wsl_pytorch(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -110,13 +109,15 @@ def test_resnext_101_32x8d_fb_wsl_pytorch(forge_property_recorder, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Post processing
+    post_processing(co_out)
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["resnext14_32x4d"])
 def test_resnext_14_osmr_pytorch(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -143,13 +144,15 @@ def test_resnext_14_osmr_pytorch(forge_property_recorder, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Post processing
+    post_processing(co_out)
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["resnext26_32x4d"])
 def test_resnext_26_osmr_pytorch(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -176,13 +179,15 @@ def test_resnext_26_osmr_pytorch(forge_property_recorder, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Post processing
+    post_processing(co_out)
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["resnext50_32x4d"])
 def test_resnext_50_osmr_pytorch(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -209,13 +214,15 @@ def test_resnext_50_osmr_pytorch(forge_property_recorder, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Post processing
+    post_processing(co_out)
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["resnext101_64x4d"])
 def test_resnext_101_osmr_pytorch(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -242,4 +249,7 @@ def test_resnext_101_osmr_pytorch(forge_property_recorder, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Post processing
+    post_processing(co_out)

--- a/forge/test/models/pytorch/vision/segformer/test_segformer.py
+++ b/forge/test/models/pytorch/vision/segformer/test_segformer.py
@@ -17,19 +17,17 @@ from test.models.pytorch.vision.segformer.utils.image_utils import get_sample_da
 
 variants_img_classification = [
     pytest.param("nvidia/mit-b0", marks=pytest.mark.push),
-    "nvidia/mit-b1",
-    "nvidia/mit-b2",
-    "nvidia/mit-b3",
-    "nvidia/mit-b4",
-    "nvidia/mit-b5",
+    pytest.param("nvidia/mit-b1", marks=pytest.mark.xfail),
+    pytest.param("nvidia/mit-b2", marks=pytest.mark.xfail),
+    pytest.param("nvidia/mit-b3", marks=pytest.mark.xfail),
+    pytest.param("nvidia/mit-b4", marks=pytest.mark.xfail),
+    pytest.param("nvidia/mit-b5", marks=pytest.mark.xfail),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants_img_classification)
 def test_segformer_image_classification_pytorch(forge_property_recorder, variant):
-    if variant != "nvidia/mit-b0":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -76,18 +74,17 @@ def test_segformer_image_classification_pytorch(forge_property_recorder, variant
 
 
 variants_semseg = [
-    "nvidia/segformer-b0-finetuned-ade-512-512",
-    "nvidia/segformer-b1-finetuned-ade-512-512",
-    "nvidia/segformer-b2-finetuned-ade-512-512",
-    "nvidia/segformer-b3-finetuned-ade-512-512",
-    "nvidia/segformer-b4-finetuned-ade-512-512",
+    pytest.param("nvidia/segformer-b0-finetuned-ade-512-512", marks=pytest.mark.xfail),
+    pytest.param("nvidia/segformer-b1-finetuned-ade-512-512", marks=pytest.mark.xfail),
+    pytest.param("nvidia/segformer-b2-finetuned-ade-512-512", marks=pytest.mark.xfail),
+    pytest.param("nvidia/segformer-b3-finetuned-ade-512-512", marks=pytest.mark.xfail),
+    pytest.param("nvidia/segformer-b4-finetuned-ade-512-512", marks=pytest.mark.xfail),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants_semseg)
 def test_segformer_semantic_segmentation_pytorch(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
@@ -27,8 +27,6 @@ varaints = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", varaints)
 def test_vovnet_osmr_pytorch(forge_property_recorder, variant):
-    if variant != "vovnet27s":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -69,7 +67,6 @@ def generate_model_vovnet39_imgcls_stigma_pytorch():
 
 @pytest.mark.nightly
 def test_vovnet_v1_39_stigma_pytorch(forge_property_recorder):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     variant = "vovnet39"
 
@@ -93,7 +90,10 @@ def test_vovnet_v1_39_stigma_pytorch(forge_property_recorder):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])
 
 
 def generate_model_vovnet57_imgcls_stigma_pytorch():
@@ -105,7 +105,6 @@ def generate_model_vovnet57_imgcls_stigma_pytorch():
 
 @pytest.mark.nightly
 def test_vovnet_v1_57_stigma_pytorch(forge_property_recorder):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     variant = "vovnet_v1_57"
 
@@ -129,7 +128,10 @@ def test_vovnet_v1_57_stigma_pytorch(forge_property_recorder):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])
 
 
 def generate_model_vovnet_imgcls_timm_pytorch(variant):
@@ -138,22 +140,13 @@ def generate_model_vovnet_imgcls_timm_pytorch(variant):
     return model, [image_tensor], {}
 
 
-variants = [
-    "ese_vovnet19b_dw",
-    "ese_vovnet39b",
-    "ese_vovnet99b",
-    pytest.param(
-        "ese_vovnet19b_dw.ra_in1k",
-        marks=[pytest.mark.xfail],
-    ),
-]
+variants = ["ese_vovnet19b_dw", "ese_vovnet39b", "ese_vovnet99b", "ese_vovnet19b_dw.ra_in1k"]
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_vovnet_timm_pytorch(forge_property_recorder, variant):
-    if variant != "ese_vovnet19b_dw.ra_in1k":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
+++ b/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
@@ -28,8 +28,6 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_wideresnet_pytorch(forge_property_recorder, variant):
-    if variant != "wide_resnet50_2":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -81,7 +79,6 @@ variants = ["wide_resnet50_2", "wide_resnet101_2"]
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_wideresnet_timm(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -103,4 +100,7 @@ def test_wideresnet_timm(forge_property_recorder, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Post processing
+    post_processing(co_out)

--- a/forge/test/models/pytorch/vision/xception/test_xception.py
+++ b/forge/test/models/pytorch/vision/xception/test_xception.py
@@ -51,8 +51,6 @@ params = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", params)
 def test_xception_timm(forge_property_recorder, variant):
-    if variant not in ["xception", "xception71.tf_in1k"]:
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(


### PR DESCRIPTION
 This PR enables the following skipped test cases:

````
pt_resnext_resnext101_32x8d_wsl_img_cls_torchhub - Maximum: 3074.87 MB
pt_resnext_resnext14_32x4d_img_cls_osmr - Maximum: 2963.51 MB
pt_resnext_resnext26_32x4d_img_cls_osmr - Maximum: 2993.91 MB
pt_resnext_resnext50_32x4d_img_cls_osmr - Maximum: 3123.09 MB
pt_resnext_resnext101_64x4d_img_cls_osmr - Maximum: 3383.74 MB
pt_segformer_nvidia_mit_b1_img_cls_hf - Maximum: 2617.79 MB
pt_segformer_nvidia_mit_b2_img_cls_hf - Maximum: 3398.21 MB
pt_segformer_nvidia_mit_b3_img_cls_hf - Maximum: 4186.75 MB
pt_segformer_nvidia_mit_b4_img_cls_hf - Maximum: 6478.97 MB
pt_segformer_nvidia_mit_b5_img_cls_hf - Maximum: 6480.77 MB
pt_segformer_nvidia_segformer_b0_finetuned_ade_512_512_sem_seg_hf - Maximum: 6643.41 MB
pt_segformer_nvidia_segformer_b1_finetuned_ade_512_512_sem_seg_hf - Maximum: 7056.41 MB
pt_segformer_nvidia_segformer_b2_finetuned_ade_512_512_sem_seg_hf - Maximum: 8088.73 MB
pt_segformer_nvidia_segformer_b3_finetuned_ade_512_512_sem_seg_hf - Maximum: 8368.20 MB
pt_segformer_nvidia_segformer_b4_finetuned_ade_512_512_sem_seg_hf - Maximum: 9963.32 MB
pt_vovnet_vovnet39_img_cls_osmr - Maximum: 1826.98 MB
pt_vovnet_vovnet57_img_cls_osmr - Maximum: 1986.41 MB
pt_vovnet_v1_vovnet39_obj_det_torchhub - Maximum: 2180.47 MB
pt_vovnet_vovnet_v1_57_obj_det_torchhub - Maximum: 2176.63 MB
pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub - Maximum: 2321.68 MB
pt_vovnet_ese_vovnet39b_obj_det_torchhub - Maximum: 2321.68 MB
pt_vovnet_ese_vovnet99b_obj_det_torchhub - Maximum: 2511.05 MB
pt_wideresnet_wide_resnet101_2_img_cls_torchvision - Maximum: 2776.35 MB
pt_wideresnet_wide_resnet50_2_img_cls_timm - Maximum: 2716.72 MB
pt_wideresnet_wide_resnet101_2_img_cls_timm - Maximum: 3149.02 MB
pt_xception_xception41_img_cls_timm - Maximum: 2572.19 MB
pt_xception_xception65_img_cls_timm - Maximum: 3141.30 MB
pt_xception_xception71_img_cls_timm - Maximum: 3269.88 MB
````
logs:
[resnext.log](https://github.com/user-attachments/files/20230980/resnext.log)
[vovnet.log](https://github.com/user-attachments/files/20231082/vovnet.log)
[wideresnet.log](https://github.com/user-attachments/files/20231095/wideresnet.log)
[xception.log](https://github.com/user-attachments/files/20231116/xception.log)

