### PR TITLE
Fix BFloat16 conversion regressions on Conv-based models in existing xfail tests

### DIFF
--- a/forge/test/models/onnx/vision/sam/test_sam_onnx.py
+++ b/forge/test/models/onnx/vision/sam/test_sam_onnx.py
@@ -35,7 +35,8 @@ def test_sam_onnx(forge_property_recorder, variant, forge_tmp_path):
 
     # Load  model and input
     framework_model, sample_inputs = get_model_inputs(variant)
-    input_tensor = sample_inputs[0]
+    framework_model.to(torch.float32)
+    input_tensor = sample_inputs[0].to(torch.float32)
     sample_inputs = [input_tensor]
 
     onnx_path = f"{forge_tmp_path}/sam_" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"

--- a/forge/test/models/onnx/vision/swin/test_swin.py
+++ b/forge/test/models/onnx/vision/swin/test_swin.py
@@ -80,6 +80,7 @@ def test_swin_v2_tiny_masked_onnx(forge_property_recorder, variant, forge_tmp_pa
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
     url = "http://images.cocodataset.org/val2017/000000039769.jpg"
     inputs = load_image(url, feature_extractor)
+    inputs = [inputs[0].to(torch.float32)]
 
     # Export model to ONNX
     onnx_path = f"{forge_tmp_path}/swin_v2_tiny_masked.onnx"
@@ -118,6 +119,8 @@ def test_swin_torchvision(forge_property_recorder, variant, forge_tmp_path):
     # Load model and input
     weight_name = variants_with_weights[variant]
     framework_model, inputs = load_vision_model_and_input(variant, "classification", weight_name)
+    framework_model.to(torch.float32)
+    inputs = [inputs[0].to(torch.float32)]
 
     # Export model to ONNX
     onnx_path = f"{forge_tmp_path}/swin_v2_torchvision.onnx"

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -215,6 +215,9 @@ def test_swin_torchvision(forge_property_recorder, variant):
     weight_name = variants_with_weights[variant]
     framework_model, inputs = load_vision_model_and_input(variant, "classification", weight_name)
 
+    framework_model.to(torch.float32)
+    inputs = [inputs[0].to(torch.float32)]
+
     # Forge compile framework model
     compiled_model = forge.compile(
         framework_model, sample_inputs=inputs, module_name=module_name, forge_property_handler=forge_property_recorder


### PR DESCRIPTION

### Summary
This PR fixes the regressions of test_full_model_xfail cases in this [Nightly run](https://github.com/tenstorrent/tt-forge-fe/actions/runs/15150281092)

- We made changes(return model and inputs in bfloat16) to utils functions( load_vision_model_and_input,get_model_inputs) in this [PR](https://github.com/tenstorrent/tt-forge-fe/pull/2067) to Set convolution-based **pytorch** models to be on bfp16. Those model's onnx tests are also using same util functions which is causing issue in its inference.
- test_swin_torchvision is regression case -> https://github.com/tenstorrent/tt-forge-fe/issues/1987#issuecomment-2888227666. load_vision_model_and_input used by many models and it returns model & inputs in bfloat16 format. 

- This PR reverts the model and inputs to float32 in test itself

### Logs
Regressions

```markdown
| Test Name                                                                 | Issue                                                                                  |
|---------------------------------------------------------------------------|-----------------------------------------------------------------------------------------|
| forge/test/models/onnx/vision/sam/test_sam_onnx.py::test_sam_onnx[facebook/sam-vit-base] | TypeError: Got unsupported ScalarType BFloat16                                          |
| forge/test/models/onnx/vision/swin/test_swin.py::test_swin_v2_tiny_masked_onnx          | RuntimeError: Input type (c10::BFloat16) and bias type (float) should be the same      |
| forge/test/models/onnx/vision/swin/test_swin.py::test_swin_torchvision[swin_v2_t]       | TypeError: Got unsupported ScalarType BFloat16                                          |
| forge/test/models/pytorch/vision/swin/test_swin.py::test_swin_torchvision[swin_b]       | [Runtime Datatype mismatch] RuntimeError Tensor data type mismatch: expected  BFloat16 got  Float32      |
| forge/test/models/pytorch/vision/swin/test_swin.py::test_swin_torchvision[swin_s]       | [Runtime Datatype mismatch] RuntimeError Tensor data type mismatch: expected BFloat16 got  Float32      |
| forge/test/models/pytorch/vision/swin/test_swin.py::test_swin_torchvision[swin_t]       | [Runtime Datatype mismatch] RuntimeError Tensor data type mismatch: expected BFloat16 got Float32       |
| forge/test/models/pytorch/vision/swin/test_swin.py::test_swin_torchvision[swin_v2_b]    | RuntimeError: value cannot be converted to type at::BFloat16 without overflow           |
| forge/test/models/pytorch/vision/swin/test_swin.py::test_swin_torchvision[swin_v2_s]    | RuntimeError: value cannot be converted to type at::BFloat16 without overflow           |
| forge/test/models/pytorch/vision/swin/test_swin.py::test_swin_torchvision[swin_v2_t]    | RuntimeError: value cannot be converted to type at::BFloat16 without overflow           |
```

After fix

[may21_sam_onnx_af.log](https://github.com/user-attachments/files/20368870/may21_sam_onnx_af.log)
[may21_swin_onnx_af_masked.log](https://github.com/user-attachments/files/20368871/may21_swin_onnx_af_masked.log)
[may21_swin_torchvision_onnx_af.log](https://github.com/user-attachments/files/20368880/may21_swin_torchvision_onnx_af.log)
[may21_swin_torchvision_pytorch_af.log](https://github.com/user-attachments/files/20368881/may21_swin_torchvision_pytorch_af.log)
