### PR TITLE
Moving data format override pass after decompose, and debug decompose 

### DIFF
--- a/forge/csrc/forge_passes.cpp
+++ b/forge/csrc/forge_passes.cpp
@@ -80,7 +80,6 @@ run_post_initial_graph_passes(
     std::shared_ptr<void> compiler_cfg = make_shared_py_object(compiler_cfg_object);
 
     passes::print_graph(graph, "INITIAL");
-    passes::apply_user_data_format_override(graph, compiler_cfg_object);
     passes::generate_initial_flops_estimate(graph);
     passes::decompose_nd_reshape_split(graph);
     passes::erase_unnecessary_4d_tm_sequence(graph);
@@ -90,6 +89,7 @@ run_post_initial_graph_passes(
 
     auto inserted_node_id_mapping = decompose_tt_forge_graph(graph, "get_f_forge_decompose", compiler_cfg);
     auto chip_id_assignments = passes::fracture(graph, fracture_groups);
+    passes::apply_user_data_format_override(graph, compiler_cfg_object);
     return std::make_tuple(inserted_node_id_mapping, chip_id_assignments);
 }
 

--- a/forge/csrc/passes/decomposing_context.cpp
+++ b/forge/csrc/passes/decomposing_context.cpp
@@ -161,15 +161,37 @@ void DecomposingContext::fuse(NodeContext operand, graphlib::PortId producer_out
     }
 }
 
-NodeContext DecomposingContext::tensor(std::shared_ptr<void> tensor, graphlib::Shape tensor_shape, DataFormat df)
+NodeContext DecomposingContext::tensor(std::shared_ptr<void> tensor, graphlib::Shape tensor_shape)
 {
+    TT_ASSERT(tensor, "Trying to create constant tensor node with null tensor");
+    // Import and call forge.tensor.pytorch_dtype_to_forge_dataformat
+    py::module_ tensor_module = py::module_::import("forge.tensor");
+
     auto new_node = graph->add_node(
         graphlib::create_node<graphlib::ConstantInputNode>(
             "dc.input_tensor." + this->node_->name() + "." + std::to_string(this->op_index), tensor, tensor_shape),
         subgraph_idx);
+
     new_node->set_shape(tensor_shape);
 
-    new_node->set_output_df((df != DataFormat::Invalid) ? df : this->node_->output_df());
+    // Try to extract torch tensor dtype and map to DataFormat
+    DataFormat output_df;
+
+    py::object py_tensor = borrow_shared_py_object(tensor);
+    py::object tensor_dtype = py_tensor.attr("dtype");
+
+    try
+    {
+        output_df = py::cast<DataFormat>(tensor_module.attr("pytorch_dtype_to_forge_dataformat")(tensor_dtype));
+    }
+    catch (py::error_already_set &e)
+    {
+        throw std::runtime_error(
+            "Encountered python error while dtype to DataFormat mapping: " + std::string(e.what()));
+    }
+
+    new_node->set_output_df(output_df);
+
     new_node->set_epoch_type(this->node_->get_epoch_type());
     this->op_index++;
 

--- a/forge/csrc/passes/decomposing_context.hpp
+++ b/forge/csrc/passes/decomposing_context.hpp
@@ -48,8 +48,7 @@ class DecomposingContext
         bool optimize_hoist = false,
         DataFormat output_df = DataFormat::Invalid);
     void fuse(NodeContext operand, graphlib::PortId out_port);
-    NodeContext tensor(
-        std::shared_ptr<void> tensor_handle, graphlib::Shape tensor_shape, DataFormat df = DataFormat::Invalid);
+    NodeContext tensor(std::shared_ptr<void> tensor_handle, graphlib::Shape tensor_shape);
 
     Graph* get_graph() { return graph; }
 

--- a/forge/csrc/passes/python_bindings.cpp
+++ b/forge/csrc/passes/python_bindings.cpp
@@ -252,15 +252,13 @@ void PassesModule(py::module &m_passes)
         .def("fuse", &tt::DecomposingContext::fuse, py::arg("operand"), py::arg("producer_output_port_id") = 0)
         .def(
             "tensor",
-            [](tt::DecomposingContext &self, py::object tensor, DataFormat df)
+            [](tt::DecomposingContext &self, py::object tensor)
             {
                 return self.tensor(
                     make_shared_py_object(tensor),
-                    graphlib::Shape::create(tensor.attr("shape").cast<std::vector<std::uint32_t>>()),
-                    df);
+                    graphlib::Shape::create(tensor.attr("shape").cast<std::vector<std::uint32_t>>()));
             },
-            py::arg("tensor"),
-            py::arg("df") = DataFormat::Invalid)
+            py::arg("tensor"))
         .def(
             "get_pytorch_tensor",
             [](tt::DecomposingContext &self, graphlib::NodeContext const &node)

--- a/forge/forge/op/eval/forge/pad.py
+++ b/forge/forge/op/eval/forge/pad.py
@@ -243,7 +243,7 @@ def extract_and_mirror(dc, input, dim_axis, start, stop):
 
     # Mirror patch
     indices = torch.arange(stop - start - 1, -1, -1)
-    indices_tensor = dc.tensor(indices, DataFormat.Int32)
+    indices_tensor = dc.tensor(indices)
     patch_mirrored = dc.op("adv_index", [patch, indices_tensor], (dim_axis,))
 
     return patch_mirrored
@@ -276,7 +276,7 @@ def create_pad(dc, shape, value, data_format):
     shape = list(shape)
     torch_tensor = torch.full(shape, value, dtype=torch_dtype)
 
-    forge_tensor = dc.tensor(torch_tensor, data_format)
+    forge_tensor = dc.tensor(torch_tensor)
     return forge_tensor
 
 

--- a/forge/test/mlir/operators/nn/test_nn.py
+++ b/forge/test/mlir/operators/nn/test_nn.py
@@ -705,7 +705,6 @@ def test_avg_pool2d(forge_property_recorder):
 
 @pytest.mark.parametrize("shape", [(1, 3, 224, 224)])
 @pytest.mark.parametrize("padding", [0, 1])
-@pytest.mark.xfail(reason="RuntimeError: Tensor 1 - data type mismatch: expected BFloat16, got Float32")
 @pytest.mark.push
 def test_avgpool2d_decompose_to_conv2d(forge_property_recorder, shape, padding):
     class AvgPool2d(nn.Module):

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v9.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v9.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+import torch
+
+import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
+from forge.forge_property_utils import Framework, Source, Task
+from forge.verify.verify import verify
+
+from test.models.pytorch.vision.yolo.model_utils.yolo_utils import (
+    YoloWrapper,
+    load_yolo_model_and_image,
+)
+
+
+@pytest.mark.nightly
+def test_yolov9(forge_property_recorder):
+    # Record Forge Property
+    module_name = forge_property_recorder.record_model_properties(
+        framework=Framework.PYTORCH,
+        model="Yolov9",
+        variant="default",
+        task=Task.OBJECT_DETECTION,
+        source=Source.GITHUB,
+    )
+
+    # Load  model and input
+    model, image_tensor = load_yolo_model_and_image(
+        "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov9c.pt"
+    )
+    framework_model = YoloWrapper(model).to(torch.bfloat16)
+    input = [image_tensor.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+    # Forge compile framework model
+    compiled_model = forge.compile(
+        framework_model,
+        sample_inputs=input,
+        module_name=module_name,
+        forge_property_handler=forge_property_recorder,
+        compiler_cfg=compiler_cfg,
+    )
+
+    # Model Verification
+    verify(input, framework_model, compiled_model, forge_property_handler=forge_property_recorder)


### PR DESCRIPTION
### Ticket
Closes #2075 

### Problem description
Since dataformat override pass is before decompose pass, constants added in decompose pass aren't casted to lower data format.
This is caught first in yolo_v9 but it is the case in many models.

### What's changed

1. To avoid doing data format override pass again after decompose, moved data format pass after decompose. The change is minimal since both passes are in post initial graph pass.
2. Bugfix : When adding new constant node in decomposing context, set its output data format based on pytorch testor dtype, not its consumer output dataformat.

### Checklist
- Added yolo_v9 test and enable bfloat16 in the test
