### PR TITLE
Fix matmul op failure in oft vision model

### DIFF
--- a/forge/test/mlir/operators/matmul/test_matmul.py
+++ b/forge/test/mlir/operators/matmul/test_matmul.py
@@ -32,3 +32,35 @@ def test_matmul(batch_size, outer_dim_x, outer_dim_y, inner_dim):
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
 
     verify(inputs, framework_model, compiled_model)
+
+
+@pytest.mark.parametrize(
+    "x_shape, y_shape",
+    [
+        ((1, 1, 3, 5), (1, 15, 5, 2)),
+        ((1, 1, 1, 4, 5), (1, 41, 14, 5, 2)),
+        ((1, 1, 1, 4, 5), (1, 9, 12, 5, 2)),
+        ((1, 1, 1, 1, 3, 3), (1, 8, 160, 160, 3, 1)),
+    ],
+)
+@pytest.mark.xfail(
+    reason="""[TTNN] RuntimeError: TT_FATAL @ third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/matmul/device/matmul_op.cpp:1545: a_shape[i] == b_shape[i]
+    info: bmm (non-bcast matmul) expects input tensors of shapes BCMK*BCKN=BCMN or equivalent """
+)
+def test_Matmul_ND(x_shape, y_shape):
+    class Matmul_ND(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, x, y):
+            return torch.matmul(x, y)
+
+    inputs = [
+        torch.rand(*x_shape),
+        torch.rand(*y_shape),
+    ]
+
+    framework_model = Matmul_ND()
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
+
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/models/pytorch/vision/oft/test_oft.py
+++ b/forge/test/models/pytorch/vision/oft/test_oft.py
@@ -15,7 +15,7 @@ from third_party.tt_forge_models.oft import ModelLoader  # isort:skip
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
+@pytest.mark.skip(reason="Getting hang at generate_initial_graph pass")
 def test_oft():
     # Record Forge Property
     module_name = record_model_properties(


### PR DESCRIPTION
### Ticket
This PR fixes https://github.com/tenstorrent/tt-forge-fe/issues/2144

### Summary 

This PR tracks [this fix ](https://github.com/tenstorrent/tt-tvm/pull/85) and verifies it with sanity

### Logs

[may27_sanity_bf.log](https://github.com/user-attachments/files/20458587/may27_sanity_bf.log)
[may27_sanity_af.log](https://github.com/user-attachments/files/20458586/may27_sanity_af.log)
[may27_oft_before_fix.log](https://github.com/user-attachments/files/20458607/may27_oft_before_fix.log)
[may27_oft_after_fix.log](https://github.com/user-attachments/files/20460515/may27_oft_after_fix_1.log)





