### PR TITLE
Fix BFloat16 conversion regressions on Conv-based models

### DIFF
--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -346,8 +346,6 @@ def test_mobilenetv2_torchvision(forge_property_recorder, variant):
     # Load model and input
     weight_name = variants_with_weights[variant]
     framework_model, inputs = load_vision_model_and_input(variant, "classification", weight_name)
-    framework_model = framework_model.to(torch.bfloat16)
-    inputs = inputs.to(torch.bfloat16)
 
     data_format_override = DataFormat.Float16_b
     compiler_cfg = CompilerConfig(default_df_override=data_format_override)

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
@@ -15,6 +15,8 @@ import forge
 from forge._C import DataFormat
 from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task
+from forge.verify.config import VerifyConfig
+from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.mobilenet.model_utils.utils import (
@@ -58,7 +60,13 @@ def test_mobilenetv3_basic(forge_property_recorder, variant):
     )
 
     # Model Verification and Inference
-    _, co_out = verify(inputs, framework_model, compiled_model, forge_property_handler=forge_property_recorder)
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.98)),
+        forge_property_handler=forge_property_recorder,
+    )
 
     # Post processing
     post_processing(co_out)

--- a/forge/test/models/pytorch/vision/vgg/test_vgg.py
+++ b/forge/test/models/pytorch/vision/vgg/test_vgg.py
@@ -290,6 +290,9 @@ def test_vgg_torchvision(forge_property_recorder, variant):
     weight_name = variants_with_weights[variant]
     framework_model, inputs = load_vision_model_and_input(variant, "classification", weight_name)
 
+    framework_model.to(torch.float32)
+    inputs = [inputs[0].to(torch.float32)]
+
     # Forge compile framework model
     compiled_model = forge.compile(
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder

--- a/forge/test/models/pytorch/vision/vit/test_vit.py
+++ b/forge/test/models/pytorch/vision/vit/test_vit.py
@@ -2,6 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+import torch
 from datasets import load_dataset
 from transformers import AutoImageProcessor, ViTForImageClassification
 
@@ -106,6 +107,8 @@ def test_vit_torchvision(forge_property_recorder, variant):
     # Load model and input
     weight_name = variants_with_weights[variant]
     framework_model, inputs = load_vision_model_and_input(variant, "classification", weight_name)
+    framework_model.to(torch.float32)
+    inputs = [inputs[0].to(torch.float32)]
 
     # Forge compile framework model
     compiled_model = forge.compile(


### PR DESCRIPTION
### What's changed
This PR fixes the regressions of test_full_model_passing cases in this [Nightly run](https://github.com/tenstorrent/tt-forge-fe/actions/runs/15150281092)

### Logs

Regressions 

[regressions_test_full_model_passing.zip](https://github.com/user-attachments/files/20363238/regressions_test_full_model_passing.zip)

After fix

[may21_mobilenetv2_after_fix.log](https://github.com/user-attachments/files/20363283/may21_mobilenetv2_after_fix.log)
[may21_mobv3_after_fix.log](https://github.com/user-attachments/files/20363294/may21_mobv3_af.log)
[may21_vgg_tv_all_after_fix.log](https://github.com/user-attachments/files/20363298/may21_vgg_tv_all_af.log)
[may21_vit_tv_after_fix.log](https://github.com/user-attachments/files/20363303/may21_vit_tv_af.log)


