### PR TITLE
Re-enable the skipped set8 tests in CI

### DIFF
--- a/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
+++ b/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
@@ -15,6 +15,7 @@ import forge
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
 from test.utils import download_model
 
 varaints = [
@@ -22,15 +23,36 @@ varaints = [
         "mixer_b16_224",
         marks=[pytest.mark.xfail],
     ),
-    "mixer_b16_224_in21k",
-    "mixer_b16_224_miil",
-    "mixer_b16_224_miil_in21k",
-    "mixer_b32_224",
-    "mixer_l16_224",
-    "mixer_l16_224_in21k",
-    "mixer_l32_224",
-    "mixer_s16_224",
-    "mixer_s32_224",
+    pytest.param(
+        "mixer_b16_224_in21k",
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param("mixer_b16_224_miil"),
+    pytest.param(
+        "mixer_b16_224_miil_in21k",
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(
+        "mixer_b32_224",
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(
+        "mixer_l16_224",
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(
+        "mixer_l16_224_in21k",
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(
+        "mixer_l32_224",
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param("mixer_s16_224"),
+    pytest.param(
+        "mixer_s32_224",
+        marks=[pytest.mark.xfail],
+    ),
     pytest.param(
         "mixer_b16_224.goog_in21k",
         marks=[pytest.mark.xfail],
@@ -41,8 +63,6 @@ varaints = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", varaints)
 def test_mlp_mixer_timm_pytorch(forge_property_recorder, variant):
-    if variant not in ["mixer_b16_224", "mixer_b16_224.goog_in21k"]:
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -79,7 +99,10 @@ def test_mlp_mixer_timm_pytorch(forge_property_recorder, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])
 
 
 @pytest.mark.nightly

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -103,9 +103,16 @@ def test_swin_v2_tiny_4_256_hf_pytorch(forge_property_recorder, variant):
 
 @pytest.mark.nightly
 @pytest.mark.skip_model_analysis
-@pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "microsoft/swinv2-tiny-patch4-window8-256",
+            marks=[pytest.mark.skip(reason="Transient failure - Segmentation fault")],
+        ),
+    ],
+)
 def test_swin_v2_tiny_image_classification(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -133,9 +140,9 @@ def test_swin_v2_tiny_image_classification(forge_property_recorder, variant):
 
 @pytest.mark.nightly
 @pytest.mark.skip_model_analysis
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
 def test_swin_v2_tiny_masked(forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/vit/test_vit.py
+++ b/forge/test/models/pytorch/vision/vit/test_vit.py
@@ -15,6 +15,7 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
 from test.models.pytorch.vision.utils.utils import load_vision_model_and_input
 from test.utils import download_model
 
@@ -31,8 +32,6 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_vit_classify_224_hf_pytorch(forge_property_recorder, variant):
-    if variant != "google/vit-base-patch16-224":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     if variant in ["google/vit-base-patch16-224"]:
@@ -83,20 +82,17 @@ variants_with_weights = {
 }
 
 variants = [
-    "vit_b_16",
-    "vit_b_32",
-    "vit_l_16",
-    "vit_l_32",
-    "vit_h_14",
+    pytest.param("vit_b_16"),
+    pytest.param("vit_b_32", marks=[pytest.mark.xfail]),
+    pytest.param("vit_l_16"),
+    pytest.param("vit_l_32", marks=[pytest.mark.xfail]),
+    pytest.param("vit_h_14", marks=[pytest.mark.xfail]),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_vit_torchvision(forge_property_recorder, variant):
-
-    if variant != "vit_b_16":
-        pytest.skip("Skipping this variant; only testing the small variant(vit_b_16) for now.")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -117,4 +113,7 @@ def test_vit_torchvision(forge_property_recorder, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -28,15 +28,13 @@ size = [
     pytest.param("s", id="yolov5s"),
     pytest.param("m", id="yolov5m"),
     pytest.param("l", id="yolov5l"),
-    pytest.param("x", id="yolov5x"),
+    pytest.param("x", id="yolov5x", marks=[pytest.mark.xfail]),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size)
 def test_yolov5_320x320(restore_package_versions, forge_property_recorder, size):
-    if size != "s":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -76,15 +74,13 @@ size = [
     pytest.param("s", id="yolov5s"),
     pytest.param("m", id="yolov5m"),
     pytest.param("l", id="yolov5l"),
-    pytest.param("x", id="yolov5x"),
+    pytest.param("x", id="yolov5x", marks=[pytest.mark.xfail]),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size)
 def test_yolov5_640x640(restore_package_versions, forge_property_recorder, size):
-    if size != "s":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -130,8 +126,6 @@ size = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size)
 def test_yolov5_480x480(restore_package_versions, forge_property_recorder, size):
-    if size != "n":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -159,8 +153,8 @@ def test_yolov5_480x480(restore_package_versions, forge_property_recorder, size)
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["yolov5s"])
+@pytest.mark.xfail
 def test_yolov5_1280x1280(restore_package_versions, forge_property_recorder, variant):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v6.py
@@ -18,18 +18,16 @@ from test.models.pytorch.vision.yolo.utils.yolov6_utils import (
 
 # Didn't dealt with yolov6n6,yolov6s6,yolov6m6,yolov6l6 variants because of its higher input size(1280)
 variants = [
-    "yolov6n",
-    "yolov6s",
-    "yolov6m",
-    "yolov6l",
+    pytest.param("yolov6n"),
+    pytest.param("yolov6s"),
+    pytest.param("yolov6m", marks=[pytest.mark.xfail]),
+    pytest.param("yolov6l", marks=[pytest.mark.xfail]),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_yolo_v6_pytorch(forge_property_recorder, variant):
-    if variant != "yolov6n":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(


### PR DESCRIPTION
 This PR enables the following skipped test cases:

````
pt_mlp_mixer_mixer_b16_224_in21k_img_cls_timm - Maximum: 2795.46 MB
pt_mlp_mixer_mixer_b16_224_miil_img_cls_timm - Maximum: 2815.50 MB
pt_mlp_mixer_mixer_b16_224_miil_in21k_img_cls_timm - Maximum: 2405.73 MB
pt_mlp_mixer_mixer_b32_224_img_cls_timm - Maximum: 2747.32 MB
pt_mlp_mixer_mixer_l16_224_img_cls_timm - Maximum: 4566.92 MB
pt_mlp_mixer_mixer_l16_224_in21k_img_cls_timm - Maximum: 6040.29 MB
pt_mlp_mixer_mixer_l32_224_img_cls_timm - Maximum: 5655.61 MB
pt_mlp_mixer_mixer_s16_224_img_cls_timm - Maximum: 3638.64 MB
pt_mlp_mixer_mixer_s32_224_img_cls_timm - Maximum: 1841.23 MB
pt_mlp_mixer_base_img_cls_github - Maximum: 2846.25 MB
pt_swin_microsoft_swinv2_tiny_patch4_window8_256_masked_img_modeling_hf - Maximum: 1960.93 MB
pt_vit_google_vit_large_patch16_224_img_cls_hf - Maximum: 4538.78 MB
pt_vit_vit_b_32_img_cls_torchvision - Maximum: 2438.75 MB
pt_vit_vit_l_16_img_cls_torchvision -  Maximum: 4728.04 MB
pt_vit_vit_l_32_img_cls_torchvision - Maximum: 4416.30 MB
pt_vit_vit_h_14_img_cls_torchvision - Maximum: 17285.52 MB
pt_yolo_v5_yolov5n_img_cls_torchhub_320x320 - Maximum: 1606.18 MB 
pt_yolo_v5_yolov5m_img_cls_torchhub_320x320 - Maximum: 1887.80 MB
pt_yolo_v5_yolov5l_img_cls_torchhub_320x320 - Maximum: 2190.95 MB
pt_yolo_v5_yolov5x_img_cls_torchhub_320x320 - Maximum: 2666.27 MB
pt_yolo_v5_yolov5n_img_cls_torchhub_640x640 - Maximum: 2617.00 MB
pt_yolo_v5_yolov5m_img_cls_torchhub_640x640 - Maximum: 2566.23 MB
pt_yolo_v5_yolov5l_img_cls_torchhub_640x640 - Maximum: 2820.91 MB
pt_yolo_v5_yolov5x_img_cls_torchhub_640x640 - Maximum: 3367.45 MB
pt_yolo_v5_yolov5s_img_cls_torchhub_480x480 - Maximum: 2630.69 MB
pt_yolo_v5_yolov5m_img_cls_torchhub_480x480 - Maximum: 2824.68 MB
pt_yolo_v5_yolov5l_img_cls_torchhub_480x480 - Maximum: 3037.34 MB
pt_yolo_v5_yolov5x_img_cls_torchhub_480x480 - Maximum: 3538.53 MB
pt_yolo_v5_yolov5s_img_cls_torchhub_1280x1280 - Maximum: 3867.04 MB
pt_yolo_v6_yolov6s_obj_det_torchhub - Maximum: 1911.02 MB
pt_yolo_v6_yolov6m_obj_det_torchhub - Maximum: 2525.12 MB
pt_yolo_v6_yolov6l_obj_det_torchhub - Maximum: 3531.28 MB
````
logs:
[mlp_mixer.log](https://github.com/user-attachments/files/20297964/mlp_mixer.log)
[vit.log](https://github.com/user-attachments/files/20298023/vit.log)
[swinv2_tiny_masked.log](https://github.com/user-attachments/files/20298025/swinv2_tiny_masked.log)
[yolov5.log](https://github.com/user-attachments/files/20298161/yolov5.log)
[yolov6.log](https://github.com/user-attachments/files/20298193/yolov6.log)
