### PR TITLE
Add support for image.resize1d op

### DIFF
--- a/forge/forge/op/__init__.py
+++ b/forge/forge/op/__init__.py
@@ -71,7 +71,7 @@ from .tm import (
 from .constant import Constant
 from .nn import Softmax, Layernorm, LogSoftmax, Batchnorm, MaxPool2dModule
 from .eltwise_nary import Concatenate, Where, IndexCopy, Stack, Interleave
-from .resize import Resize2d, Resize3d, Upsample2d, Downsample2d
+from .resize import Resize1d, Resize2d, Resize3d, Upsample2d, Downsample2d
 from .embedding import Embedding
 from .dram_queue import DRAMQueue
 from .quantize import Quantize, Dequantize, Requantize, ForgeRequantize

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -122,6 +122,7 @@ op_to_module_map = {
     "avg_pool3d": "pooling",
     "adaptive_max_pool2d": "pooling",
     "constant": "constant",
+    "resize1d": "resize",
     "resize2d": "resize",
     "resize3d": "resize",
     "upsample2d": "resize",

--- a/forge/forge/op/eval/forge/resize.py
+++ b/forge/forge/op/eval/forge/resize.py
@@ -20,8 +20,29 @@ import os
 
 
 def eval(type, attr, ops):
+    if type == "resize1d":
+        assert len(attr) == 4, "Resize1d should have 4 attrs: [size, method, align_corners, channel_last]"
+        assert len(ops) == 1
+        size, method, align_corners, channel_last = attr
+        acts = ops[0]
+        shape = acts.shape
 
-    if type == "resize2d":
+        if channel_last:
+            acts = acts.permute((0, 2, 1))
+
+        result = torch.nn.functional.interpolate(
+            acts,
+            size=size,
+            mode="linear",
+            align_corners=bool(align_corners),
+        )
+
+        if channel_last:
+            result = result.permute((0, 2, 1))
+
+        return result
+
+    elif type == "resize2d":
         assert len(attr) == 5, "Resize2d should have 4 attrs: [size, size, method, align_corners, channel_last]"
         assert len(ops) == 1
         resize_method = INT_TO_RESIZE2d_METHOD[attr[-3]]
@@ -90,7 +111,32 @@ def eval(type, attr, ops):
 
 
 def shape(type, attr, ops):
-    if type == "resize2d":
+
+    if type == "resize1d":
+        assert len(attr) == 4, "Resize1d should have 4 attrs: [size, method, align_corners, channel_last]"
+        size, _, _, channel_last = attr
+        shape = list(ops[0])
+
+        if channel_last:
+            old_w = shape[-2]
+            upsample = size >= old_w
+            if upsample:
+                assert size % old_w == 0, "Only support upsample with integer scale factor"
+            else:
+                assert old_w % size == 0, "Only support downsample with integer scale factor"
+            shape[-2] = size
+        else:
+            old_w = shape[-1]
+            upsample = size >= old_w
+            if upsample:
+                assert size % old_w == 0, "Only support upsample with integer scale factor"
+            else:
+                assert old_w % size == 0, "Only support downsample with integer scale factor"
+            shape[-1] = size
+
+        return shape, []
+
+    elif type == "resize2d":
         assert len(attr) == 5, "Resize2d should have 4 attrs: [size, size, method, align_corners]"
         shape = list(ops[0])
         channel_last = attr[-1]

--- a/forge/forge/op/resize.py
+++ b/forge/forge/op/resize.py
@@ -21,6 +21,47 @@ INT_TO_RESIZE2d_METHOD = {
 }
 
 
+def Resize1d(
+    name: str,
+    operandA: Tensor,
+    size: int,
+    method: str = "linear",
+    align_corners: bool = False,
+    channel_last: bool = False,
+) -> Tensor:
+    """
+    Resize input activations in 1D, with default method 'linear'
+
+    Parameters
+    ----------
+    name: str
+        Op name, unique to the module, or leave blank to autoset
+
+    operandA: Tensor
+        Input tensor to resize
+
+    size: int
+        Target size
+
+    method: str
+        Interpolation method: 'linear'
+
+    Returns
+    -------
+    Tensor
+        Forge tensor
+    """
+    assert method == "linear", f"Expected method to be 'linear', got {method}"
+    result: Tensor = op(
+        "resize1d",
+        name,
+        operandA,
+        attrs=(size, RESIZE2d_METHOD_TO_INT[method], int(align_corners), int(channel_last)),
+    ).get_tensor()
+
+    return result
+
+
 def Resize2d(
     name: str,
     operandA: Tensor,

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1477,6 +1477,34 @@ def populate_pad_args(graph, nid, compiler_cfg):
     return args
 
 
+def populate_resize1d_args(graph, nid, compiler_cfg):
+    args = []
+    node = graph["nodes"][nid]
+
+    sizes = [int(x) for x in node["attrs"]["size"][0]]
+    assert len(sizes) == 1, "Resize1D should only have one size dimension"
+
+    method = node["attrs"]["method"][0][0]
+    assert method in ["nearest_neighbor", "linear", "cubic"], "Unsupported interpolation method"
+
+    assert int(node["attrs"]["num_inputs"]) == 1
+    input_nid = node["inputs"][0][0]
+    input_shape = graph["nodes"][input_nid]["attrs"]["shape"][0][0]
+
+    args.append(("size", f"{sizes[0]}"))
+
+    args.append(("method", f'"{method}"'))
+
+    coordinate_transform_mode = node["attrs"]["coordinate_transformation_mode"][0][0]
+    align_corners = "True" if coordinate_transform_mode == "align_corners" else "False"
+    args.append(("align_corners", f"{align_corners}"))
+
+    channel_last = int(node["attrs"]["layout"][0][0] == "NWC")
+    args.append(("channel_last", f"{channel_last}"))
+
+    return args
+
+
 def populate_resize2d_args(graph, nid, compiler_cfg):
     args = []
     node = graph["nodes"][nid]
@@ -1695,6 +1723,7 @@ tvm_to_forge_op_map = {
     "greater_equal": "greater_equal",
     "greater": "greater",
     "identity": "identity",
+    "image.resize1d": "resize1d",
     "image.resize2d": "resize2d",
     "image.resize3d": "resize3d",
     "layernorm": "layernorm",
@@ -1827,6 +1856,7 @@ forge_op_to_function_name = {
     "repeat": "forge.op.Repeat",
     "repeat_interleave": "forge.op.RepeatInterleave",
     "reshape": "forge.op.Reshape",
+    "resize1d": "forge.op.Resize1d",
     "resize2d": "forge.op.Resize2d",
     "resize3d": "forge.op.Resize3d",
     "select": "forge.op.Select",
@@ -1886,6 +1916,7 @@ forge_ops_needing_arguments = {
     "repeat": populate_repeat_args,
     "repeat_interleave": populate_repeat_interleave_args,
     "reshape": populate_reshape_args,
+    "resize1d": populate_resize1d_args,
     "resize2d": populate_resize2d_args,
     "resize3d": populate_resize3d_args,
     "select": populate_select_args,


### PR DESCRIPTION
This PR adds support for image.resize1d op till mlir stage.

Logs:
[image_resize1d.log](https://github.com/user-attachments/files/20498010/image_resize1d.log)
