### PR TITLE
Always build wheel on nightly

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -54,6 +54,8 @@ jobs:
           ros_res=$(if [ -z "${{ inputs.run_ops_sweeps }}" ]; then echo $default_run_ops_sweeps; else echo ${{ inputs.run_ops_sweeps }}; fi)
           if [ -z "${{ inputs.rebuild }}" ]; then
             echo "rebuild=All" >> $GITHUB_OUTPUT
+          elif [ "${{ github.event_name }}" == 'schedule' ]; then
+            echo "rebuild=All" >> $GITHUB_OUTPUT
           else
             echo "rebuild=$(if [ ${{ inputs.rebuild }} == 'true' ]; then echo Release; else echo None; fi)" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Always rebuild the wheel in the nightly job so it can be picked up by `tt-forge` nightly release job.

https://github.com/tenstorrent/tt-forge/actions/runs/15179302234/job/42685332775#step:4:129


Test
https://github.com/tenstorrent/tt-forge-fe/actions/runs/15196733431/job/42742551052#step:2:8