### PR TITLE
Fix runtime tensor type error by disabling return_dict

### DIFF
--- a/forge/test/models/onnx/vision/unet/test_unet.py
+++ b/forge/test/models/onnx/vision/unet/test_unet.py
@@ -12,7 +12,7 @@ from utils import load_inputs
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail()
+@pytest.mark.xfail
 def test_unet_onnx(forge_property_recorder, forge_tmp_path):
 
     # Build Module Name

--- a/forge/test/models/pytorch/vision/deit/test_deit.py
+++ b/forge/test/models/pytorch/vision/deit/test_deit.py
@@ -64,11 +64,16 @@ def test_deit_imgcls_hf_pytorch(forge_property_recorder, variant):
     if variant == "facebook/deit-base-patch16-224":
         pcc = 0.96
 
-    # Model Verification
-    verify(
+    # Model Verification and inference
+    _, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
         VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)),
         forge_property_handler=forge_property_recorder,
     )
+
+    # Post processing
+    logits = co_out[0]
+    predicted_class_idx = logits.argmax(-1).item()
+    print("Predicted class:", framework_model.config.id2label[predicted_class_idx])

--- a/forge/test/models/pytorch/vision/regnet/test_regnet.py
+++ b/forge/test/models/pytorch/vision/regnet/test_regnet.py
@@ -49,8 +49,13 @@ def test_regnet_img_classification(forge_property_recorder, variant):
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    # Model Verification and inference
+    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # post processing
+    logits = co_out[0]
+    predicted_label = logits.argmax(-1).item()
+    print(framework_model.config.id2label[predicted_label])
 
 
 variants_with_weights = {


### PR DESCRIPTION
### Problem description

```
RuntimeError: Unknown type of tensor: <class 'transformers.modeling_outputs.ImageClassifierOutput'>
RuntimeError: Unknown type of tensor: <class 'transformers.modeling_outputs.ImageClassifierOutputWithNoAttention'>
AttributeError: 'ForgePropertyHandler' object has no attribute 'record_model_propertiese'
```

### What's changed

- Runtime error was resolved by setting return_dict=False. This forces the model to return outputs as tuples instead of dict & post processing steps are added as tests passing e2e.
- Typo in record_model_properties is corrected

Note: `facebook/deit-base-distilled-patch16-224, facebook/deit-small-patch16-224,facebook/deit-tiny-patch16-224 `all this variants are passing e2e. but only base variant (facebook/deit-base-distilled-patch16-224) is added to push marker.

### Logs

[may16_deit_before_fix.log](https://github.com/user-attachments/files/20256794/may16_deit_bf.log)
[may16_deit_after_fix.log](https://github.com/user-attachments/files/20256793/may16_deit_af_1.log)
[may16_regnet_classi_before_fix.log](https://github.com/user-attachments/files/20256796/may16_regnet_classi_bf.log)
[may16_regnet_classi_after_fix.log](https://github.com/user-attachments/files/20256795/may16_regnet_classi_af_1.log)
