### PR TITLE
[ci] add blackhole p150 tests

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -88,7 +88,7 @@ jobs:
       test_group_cnt: ${{ needs.set-inputs.outputs.test_group_cnt }}
       test_group_ids: ${{ needs.set-inputs.outputs.test_group_ids }}
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      runs-on: '[{"runs-on": "n150"}]'
+      runs-on: '[{"runs-on": "n150"}, {"runs-on": "p150"}]'
       run_id: ${{ needs.build.outputs.run_id }}
 
   perf-benchmark:

--- a/.github/workflows/test-sub.yml
+++ b/.github/workflows/test-sub.yml
@@ -26,7 +26,7 @@ on:
         description: 'Runs on'
         required: false
         type: string
-        default: '[{"runs-on": "n150"}, {"runs-on": "n300"}]'
+        default: '[{"runs-on": "n150"}, {"runs-on": "n300"}, {"runs-on": "p150"}]'
       operators:
         description: 'Operators to test (comma separated)'
         required: false
@@ -149,6 +149,7 @@ jobs:
           FORGE_DISABLE_REPORTIFY_DUMP: 1
           OPERATORS: ${{ inputs.operators }}
           FILTERS: ${{ inputs.filters }}
+          ARCH_NAME: ${{ matrix.build.runs-on == 'p150' && 'blackhole' || (matrix.build.runs-on == 'n150' || matrix.build.runs-on == 'n300') && 'wormhole_b0' || '' }}
         shell: bash
         run: |
           source env/activate

--- a/.github/workflows/test-sub.yml
+++ b/.github/workflows/test-sub.yml
@@ -153,13 +153,25 @@ jobs:
         shell: bash
         run: |
           source env/activate
-          pytest --splits ${{ inputs.test_group_cnt }} \
-                 --group ${{ matrix.test_group_id }} \
-                 --splitting-algorithm least_duration \
-                 -m "${{ inputs.test_mark }}" \
-                 --junit-xml=${{ steps.strings.outputs.test_report_path }} \
-                 --log-memory-usage \
-                 2>&1 | tee pytest.log
+          # Skip tests marked as fails_on_bh when running on p150
+          if [[ "${{ matrix.build.runs-on }}" == "p150" ]]; then
+            pytest --splits ${{ inputs.test_group_cnt }} \
+                   --group ${{ matrix.test_group_id }} \
+                   --splitting-algorithm least_duration \
+                   -m "${{ inputs.test_mark }}" \
+                   -k "not fails_on_bh" \
+                   --junit-xml=${{ steps.strings.outputs.test_report_path }} \
+                   --log-memory-usage \
+                   2>&1 | tee pytest.log
+          else
+            pytest --splits ${{ inputs.test_group_cnt }} \
+                   --group ${{ matrix.test_group_id }} \
+                   --splitting-algorithm least_duration \
+                   -m "${{ inputs.test_mark }}" \
+                   --junit-xml=${{ steps.strings.outputs.test_report_path }} \
+                   --log-memory-usage \
+                   2>&1 | tee pytest.log
+          fi
 
       - name: Upload Test Log
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,7 @@ on:
         options:
           - n150
           - n300
+          - p150
       test_group_cnt:
         description: 'Test group count'
         required: false

--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -166,8 +166,14 @@ class MLIRGenerator
     mlir::ModuleOp emit_mlir(tt::ForgeGraphModule &module)
     {
         graphModule_ = mlir::ModuleOp::create(get_module_location(module), module.name());
+        std::string archStr = std::getenv("ARCH_NAME");
+        mlir::tt::Arch arch = mlir::tt::Arch::WormholeB0;
+        if (archStr == "blackhole")
+        {
+            arch = mlir::tt::Arch::Blackhole;
+        }
         graphModule_->setAttr(
-            mlir::tt::SystemDescAttr::name, mlir::tt::SystemDescAttr::getDefault(builder_.getContext()));
+            mlir::tt::SystemDescAttr::name, mlir::tt::SystemDescAttr::getDefault(builder_.getContext(), arch));
         builder_.setInsertionPointToStart(&graphModule_.getBodyRegion().front());
 
         // Collect all the supported TTIR operations

--- a/forge/test/mlir/test_loss.py
+++ b/forge/test/mlir/test_loss.py
@@ -49,7 +49,7 @@ def test_l1_loss(forge_property_recorder, prediction_shape, reduction):
 @pytest.mark.parametrize(
     "prediction_shape",
     [
-        (3, 5),
+        pytest.param((3, 5), marks=pytest.mark.fails_on_bh),
         (32, 32),
         (33, 127),
         (128, 20),

--- a/forge/test/models/onnx/vision/resnet/test_resnet.py
+++ b/forge/test/models/onnx/vision/resnet/test_resnet.py
@@ -27,6 +27,7 @@ opset_versions = [7, 17]
 
 @pytest.mark.push
 @pytest.mark.nightly
+@pytest.mark.fails_on_bh
 @pytest.mark.parametrize("variant", variants, ids=variants)
 @pytest.mark.parametrize("opset_version", opset_versions, ids=opset_versions)
 def test_resnet_onnx(forge_property_recorder, variant, forge_tmp_path, opset_version):

--- a/forge/test/models/pytorch/text/bert/test_bert.py
+++ b/forge/test/models/pytorch/text/bert/test_bert.py
@@ -29,6 +29,7 @@ from test.utils import download_model
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["bert-base-uncased"])
 @pytest.mark.push
+@pytest.mark.fails_on_bh
 def test_bert_masked_lm_pytorch(forge_property_recorder, variant):
     # Record Forge Property
     module_name = forge_property_recorder.record_model_properties(
@@ -104,7 +105,7 @@ def generate_model_bert_qa_hf_pytorch(variant):
 
 
 variants = [
-    pytest.param("phiyodr/bert-large-finetuned-squad2", marks=[pytest.mark.push]),
+    pytest.param("phiyodr/bert-large-finetuned-squad2", marks=[pytest.mark.push, pytest.mark.fails_on_bh]),
     pytest.param("bert-large-cased-whole-word-masking-finetuned-squad"),
 ]
 

--- a/forge/test/models/pytorch/text/falcon/test_falcon.py
+++ b/forge/test/models/pytorch/text/falcon/test_falcon.py
@@ -51,7 +51,7 @@ def test_falcon(forge_property_recorder, variant):
 
 
 variants = [
-    pytest.param("tiiuae/Falcon3-1B-Base", marks=pytest.mark.push),
+    pytest.param("tiiuae/Falcon3-1B-Base", marks=[pytest.mark.push, pytest.mark.fails_on_bh]),
     pytest.param(
         "tiiuae/Falcon3-3B-Base",
         marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 25 GB)"),

--- a/forge/test/models/pytorch/vision/resnet/test_resnet.py
+++ b/forge/test/models/pytorch/vision/resnet/test_resnet.py
@@ -28,6 +28,7 @@ variants = [
 
 @pytest.mark.push
 @pytest.mark.nightly
+@pytest.mark.fails_on_bh
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_resnet_hf(variant, forge_property_recorder):
     random.seed(0)

--- a/forge/test/models/pytorch/vision/resnext/test_resnext.py
+++ b/forge/test/models/pytorch/vision/resnext/test_resnext.py
@@ -22,6 +22,7 @@ from test.utils import download_model
 
 @pytest.mark.push
 @pytest.mark.nightly
+@pytest.mark.fails_on_bh
 @pytest.mark.parametrize("variant", ["resnext50_32x4d"])
 def test_resnext_50_torchhub_pytorch(forge_property_recorder, variant):
     # Record Forge Property
@@ -57,6 +58,7 @@ def test_resnext_50_torchhub_pytorch(forge_property_recorder, variant):
 
 @pytest.mark.push
 @pytest.mark.nightly
+@pytest.mark.fails_on_bh
 @pytest.mark.parametrize("variant", ["resnext101_32x8d"])
 def test_resnext_101_torchhub_pytorch(forge_property_recorder, variant):
     # Record Forge Property

--- a/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
@@ -32,7 +32,7 @@ from test.models.pytorch.vision.vovnet.model_utils.src_vovnet_stigma import (
 from test.utils import download_model
 
 varaints = [
-    pytest.param("vovnet27s", marks=pytest.mark.push),
+    pytest.param("vovnet27s", marks=[pytest.mark.push, pytest.mark.fails_on_bh]),
     "vovnet39",
     "vovnet57",
 ]

--- a/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
+++ b/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
@@ -23,7 +23,7 @@ from test.models.pytorch.vision.wideresnet.model_utils.utils import (
 from test.utils import download_model
 
 variants = [
-    pytest.param("wide_resnet50_2", marks=[pytest.mark.push]),
+    pytest.param("wide_resnet50_2", marks=[pytest.mark.push, pytest.mark.fails_on_bh]),
     pytest.param("wide_resnet101_2"),
 ]
 

--- a/forge/test/models/tensorflow/vision/resnet/test_resnet.py
+++ b/forge/test/models/tensorflow/vision/resnet/test_resnet.py
@@ -16,6 +16,7 @@ from test.models.tensorflow.vision.resnet.model_utils.image_utils import get_sam
 
 @pytest.mark.push
 @pytest.mark.nightly
+@pytest.mark.fails_on_bh
 def test_resnet_tensorflow(forge_property_recorder):
 
     # Record model details

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,7 @@ markers =
     slow: marks tests as slow               # deprecated - slow tests, should not be run in push pipeline
     run_in_pp: marks tests as run_in_pp     # deprecated - tests that should run in push pipeline
     skip_model_analysis: marks tests as skip_model_analysis
+    fails_on_bh: tests failing on Blackhole (p150)
 
 # Where pytest should look for tests
 testpaths =


### PR DESCRIPTION
### Ticket
#614 

### Problem description
Adding CI tests for Blackhole (p150) cards.

### What's changed
1. Lowering to mlir with a BH system descriptor (depends on the envvar `ARCH_NAME`)
2. Add p150 to "runs-on" option of workflows.
3. (TODO) Mark failing tests with `xfail`.

### Notice
tt-mlir must be uplifted to include https://github.com/tenstorrent/tt-mlir/commit/ab01ff9080c8a85e17c0a8172f7fb3127d5c0cfa 