### PR TITLE
[CI] Skipping Ministral 3B test due to OOM Problem.

### DIFF
--- a/forge/test/models/pytorch/text/ministral/test_ministral_3b.py
+++ b/forge/test/models/pytorch/text/ministral/test_ministral_3b.py
@@ -19,7 +19,9 @@ variants = ["ministral/Ministral-3b-instruct"]
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
-@pytest.mark.xfail
+@pytest.mark.skip(
+    reason="Insufficient host DRAM to run this model (requires a bit more than 26 GB during compile time)"
+)
 def test_ministral_3b(variant):
 
     # Record Forge Property


### PR DESCRIPTION
This PR skips ministral_3b test as it consumes 26 GB of host DRAM.