### PR TITLE
Add post processing steps for e2e passing pytorch models

### DIFF
--- a/forge/test/models/pytorch/text/albert/test_albert.py
+++ b/forge/test/models/pytorch/text/albert/test_albert.py
@@ -202,8 +202,15 @@ def test_albert_question_answering_pytorch(variant):
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post processing
+    answer_start_index = co_out[0].argmax()
+    answer_end_index = co_out[1].argmax()
+
+    predict_answer_tokens = input_tokens.input_ids[0, answer_start_index : answer_end_index + 1]
+    print("predicted answer ", tokenizer.decode(predict_answer_tokens, skip_special_tokens=True))
 
 
 @pytest.mark.nightly

--- a/forge/test/models/pytorch/text/dpr/test_dpr.py
+++ b/forge/test/models/pytorch/text/dpr/test_dpr.py
@@ -124,19 +124,16 @@ def test_dpr_question_encoder_pytorch(variant):
     if variant == "facebook/dpr-question_encoder-multiset-base":
         verify_values = False
 
-    # Model Verification
-    verify(
+    # Model Verification and Inference
+    _, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
         verify_cfg=VerifyConfig(verify_values=verify_values),
     )
 
-    # Inference
-    embeddings = compiled_model(*inputs)
-
     # Results
-    print("embeddings", embeddings)
+    print("embeddings", co_out)
 
 
 variants = ["facebook/dpr-reader-single-nq-base", "facebook/dpr-reader-multiset-base"]
@@ -179,20 +176,17 @@ def test_dpr_reader_pytorch(variant):
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
 
-    # Model Verification
-    verify(
+    # Model Verification and Inference
+    _, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
     )
 
-    # Inference
-    outputs = compiled_model(*inputs)
-
     # Post processing
-    start_logits = outputs[0]
-    end_logits = outputs[1]
-    relevance_logits = outputs[2]
+    start_logits = co_out[0]
+    end_logits = co_out[1]
+    relevance_logits = co_out[2]
 
     start_indices = torch.argmax(start_logits, dim=1)
     end_indices = torch.argmax(end_logits, dim=1)

--- a/forge/test/models/pytorch/text/llama/test_llama3.py
+++ b/forge/test/models/pytorch/text/llama/test_llama3.py
@@ -307,5 +307,10 @@ def test_llama3_sequence_classification(variant):
         module_name,
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model)
+
+    # post processing
+    predicted_value = co_out[0].argmax(-1).item()
+
+    print(f"Prediction : {framework_model.config.id2label[predicted_value]}")

--- a/forge/test/models/pytorch/text/phi1/test_phi1_5_pt.py
+++ b/forge/test/models/pytorch/text/phi1/test_phi1_5_pt.py
@@ -88,8 +88,15 @@ def test_phi_1_5_token_classification_pytorch(variant):
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, inputs, module_name)
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model)
+
+    # post processing
+    predicted_token_class_ids = co_out[0].argmax(-1)[0]
+    predicted_tokens_classes = [framework_model.config.id2label[t.item()] for t in predicted_token_class_ids]
+
+    print(f"Context: {input_prompt}")
+    print(f"Answer: {predicted_tokens_classes}")
 
 
 @pytest.mark.nightly
@@ -128,5 +135,9 @@ def test_phi_1_5_sequence_classification_pytorch(variant):
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, inputs, module_name)
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model)
+
+    # post processing
+    predicted_value = co_out[0].argmax(-1).item()
+    print(f"Predicted Sentiment: {framework_model.config.id2label[predicted_value]}")

--- a/forge/test/models/pytorch/text/phi1/test_phi1_pt.py
+++ b/forge/test/models/pytorch/text/phi1/test_phi1_pt.py
@@ -88,8 +88,15 @@ def test_phi_token_classification_pytorch(variant):
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, inputs, module_name)
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model)
+
+    # post processing
+    predicted_token_class_ids = co_out[0].argmax(-1)[0]
+    predicted_tokens_classes = [framework_model.config.id2label[t.item()] for t in predicted_token_class_ids]
+
+    print(f"Context: {input_prompt}")
+    print(f"Answer: {predicted_tokens_classes}")
 
 
 @pytest.mark.nightly
@@ -128,5 +135,9 @@ def test_phi_sequence_classification_pytorch(variant):
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, inputs, module_name)
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model)
+
+    # post processing
+    predicted_value = co_out[0].argmax(-1).item()
+    print(f"Predicted Sentiment: {framework_model.config.id2label[predicted_value]}")

--- a/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
+++ b/forge/test/models/pytorch/vision/alexnet/test_alexnet.py
@@ -21,6 +21,7 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
 from test.utils import download_model
 
 
@@ -73,7 +74,10 @@ def test_alexnet_torchhub():
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post processing
+    print_cls_results(fw_out[0], co_out[0])
 
 
 @pytest.mark.nightly

--- a/forge/test/models/pytorch/vision/densenet/test_densenet.py
+++ b/forge/test/models/pytorch/vision/densenet/test_densenet.py
@@ -90,8 +90,8 @@ def test_densenet_121_pytorch(variant):
         compiler_cfg=compiler_cfg,
     )
 
-    # Model Verification
-    _, co_out = verify(
+    # Model Verification and Inference
+    fw_out, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
@@ -101,6 +101,8 @@ def test_densenet_121_pytorch(variant):
     # post processing
     if variant == "densenet121_hf_xray":
         outputs = op_norm(co_out[0], model.op_threshs)
+    else:
+        print_cls_results(fw_out[0], co_out[0])
 
 
 @pytest.mark.nightly
@@ -140,8 +142,11 @@ def test_densenet_161_pytorch(variant):
         compiler_cfg=compiler_cfg,
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    fw_out, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post Processing
+    print_cls_results(fw_out[0], co_out[0])
 
 
 @pytest.mark.nightly
@@ -182,8 +187,11 @@ def test_densenet_169_pytorch(variant):
         compiler_cfg=compiler_cfg,
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    fw_out, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post Processing
+    print_cls_results(fw_out[0], co_out[0])
 
 
 @pytest.mark.nightly
@@ -220,7 +228,7 @@ def test_densenet_201_pytorch(variant):
         compiler_cfg=compiler_cfg,
     )
 
-    # Model Verification
+    # Model Verification and Inference
     fw_out, co_out = verify(inputs, framework_model, compiled_model)
 
     # Run model on sample data and print results

--- a/forge/test/models/pytorch/vision/dla/test_dla.py
+++ b/forge/test/models/pytorch/vision/dla/test_dla.py
@@ -16,6 +16,7 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
 from test.models.pytorch.vision.dla.model_utils.utils import load_dla_model
 from test.models.pytorch.vision.vision_utils.utils import load_timm_model_and_input
 
@@ -59,8 +60,11 @@ def test_dla_pytorch(variant):
         framework_model, sample_inputs=inputs, module_name=module_name, compiler_cfg=compiler_cfg
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    fw_out, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post processing
+    print_cls_results(fw_out[0], co_out[0])
 
 
 variants = ["dla34.in1k"]
@@ -92,5 +96,8 @@ def test_dla_timm(variant):
         framework_model, sample_inputs=inputs, module_name=module_name, compiler_cfg=compiler_cfg
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    fw_out, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post processing
+    print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/pytorch/vision/mgp_str_base/model_utils/utils.py
+++ b/forge/test/models/pytorch/vision/mgp_str_base/model_utils/utils.py
@@ -10,7 +10,7 @@ from transformers import MgpstrForSceneTextRecognition, MgpstrProcessor
 
 
 def load_model(variant):
-    model = MgpstrForSceneTextRecognition.from_pretrained(variant)
+    model = MgpstrForSceneTextRecognition.from_pretrained(variant, return_dict=False)
     model.eval()
     return model
 
@@ -23,4 +23,4 @@ def load_input(variant):
         images=image,
         return_tensors="pt",
     )
-    return [inputs["pixel_values"]]
+    return [inputs["pixel_values"]], processor

--- a/forge/test/models/pytorch/vision/mnist/test_mnist.py
+++ b/forge/test/models/pytorch/vision/mnist/test_mnist.py
@@ -18,6 +18,7 @@ from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
 from test.models.pytorch.vision.mnist.model_utils.utils import load_input, load_model
 
 
@@ -48,10 +49,13 @@ def test_mnist():
         compiler_cfg=compiler_cfg,
     )
 
-    # Model Verification
-    verify(
+    # Model Verification and Inference
+    fw_out, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
         verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.97)),
     )
+
+    # Post Processing
+    print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -363,5 +363,8 @@ def test_mobilenetv2_torchvision(variant):
         compiler_cfg=compiler_cfg,
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    fw_out, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post processing
+    print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3_ssd.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3_ssd.py
@@ -16,6 +16,7 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
 from test.models.pytorch.vision.mobilenet.model_utils.mobilenet_v3_ssd_utils import (
     load_input,
     load_model,
@@ -37,7 +38,7 @@ def test_mobilenetv3_ssd(variant):
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.PYTORCH,
-        model=ModelArch.MOBILENET_V3_SSD,
+        model=ModelArch.MOBILENETV3SSD,
         variant=variant,
         source=Source.TORCHVISION,
         task=Task.IMAGE_CLASSIFICATION,
@@ -60,5 +61,8 @@ def test_mobilenetv3_ssd(variant):
         compiler_cfg=compiler_cfg,
     )
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    fw_out, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post processing
+    print_cls_results(fw_out[0], co_out[0])


### PR DESCRIPTION
### Ticket

- Solves https://github.com/tenstorrent/tt-forge-fe/issues/2154

### Summary

- This PR adds post processing steps for e2e passing pytorch models

### Logs

[may28_albert_qa.log](https://github.com/user-attachments/files/20501399/may28_albert_qa.log)
[may28_alex_1.log](https://github.com/user-attachments/files/20501400/may28_alex_1.log)
[may28_densenet_1.log](https://github.com/user-attachments/files/20501401/may28_densenet_1.log)
[may28_dla_34.log](https://github.com/user-attachments/files/20501403/may28_dla_34.log)
[may28_llama3_seq.log](https://github.com/user-attachments/files/20501433/may28_llama3_seq.log)
[may28_mgp.log](https://github.com/user-attachments/files/20501434/may28_mgp.log)
[may28_mnist.log](https://github.com/user-attachments/files/20501435/may28_mnist.log)
[may28_mob_v3_ssd.log](https://github.com/user-attachments/files/20501436/may28_mob_v3_ssd.log)
[may28_mob_v2_tv.log](https://github.com/user-attachments/files/20501437/may28_mov_v2_tv.log)
[may29_phi_1_5_tk_seq.log](https://github.com/user-attachments/files/20501438/may29_phi_1_5_tk_seq.log)
[may29_phi_1_seq.log](https://github.com/user-attachments/files/20501439/may29_phi_seq.log)
[may29_phi_1_tk.log](https://github.com/user-attachments/files/20501440/may29_phi_tk.log)

