### PR TITLE
Set convolution-based models to be on bfp16

### DIFF
--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_xl.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_xl.py
@@ -6,6 +6,8 @@ import pytest
 import torch
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, ModelGroup, Source, Task
 from forge.verify.verify import verify
 
@@ -73,14 +75,23 @@ def test_stable_diffusion_generation(forge_property_recorder, variant):
         added_cond_kwargs,
         add_time_ids,
     ) = stable_diffusion_preprocessing_xl(pipe, prompt)
-    inputs = [latent_model_input, timestep, prompt_embeds]
+    inputs = [latent_model_input.to(torch.bfloat16), timestep.to(torch.bfloat16), prompt_embeds.to(torch.bfloat16)]
 
     # Wrap the pipeline in the wrapper
-    framework_model = StableDiffusionXLWrapper(framework_model, added_cond_kwargs, cross_attention_kwargs=None)
+    framework_model = StableDiffusionXLWrapper(framework_model, added_cond_kwargs, cross_attention_kwargs=None).to(
+        torch.bfloat16
+    )
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
+++ b/forge/test/models/pytorch/vision/autoencoder/test_autoencoder.py
@@ -6,10 +6,13 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 import pytest
+import torch
 import torchvision.transforms as transforms
 from datasets import load_dataset
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -30,7 +33,7 @@ def test_conv_ae_pytorch(forge_property_recorder):
     # Instantiate model
     # NOTE: The model has not been pre-trained or fine-tuned.
     # This is for demonstration purposes only.
-    framework_model = ConvAE()
+    framework_model = ConvAE().to(torch.bfloat16)
 
     # Define transform to normalize data
     transform = transforms.Compose(
@@ -45,11 +48,18 @@ def test_conv_ae_pytorch(forge_property_recorder):
     sample = dataset["train"][0]["image"]
     sample_tensor = transform(sample).unsqueeze(0)
 
-    inputs = [sample_tensor]
+    inputs = [sample_tensor.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -75,7 +85,7 @@ def test_linear_ae_pytorch(forge_property_recorder):
     # Instantiate model
     # NOTE: The model has not been pre-trained or fine-tuned.
     # This is for demonstration purposes only.
-    framework_model = LinearAE()
+    framework_model = LinearAE().to(torch.bfloat16)
 
     # Define transform to normalize data
     transform = transforms.Compose(
@@ -91,18 +101,25 @@ def test_linear_ae_pytorch(forge_property_recorder):
     sample = dataset["train"][0]["image"]
     sample_tensor = transform(sample).squeeze(0)
 
-    inputs = [sample_tensor]
+    inputs = [sample_tensor.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification and Inference
     _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
 
     # Post processing
-    output_image = co_out[0].view(1, 28, 28).detach().numpy()
+    output_image = co_out[0].to(torch.float32).view(1, 28, 28).detach().numpy()
     save_path = "forge/test/models/pytorch/vision/autoencoder/results"
     os.makedirs(save_path, exist_ok=True)
     reconstructed_image_path = f"{save_path}/reconstructed_image.png"

--- a/forge/test/models/pytorch/vision/beit/model_utils/utils.py
+++ b/forge/test/models/pytorch/vision/beit/model_utils/utils.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import requests
+import torch
 from PIL import Image
 from transformers import BeitForImageClassification, BeitImageProcessor
 
@@ -17,4 +18,4 @@ def load_input(variant):
     image = Image.open(requests.get(url, stream=True).raw)
     processor = BeitImageProcessor.from_pretrained(variant)
     inputs = processor(images=image, return_tensors="pt")
-    return [inputs["pixel_values"]]
+    return [inputs["pixel_values"].to(torch.bfloat16)]

--- a/forge/test/models/pytorch/vision/beit/test_beit.py
+++ b/forge/test/models/pytorch/vision/beit/test_beit.py
@@ -2,8 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+import torch
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -35,12 +38,19 @@ def test_beit_image_classification(forge_property_recorder, variant):
     )
 
     # Load model and input
-    framework_model = load_model(variant)
+    framework_model = load_model(variant).to(torch.bfloat16)
     inputs = load_input(variant)
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/detr/test_detr.py
+++ b/forge/test/models/pytorch/vision/detr/test_detr.py
@@ -9,6 +9,8 @@ import torch
 from transformers import DetrForObjectDetection, DetrForSegmentation
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import (
     Framework,
     ModelGroup,
@@ -104,17 +106,24 @@ def test_detr_segmentation(forge_property_recorder, variant):
 
     # Load the model
     framework_model = DetrForSegmentation.from_pretrained(variant)
-    framework_model = DetrWrapper(framework_model, task="segmentation")
+    framework_model = DetrWrapper(framework_model, task="segmentation").to(torch.bfloat16)
 
     # Preprocess the image for the model
     image_url = "http://images.cocodataset.org/val2017/000000397133.jpg"
     input_batch = preprocess_input_data(image_url)
 
-    inputs = [input_batch]
+    inputs = [input_batch.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
@@ -20,6 +20,8 @@ from torchvision.models import (
 from torchvision.models._api import WeightsEnum
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import (
     Framework,
     ModelGroup,
@@ -75,7 +77,7 @@ def test_efficientnet_timm(forge_property_recorder, variant):
     )
 
     # Load model
-    framework_model = download_model(timm.create_model, variant, pretrained=True)
+    framework_model = download_model(timm.create_model, variant, pretrained=True).to(torch.bfloat16)
     framework_model.eval()
 
     # Load and pre-process image
@@ -95,11 +97,18 @@ def test_efficientnet_timm(forge_property_recorder, variant):
         )
         img_tensor = torch.rand(1, 3, 224, 224)
 
-    inputs = [img_tensor]
+    inputs = [img_tensor.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -148,6 +157,7 @@ def test_efficientnet_torchvision(forge_property_recorder, variant):
         framework_model = efficientnet_b4(weights=EfficientNet_B4_Weights.IMAGENET1K_V1)
 
     framework_model.eval()
+    framework_model = framework_model.to(torch.bfloat16)
 
     # Load and pre-process image
     try:
@@ -166,11 +176,18 @@ def test_efficientnet_torchvision(forge_property_recorder, variant):
         )
         img_tensor = torch.rand(1, 3, 224, 224)
 
-    inputs = [img_tensor]
+    inputs = [img_tensor.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/efficientnet/test_efficientnet_lite.py
+++ b/forge/test/models/pytorch/vision/efficientnet/test_efficientnet_lite.py
@@ -3,8 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 ## https://github.com/RangiLyu/EfficientNet-Lite/
 import pytest
+import torch
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -35,10 +38,19 @@ def test_efficientnet_lite_timm(forge_property_recorder, variant):
 
     # Load the model and inputs
     framework_model, inputs = load_timm_model_and_input(variant)
+    framework_model = framework_model.to(torch.bfloat16)
+    inputs = inputs.to(torch.bfloat16)
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/fpn/test_fpn.py
+++ b/forge/test/models/pytorch/vision/fpn/test_fpn.py
@@ -5,6 +5,8 @@ import pytest
 import torch
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -19,17 +21,24 @@ def test_fpn_pytorch(forge_property_recorder):
     )
 
     # Load FPN model
-    framework_model = FPNWrapper()
+    framework_model = FPNWrapper().to(torch.bfloat16)
 
-    feat0 = torch.rand(1, 256, 64, 64)
-    feat1 = torch.rand(1, 512, 16, 16)
-    feat2 = torch.rand(1, 2048, 8, 8)
+    feat0 = torch.rand(1, 256, 64, 64).to(torch.bfloat16)
+    feat1 = torch.rand(1, 512, 16, 16).to(torch.bfloat16)
+    feat2 = torch.rand(1, 2048, 8, 8).to(torch.bfloat16)
 
     inputs = [feat0, feat1, feat2]
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/ghostnet/model_utils/utils.py
+++ b/forge/test/models/pytorch/vision/ghostnet/model_utils/utils.py
@@ -30,7 +30,7 @@ def load_ghostnet_model(variant):
     transforms = create_transform(**data_config, is_training=False)
     img_tensor = transforms(img).unsqueeze(0)
 
-    return framework_model, [img_tensor]
+    return framework_model.to(torch.bfloat16), [img_tensor.to(torch.bfloat16)]
 
 
 url = "https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt"

--- a/forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py
+++ b/forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py
@@ -5,6 +5,8 @@
 import pytest
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -38,9 +40,16 @@ def test_ghostnet_timm(forge_property_recorder, variant):
     # Load the model and prepare input data
     framework_model, inputs = load_ghostnet_model(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification and Inference

--- a/forge/test/models/pytorch/vision/hrnet/test_hrnet.py
+++ b/forge/test/models/pytorch/vision/hrnet/test_hrnet.py
@@ -14,6 +14,8 @@ from timm.data.transforms_factory import create_transform
 from torchvision import transforms
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -60,7 +62,7 @@ def generate_model_hrnet_imgcls_osmr_pytorch(variant):
         input_batch = torch.rand(1, 3, 224, 224)
     print(input_batch.shape)
 
-    return model, [input_batch], {}
+    return model.to(torch.bfloat16), [input_batch.to(torch.bfloat16)], {}
 
 
 variants = [
@@ -103,9 +105,17 @@ def test_hrnet_osmr_pytorch(forge_property_recorder, variant):
     framework_model, inputs, _ = generate_model_hrnet_imgcls_osmr_pytorch(
         variant,
     )
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -151,7 +161,7 @@ def generate_model_hrnet_imgcls_timm_pytorch(variant):
         input_tensor = torch.rand(1, 3, 224, 224)
     print(input_tensor.shape)
 
-    return model, [input_tensor], {}
+    return model.to(torch.bfloat16), [input_tensor.to(torch.bfloat16)], {}
 
 
 variants = [
@@ -198,9 +208,17 @@ def test_hrnet_timm_pytorch(forge_property_recorder, variant):
     framework_model, inputs, _ = generate_model_hrnet_imgcls_timm_pytorch(
         variant,
     )
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/inception/test_inception_v4.py
+++ b/forge/test/models/pytorch/vision/inception/test_inception_v4.py
@@ -3,9 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 ## Inception V4
 import pytest
+import torch
 from pytorchcv.model_provider import get_model as ptcv_get_model
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -23,7 +26,7 @@ def generate_model_inceptionV4_imgcls_osmr_pytorch(variant):
     # Load and pre-process image
     img_tensor = get_image()
 
-    return framework_model, [img_tensor]
+    return framework_model.to(torch.bfloat16), [img_tensor.to(torch.bfloat16)]
 
 
 @pytest.mark.nightly
@@ -36,9 +39,16 @@ def test_inception_v4_osmr_pytorch(forge_property_recorder):
 
     framework_model, inputs = generate_model_inceptionV4_imgcls_osmr_pytorch("inceptionv4")
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -48,7 +58,7 @@ def test_inception_v4_osmr_pytorch(forge_property_recorder):
 def generate_model_inceptionV4_imgcls_timm_pytorch(variant):
     # Load model & Preprocess image
     framework_model, img_tensor = download_model(preprocess_timm_model, variant)
-    return framework_model, [img_tensor]
+    return framework_model.to(torch.bfloat16), [img_tensor.to(torch.bfloat16)]
 
 
 variants = [
@@ -77,9 +87,16 @@ def test_inception_v4_timm_pytorch(forge_property_recorder, variant):
 
     framework_model, inputs = generate_model_inceptionV4_imgcls_timm_pytorch(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
+++ b/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
@@ -12,6 +12,8 @@ from timm.data import resolve_data_config
 from timm.data.transforms_factory import create_transform
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -125,14 +127,21 @@ def test_mlp_mixer_pytorch(forge_property_recorder):
         dim=512,
         depth=12,
         num_classes=1000,
-    )
+    ).to(torch.bfloat16)
     framework_model.eval()
 
-    inputs = [torch.randn(1, 3, 256, 256)]
+    inputs = [torch.randn(1, 3, 256, 256).to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/mnist/model_utils/utils.py
+++ b/forge/test/models/pytorch/vision/mnist/model_utils/utils.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
+import torch
 from torch.utils.data import DataLoader
 from torchvision import datasets, transforms
 
@@ -18,4 +19,4 @@ def load_input():
     test_dataset = datasets.MNIST(root="./data", train=False, transform=transform, download=True)
     dataloader = DataLoader(test_dataset, batch_size=1)
     test_input, _ = next(iter(dataloader))
-    return [test_input]
+    return [test_input.to(torch.bfloat16)]

--- a/forge/test/models/pytorch/vision/mobilenet/model_utils/mobilenet_v3_ssd_utils.py
+++ b/forge/test/models/pytorch/vision/mobilenet/model_utils/mobilenet_v3_ssd_utils.py
@@ -23,4 +23,4 @@ def load_input():
     transform = transforms.Compose([transforms.Resize((320, 320)), transforms.ToTensor()])
     img_tensor = [transform(image).unsqueeze(0)]
     batch_tensor = torch.cat(img_tensor, dim=0)
-    return [batch_tensor]
+    return [batch_tensor.to(torch.bfloat16)]

--- a/forge/test/models/pytorch/vision/mobilenet/model_utils/utils.py
+++ b/forge/test/models/pytorch/vision/mobilenet/model_utils/utils.py
@@ -39,7 +39,7 @@ def load_mobilenet_model(model_name):
     input_tensor = preprocess(input_image)
     input_batch = input_tensor.unsqueeze(0)
 
-    return model, [input_batch]
+    return model.to(torch.bfloat16), [input_batch.to(torch.bfloat16)]
 
 
 url = "https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt"

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
@@ -3,10 +3,13 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import requests
+import torch
 from PIL import Image
 from transformers import AutoImageProcessor, AutoModelForImageClassification
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -33,9 +36,16 @@ def test_mobilenetv1_basic(forge_property_recorder):
     # Load the model and prepare input data
     framework_model, inputs = load_mobilenet_model("mobilenet_v1")
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     #  Model Verification and Inference
@@ -58,7 +68,7 @@ def generate_model_mobilenetv1_imgcls_hf_pytorch(variant):
 
     image_tensor = inputs.pixel_values
 
-    return model, [image_tensor], {}
+    return model.to(torch.bfloat16), [image_tensor.to(torch.bfloat16)], {}
 
 
 @pytest.mark.nightly
@@ -77,9 +87,16 @@ def test_mobilenetv1_192(forge_property_recorder, variant):
 
     framework_model, inputs, _ = generate_model_mobilenetv1_imgcls_hf_pytorch(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -98,7 +115,7 @@ def generate_model_mobilenetV1I224_imgcls_hf_pytorch(variant):
 
     image_tensor = inputs.pixel_values
 
-    return model, [image_tensor], {}
+    return model.to(torch.bfloat16), [image_tensor.to(torch.bfloat16)], {}
 
 
 @pytest.mark.nightly
@@ -117,9 +134,16 @@ def test_mobilenetv1_224(forge_property_recorder, variant):
 
     framework_model, inputs, _ = generate_model_mobilenetV1I224_imgcls_hf_pytorch(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -145,11 +169,20 @@ def test_mobilenet_v1_timm(forge_property_recorder, variant):
 
     # Load the model and inputs
     framework_model, inputs = load_timm_model_and_input(variant)
+    framework_model = framework_model.to(torch.bfloat16)
+    inputs = inputs.to(torch.bfloat16)
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=[inputs],
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification and Inference
-    fw_out, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    fw_out, co_out = verify([inputs], framework_model, compiled_model, forge_property_handler=forge_property_recorder)

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -18,6 +18,8 @@ from transformers import (
 )
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, ModelGroup, Source, Task
 from forge.verify.verify import verify
 
@@ -46,9 +48,16 @@ def test_mobilenetv2_basic(forge_property_recorder):
     # Load the model and prepare input data
     framework_model, inputs = load_mobilenet_model("mobilenet_v2")
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification and Inference
@@ -68,7 +77,7 @@ def generate_model_mobilenetV2I96_imgcls_hf_pytorch(variant):
     inputs = preprocessor(images=image, return_tensors="pt")
     image_tensor = inputs.pixel_values
 
-    return model, [image_tensor], {}
+    return model.to(torch.bfloat16), [image_tensor.to(torch.bfloat16)], {}
 
 
 @pytest.mark.nightly
@@ -87,9 +96,16 @@ def test_mobilenetv2_96(forge_property_recorder, variant):
 
     framework_model, inputs, _ = generate_model_mobilenetV2I96_imgcls_hf_pytorch(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -106,7 +122,7 @@ def generate_model_mobilenetV2I160_imgcls_hf_pytorch(variant):
     inputs = preprocessor(images=image, return_tensors="pt")
     image_tensor = inputs.pixel_values
 
-    return model, [image_tensor], {}
+    return model.to(torch.bfloat16), [image_tensor.to(torch.bfloat16)], {}
 
 
 @pytest.mark.nightly
@@ -125,9 +141,16 @@ def test_mobilenetv2_160(forge_property_recorder, variant):
 
     framework_model, inputs, _ = generate_model_mobilenetV2I160_imgcls_hf_pytorch(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -146,7 +169,7 @@ def generate_model_mobilenetV2I244_imgcls_hf_pytorch(variant):
 
     image_tensor = inputs.pixel_values
 
-    return model, [image_tensor], {}
+    return model.to(torch.bfloat16), [image_tensor.to(torch.bfloat16)], {}
 
 
 @pytest.mark.nightly
@@ -165,9 +188,16 @@ def test_mobilenetv2_224(forge_property_recorder, variant):
 
     framework_model, inputs, _ = generate_model_mobilenetV2I244_imgcls_hf_pytorch(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -195,7 +225,7 @@ def generate_model_mobilenetV2_imgcls_timm_pytorch(variant):
         )
         image_tensor = torch.rand(1, 3, 224, 224)
 
-    return model, [image_tensor], {}
+    return model.to(torch.bfloat16), [image_tensor.to(torch.bfloat16)], {}
 
 
 @pytest.mark.nightly
@@ -213,9 +243,16 @@ def test_mobilenetv2_timm(forge_property_recorder, variant):
 
     framework_model, inputs, _ = generate_model_mobilenetV2_imgcls_timm_pytorch(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -250,7 +287,7 @@ def generate_model_mobilenetV2_semseg_hf_pytorch(variant):
         )
         img_tensor = torch.rand(1, 3, 224, 224)
 
-    return framework_model, [img_tensor], {}
+    return framework_model.to(torch.bfloat16), [img_tensor.to(torch.bfloat16)], {}
 
 
 variants = ["google/deeplabv3_mobilenet_v2_1.0_513"]
@@ -272,9 +309,16 @@ def test_mobilenetv2_deeplabv3(forge_property_recorder, variant):
 
     framework_model, inputs, _ = generate_model_mobilenetV2_semseg_hf_pytorch(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -302,10 +346,19 @@ def test_mobilenetv2_torchvision(forge_property_recorder, variant):
     # Load model and input
     weight_name = variants_with_weights[variant]
     framework_model, inputs = load_vision_model_and_input(variant, "classification", weight_name)
+    framework_model = framework_model.to(torch.bfloat16)
+    inputs = inputs.to(torch.bfloat16)
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
@@ -12,6 +12,8 @@ from timm.data import resolve_data_config
 from timm.data.transforms_factory import create_transform
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -43,9 +45,16 @@ def test_mobilenetv3_basic(forge_property_recorder, variant):
     # Load the model and prepare input data
     framework_model, inputs = load_mobilenet_model(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification and Inference
@@ -80,7 +89,7 @@ def generate_model_mobilenetV3_imgcls_timm_pytorch(variant):
         )
         image_tensor = torch.rand(1, 3, 224, 224)
 
-    return model, [image_tensor], {}
+    return model.to(torch.bfloat16), [image_tensor.to(torch.bfloat16)], {}
 
 
 variants = ["mobilenetv3_large_100", "mobilenetv3_small_100"]
@@ -104,9 +113,16 @@ def test_mobilenetv3_timm(forge_property_recorder, variant):
         variant,
     )
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3_ssd.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3_ssd.py
@@ -2,8 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+import torch
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -36,12 +39,19 @@ def test_mobilenetv3_ssd(forge_property_recorder, variant):
 
     # Load model and input
     weight_name = variants_with_weights[variant]
-    framework_model = load_model(variant, weight_name)
+    framework_model = load_model(variant, weight_name).to(torch.bfloat16)
     inputs = load_input()
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/regnet/model_utils/image_utils.py
+++ b/forge/test/models/pytorch/vision/regnet/model_utils/image_utils.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import requests
+import torch
 from PIL import Image
 from transformers import AutoImageProcessor
 
@@ -19,4 +20,4 @@ def preprocess_input_data(image_url, variant):
     # Preprocess the image
     image_tensor = preprocessor(images=image, return_tensors="pt").pixel_values
 
-    return [image_tensor]
+    return [image_tensor.to(torch.bfloat16)]

--- a/forge/test/models/pytorch/vision/resnext/model_utils/utils.py
+++ b/forge/test/models/pytorch/vision/resnext/model_utils/utils.py
@@ -39,7 +39,7 @@ def get_resnext_model_and_input(repo_or_dir, model_name):
 
     input_batch = get_image_tensor()
 
-    return model, [input_batch]
+    return model.to(torch.bfloat16), [input_batch.to(torch.bfloat16)]
 
 
 url = "https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt"

--- a/forge/test/models/pytorch/vision/resnext/test_resnext.py
+++ b/forge/test/models/pytorch/vision/resnext/test_resnext.py
@@ -7,6 +7,8 @@ import torch
 from pytorchcv.model_provider import get_model as ptcv_get_model
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -34,9 +36,16 @@ def test_resnext_50_torchhub_pytorch(forge_property_recorder, variant):
     # Load the model and prepare input data
     framework_model, inputs = get_resnext_model_and_input("pytorch/vision:v0.10.0", variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification and Inference
@@ -62,9 +71,16 @@ def test_resnext_101_torchhub_pytorch(forge_property_recorder, variant):
     # Load the model and prepare input data
     framework_model, inputs = get_resnext_model_and_input("pytorch/vision:v0.10.0", variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification and Inference
@@ -90,13 +106,21 @@ def test_resnext_101_32x8d_fb_wsl_pytorch(forge_property_recorder, variant):
     # Load the model and prepare input data
     framework_model = download_model(torch.hub.load, "facebookresearch/WSL-Images", variant)
     framework_model.eval()
+    framework_model.to(torch.bfloat16)
 
     input_batch = get_image_tensor()
-    inputs = [input_batch]
+    inputs = [input_batch.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -120,15 +144,22 @@ def test_resnext_14_osmr_pytorch(forge_property_recorder, variant):
     )
 
     # Load the model and prepare input data
-    framework_model = download_model(ptcv_get_model, variant, pretrained=True)
+    framework_model = download_model(ptcv_get_model, variant, pretrained=True).to(torch.bfloat16)
     framework_model.eval()
 
     input_batch = get_image_tensor()
-    inputs = [input_batch]
+    inputs = [input_batch.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -152,15 +183,22 @@ def test_resnext_26_osmr_pytorch(forge_property_recorder, variant):
     )
 
     # STEP 2: Create Forge module from PyTorch model
-    framework_model = download_model(ptcv_get_model, variant, pretrained=True)
+    framework_model = download_model(ptcv_get_model, variant, pretrained=True).to(torch.bfloat16)
     framework_model.eval()
 
     input_batch = get_image_tensor()
-    inputs = [input_batch]
+    inputs = [input_batch.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -184,15 +222,22 @@ def test_resnext_50_osmr_pytorch(forge_property_recorder, variant):
     )
 
     # STEP 2: Create Forge module from PyTorch model
-    framework_model = download_model(ptcv_get_model, variant, pretrained=True)
+    framework_model = download_model(ptcv_get_model, variant, pretrained=True).to(torch.bfloat16)
     framework_model.eval()
 
     input_batch = get_image_tensor()
-    inputs = [input_batch]
+    inputs = [input_batch.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -216,15 +261,22 @@ def test_resnext_101_osmr_pytorch(forge_property_recorder, variant):
     )
 
     # STEP 2: Create Forge module from PyTorch model
-    framework_model = download_model(ptcv_get_model, variant, pretrained=True)
+    framework_model = download_model(ptcv_get_model, variant, pretrained=True).to(torch.bfloat16)
     framework_model.eval()
 
     input_batch = get_image_tensor()
-    inputs = [input_batch]
+    inputs = [input_batch.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
+++ b/forge/test/models/pytorch/vision/retinanet/test_retinanet.py
@@ -7,8 +7,11 @@ import zipfile
 
 import pytest
 import requests
+import torch
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -61,14 +64,22 @@ def test_retinanet(forge_property_recorder, variant):
 
     framework_model = Model.load(checkpoint_path)
     framework_model.eval()
+    framework_model.to(torch.bfloat16)
 
     # Prepare input
     input_batch = img_preprocess()
-    inputs = [input_batch]
+    inputs = [input_batch.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -102,9 +113,16 @@ def test_retinanet_torchvision(forge_property_recorder, variant):
     weight_name = variants_with_weights[variant]
     framework_model, inputs = load_vision_model_and_input(variant, "detection", weight_name)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/rmbg/model_utils/utils.py
+++ b/forge/test/models/pytorch/vision/rmbg/model_utils/utils.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import requests
+import torch
 from PIL import Image
 from torchvision import transforms
 from transformers import AutoModelForImageSegmentation
@@ -25,4 +26,4 @@ def load_input():
         ]
     )
     inputs = transform_image(image).unsqueeze(0)
-    return [inputs]
+    return [inputs.to(torch.bfloat16)]

--- a/forge/test/models/pytorch/vision/rmbg/test_rmbg.py
+++ b/forge/test/models/pytorch/vision/rmbg/test_rmbg.py
@@ -3,8 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+import torch
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -26,12 +29,19 @@ def test_rmbg(forge_property_recorder, variant):
     )
 
     # Load model and input
-    framework_model = load_model(variant)
+    framework_model = load_model(variant).to(torch.bfloat16)
     inputs = load_input()
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/sam/model_utils/model.py
+++ b/forge/test/models/pytorch/vision/sam/model_utils/model.py
@@ -26,10 +26,10 @@ def get_model_inputs(variant, input_url="https://huggingface.co/ybelkada/segment
     input_points = [[[450, 600]]]
     inputs = processor(raw_image, input_points=input_points, return_tensors="pt").to("cpu")
     sample_inputs = (
-        inputs["pixel_values"],
-        inputs["input_points"],
+        inputs["pixel_values"].to(torch.bfloat16),
+        inputs["input_points"].to(torch.bfloat16),
     )
-    return framework_model, sample_inputs
+    return framework_model.to(torch.bfloat16), sample_inputs
 
 
 class SamWrapper(torch.nn.Module):

--- a/forge/test/models/pytorch/vision/sam/test_sam.py
+++ b/forge/test/models/pytorch/vision/sam/test_sam.py
@@ -5,6 +5,8 @@
 import pytest
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, ModelGroup, Source, Task
 from forge.verify.verify import verify
 
@@ -41,11 +43,16 @@ def test_sam(forge_property_recorder, variant):
 
     # Forge compile framework model
     framework_model = SamWrapper(framework_model)
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     compiled_model = forge.compile(
         framework_model,
         sample_inputs=sample_inputs,
         module_name=module_name,
         forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/ssd300_resnet50/test_ssd300_resnet50.py
+++ b/forge/test/models/pytorch/vision/ssd300_resnet50/test_ssd300_resnet50.py
@@ -7,6 +7,8 @@ import requests
 import torch
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -34,6 +36,7 @@ def test_pytorch_ssd300_resnet50(forge_property_recorder):
 
     checkpoint = torch.load(checkpoint_path, map_location=torch.device("cpu"))
     framework_model.load_state_dict(checkpoint["model"])
+    framework_model.to(torch.bfloat16)
     framework_model.eval()
 
     # STEP 3 : prepare input
@@ -42,11 +45,18 @@ def test_pytorch_ssd300_resnet50(forge_property_recorder):
     CHW = np.swapaxes(np.swapaxes(HWC, 0, 2), 1, 2)
     batch = np.expand_dims(CHW, axis=0)
     input_batch = torch.from_numpy(batch).float()
-    inputs = [input_batch]
+    inputs = [input_batch.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/ssd300_vgg16/test_ssd300_vgg16.py
+++ b/forge/test/models/pytorch/vision/ssd300_vgg16/test_ssd300_vgg16.py
@@ -4,6 +4,8 @@
 import pytest
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -32,9 +34,16 @@ def test_ssd300_vgg16(forge_property_recorder, variant):
     weight_name = variants_with_weights[variant]
     framework_model, inputs = load_vision_model_and_input(variant, "detection", weight_name)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3.py
+++ b/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3.py
@@ -4,6 +4,8 @@
 import pytest
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -32,9 +34,16 @@ def test_ssdlite320_mobilenetv3(forge_property_recorder, variant):
     weight_name = variants_with_weights[variant]
     framework_model, inputs = load_vision_model_and_input(variant, "detection", weight_name)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/swin/model_utils/image_utils.py
+++ b/forge/test/models/pytorch/vision/swin/model_utils/image_utils.py
@@ -10,7 +10,7 @@ from torchvision import models
 def load_image(image_path, feature_extractor):
     image = Image.open(requests.get(image_path, stream=True).raw)
     img_tensor = feature_extractor(images=image, return_tensors="pt").pixel_values
-    return [img_tensor]
+    return [img_tensor.to(torch.bfloat16)]
 
 
 variants_with_weights = {

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # STEP 0: import Forge library
 import pytest
+import torch
 from transformers import (
     SwinForImageClassification,
     Swinv2ForImageClassification,
@@ -12,6 +13,8 @@ from transformers import (
 )
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import (
     Framework,
     ModelGroup,
@@ -47,16 +50,23 @@ def test_swin_v1_tiny_4_224_hf_pytorch(forge_property_recorder, variant):
 
     # STEP 1: Create Forge module from PyTorch model
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
-    framework_model = SwinForImageClassification.from_pretrained(variant)
+    framework_model = SwinForImageClassification.from_pretrained(variant).to(torch.bfloat16)
     framework_model.eval()
 
     # STEP 2: Prepare input samples
     url = "http://images.cocodataset.org/val2017/000000039769.jpg"
     inputs = load_image(url, feature_extractor)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -149,7 +159,7 @@ def test_swin_v2_tiny_masked(forge_property_recorder, variant):
         framework=Framework.PYTORCH,
         model="swin",
         variant=variant,
-        task=Task.MASKED_IMAGE_MODELLING,
+        task=Task.MASKED_IMAGE_MODELING,
         source=Source.HUGGINGFACE,
     )
 

--- a/forge/test/models/pytorch/vision/unet/test_unet.py
+++ b/forge/test/models/pytorch/vision/unet/test_unet.py
@@ -21,6 +21,8 @@ from torchvision.transforms import (
 )
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import (
     Framework,
     ModelGroup,
@@ -41,7 +43,7 @@ def generate_model_unet_imgseg_osmr_pytorch(variant):
 
     img_tensor = x = torch.randn(1, 3, 224, 224)
 
-    return model, [img_tensor], {}
+    return model.to(torch.bfloat16), [img_tensor.to(torch.bfloat16)], {}
 
 
 @pytest.mark.xfail
@@ -60,9 +62,16 @@ def test_unet_osmr_cityscape_pytorch(forge_property_recorder):
 
     framework_model, inputs, _ = generate_model_unet_imgseg_osmr_pytorch("unet_cityscapes")
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -151,7 +160,7 @@ def generate_model_unet_imgseg_smp_pytorch(variant):
     img_tensor = (img_tensor - mean) / std
     print(img_tensor.shape)
 
-    return model, [img_tensor], {}
+    return model.to(torch.bfloat16), [img_tensor.to(torch.bfloat16)], {}
 
 
 @pytest.mark.nightly
@@ -169,9 +178,16 @@ def test_unet_qubvel_pytorch(forge_property_recorder):
 
     framework_model, inputs, _ = generate_model_unet_imgseg_smp_pytorch(None)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -210,7 +226,7 @@ def generate_model_unet_imgseg_torchhub_pytorch(variant):
     input_tensor = preprocess(input_image)
     img_batch = input_tensor.unsqueeze(0)
 
-    return model, [img_batch], {}
+    return model.to(torch.bfloat16), [img_batch.to(torch.bfloat16)], {}
 
 
 @pytest.mark.nightly
@@ -226,9 +242,16 @@ def test_unet_torchhub_pytorch(forge_property_recorder):
         "unet",
     )
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
@@ -248,13 +271,20 @@ def test_unet_carvana(forge_property_recorder):
     )
 
     # Load model and input
-    framework_model = UNET(in_channels=3, out_channels=1)
+    framework_model = UNET(in_channels=3, out_channels=1).to(torch.bfloat16)
     framework_model.eval()
-    inputs = [torch.rand((1, 3, 224, 224))]
+    inputs = [torch.rand((1, 3, 224, 224)).to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/vision_utils/utils.py
+++ b/forge/test/models/pytorch/vision/vision_utils/utils.py
@@ -43,4 +43,4 @@ def load_vision_model_and_input(variant, task, weight_name):
     # Current limitation of compiler/runtime is that it does not support non-contiguous tensors properly.
     batch_t = batch_t.contiguous()
 
-    return model, [batch_t]
+    return model.to(torch.bfloat16), [batch_t.to(torch.bfloat16)]

--- a/forge/test/models/pytorch/vision/wideresnet/model_utils/utils.py
+++ b/forge/test/models/pytorch/vision/wideresnet/model_utils/utils.py
@@ -31,7 +31,7 @@ def generate_model_wideresnet_imgcls_pytorch(variant):
     input_tensor = preprocess(input_image)
     img_tensor = input_tensor.unsqueeze(0)
 
-    return framework_model, [img_tensor]
+    return framework_model.to(torch.bfloat16), [img_tensor.to(torch.bfloat16)]
 
 
 url = "https://raw.githubusercontent.com/pytorch/hub/master/imagenet_classes.txt"

--- a/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
+++ b/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
@@ -5,11 +5,14 @@ import urllib
 
 import pytest
 import timm
+import torch
 from PIL import Image
 from timm.data import resolve_data_config
 from timm.data.transforms_factory import create_transform
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -41,9 +44,16 @@ def test_wideresnet_pytorch(forge_property_recorder, variant):
     # Load the model and prepare input data
     (framework_model, inputs) = generate_model_wideresnet_imgcls_pytorch(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification and Inference
@@ -67,7 +77,7 @@ def generate_model_wideresnet_imgcls_timm(variant):
     img = Image.open(filename).convert("RGB")
     img_tensor = transform(img).unsqueeze(0)
 
-    return framework_model, [img_tensor]
+    return framework_model.to(torch.bfloat16), [img_tensor.to(torch.bfloat16)]
 
 
 variants = ["wide_resnet50_2", "wide_resnet101_2"]
@@ -88,9 +98,16 @@ def test_wideresnet_timm(forge_property_recorder, variant):
 
     (framework_model, inputs) = generate_model_wideresnet_imgcls_timm(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/xception/test_xception.py
+++ b/forge/test/models/pytorch/vision/xception/test_xception.py
@@ -5,11 +5,14 @@ import urllib
 
 import pytest
 import timm
+import torch
 from PIL import Image
 from timm.data import resolve_data_config
 from timm.data.transforms_factory import create_transform
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -33,7 +36,7 @@ def generate_model_xception_imgcls_timm(variant):
     img = Image.open(filename).convert("RGB")
     img_tensor = transform(img).unsqueeze(0)
 
-    return framework_model, [img_tensor]
+    return framework_model.to(torch.bfloat16), [img_tensor.to(torch.bfloat16)]
 
 
 params = [
@@ -63,9 +66,16 @@ def test_xception_timm(forge_property_recorder, variant):
 
     (framework_model, inputs) = generate_model_xception_imgcls_timm(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification and Inference

--- a/forge/test/models/pytorch/vision/yolo/model_utils/yolos_utils.py
+++ b/forge/test/models/pytorch/vision/yolo/model_utils/yolos_utils.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import requests
+import torch
 from PIL import Image
 from transformers import AutoImageProcessor, AutoModelForObjectDetection
 
@@ -9,7 +10,7 @@ from transformers import AutoImageProcessor, AutoModelForObjectDetection
 def load_model(variant):
     model = AutoModelForObjectDetection.from_pretrained(variant)
     model.eval()
-    return model
+    return model.to(torch.bfloat16)
 
 
 def load_input(variant):
@@ -17,4 +18,4 @@ def load_input(variant):
     image = Image.open(requests.get(test_input, stream=True).raw)
     image_processor = AutoImageProcessor.from_pretrained(variant)
     inputs = image_processor(images=image, return_tensors="pt")
-    return [inputs["pixel_values"]]
+    return [inputs["pixel_values"].to(torch.bfloat16)]

--- a/forge/test/models/pytorch/vision/yolo/test_yolos.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolos.py
@@ -4,6 +4,8 @@
 import pytest
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
@@ -38,9 +40,16 @@ def test_yolos(forge_property_recorder, variant):
     framework_model = load_model(variant)
     inputs = load_input(variant)
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification

--- a/forge/test/models/pytorch/vision/yolo/test_yolox.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolox.py
@@ -28,6 +28,8 @@ import torch
 from yolox.exp import get_exp
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
@@ -81,6 +83,7 @@ def test_yolox_pytorch(forge_property_recorder, variant):
     framework_model.head.decode_in_inference = False
 
     framework_model.eval()
+    framework_model.to(torch.bfloat16)
     model_name = f"pt_{variant}"
 
     # prepare input
@@ -97,11 +100,18 @@ def test_yolox_pytorch(forge_property_recorder, variant):
     img_tensor = preprocess(img, input_shape)
     img_tensor = img_tensor.unsqueeze(0)
 
-    inputs = [img_tensor]
+    inputs = [img_tensor.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
     )
 
     # Model Verification


### PR DESCRIPTION
### Ticket

- https://github.com/tenstorrent/tt-forge-fe/issues/1987

### Summary 

- Set convolution-based models to be on bfp16 

### Note 

- New regressions are tracked in [#1987](https://github.com/tenstorrent/tt-forge-fe/issues/1987).

- In the VGG models, the PCC for vgg19 and bn_vgg19b is below 0.99 even in the float32 case. As [Everything above 0.95 is tolerable for now](https://github.com/tenstorrent/tt-forge-fe/issues/1987#issuecomment-2891165285)  pcc adjusted accordingly.

| Test Name       | PCC (float32) | PCC (bfloat16) |
|----------------|----------------|-----------------|
| forge/test/models/pytorch/vision/vgg/test_vgg.py::test_vgg_osmr_pytorch[vgg16]    | >=0.99         |   0.9895039351320837      |
| forge/test/models/pytorch/vision/vgg/test_vgg.py::test_vgg_osmr_pytorch[vgg19]    |    0.9856318375050916      |     0.9772661805379736      |
|  forge/test/models/pytorch/vision/vgg/test_vgg.py::test_vgg_osmr_pytorch[bn_vgg19b]   | 0.986650973327936        |    0.9691731206520947       |





