### PR TITLE
Remove xfail markers for passing models ops tests

### DIFF
--- a/forge/test/models_ops/test_add.py
+++ b/forge/test/models_ops/test_add.py
@@ -4132,19 +4132,16 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 100, 8, 14, 20), torch.float32)],
         {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add1,
-            [((100, 264, 14, 20), torch.float32), ((264, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add1,
+        [((100, 264, 14, 20), torch.float32), ((264, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add0,
@@ -4156,40 +4153,31 @@ forge_modules_and_shapes_dtypes_list = [
         [((100, 8, 9240), torch.float32)],
         {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add31,
-            [((100, 264, 14, 20), torch.float32)],
-            {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add31,
+        [((100, 264, 14, 20), torch.float32)],
+        {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add1,
-            [((100, 128, 14, 20), torch.float32), ((128, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add1,
+        [((100, 128, 14, 20), torch.float32), ((128, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add30,
         [((100, 8, 4480), torch.float32)],
         {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add32,
-            [((100, 128, 14, 20), torch.float32)],
-            {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add32,
+        [((100, 128, 14, 20), torch.float32)],
+        {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Add1,
@@ -4202,32 +4190,26 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add1,
-            [((100, 64, 27, 40), torch.float32), ((64, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add1,
+        [((100, 64, 27, 40), torch.float32), ((64, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add30,
         [((100, 8, 8640), torch.float32)],
         {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add33,
-            [((100, 64, 27, 40), torch.float32)],
-            {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add33,
+        [((100, 64, 27, 40), torch.float32)],
+        {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Add1,
@@ -4240,32 +4222,26 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add1,
-            [((100, 32, 54, 80), torch.float32), ((32, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add1,
+        [((100, 32, 54, 80), torch.float32), ((32, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add30,
         [((100, 8, 17280), torch.float32)],
         {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add34,
-            [((100, 32, 54, 80), torch.float32)],
-            {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add34,
+        [((100, 32, 54, 80), torch.float32)],
+        {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Add1,
@@ -4278,32 +4254,26 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add1,
-            [((100, 16, 107, 160), torch.float32), ((16, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add1,
+        [((100, 16, 107, 160), torch.float32), ((16, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add30,
         [((100, 8, 34240), torch.float32)],
         {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add35,
-            [((100, 16, 107, 160), torch.float32)],
-            {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add35,
+        [((100, 16, 107, 160), torch.float32)],
+        {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Add1,
@@ -10362,24 +10332,21 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 256, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_obj_det_hf",
-                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 256, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_obj_det_hf",
+                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -10396,41 +10363,35 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 512, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_obj_det_hf",
-                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 512, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_obj_det_hf",
+                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 768, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 768, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -10447,25 +10408,22 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 1024, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_obj_det_hf",
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 1024, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_obj_det_hf",
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -14702,13 +14660,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((2, 1, 1024), torch.float32), ((2, 1, 1024), torch.float32)],
         {"model_names": ["pt_stereo_facebook_musicgen_small_music_generation_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add1,
-            [((2, 1, 1024), torch.float32), ((1, 1024), torch.float32)],
-            {"model_names": ["pt_stereo_facebook_musicgen_small_music_generation_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add1,
+        [((2, 1, 1024), torch.float32), ((1, 1024), torch.float32)],
+        {"model_names": ["pt_stereo_facebook_musicgen_small_music_generation_hf"], "pcc": 0.99},
     ),
     (
         Add0,
@@ -14785,13 +14740,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((2, 1, 2048), torch.float32), ((2, 1, 2048), torch.float32)],
         {"model_names": ["pt_stereo_facebook_musicgen_large_music_generation_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add1,
-            [((2, 1, 2048), torch.float32), ((1, 2048), torch.float32)],
-            {"model_names": ["pt_stereo_facebook_musicgen_large_music_generation_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add1,
+        [((2, 1, 2048), torch.float32), ((1, 2048), torch.float32)],
+        {"model_names": ["pt_stereo_facebook_musicgen_large_music_generation_hf"], "pcc": 0.99},
     ),
     (
         Add97,
@@ -14808,13 +14760,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((2, 1, 1536), torch.float32), ((2, 1, 1536), torch.float32)],
         {"model_names": ["pt_stereo_facebook_musicgen_medium_music_generation_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add1,
-            [((2, 1, 1536), torch.float32), ((1, 1536), torch.float32)],
-            {"model_names": ["pt_stereo_facebook_musicgen_medium_music_generation_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add1,
+        [((2, 1, 1536), torch.float32), ((1, 1536), torch.float32)],
+        {"model_names": ["pt_stereo_facebook_musicgen_medium_music_generation_hf"], "pcc": 0.99},
     ),
     (
         Add98,
@@ -15286,19 +15235,16 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 596, 4096), torch.float32), ((1, 596, 4096), torch.float32)],
         {"model_names": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add1,
-            [((2, 2432, 64, 64), torch.float32), ((2432, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_stable_diffusion_stable_diffusion_3_5_large_cond_gen_hf",
-                    "pt_stable_diffusion_stable_diffusion_3_5_large_turbo_cond_gen_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add1,
+        [((2, 2432, 64, 64), torch.float32), ((2432, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_stable_diffusion_stable_diffusion_3_5_large_cond_gen_hf",
+                "pt_stable_diffusion_stable_diffusion_3_5_large_turbo_cond_gen_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -15513,13 +15459,10 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add1,
-            [((2, 1536, 64, 64), torch.float32), ((1536, 1, 1), torch.float32)],
-            {"model_names": ["pt_stable_diffusion_stable_diffusion_3_5_medium_cond_gen_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add1,
+        [((2, 1536, 64, 64), torch.float32), ((1536, 1, 1), torch.float32)],
+        {"model_names": ["pt_stable_diffusion_stable_diffusion_3_5_medium_cond_gen_hf"], "pcc": 0.99},
     ),
     (
         Add1,
@@ -15581,26 +15524,20 @@ forge_modules_and_shapes_dtypes_list = [
         [((2, 24, 333, 1), torch.float32)],
         {"model_names": ["pt_stable_diffusion_stable_diffusion_3_5_medium_cond_gen_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add114,
-            [((2, 24, 4429, 4429), torch.float32)],
-            {"model_names": ["pt_stable_diffusion_stable_diffusion_3_5_medium_cond_gen_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add114,
+        [((2, 24, 4429, 4429), torch.float32)],
+        {"model_names": ["pt_stable_diffusion_stable_diffusion_3_5_medium_cond_gen_hf"], "pcc": 0.99},
     ),
     (
         Add1,
         [((2, 4096, 1536), torch.float32), ((2, 4096, 1536), torch.float32)],
         {"model_names": ["pt_stable_diffusion_stable_diffusion_3_5_medium_cond_gen_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add121,
-            [((2, 24, 4096, 4096), torch.float32)],
-            {"model_names": ["pt_stable_diffusion_stable_diffusion_3_5_medium_cond_gen_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add121,
+        [((2, 24, 4096, 4096), torch.float32)],
+        {"model_names": ["pt_stable_diffusion_stable_diffusion_3_5_medium_cond_gen_hf"], "pcc": 0.99},
     ),
     (
         Add122,
@@ -20532,19 +20469,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 64, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_obj_det_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 64, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_obj_det_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -20579,19 +20513,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 128, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_obj_det_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 128, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_obj_det_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -20681,19 +20612,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 2048, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_obj_det_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 2048, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_obj_det_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -20749,13 +20677,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 100, 8, 14, 20), torch.float32)],
         {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add0,
-            [((100, 8, 1, 1), torch.float32)],
-            {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((100, 8, 1, 1), torch.float32)],
+        {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Add231,
@@ -21878,22 +21803,19 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 72, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_ghostnet_ghostnet_100_img_cls_timm",
-                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 72, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_ghostnet_ghostnet_100_img_cls_timm",
+                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -22004,24 +21926,21 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 120, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_ghostnet_ghostnet_100_img_cls_timm",
-                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 120, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_ghostnet_ghostnet_100_img_cls_timm",
+                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -22128,22 +22047,19 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 480, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_ghostnet_ghostnet_100_img_cls_timm",
-                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 480, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_ghostnet_ghostnet_100_img_cls_timm",
+                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -22172,39 +22088,33 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 672, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_ghostnet_ghostnet_100_img_cls_timm",
-                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 672, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_ghostnet_ghostnet_100_img_cls_timm",
+                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+            ],
+            "pcc": 0.99,
+        },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 960, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_ghostnet_ghostnet_100_img_cls_timm",
-                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 960, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_ghostnet_ghostnet_100_img_cls_timm",
+                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -24107,19 +24017,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 16, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 16, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -24169,19 +24076,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 96, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 96, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add0,
@@ -24208,19 +24112,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 240, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 240, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -24266,19 +24167,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 144, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 144, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add0,
@@ -24302,19 +24200,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 288, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 288, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -24338,19 +24233,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 576, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 576, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Add1,
@@ -24472,13 +24364,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 1280), torch.float32)],
         {"model_names": ["pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add0,
-            [((1, 1280, 1, 1), torch.float32)],
-            {"model_names": ["pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Add0,
+        [((1, 1280, 1, 1), torch.float32)],
+        {"model_names": ["pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm"], "pcc": 0.99},
     ),
     (
         Add0,
@@ -27890,40 +27779,16 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 4096, 1, 1), torch.float32), ((4096, 1, 1), torch.float32)],
         {"model_names": ["pt_vgg_vgg19_bn_obj_det_timm"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Add255,
-            [((197, 1, 2304), torch.float32)],
-            {"model_names": ["pt_vit_vit_b_16_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    pytest.param(
-        (
-            Add283,
-            [((1, 12, 197, 197), torch.float32)],
-            {"model_names": ["pt_vit_vit_b_16_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (Add255, [((197, 1, 2304), torch.float32)], {"model_names": ["pt_vit_vit_b_16_img_cls_torchvision"], "pcc": 0.99}),
+    (
+        Add283,
+        [((1, 12, 197, 197), torch.float32)],
+        {"model_names": ["pt_vit_vit_b_16_img_cls_torchvision"], "pcc": 0.99},
     ),
     (Add9, [((197, 768), torch.float32)], {"model_names": ["pt_vit_vit_b_16_img_cls_torchvision"], "pcc": 0.99}),
     (Add284, [((1, 50, 768), torch.float32)], {"model_names": ["pt_vit_vit_b_32_img_cls_torchvision"], "pcc": 0.99}),
-    pytest.param(
-        (
-            Add255,
-            [((50, 1, 2304), torch.float32)],
-            {"model_names": ["pt_vit_vit_b_32_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    pytest.param(
-        (
-            Add285,
-            [((1, 12, 50, 50), torch.float32)],
-            {"model_names": ["pt_vit_vit_b_32_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
+    (Add255, [((50, 1, 2304), torch.float32)], {"model_names": ["pt_vit_vit_b_32_img_cls_torchvision"], "pcc": 0.99}),
+    (Add285, [((1, 12, 50, 50), torch.float32)], {"model_names": ["pt_vit_vit_b_32_img_cls_torchvision"], "pcc": 0.99}),
     (Add9, [((50, 768), torch.float32)], {"model_names": ["pt_vit_vit_b_32_img_cls_torchvision"], "pcc": 0.99}),
     (
         Add1,
@@ -27933,22 +27798,8 @@ forge_modules_and_shapes_dtypes_list = [
     (Add54, [((1, 50, 3072), torch.float32)], {"model_names": ["pt_vit_vit_b_32_img_cls_torchvision"], "pcc": 0.99}),
     (Add9, [((1, 50, 768), torch.float32)], {"model_names": ["pt_vit_vit_b_32_img_cls_torchvision"], "pcc": 0.99}),
     (Add286, [((1, 50, 1024), torch.float32)], {"model_names": ["pt_vit_vit_l_32_img_cls_torchvision"], "pcc": 0.99}),
-    pytest.param(
-        (
-            Add54,
-            [((50, 1, 3072), torch.float32)],
-            {"model_names": ["pt_vit_vit_l_32_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    pytest.param(
-        (
-            Add285,
-            [((1, 16, 50, 50), torch.float32)],
-            {"model_names": ["pt_vit_vit_l_32_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
+    (Add54, [((50, 1, 3072), torch.float32)], {"model_names": ["pt_vit_vit_l_32_img_cls_torchvision"], "pcc": 0.99}),
+    (Add285, [((1, 16, 50, 50), torch.float32)], {"model_names": ["pt_vit_vit_l_32_img_cls_torchvision"], "pcc": 0.99}),
     (Add91, [((50, 1024), torch.float32)], {"model_names": ["pt_vit_vit_l_32_img_cls_torchvision"], "pcc": 0.99}),
     (
         Add1,
@@ -27963,21 +27814,11 @@ forge_modules_and_shapes_dtypes_list = [
         {"model_names": ["pt_vit_vit_h_14_img_cls_torchvision"], "pcc": 0.99},
     ),
     (Add287, [((1, 1370, 1280), torch.float32)], {"model_names": ["pt_vit_vit_h_14_img_cls_torchvision"], "pcc": 0.99}),
-    pytest.param(
-        (
-            Add288,
-            [((1370, 1, 3840), torch.float32)],
-            {"model_names": ["pt_vit_vit_h_14_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    pytest.param(
-        (
-            Add289,
-            [((1, 16, 1370, 1370), torch.float32)],
-            {"model_names": ["pt_vit_vit_h_14_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (Add288, [((1370, 1, 3840), torch.float32)], {"model_names": ["pt_vit_vit_h_14_img_cls_torchvision"], "pcc": 0.99}),
+    (
+        Add289,
+        [((1, 16, 1370, 1370), torch.float32)],
+        {"model_names": ["pt_vit_vit_h_14_img_cls_torchvision"], "pcc": 0.99},
     ),
     (Add96, [((1370, 1280), torch.float32)], {"model_names": ["pt_vit_vit_h_14_img_cls_torchvision"], "pcc": 0.99}),
     (
@@ -27987,21 +27828,11 @@ forge_modules_and_shapes_dtypes_list = [
     ),
     (Add103, [((1, 1370, 5120), torch.float32)], {"model_names": ["pt_vit_vit_h_14_img_cls_torchvision"], "pcc": 0.99}),
     (Add96, [((1, 1370, 1280), torch.float32)], {"model_names": ["pt_vit_vit_h_14_img_cls_torchvision"], "pcc": 0.99}),
-    pytest.param(
-        (
-            Add54,
-            [((197, 1, 3072), torch.float32)],
-            {"model_names": ["pt_vit_vit_l_16_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    pytest.param(
-        (
-            Add283,
-            [((1, 16, 197, 197), torch.float32)],
-            {"model_names": ["pt_vit_vit_l_16_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (Add54, [((197, 1, 3072), torch.float32)], {"model_names": ["pt_vit_vit_l_16_img_cls_torchvision"], "pcc": 0.99}),
+    (
+        Add283,
+        [((1, 16, 197, 197), torch.float32)],
+        {"model_names": ["pt_vit_vit_l_16_img_cls_torchvision"], "pcc": 0.99},
     ),
     (Add91, [((197, 1024), torch.float32)], {"model_names": ["pt_vit_vit_l_16_img_cls_torchvision"], "pcc": 0.99}),
     (

--- a/forge/test/models_ops/test_equal.py
+++ b/forge/test/models_ops/test_equal.py
@@ -50,36 +50,22 @@ forge_modules_and_shapes_dtypes_list = [
             )
         ],
     ),
-    pytest.param(
-        (
-            Equal0,
-            [((1, 7), torch.int64)],
-            {"model_names": ["pt_gpt2_mnoukhov_gpt2_imdb_sentiment_classifier_seq_cls_hf"], "pcc": 0.99},
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp:27: tt::exception info: BinaryOpType cannot be mapped to BcastOpMath"
-            )
-        ],
+    (
+        Equal0,
+        [((1, 7), torch.int64)],
+        {"model_names": ["pt_gpt2_mnoukhov_gpt2_imdb_sentiment_classifier_seq_cls_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Equal0,
-            [((1, 32), torch.int64)],
-            {
-                "model_names": [
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp:27: tt::exception info: BinaryOpType cannot be mapped to BcastOpMath"
-            )
-        ],
+    (
+        Equal0,
+        [((1, 32), torch.int64)],
+        {
+            "model_names": [
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     pytest.param(
         (Equal0, [((1, 256), torch.int64)], {"model_names": ["pt_phi4_microsoft_phi_4_seq_cls_hf"], "pcc": 0.99}),

--- a/forge/test/models_ops/test_greater.py
+++ b/forge/test/models_ops/test_greater.py
@@ -278,139 +278,97 @@ def ids_func(param):
 
 
 forge_modules_and_shapes_dtypes_list = [
-    pytest.param(
-        (
-            Greater0,
-            [((1, 1, 256, 256), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_phi3_microsoft_phi_3_mini_4k_instruct_clm_hf",
-                    "onnx_phi3_microsoft_phi_3_mini_128k_instruct_clm_hf",
-                    "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
-                    "pt_codegen_salesforce_codegen_350m_nl_clm_hf",
-                    "pt_codegen_salesforce_codegen_350m_mono_clm_hf",
-                    "pt_codegen_salesforce_codegen_350m_multi_clm_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_2_7b_clm_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_125m_clm_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf",
-                    "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_3b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
-                    "pt_opt_facebook_opt_1_3b_clm_hf",
-                    "pt_opt_facebook_opt_350m_clm_hf",
-                    "pt_opt_facebook_opt_125m_clm_hf",
-                    "pt_phi2_microsoft_phi_2_clm_hf",
-                    "pt_phi2_microsoft_phi_2_pytdml_clm_hf",
-                    "pt_phi3_microsoft_phi_3_mini_128k_instruct_clm_hf",
-                    "pt_phi3_microsoft_phi_3_mini_4k_instruct_clm_hf",
-                    "pt_phi3_5_microsoft_phi_3_5_mini_instruct_clm_hf",
-                    "pt_xglm_facebook_xglm_564m_clm_hf",
-                    "pt_xglm_facebook_xglm_1_7b_clm_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp:27: tt::exception info: BinaryOpType cannot be mapped to BcastOpMath"
-            )
-        ],
+    (
+        Greater0,
+        [((1, 1, 256, 256), torch.float32)],
+        {
+            "model_names": [
+                "onnx_phi3_microsoft_phi_3_mini_4k_instruct_clm_hf",
+                "onnx_phi3_microsoft_phi_3_mini_128k_instruct_clm_hf",
+                "pt_bart_facebook_bart_large_mnli_seq_cls_hf",
+                "pt_codegen_salesforce_codegen_350m_nl_clm_hf",
+                "pt_codegen_salesforce_codegen_350m_mono_clm_hf",
+                "pt_codegen_salesforce_codegen_350m_multi_clm_hf",
+                "pt_gptneo_eleutherai_gpt_neo_2_7b_clm_hf",
+                "pt_gptneo_eleutherai_gpt_neo_125m_clm_hf",
+                "pt_gptneo_eleutherai_gpt_neo_1_3b_clm_hf",
+                "pt_llama3_meta_llama_meta_llama_3_8b_clm_hf",
+                "pt_llama3_meta_llama_llama_3_1_8b_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_1b_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_3b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_1b_instruct_clm_hf",
+                "pt_llama3_meta_llama_meta_llama_3_8b_instruct_clm_hf",
+                "pt_llama3_meta_llama_llama_3_1_8b_instruct_clm_hf",
+                "pt_opt_facebook_opt_1_3b_clm_hf",
+                "pt_opt_facebook_opt_350m_clm_hf",
+                "pt_opt_facebook_opt_125m_clm_hf",
+                "pt_phi2_microsoft_phi_2_clm_hf",
+                "pt_phi2_microsoft_phi_2_pytdml_clm_hf",
+                "pt_phi3_microsoft_phi_3_mini_128k_instruct_clm_hf",
+                "pt_phi3_microsoft_phi_3_mini_4k_instruct_clm_hf",
+                "pt_phi3_5_microsoft_phi_3_5_mini_instruct_clm_hf",
+                "pt_xglm_facebook_xglm_564m_clm_hf",
+                "pt_xglm_facebook_xglm_1_7b_clm_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
-    pytest.param(
-        (
-            Greater0,
-            [((2, 1, 1, 13), torch.float32)],
-            {
-                "model_names": [
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp:27: tt::exception info: BinaryOpType cannot be mapped to BcastOpMath"
-            )
-        ],
+    (
+        Greater0,
+        [((2, 1, 1, 13), torch.float32)],
+        {
+            "model_names": [
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
-    pytest.param(
-        (
-            Greater0,
-            [((2, 1, 7, 7), torch.float32)],
-            {"model_names": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"], "pcc": 0.99},
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp:27: tt::exception info: BinaryOpType cannot be mapped to BcastOpMath"
-            )
-        ],
+    (
+        Greater0,
+        [((2, 1, 7, 7), torch.float32)],
+        {"model_names": ["pt_clip_openai_clip_vit_base_patch32_text_gen_hf_text"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Greater0,
-            [((1, 1, 32, 32), torch.float32)],
-            {
-                "model_names": [
-                    "pt_bloom_bigscience_bloom_1b1_clm_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf",
-                    "pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf",
-                    "pt_llama3_huggyllama_llama_7b_clm_hf",
-                    "pt_llama3_meta_llama_llama_3_2_3b_clm_hf",
-                    "pt_opt_facebook_opt_125m_qa_hf",
-                    "pt_opt_facebook_opt_125m_seq_cls_hf",
-                    "pt_opt_facebook_opt_350m_qa_hf",
-                    "pt_opt_facebook_opt_1_3b_qa_hf",
-                    "pt_opt_facebook_opt_350m_seq_cls_hf",
-                    "pt_opt_facebook_opt_1_3b_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp:27: tt::exception info: BinaryOpType cannot be mapped to BcastOpMath"
-            )
-        ],
+    (
+        Greater0,
+        [((1, 1, 32, 32), torch.float32)],
+        {
+            "model_names": [
+                "pt_bloom_bigscience_bloom_1b1_clm_hf",
+                "pt_gptneo_eleutherai_gpt_neo_1_3b_seq_cls_hf",
+                "pt_gptneo_eleutherai_gpt_neo_125m_seq_cls_hf",
+                "pt_gptneo_eleutherai_gpt_neo_2_7b_seq_cls_hf",
+                "pt_llama3_huggyllama_llama_7b_clm_hf",
+                "pt_llama3_meta_llama_llama_3_2_3b_clm_hf",
+                "pt_opt_facebook_opt_125m_qa_hf",
+                "pt_opt_facebook_opt_125m_seq_cls_hf",
+                "pt_opt_facebook_opt_350m_qa_hf",
+                "pt_opt_facebook_opt_1_3b_qa_hf",
+                "pt_opt_facebook_opt_350m_seq_cls_hf",
+                "pt_opt_facebook_opt_1_3b_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
-    pytest.param(
-        (
-            Greater0,
-            [((1, 12, 128, 128), torch.float32)],
-            {
-                "model_names": [
-                    "pt_distilbert_distilbert_base_uncased_mlm_hf",
-                    "pt_distilbert_distilbert_base_cased_mlm_hf",
-                    "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
-                    "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
-                    "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp:27: tt::exception info: BinaryOpType cannot be mapped to BcastOpMath"
-            )
-        ],
+    (
+        Greater0,
+        [((1, 12, 128, 128), torch.float32)],
+        {
+            "model_names": [
+                "pt_distilbert_distilbert_base_uncased_mlm_hf",
+                "pt_distilbert_distilbert_base_cased_mlm_hf",
+                "pt_distilbert_davlan_distilbert_base_multilingual_cased_ner_hrl_token_cls_hf",
+                "pt_distilbert_distilbert_base_uncased_finetuned_sst_2_english_seq_cls_hf",
+                "pt_distilbert_distilbert_base_multilingual_cased_mlm_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
-    pytest.param(
-        (
-            Greater0,
-            [((1, 12, 384, 384), torch.float32)],
-            {"model_names": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"], "pcc": 0.99},
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp:27: tt::exception info: BinaryOpType cannot be mapped to BcastOpMath"
-            )
-        ],
+    (
+        Greater0,
+        [((1, 12, 384, 384), torch.float32)],
+        {"model_names": ["pt_distilbert_distilbert_base_cased_distilled_squad_qa_hf"], "pcc": 0.99},
     ),
     (
         Greater1,

--- a/forge/test/models_ops/test_layernorm.py
+++ b/forge/test/models_ops/test_layernorm.py
@@ -1363,41 +1363,32 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"dim": "-1", "epsilon": "0.0"},
         },
     ),
-    pytest.param(
-        (
-            Layernorm14,
-            [((2, 1, 1024), torch.float32)],
-            {
-                "model_names": ["pt_stereo_facebook_musicgen_small_music_generation_hf"],
-                "pcc": 0.99,
-                "args": {"dim": "-1", "epsilon": "1e-05"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Layernorm14,
+        [((2, 1, 1024), torch.float32)],
+        {
+            "model_names": ["pt_stereo_facebook_musicgen_small_music_generation_hf"],
+            "pcc": 0.99,
+            "args": {"dim": "-1", "epsilon": "1e-05"},
+        },
     ),
-    pytest.param(
-        (
-            Layernorm15,
-            [((2, 1, 2048), torch.float32)],
-            {
-                "model_names": ["pt_stereo_facebook_musicgen_large_music_generation_hf"],
-                "pcc": 0.99,
-                "args": {"dim": "-1", "epsilon": "1e-05"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Layernorm15,
+        [((2, 1, 2048), torch.float32)],
+        {
+            "model_names": ["pt_stereo_facebook_musicgen_large_music_generation_hf"],
+            "pcc": 0.99,
+            "args": {"dim": "-1", "epsilon": "1e-05"},
+        },
     ),
-    pytest.param(
-        (
-            Layernorm16,
-            [((2, 1, 1536), torch.float32)],
-            {
-                "model_names": ["pt_stereo_facebook_musicgen_medium_music_generation_hf"],
-                "pcc": 0.99,
-                "args": {"dim": "-1", "epsilon": "1e-05"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Layernorm16,
+        [((2, 1, 1536), torch.float32)],
+        {
+            "model_names": ["pt_stereo_facebook_musicgen_medium_music_generation_hf"],
+            "pcc": 0.99,
+            "args": {"dim": "-1", "epsilon": "1e-05"},
+        },
     ),
     (
         Layernorm17,

--- a/forge/test/models_ops/test_multiply.py
+++ b/forge/test/models_ops/test_multiply.py
@@ -2852,13 +2852,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((100, 8, 9240), torch.float32)],
         {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply13,
-            [((100, 264, 14, 20), torch.float32)],
-            {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply13,
+        [((100, 264, 14, 20), torch.float32)],
+        {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Multiply0,
@@ -2875,13 +2872,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((100, 8, 4480), torch.float32)],
         {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply14,
-            [((100, 128, 14, 20), torch.float32)],
-            {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply14,
+        [((100, 128, 14, 20), torch.float32)],
+        {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Multiply0,
@@ -2898,13 +2892,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((100, 8, 8640), torch.float32)],
         {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply15,
-            [((100, 64, 27, 40), torch.float32)],
-            {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply15,
+        [((100, 64, 27, 40), torch.float32)],
+        {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Multiply0,
@@ -2921,13 +2912,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((100, 8, 17280), torch.float32)],
         {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply16,
-            [((100, 32, 54, 80), torch.float32)],
-            {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply16,
+        [((100, 32, 54, 80), torch.float32)],
+        {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Multiply0,
@@ -2944,13 +2932,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((100, 8, 34240), torch.float32)],
         {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply17,
-            [((100, 16, 107, 160), torch.float32)],
-            {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply17,
+        [((100, 16, 107, 160), torch.float32)],
+        {"model_names": ["onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Multiply0,
@@ -4827,20 +4812,17 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((64, 3, 64, 64), torch.float32), ((3, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_swin_microsoft_swinv2_tiny_patch4_window8_256_img_cls_hf",
-                    "pt_swin_swin_v2_s_img_cls_torchvision",
-                    "pt_swin_swin_v2_t_img_cls_torchvision",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((64, 3, 64, 64), torch.float32), ((3, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_swin_microsoft_swinv2_tiny_patch4_window8_256_img_cls_hf",
+                "pt_swin_swin_v2_s_img_cls_torchvision",
+                "pt_swin_swin_v2_t_img_cls_torchvision",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply1,
@@ -4859,20 +4841,17 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((16, 6, 64, 64), torch.float32), ((6, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_swin_microsoft_swinv2_tiny_patch4_window8_256_img_cls_hf",
-                    "pt_swin_swin_v2_s_img_cls_torchvision",
-                    "pt_swin_swin_v2_t_img_cls_torchvision",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((16, 6, 64, 64), torch.float32), ((6, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_swin_microsoft_swinv2_tiny_patch4_window8_256_img_cls_hf",
+                "pt_swin_swin_v2_s_img_cls_torchvision",
+                "pt_swin_swin_v2_t_img_cls_torchvision",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply1,
@@ -4891,20 +4870,17 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((4, 12, 64, 64), torch.float32), ((12, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_swin_microsoft_swinv2_tiny_patch4_window8_256_img_cls_hf",
-                    "pt_swin_swin_v2_s_img_cls_torchvision",
-                    "pt_swin_swin_v2_t_img_cls_torchvision",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((4, 12, 64, 64), torch.float32), ((12, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_swin_microsoft_swinv2_tiny_patch4_window8_256_img_cls_hf",
+                "pt_swin_swin_v2_s_img_cls_torchvision",
+                "pt_swin_swin_v2_t_img_cls_torchvision",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply1,
@@ -4968,22 +4944,19 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 256, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 256, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -4999,22 +4972,19 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 512, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 512, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -5030,22 +5000,19 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 768, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 768, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -5061,24 +5028,21 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 1024, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pd_googlenet_base_img_cls_paddlemodels",
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 1024, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pd_googlenet_base_img_cls_paddlemodels",
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -13644,20 +13608,17 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 596, 11008), torch.float32), ((1, 596, 11008), torch.float32)],
         {"model_names": ["pt_llava_llava_hf_llava_1_5_7b_hf_cond_gen_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply62,
-            [((2, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_stable_diffusion_stable_diffusion_3_5_large_cond_gen_hf",
-                    "pt_stable_diffusion_stable_diffusion_3_5_large_turbo_cond_gen_hf",
-                    "pt_stable_diffusion_stable_diffusion_3_5_medium_cond_gen_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply62,
+        [((2, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_stable_diffusion_stable_diffusion_3_5_large_cond_gen_hf",
+                "pt_stable_diffusion_stable_diffusion_3_5_large_turbo_cond_gen_hf",
+                "pt_stable_diffusion_stable_diffusion_3_5_medium_cond_gen_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -14034,14 +13995,7 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply65,
-            [((1, 1, 32), torch.float32)],
-            {"model_names": ["pt_bloom_bigscience_bloom_1b1_clm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
+    (Multiply65, [((1, 1, 32), torch.float32)], {"model_names": ["pt_bloom_bigscience_bloom_1b1_clm_hf"], "pcc": 0.99}),
     (
         Multiply66,
         [((1, 1, 32, 32), torch.float32)],
@@ -15282,13 +15236,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 4096, 6), torch.float32), ((1, 4096, 6), torch.float32)],
         {"model_names": ["pt_mamba_state_spaces_mamba_1_4b_hf_clm_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((1, 4096, 1, 16), torch.float32), ((1, 4096, 6, 1), torch.float32)],
-            {"model_names": ["pt_mamba_state_spaces_mamba_1_4b_hf_clm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((1, 4096, 1, 16), torch.float32), ((1, 4096, 6, 1), torch.float32)],
+        {"model_names": ["pt_mamba_state_spaces_mamba_1_4b_hf_clm_hf"], "pcc": 0.99},
     ),
     (
         Multiply70,
@@ -15349,13 +15300,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 2048, 6), torch.float32), ((1, 2048, 6), torch.float32)],
         {"model_names": ["pt_mamba_state_spaces_mamba_370m_hf_clm_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((1, 2048, 1, 16), torch.float32), ((1, 2048, 6, 1), torch.float32)],
-            {"model_names": ["pt_mamba_state_spaces_mamba_370m_hf_clm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((1, 2048, 1, 16), torch.float32), ((1, 2048, 6, 1), torch.float32)],
+        {"model_names": ["pt_mamba_state_spaces_mamba_370m_hf_clm_hf"], "pcc": 0.99},
     ),
     (
         Multiply72,
@@ -15407,13 +15355,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 5120, 6), torch.float32), ((1, 5120, 6), torch.float32)],
         {"model_names": ["pt_mamba_state_spaces_mamba_2_8b_hf_clm_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((1, 5120, 1, 16), torch.float32), ((1, 5120, 6, 1), torch.float32)],
-            {"model_names": ["pt_mamba_state_spaces_mamba_2_8b_hf_clm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((1, 5120, 1, 16), torch.float32), ((1, 5120, 6, 1), torch.float32)],
+        {"model_names": ["pt_mamba_state_spaces_mamba_2_8b_hf_clm_hf"], "pcc": 0.99},
     ),
     (
         Multiply74,
@@ -15465,13 +15410,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 3072, 6), torch.float32), ((1, 3072, 6), torch.float32)],
         {"model_names": ["pt_mamba_state_spaces_mamba_790m_hf_clm_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((1, 3072, 1, 16), torch.float32), ((1, 3072, 6, 1), torch.float32)],
-            {"model_names": ["pt_mamba_state_spaces_mamba_790m_hf_clm_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((1, 3072, 1, 16), torch.float32), ((1, 3072, 6, 1), torch.float32)],
+        {"model_names": ["pt_mamba_state_spaces_mamba_790m_hf_clm_hf"], "pcc": 0.99},
     ),
     (
         Multiply76,
@@ -20221,13 +20163,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((100, 8, 33, 280), torch.float32), ((100, 8, 1, 1), torch.float32)],
         {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((100, 264, 14, 20), torch.float32), ((264, 1, 1), torch.float32)],
-            {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((100, 264, 14, 20), torch.float32), ((264, 1, 1), torch.float32)],
+        {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Multiply0,
@@ -20239,13 +20178,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((100, 8, 16, 280), torch.float32), ((100, 8, 1, 1), torch.float32)],
         {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((100, 128, 14, 20), torch.float32), ((128, 1, 1), torch.float32)],
-            {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((100, 128, 14, 20), torch.float32), ((128, 1, 1), torch.float32)],
+        {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Multiply0,
@@ -20257,13 +20193,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((100, 8, 8, 1080), torch.float32), ((100, 8, 1, 1), torch.float32)],
         {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((100, 64, 27, 40), torch.float32), ((64, 1, 1), torch.float32)],
-            {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((100, 64, 27, 40), torch.float32), ((64, 1, 1), torch.float32)],
+        {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Multiply0,
@@ -20275,13 +20208,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((100, 8, 4, 4320), torch.float32), ((100, 8, 1, 1), torch.float32)],
         {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((100, 32, 54, 80), torch.float32), ((32, 1, 1), torch.float32)],
-            {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((100, 32, 54, 80), torch.float32), ((32, 1, 1), torch.float32)],
+        {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Multiply0,
@@ -20293,13 +20223,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((100, 8, 2, 17120), torch.float32), ((100, 8, 1, 1), torch.float32)],
         {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((100, 16, 107, 160), torch.float32), ((16, 1, 1), torch.float32)],
-            {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((100, 16, 107, 160), torch.float32), ((16, 1, 1), torch.float32)],
+        {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
     (
         Multiply0,
@@ -22419,22 +22346,19 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 72, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_ghostnet_ghostnet_100_img_cls_timm",
-                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 72, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_ghostnet_ghostnet_100_img_cls_timm",
+                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -22593,24 +22517,21 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 120, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_ghostnet_ghostnet_100_img_cls_timm",
-                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 120, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_ghostnet_ghostnet_100_img_cls_timm",
+                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -22778,22 +22699,19 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 480, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_ghostnet_ghostnet_100_img_cls_timm",
-                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 480, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_ghostnet_ghostnet_100_img_cls_timm",
+                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -22807,22 +22725,19 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 672, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_ghostnet_ghostnet_100_img_cls_timm",
-                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 672, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_ghostnet_ghostnet_100_img_cls_timm",
+                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -22863,22 +22778,19 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 960, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_ghostnet_ghostnet_100_img_cls_timm",
-                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 960, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_ghostnet_ghostnet_100_img_cls_timm",
+                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -24273,19 +24185,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 16, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 16, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -24351,19 +24260,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 96, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 96, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -24383,19 +24289,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 240, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 240, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply1,
@@ -24457,19 +24360,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 144, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 144, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -24531,19 +24431,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 288, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 288, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -24583,19 +24480,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 576, 1, 1), torch.float32)],
-            {
-                "model_names": [
-                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 576, 1, 1), torch.float32)],
+        {
+            "model_names": [
+                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply0,
@@ -24727,13 +24621,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((1, 1280), torch.float32), ((1, 1280), torch.float32)],
         {"model_names": ["pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply1,
-            [((1, 1280, 1, 1), torch.float32)],
-            {"model_names": ["pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply1,
+        [((1, 1280, 1, 1), torch.float32)],
+        {"model_names": ["pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm"], "pcc": 0.99},
     ),
     (
         Multiply0,
@@ -26641,13 +26532,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((64, 4, 64, 32), torch.float32), ((64, 4, 64, 32), torch.float32)],
         {"model_names": ["pt_swin_swin_v2_b_img_cls_torchvision"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((64, 4, 64, 64), torch.float32), ((4, 1, 1), torch.float32)],
-            {"model_names": ["pt_swin_swin_v2_b_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((64, 4, 64, 64), torch.float32), ((4, 1, 1), torch.float32)],
+        {"model_names": ["pt_swin_swin_v2_b_img_cls_torchvision"], "pcc": 0.99},
     ),
     (
         Multiply1,
@@ -26659,13 +26547,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((16, 8, 64, 32), torch.float32), ((16, 8, 64, 32), torch.float32)],
         {"model_names": ["pt_swin_swin_v2_b_img_cls_torchvision"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((16, 8, 64, 64), torch.float32), ((8, 1, 1), torch.float32)],
-            {"model_names": ["pt_swin_swin_v2_b_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((16, 8, 64, 64), torch.float32), ((8, 1, 1), torch.float32)],
+        {"model_names": ["pt_swin_swin_v2_b_img_cls_torchvision"], "pcc": 0.99},
     ),
     (
         Multiply1,
@@ -26677,13 +26562,10 @@ forge_modules_and_shapes_dtypes_list = [
         [((4, 16, 64, 32), torch.float32), ((4, 16, 64, 32), torch.float32)],
         {"model_names": ["pt_swin_swin_v2_b_img_cls_torchvision"], "pcc": 0.99},
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((4, 16, 64, 64), torch.float32), ((16, 1, 1), torch.float32)],
-            {"model_names": ["pt_swin_swin_v2_b_img_cls_torchvision"], "pcc": 0.99},
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((4, 16, 64, 64), torch.float32), ((16, 1, 1), torch.float32)],
+        {"model_names": ["pt_swin_swin_v2_b_img_cls_torchvision"], "pcc": 0.99},
     ),
     (
         Multiply1,

--- a/forge/test/models_ops/test_notequal.py
+++ b/forge/test/models_ops/test_notequal.py
@@ -38,39 +38,18 @@ def ids_func(param):
 
 
 forge_modules_and_shapes_dtypes_list = [
-    pytest.param(
-        (Notequal0, [((1, 9), torch.int64)], {"model_names": ["pd_roberta_rbt4_ch_seq_cls_padlenlp"], "pcc": 0.99}),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp:27: tt::exception info: BinaryOpType cannot be mapped to BcastOpMath"
-            )
-        ],
-    ),
-    pytest.param(
-        (Notequal0, [((1, 11), torch.int64)], {"model_names": ["pd_roberta_rbt4_ch_clm_padlenlp"], "pcc": 0.99}),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp:27: tt::exception info: BinaryOpType cannot be mapped to BcastOpMath"
-            )
-        ],
-    ),
-    pytest.param(
-        (
-            Notequal0,
-            [((1, 128), torch.int64)],
-            {
-                "model_names": [
-                    "pt_roberta_xlm_roberta_base_mlm_hf",
-                    "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/ttnn/cpp/ttnn/operations/eltwise/binary/device/broadcast_height_and_width_multi_core_program_factory.cpp:27: tt::exception info: BinaryOpType cannot be mapped to BcastOpMath"
-            )
-        ],
+    (Notequal0, [((1, 9), torch.int64)], {"model_names": ["pd_roberta_rbt4_ch_seq_cls_padlenlp"], "pcc": 0.99}),
+    (Notequal0, [((1, 11), torch.int64)], {"model_names": ["pd_roberta_rbt4_ch_clm_padlenlp"], "pcc": 0.99}),
+    (
+        Notequal0,
+        [((1, 128), torch.int64)],
+        {
+            "model_names": [
+                "pt_roberta_xlm_roberta_base_mlm_hf",
+                "pt_roberta_cardiffnlp_twitter_roberta_base_sentiment_seq_cls_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
 ]
 


### PR DESCRIPTION
In the [latest models ops nightly pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/15288215332/job/43025994146), `Data mismatch between framework output and compiled model output `issues and `BinaryOpType cannot be mapped to BcastOpMath `issue was resolved in the **add**, **equal**, **greater**, **layernorm**, multiply and **not-equal** op tests. so removed xfail markers for those ops tests.


Generated models ops test report: 
[model_ops_tests_report.xlsx](https://github.com/user-attachments/files/20482939/model_ops_tests_report.xlsx)
