### PR TITLE
Fix forge property recording and import record_model_properties function in models tests

### DIFF
--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -372,8 +372,8 @@ class ForgePropertyHandler:
         should be recorded.
     """
 
-    def __init__(self, store: ForgePropertyStore = ForgePropertyStore()):
-        self.store = store
+    def __init__(self, store: Optional[ForgePropertyStore] = None):
+        self.store = store if store is not None else ForgePropertyStore()
         self.record_execution(ExecutionStage.FAILED_BEFORE_FORGE_COMPILATION_INITIATION)
 
     def add(self, key: str, value: Any):

--- a/forge/test/models/pytorch/multimodal/llava/test_llava.py
+++ b/forge/test/models/pytorch/multimodal/llava/test_llava.py
@@ -8,7 +8,13 @@ import torch
 from transformers import AutoProcessor, LlavaForConditionalGeneration
 
 import forge
-from forge.forge_property_utils import Framework, ModelGroup, Source, Task
+from forge.forge_property_utils import (
+    Framework,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
 from forge.verify.verify import verify
 
 from test.models.pytorch.multimodal.llava.model_utils.utils import load_inputs

--- a/forge/test/models/pytorch/multimodal/oft/test_oft.py
+++ b/forge/test/models/pytorch/multimodal/oft/test_oft.py
@@ -10,6 +10,7 @@ from forge.forge_property_utils import (
     ModelPriority,
     Source,
     Task,
+    record_model_properties,
 )
 from forge.verify.verify import verify
 

--- a/forge/test/models/pytorch/multimodal/phi3/test_phi3_5_vision.py
+++ b/forge/test/models/pytorch/multimodal/phi3/test_phi3_5_vision.py
@@ -7,7 +7,13 @@ import torch
 from transformers import AutoModelForCausalLM, AutoProcessor
 
 import forge
-from forge.forge_property_utils import Framework, ModelGroup, Source, Task
+from forge.forge_property_utils import (
+    Framework,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
 from forge.verify.verify import verify
 
 from test.models.pytorch.multimodal.phi3.model_utils.utils import load_input

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 
-from forge.forge_property_utils import Framework
+from forge.forge_property_utils import Framework, record_model_properties
 
 from test.models.pytorch.multimodal.stable_diffusion.model_utils.model import (
     denoising_loop,

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
@@ -6,7 +6,13 @@ import pytest
 import torch
 
 import forge
-from forge.forge_property_utils import Framework, ModelGroup, Source, Task
+from forge.forge_property_utils import (
+    Framework,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
 from forge.verify.verify import verify
 
 from test.models.pytorch.multimodal.stable_diffusion.model_utils.model import (

--- a/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
@@ -12,7 +12,13 @@ from transformers import (
 )
 
 import forge
-from forge.forge_property_utils import Framework, ModelGroup, Source, Task
+from forge.forge_property_utils import (
+    Framework,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
 from forge.verify.verify import verify
 
 from test.models.pytorch.text.gemma.model_utils.model_utils import (

--- a/forge/test/models/pytorch/text/gemma/test_gemma_v1.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_v1.py
@@ -5,7 +5,13 @@ import pytest
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import forge
-from forge.forge_property_utils import Framework, ModelGroup, Source, Task
+from forge.forge_property_utils import (
+    Framework,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
 from forge.verify.verify import verify
 
 from test.models.pytorch.text.gemma.model_utils.model_utils import (

--- a/forge/test/models/pytorch/text/gliner/test_gliner.py
+++ b/forge/test/models/pytorch/text/gliner/test_gliner.py
@@ -12,6 +12,7 @@ from forge.forge_property_utils import (
     ModelPriority,
     Source,
     Task,
+    record_model_properties,
 )
 from forge.verify.verify import verify
 

--- a/forge/test/models/pytorch/text/mistral/test_mistral.py
+++ b/forge/test/models/pytorch/text/mistral/test_mistral.py
@@ -6,7 +6,13 @@ import pytest
 from transformers import AutoModelForCausalLM, AutoTokenizer, MistralConfig
 
 import forge
-from forge.forge_property_utils import Framework, ModelGroup, Source, Task
+from forge.forge_property_utils import (
+    Framework,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
 from forge.verify.verify import verify
 
 from test.models.pytorch.text.mistral.model_utils.utils import get_current_weather

--- a/forge/test/models/pytorch/text/phi1/test_phi1_5_pt.py
+++ b/forge/test/models/pytorch/text/phi1/test_phi1_5_pt.py
@@ -16,6 +16,7 @@ from forge.forge_property_utils import (
     ModelPriority,
     Source,
     Task,
+    record_model_properties,
 )
 from forge.verify.verify import verify
 

--- a/forge/test/models/pytorch/text/phi1/test_phi1_pt.py
+++ b/forge/test/models/pytorch/text/phi1/test_phi1_pt.py
@@ -16,6 +16,7 @@ from forge.forge_property_utils import (
     ModelPriority,
     Source,
     Task,
+    record_model_properties,
 )
 from forge.verify.verify import verify
 

--- a/forge/test/models/pytorch/text/phi2/test_phi2.py
+++ b/forge/test/models/pytorch/text/phi2/test_phi2.py
@@ -18,6 +18,7 @@ from forge.forge_property_utils import (
     ModelPriority,
     Source,
     Task,
+    record_model_properties,
 )
 from forge.verify.verify import verify
 

--- a/forge/test/models/pytorch/text/phi3/test_phi3.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3.py
@@ -21,6 +21,7 @@ from forge.forge_property_utils import (
     ModelPriority,
     Source,
     Task,
+    record_model_properties,
 )
 from forge.verify.verify import verify
 

--- a/forge/test/models/pytorch/text/phi3/test_phi3_5.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3_5.py
@@ -11,6 +11,7 @@ from forge.forge_property_utils import (
     ModelPriority,
     Source,
     Task,
+    record_model_properties,
 )
 from forge.verify.verify import verify
 

--- a/forge/test/models/pytorch/text/phi4/test_phi4.py
+++ b/forge/test/models/pytorch/text/phi4/test_phi4.py
@@ -16,6 +16,7 @@ from forge.forge_property_utils import (
     ModelPriority,
     Source,
     Task,
+    record_model_properties,
 )
 from forge.verify.verify import verify
 

--- a/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
@@ -9,7 +9,13 @@ from transformers import (
 )
 
 import forge
-from forge.forge_property_utils import Framework, ModelGroup, Source, Task
+from forge.forge_property_utils import (
+    Framework,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
 from forge.verify.verify import verify
 
 # Variants for testing

--- a/forge/test/models/pytorch/vision/sam/test_sam.py
+++ b/forge/test/models/pytorch/vision/sam/test_sam.py
@@ -8,7 +8,13 @@ import torch
 import forge
 from forge._C import DataFormat
 from forge.config import CompilerConfig
-from forge.forge_property_utils import Framework, ModelGroup, Source, Task
+from forge.forge_property_utils import (
+    Framework,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.sam.model_utils.model import (

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_world.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_world.py
@@ -8,7 +8,13 @@ import torch
 from ultralytics import YOLO
 
 import forge
-from forge.forge_property_utils import Framework, ModelGroup, Source, Task
+from forge.forge_property_utils import (
+    Framework,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.yolo.model_utils.yolovx_utils import get_test_input


### PR DESCRIPTION
1. This PR addresses an issue where all instances of ForgePropertyHandler share a single default ForgePropertyStore due to the use of a mutable default argument in the constructor. This behavior leads to unexpected persistence of property values across different handler instances(i.e each test execution). The default argument `store: ForgePropertyStore = ForgePropertyStore()` is evaluated once when the class is defined, not each time __init__ is called. Every time we do ForgePropertyHandler() without passing a store, it reuses that one ForgePropertyStore instance created at definition time. Changes made to self.store in one handler (e.g. setting model properties) stay on that same object and thus appear in subsequent handlers which leads to duplicate model names.
2. Imported missing record_model_properties function in the models tests