### PR TITLE
[Nightly] Paddle ocr tests fix

### DIFF
--- a/forge/test/models/paddlepaddle/multimodal/paddleocr/test_paddleocr_rec.py
+++ b/forge/test/models/paddlepaddle/multimodal/paddleocr/test_paddleocr_rec.py
@@ -9,7 +9,6 @@ import pytest
 import cv2
 
 import forge
-from forge.config import CompilerConfig
 from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
@@ -46,9 +45,6 @@ def test_paddleocr_rec(forge_property_recorder, variant, url):
         source=Source.PADDLE,
         task=Task.SCENE_TEXT_RECOGNITION,
     )
-
-    forge_property_recorder.record_group("generality")
-    forge_property_recorder.record_model_name(module_name)
 
     # Fetch model
     framework_model = fetch_paddle_model(url, cache_dir)


### PR DESCRIPTION
### Problem description
Some of the nightly tests were failing due to:
```
forge_property_recorder.record_group("generality")
```
which is a deprecatad way of recording model's group.

### What's changed
Removed it from the test, as the default group is "generality", so there is no need to record it in the test. Also removed recording of the name as now all of it is recorded in the `record_model_properties` function.