### PR TITLE
Fix PCC regressions in Swin torchvision variants

### DIFF
--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -237,10 +237,9 @@ def test_swin_torchvision(variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model)
-    compiled_model = forge.compile(
+    verify(
+        inputs,
         framework_model,
-        sample_inputs=inputs,
-        module_name=module_name,
-        verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)),
+        compiled_model,
+        VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)),
     )


### PR DESCRIPTION
### Summary

This PR fixes PCC regressions in Swin torchvision variants by properly passing Adjusted PCC  to verify function. 


### Logs
[may26_swin_tv_fix_check.log](https://github.com/user-attachments/files/20438534/may26_swin_tv_fix_check.log)
