### PR TITLE
Re-enable the skipped set9 tests in CI

### DIFF
--- a/forge/test/models/onnx/vision/dla/test_dla.py
+++ b/forge/test/models/onnx/vision/dla/test_dla.py
@@ -31,8 +31,6 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_dla_onnx(forge_property_recorder, variant, tmp_path):
-    if variant != "dla34":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
+++ b/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
@@ -61,8 +61,8 @@ def test_alexnet_torchhub(forge_property_recorder):
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 def test_alexnet_osmr(forge_property_recorder):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/dla/model_utils/utils.py
+++ b/forge/test/models/pytorch/vision/dla/model_utils/utils.py
@@ -31,7 +31,7 @@ def load_dla_model(variant):
     )
     img_tensor = transform(image).unsqueeze(0)
 
-    framework_model = func(pretrained="imagenet")
+    framework_model = func(pretrained=None)
     framework_model.eval()
 
     inputs = [img_tensor]

--- a/forge/test/models/pytorch/vision/dla/test_dla.py
+++ b/forge/test/models/pytorch/vision/dla/test_dla.py
@@ -7,31 +7,26 @@ import forge
 from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
-from test.models.pytorch.vision.dla.model_utils.utils import (
-    load_dla_model,
-    post_processing,
-)
+from test.models.pytorch.vision.dla.model_utils.utils import load_dla_model
 from test.models.pytorch.vision.vision_utils.utils import load_timm_model_and_input
 
 variants = [
-    "dla34",
-    "dla46_c",
-    "dla46x_c",
-    "dla60",
-    "dla60x",
-    "dla60x_c",
-    "dla102",
-    "dla102x",
-    "dla102x2",
-    "dla169",
+    pytest.param("dla34"),
+    pytest.param("dla46_c"),
+    pytest.param("dla46x_c"),
+    pytest.param("dla60"),
+    pytest.param("dla60x"),
+    pytest.param("dla60x_c"),
+    pytest.param("dla102", marks=[pytest.mark.xfail]),
+    pytest.param("dla102x"),
+    pytest.param("dla102x2"),
+    pytest.param("dla169", marks=[pytest.mark.xfail]),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_dla_pytorch(forge_property_recorder, variant):
-    if variant != "dla34":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -48,12 +43,6 @@ def test_dla_pytorch(forge_property_recorder, variant):
 
     # Model Verification
     verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-    # Inference
-    output = compiled_model(*inputs)
-
-    # post processing
-    post_processing(output)
 
 
 variants = ["dla34.in1k"]

--- a/forge/test/models/pytorch/vision/inception/test_inception_v4.py
+++ b/forge/test/models/pytorch/vision/inception/test_inception_v4.py
@@ -52,7 +52,10 @@ def generate_model_inceptionV4_imgcls_timm_pytorch(variant):
 
 
 variants = [
-    "inception_v4",
+    pytest.param(
+        "inception_v4",
+        marks=[pytest.mark.xfail],
+    ),
     pytest.param(
         "inception_v4.tf_in1k",
         marks=[pytest.mark.xfail],
@@ -63,8 +66,6 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_inception_v4_timm_pytorch(forge_property_recorder, variant):
-    if variant != "inception_v4.tf_in1k":
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(

--- a/forge/test/models/pytorch/vision/unet/test_unet.py
+++ b/forge/test/models/pytorch/vision/unet/test_unet.py
@@ -96,37 +96,6 @@ def get_imagenet_sample():
     return img_tensor
 
 
-@pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Model script not found")
-@pytest.mark.nightly
-def test_unet_holocron_pytorch(forge_property_recorder):
-    pytest.skip("Skipping due to the current CI/CD pipeline limitations")
-
-    # Record Forge Property
-    module_name = forge_property_recorder.record_model_properties(
-        framework=Framework.PYTORCH,
-        model="unet",
-        variant="holocron",
-        source=Source.TORCH_HUB,
-        task=Task.IMAGE_SEGMENTATION,
-    )
-
-    from holocron.models.segmentation.unet import unet_tvvgg11
-
-    framework_model = download_model(unet_tvvgg11, pretrained=True).eval()
-
-    img_tensor = get_imagenet_sample()
-    inputs = [img_tensor]
-
-    # Forge compile framework model
-    compiled_model = forge.compile(
-        framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder
-    )
-
-    # Model Verification
-    verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
-
-
 def generate_model_unet_imgseg_smp_pytorch(variant):
     # encoder_name = "vgg19"
     encoder_name = "resnet101"

--- a/forge/test/models/pytorch/vision/yolo/test_yolox.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolox.py
@@ -29,30 +29,24 @@ from yolox.exp import get_exp
 
 import forge
 from forge.forge_property_utils import Framework, Source, Task
-from forge.verify.config import VerifyConfig
-from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.yolo.model_utils.yolox_utils import preprocess
 
 variants = [
-    "yolox_nano",
-    "yolox_tiny",
-    "yolox_s",
-    "yolox_m",
-    "yolox_l",
-    "yolox_darknet",
-    "yolox_x",
+    pytest.param("yolox_nano", marks=[pytest.mark.xfail]),
+    pytest.param("yolox_tiny"),
+    pytest.param("yolox_s"),
+    pytest.param("yolox_m"),
+    pytest.param("yolox_l"),
+    pytest.param("yolox_darknet", marks=[pytest.mark.xfail]),
+    pytest.param("yolox_x", marks=[pytest.mark.xfail]),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_yolox_pytorch(forge_property_recorder, variant):
-    pcc = 0.97
-    if variant != "yolox_nano":
-        pcc = 0.99
-        pytest.skip("Skipping due to the current CI/CD pipeline limitations")
 
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -109,7 +103,6 @@ def test_yolox_pytorch(forge_property_recorder, variant):
         inputs,
         framework_model,
         compiled_model,
-        verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)),
         forge_property_handler=forge_property_recorder,
     )
 


### PR DESCRIPTION
 This PR enables the following skipped test cases:

````
pt_alexnet_base_img_cls_osmr - Maximum: 1763.76 MB
pt_densenet_densenet121_hf_xray_img_cls_torchvision - Maximum: 2265.23 MB
pt_dla_dla46_c_visual_bb_torchvision - Maximum: 1666.79 MB
pt_dla_dla46x_c_visual_bb_torchvision - Maximum: 1747.96 MB
pt_dla_dla60_visual_bb_torchvision - Maximum: 2036.94 MB
pt_dla_dla60x_visual_bb_torchvision - Maximum: 2185.11 MB
pt_dla_dla60x_c_visual_bb_torchvision - Maximum: 2043.76 MB
pt_dla_dla102_visual_bb_torchvision - Maximum: 2446.62 MB
pt_dla_dla102x_visual_bb_torchvision - Maximum: 2712.55 MB
pt_dla_dla102x2_visual_bb_torchvision - Maximum: 3108.21 MB
pt_dla_dla169_visual_bb_torchvision - Maximum: 3582.04 MB
pt_inception_inception_v4_img_cls_timm - Maximum: 1760.77 MB
pt_inception_inception_v4_tf_in1k_img_cls_timm - Maximum: 1990.11 MB
pt_yolox_yolox_tiny_obj_det_torchhub - Maximum: 2225.88 MB
pt_yolox_yolox_s_obj_det_torchhub - Maximum: 2715.37 MB
pt_yolox_yolox_m_obj_det_torchhub - Maximum: 3609.36 MB
pt_yolox_yolox_l_obj_det_torchhub - Maximum: 4918.19 MB
pt_yolox_yolox_darknet_obj_det_torchhub - Maximum: 5295.51 MB
pt_yolox_yolox_x_obj_det_torchhub - Maximum: 7156.61 MB
onnx_dla_dla46_c_visual_bb_torchvision - Maximum: 1561.47 MB
onnx_dla_dla34_visual_bb_torchvision - Maximum: 1585.99 MB
onnx_dla_dla46x_c_visual_bb_torchvision - Maximum: 1573.73 MB
onnx_dla_dla60x_c_visual_bb_torchvision - Maximum: 2142.26 MB
onnx_dla_dla60_visual_bb_torchvision - Maximum: 2127.55 MB
onnx_dla_dla60x_visual_bb_torchvision - Maximum: 3220.59 MB
onnx_dla_dla102_visual_bb_torchvision - Maximum: 3022.43 MB
onnx_dla_dla102x_visual_bb_torchvision - Maximum: 3022.43 MB
onnx_dla_dla102x2_visual_bb_torchvision - Maximum: 3834.85 MB
onnx_dla_dla169_visual_bb_torchvision -  Maximum: 4322.80 MB
````
logs:
[alexnet.log](https://github.com/user-attachments/files/20350086/alexnet.log)
[densenet.log](https://github.com/user-attachments/files/20350287/densenet.log)
[dla.log](https://github.com/user-attachments/files/20350716/dla.log)
[yolox.log](https://github.com/user-attachments/files/20350904/yolox.log)
[inception1.log](https://github.com/user-attachments/files/20350958/inception1.log)
[dla_onnx.log](https://github.com/user-attachments/files/20351402/dla_onnx.log)


Dla model was facing `ConnectionResetError: [Errno 104] Connection reset by peer`
While checking the official [repo](https://github.com/ucbdrive/dla) , it was found that the pretrained weights link have become invalid which is causing this issue and several [issues](https://github.com/ucbdrive/dla/issues/26) have been created for the same, hence model is not being loaded from checkpoints and only architecture support is given in forge now, following that post-processing has also been removed since model is not loaded from pretrained weights.
