### PR TITLE
Tests fix: removing forge_property_utils::record_group leftovers.

### DIFF
--- a/forge/test/models/onnx/text/deepcogito/test_cogito_v1_onnx.py
+++ b/forge/test/models/onnx/text/deepcogito/test_cogito_v1_onnx.py
@@ -28,7 +28,6 @@ def test_cogito_generation_onnx(forge_property_recorder, forge_tmp_path, variant
         task=Task.TEXT_GENERATION,
         source=Source.HUGGINGFACE,
     )
-    forge_property_recorder.record_group("generality")
 
     # Load model and tokenizer
     sample_inputs, framework_model = get_input_model(variant)

--- a/forge/test/models/onnx/vision/dla/test_dla.py
+++ b/forge/test/models/onnx/vision/dla/test_dla.py
@@ -39,9 +39,6 @@ def test_dla_onnx(forge_property_recorder, variant, tmp_path):
         framework=Framework.ONNX, model="dla", variant=variant, task=Task.VISUAL_BACKBONE, source=Source.TORCHVISION
     )
 
-    # Record Forge Property
-    forge_property_recorder.record_group("generality")
-
     # Load data sample
     url = "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
     image = Image.open(requests.get(url, stream=True).raw)


### PR DESCRIPTION
Tests fix: removing forge_property_utils::record_group leftovers from tests, since it does not exist.