### PR TITLE
Enable fusing for resnet benchmark

### DIFF
--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -192,6 +192,10 @@ PYBIND11_MODULE(_C, m)
             [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_memory_layout_analysis(enable); },
             py::arg("enable"))
         .def(
+            "set_enable_fusing",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_fusing(enable); },
+            py::arg("enable"))
+        .def(
             "set_custom_config",
             [](tt::passes::MLIRConfig &self, const std::string &config) { return self.set_custom_config(config); },
             py::arg("config"))

--- a/forge/csrc/passes/mlir_compiler.cpp
+++ b/forge/csrc/passes/mlir_compiler.cpp
@@ -136,7 +136,8 @@ void to_json(::nlohmann::json& j, const MLIRConfig& p)
     j = nlohmann::json{
         {"enable_consteval", p.enable_consteval},
         {"enable_optimizer", p.enable_optimizer},
-        {"enable_consteval", p.enable_consteval},
+        {"enable_memory_layout_analysis", p.enable_memory_layout_analysis},
+        {"enable_fusing", p.enable_fusing},
         {"custom_config", p.custom_config}};
 }
 
@@ -144,7 +145,8 @@ void from_json(const ::nlohmann::json& j, MLIRConfig& p)
 {
     j.at("enable_consteval").get_to(p.enable_consteval);
     j.at("enable_optimizer").get_to(p.enable_optimizer);
-    j.at("enable_consteval").get_to(p.enable_consteval);
+    j.at("enable_memory_layout_analysis").get_to(p.enable_memory_layout_analysis);
+    j.at("enable_fusing").get_to(p.enable_fusing);
     j.at("custom_config").get_to(p.custom_config);
 }
 }  // namespace tt::passes

--- a/forge/csrc/passes/mlir_compiler.hpp
+++ b/forge/csrc/passes/mlir_compiler.hpp
@@ -29,6 +29,7 @@ struct MLIRConfig
     std::optional<bool> enable_consteval = std::nullopt;
     std::optional<bool> enable_optimizer = std::nullopt;
     std::optional<bool> enable_memory_layout_analysis = std::nullopt;
+    std::optional<bool> enable_fusing = std::nullopt;
 
     // Custom configuration string for the MLIR compiler.
     std::string custom_config = "";
@@ -48,6 +49,12 @@ struct MLIRConfig
     MLIRConfig& set_enable_memory_layout_analysis(bool enable)
     {
         enable_memory_layout_analysis = enable;
+        return *this;
+    }
+
+    MLIRConfig& set_enable_fusing(bool enable)
+    {
+        enable_fusing = enable;
         return *this;
     }
 

--- a/forge/csrc/passes/mlir_passes.cpp
+++ b/forge/csrc/passes/mlir_passes.cpp
@@ -61,6 +61,10 @@ std::string config_to_pipeline_options(const std::optional<MLIRConfig> &mlir_con
         {
             options << " memory-layout-analysis-enabled=" << *mlir_config->enable_memory_layout_analysis;
         }
+        if (mlir_config->enable_fusing.has_value())
+        {
+            options << " enable-fusing-pass=" << *mlir_config->enable_fusing;
+        }
 
         // Add custom configuration options.
         options << " " << mlir_config->custom_config;

--- a/forge/test/benchmark/benchmark/models/resnet_hf.py
+++ b/forge/test/benchmark/benchmark/models/resnet_hf.py
@@ -109,7 +109,7 @@ def test_resnet_hf(training, batch_size, data_format, input_size, channel_size, 
         compiler_cfg.default_df_override = DataFormat.Float16_b
 
     # Turn on MLIR optimizations.
-    compiler_cfg.mlir_config = MLIRConfig().set_enable_consteval(True).set_enable_optimizer(True)
+    compiler_cfg.mlir_config = MLIRConfig().set_enable_optimizer(True).set_enable_fusing(True)
 
     compiled_model = forge.compile(framework_model, sample_inputs=inputs[0], compiler_cfg=compiler_cfg)
 


### PR DESCRIPTION
Uplift tt-mlir to commit that fixes fusing issues. Also add "enable-fusing-pass" option to MLIRConfig and enable it for resnet.

Resnet is now at about 170 fps. 🚀 @mtopalovicTT 