### PR TITLE
Add support for Alexnet-b pytorch model

### DIFF
--- a/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
+++ b/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
@@ -15,6 +15,7 @@ from forge.config import CompilerConfig
 from forge.forge_property_utils import Framework, Source, Task, record_model_properties
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
 from test.utils import download_model
 
 
@@ -71,7 +72,6 @@ def test_alexnet_torchhub():
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 def test_alexnet_osmr():
 
     # Record Forge Property
@@ -80,7 +80,10 @@ def test_alexnet_osmr():
     )
 
     # Load model
-    framework_model = download_model(ptcv_get_model, "alexnet", pretrained=True)
+
+    # Using AlexNet-b instead of AlexNet-a to avoid LocalResponseNorm,
+    # which internally uses avgpool3d — currently unsupported for bfloat16.
+    framework_model = download_model(ptcv_get_model, "alexnetb", pretrained=True).to(torch.bfloat16)
     framework_model.eval()
 
     # Load and pre-process image
@@ -102,10 +105,21 @@ def test_alexnet_osmr():
         )
         img_tensor = torch.rand(1, 3, 224, 224)
 
-    inputs = [img_tensor]
+    inputs = [img_tensor.to(torch.bfloat16)]
+
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     # Forge compile framework model
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
+    compiled_model = forge.compile(
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+        compiler_cfg=compiler_cfg,
+    )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and inference
+    fw_out, co_out = verify(inputs, framework_model, compiled_model)
+
+    # post processing
+    print_cls_results(fw_out[0], co_out[0])


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge-fe/issues/1987#issuecomment-2889684846

### Problem description
AlexNet-a has [LocalResponseNorm](https://github.com/osmr/pytorchcv/blob/7f31dc8fe521e99012ac863a946e10a314118c16/pytorchcv/models/alexnet.py#L54), which internally uses [avgpool3d](https://github.com/pytorch/pytorch/blob/7bcf7da3a268b435777fe87c7794c382f444e86d/torch/nn/functional.py#L2588) — currently unsupported for bfloat16.

### What's changed
Added bfloat16 support for the [alexnet-b](https://github.com/osmr/pytorchcv/blob/7f31dc8fe521e99012ac863a946e10a314118c16/pytorchcv/models/alexnet.py#L227C10-L232C24) variant, which avoids LocalResponseNorm

### Logs

[may27_alexnetb_osmr_bfp16.log](https://github.com/user-attachments/files/20454332/may27_alexnetb_osmr_bfp16.log)



