### PR TITLE
[test] try to release memory after each test

### DIFF
--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -144,7 +144,7 @@ PYBIND11_MODULE(_C, m)
     py::module m_runtime = m.def_submodule("runtime", "Submodule defining runtime functions");
     RuntimeModule(m_runtime);
 
-    py::module_ m_verif = m.def_submodule("verif", "Submodule defining verification functions");
+    py::module_ m_verif = m.def_submodule("verif", "Submodule defining verification and test utilities");
     VerifModule(m_verif);
 
     py::enum_<tt::MathFidelity>(m, "MathFidelity")

--- a/forge/csrc/verif/python_bindings.cpp
+++ b/forge/csrc/verif/python_bindings.cpp
@@ -4,6 +4,8 @@
 
 #include "verif/python_bindings.hpp"
 
+#include <malloc.h>
+
 #include "verif/verif_ops.hpp"
 
 namespace tt
@@ -22,6 +24,10 @@ void VerifModule(py::module &m_verif)
     m_verif.def("max_abs_diff", &max_abs_diff, "max_abs_diff");
     m_verif.def("has_special_values", &has_special_values, "has_special_values");
     m_verif.def("calculate_tensor_pcc", &calculate_tensor_pcc, "calculate_tensor_pcc");
+    m_verif.def(
+        "malloc_trim",
+        []() { malloc_trim(0); },
+        "Call malloc_trim(0) to force malloc to release any unused memory back to the OS");
 }
 
 }  // namespace tt


### PR DESCRIPTION
Run garbage collection and call `malloc_trim()` after each test.

`malloc_trim(0)` forces releasing of any unused memory to the OS.

The growth of `pytest` process memory usage as each test gets executed is much lower now, but the memory usage still grows in time. There doesn't seem to be any significant memory leaks on our side, so it looks that some state which is persisted across tests is contributing to the memory usage growth. This still needs to be investigated.

Memory usage logs are also updated with new columns so that we can track the memory usage after gc and trimming.

Closes #2044, Closes #2045