### PR TITLE
[test] make input tensors contiguous

### DIFF
--- a/forge/test/models/pytorch/vision/densenet/test_densenet.py
+++ b/forge/test/models/pytorch/vision/densenet/test_densenet.py
@@ -92,10 +92,7 @@ def test_densenet_121_pytorch(forge_property_recorder, variant):
 @pytest.mark.parametrize(
     "variant",
     [
-        pytest.param(
-            "densenet161",
-            marks=[pytest.mark.xfail],
-        ),
+        "densenet161",
     ],
 )
 def test_densenet_161_pytorch(forge_property_recorder, variant):
@@ -131,10 +128,7 @@ def test_densenet_161_pytorch(forge_property_recorder, variant):
 @pytest.mark.parametrize(
     "variant",
     [
-        pytest.param(
-            "densenet169",
-            marks=[pytest.mark.xfail],
-        ),
+        "densenet169",
     ],
 )
 def test_densenet_169_pytorch(forge_property_recorder, variant):

--- a/forge/test/models/pytorch/vision/densenet/utils/densenet_utils.py
+++ b/forge/test/models/pytorch/vision/densenet/utils/densenet_utils.py
@@ -39,6 +39,10 @@ def get_input_img():
 
         # Preprocessing
         img_tensor = transform(img).unsqueeze(0)
+
+        # Make the tensor contiguous.
+        # Current limitation of compiler/runtime is that it does not support non-contiguous tensors properly.
+        img_tensor = img_tensor.contiguous()
     except:
         logger.warning(
             "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -304,7 +304,6 @@ variants_with_weights = {
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_mobilenetv2_torchvision(forge_property_recorder, variant):
 

--- a/forge/test/models/pytorch/vision/regnet/test_regnet.py
+++ b/forge/test/models/pytorch/vision/regnet/test_regnet.py
@@ -71,7 +71,7 @@ variants = [
     "regnet_y_8gf",
     "regnet_y_16gf",
     "regnet_y_32gf",
-    "regnet_y_128gf",
+    pytest.param("regnet_y_128gf", marks=pytest.mark.xfail(reason="Cannot fit in L1")),
     "regnet_x_400mf",
     "regnet_x_800mf",
     "regnet_x_1_6gf",
@@ -83,7 +83,6 @@ variants = [
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_regnet_torchvision(forge_property_recorder, variant):
 

--- a/forge/test/models/pytorch/vision/resnet/test_resnet.py
+++ b/forge/test/models/pytorch/vision/resnet/test_resnet.py
@@ -144,7 +144,6 @@ variants_with_weights = {
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_resnet_torchvision(forge_property_recorder, variant):
 

--- a/forge/test/models/pytorch/vision/utils/utils.py
+++ b/forge/test/models/pytorch/vision/utils/utils.py
@@ -39,4 +39,8 @@ def load_vision_model_and_input(variant, task, weight_name):
     img_t = preprocess(image)
     batch_t = torch.unsqueeze(img_t, 0)
 
+    # Make the tensor contiguous.
+    # Current limitation of compiler/runtime is that it does not support non-contiguous tensors properly.
+    batch_t = batch_t.contiguous()
+
     return model, [batch_t]

--- a/forge/test/models/pytorch/vision/vgg/test_vgg.py
+++ b/forge/test/models/pytorch/vision/vgg/test_vgg.py
@@ -16,6 +16,8 @@ from vgg_pytorch import VGG
 
 import forge
 from forge.forge_property_utils import Framework, Source, Task
+from forge.verify.config import VerifyConfig
+from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
 from test.models.models_utils import print_cls_results
@@ -260,7 +262,6 @@ variants = [
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_vgg_torchvision(forge_property_recorder, variant):
 
@@ -285,5 +286,11 @@ def test_vgg_torchvision(forge_property_recorder, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
+    verify_cfg = VerifyConfig()
+    if variant == "vgg16_bn":
+        verify_cfg = VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.98))
+
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    verify(
+        inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder, verify_cfg=verify_cfg
+    )

--- a/forge/test/models/pytorch/vision/vit/test_vit.py
+++ b/forge/test/models/pytorch/vision/vit/test_vit.py
@@ -74,7 +74,7 @@ variants_with_weights = {
 }
 
 variants = [
-    pytest.param("vit_b_16", marks=[pytest.mark.xfail]),
+    "vit_b_16",
     "vit_b_32",
     "vit_l_16",
     "vit_l_32",


### PR DESCRIPTION
Some of the model tests have non-contiguous tensors as inputs.

This causes runtime assertion failures, since we expect that all inputs are contiguous - this is current compiler/runtime limitation.

Modified the functions for loading of the image tensors to create contiguous tensors.