### PR TITLE
Use build from Push run when running tests without rebuild

### DIFF
--- a/.github/workflows/perf-benchmark-sub.yml
+++ b/.github/workflows/perf-benchmark-sub.yml
@@ -122,7 +122,7 @@ jobs:
         github_token: ${{secrets.GITHUB_TOKEN}}
         workflow_conclusion: success
         workflow_search: true
-        workflow: on-nightly.yml
+        workflow: on-push.yml
         name: forge-wheel
         repo: tenstorrent/tt-forge-fe
         check_artifacts: true

--- a/.github/workflows/test-sub.yml
+++ b/.github/workflows/test-sub.yml
@@ -131,7 +131,7 @@ jobs:
           github_token: ${{secrets.GITHUB_TOKEN}}
           workflow_conclusion: success
           workflow_search: true
-          workflow: on-nightly.yml
+          workflow: on-push.yml
           name: forge-wheel
           repo: tenstorrent/tt-forge-fe
           check_artifacts: true


### PR DESCRIPTION
### Ticket
slack

### Problem description
Running test without rebuilding uses wheel from the last nightly.
This makes troubles when developers need to iterate quickly on the patch.

### What's changed
When running tests/nightly/performance without rebuilding forge-fe get most recent build from on-push main instead of nightly.

### Checklist
- [ ] New/Existing tests provide coverage for changes
  tested with Test and Performance runs it picks-up latest wheel