### PR TITLE
Fix C++ ops runtime error in ssd mobilenetv3

### DIFF
--- a/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/model_utils/model_utils.py
+++ b/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/model_utils/model_utils.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torchvision.models.detection import _utils as det_utils
+from torchvision.models.detection.anchor_utils import DefaultBoxGenerator
+from torchvision.models.detection.transform import GeneralizedRCNNTransform
+from torchvision.ops import boxes as box_ops
+
+
+def postprocess_detections(
+    head_outputs: dict[str, Tensor], image_anchors: list[Tensor], image_shapes: list[tuple[int, int]]
+) -> list[dict[str, Tensor]]:
+    bbox_regression = head_outputs["bbox_regression"]
+    pred_scores = F.softmax(head_outputs["cls_logits"], dim=-1)
+
+    num_classes = pred_scores.size(-1)
+    device = pred_scores.device
+
+    detections: list[dict[str, Tensor]] = []
+
+    for boxes, scores, anchors, image_shape in zip(bbox_regression, pred_scores, image_anchors, image_shapes):
+        box_coder = det_utils.BoxCoder(weights=(10.0, 10.0, 5.0, 5.0))
+        boxes = box_coder.decode_single(boxes, anchors)
+        boxes = box_ops.clip_boxes_to_image(boxes, image_shape)
+
+        image_boxes = []
+        image_scores = []
+        image_labels = []
+        for label in range(1, num_classes):
+            score = scores[:, label]
+
+            keep_idxs = score > 0.01
+            score = score[keep_idxs]
+            box = boxes[keep_idxs]
+
+            # keep only topk scoring predictions
+            num_topk = det_utils._topk_min(score, 400, 0)
+            score, idxs = score.topk(num_topk)
+            box = box[idxs]
+
+            image_boxes.append(box)
+            image_scores.append(score)
+            image_labels.append(torch.full_like(score, fill_value=label, dtype=torch.int64, device=device))
+
+        image_boxes = torch.cat(image_boxes, dim=0)
+        image_scores = torch.cat(image_scores, dim=0)
+        image_labels = torch.cat(image_labels, dim=0)
+
+        # non-maximum suppression
+        keep = box_ops.batched_nms(image_boxes, image_scores, image_labels, 0.45)
+        keep = keep[:200]
+
+        detections.append(
+            {
+                "boxes": image_boxes[keep],
+                "scores": image_scores[keep],
+                "labels": image_labels[keep],
+            }
+        )
+    return detections
+
+
+class Postprocessor:
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def process(self, x, y, images):
+        fw_head_outputs = {
+            "bbox_regression": x[0],
+            "cls_logits": x[1],
+        }
+        anchors_fw = x[2]
+        anchors_co = y[2]
+        co_head_outputs = {
+            "bbox_regression": y[0],
+            "cls_logits": y[1],
+        }
+        anchor_generator = DefaultBoxGenerator(
+            [[2], [2, 3], [2, 3], [2, 3], [2], [2]],
+            scales=[0.07, 0.15, 0.33, 0.51, 0.69, 0.87, 1.05],
+            steps=[8, 16, 32, 64, 100, 300],
+        )
+
+        image_mean = [0.48235, 0.45882, 0.40784]
+        image_std = [1.0 / 255.0, 1.0 / 255.0, 1.0 / 255.0]
+
+        transform = GeneralizedRCNNTransform(
+            min((300, 300)), max(300, 300), image_mean, image_std, size_divisible=1, fixed_size=(300, 300)
+        )
+        images, targets = transform(images)
+        anchors_fw = anchor_generator(images, [x[2]])
+        anchors_co = anchor_generator(images, [y[2]])
+
+        original_image_sizes: list[tuple[int, int]] = []
+        for img in images:
+            val = img.shape[-2:]
+            original_image_sizes.append((val[0], val[1]))
+        detections_fw = postprocess_detections(fw_head_outputs, anchors_fw, images.image_size)
+        detections_fw = self.model.transform.postprocess(detections_fw, images.image_size, original_image_sizes)
+
+        detections_co = postprocess_detections(co_head_outputs, anchors_co, images.image_size)
+        detections_co = self.model.transform.postprocess(detections_fw, images.image_size, original_image_sizes)
+
+        return detections_fw, detections_co
+
+
+class Processor:
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def process(self, x, y):
+        fw_head_outputs = {
+            "bbox_regression": x[0],
+            "cls_logits": x[1],
+        }
+        co_head_outputs = {
+            "bbox_regression": y[0],
+            "cls_logits": y[1],
+        }
+        detections_fw = postprocess_detections(fw_head_outputs, self.model.anchors, self.model.images.image_sizes)
+        detections_fw = self.model.transform.postprocess(
+            detections_fw, self.model.images.image_sizes, self.model.original_image_sizes
+        )
+
+        detections_co = self.model.postprocess_detections(
+            co_head_outputs, self.model.anchors, self.model.images.image_sizes
+        )
+        detections_co = self.model.transform.postprocess(
+            detections_co, self.model.images.image_sizes, self.model.original_image_sizes
+        )
+
+        return detections_fw, detections_co

--- a/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/model_utils/model_utils.py
+++ b/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/model_utils/model_utils.py
@@ -108,32 +108,3 @@ class Postprocessor:
         detections_co = self.model.transform.postprocess(detections_fw, images.image_size, original_image_sizes)
 
         return detections_fw, detections_co
-
-
-class Processor:
-    def __init__(self, model):
-        super().__init__()
-        self.model = model
-
-    def process(self, x, y):
-        fw_head_outputs = {
-            "bbox_regression": x[0],
-            "cls_logits": x[1],
-        }
-        co_head_outputs = {
-            "bbox_regression": y[0],
-            "cls_logits": y[1],
-        }
-        detections_fw = postprocess_detections(fw_head_outputs, self.model.anchors, self.model.images.image_sizes)
-        detections_fw = self.model.transform.postprocess(
-            detections_fw, self.model.images.image_sizes, self.model.original_image_sizes
-        )
-
-        detections_co = self.model.postprocess_detections(
-            co_head_outputs, self.model.anchors, self.model.images.image_sizes
-        )
-        detections_co = self.model.transform.postprocess(
-            detections_co, self.model.images.image_sizes, self.model.original_image_sizes
-        )
-
-        return detections_fw, detections_co

--- a/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/model_utils/model_utils.py
+++ b/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/model_utils/model_utils.py
@@ -51,7 +51,6 @@ def postprocess_detections(
         image_scores = torch.cat(image_scores, dim=0)
         image_labels = torch.cat(image_labels, dim=0)
 
-        # non-maximum suppression
         keep = box_ops.batched_nms(image_boxes, image_scores, image_labels, 0.45)
         keep = keep[:200]
 
@@ -75,8 +74,6 @@ class Postprocessor:
             "bbox_regression": x[0],
             "cls_logits": x[1],
         }
-        anchors_fw = x[2]
-        anchors_co = y[2]
         co_head_outputs = {
             "bbox_regression": y[0],
             "cls_logits": y[1],
@@ -102,9 +99,9 @@ class Postprocessor:
             val = img.shape[-2:]
             original_image_sizes.append((val[0], val[1]))
         detections_fw = postprocess_detections(fw_head_outputs, anchors_fw, images.image_size)
-        detections_fw = self.model.transform.postprocess(detections_fw, images.image_size, original_image_sizes)
+        detections_fw_op = self.model.transform.postprocess(detections_fw, images.image_size, original_image_sizes)
 
         detections_co = postprocess_detections(co_head_outputs, anchors_co, images.image_size)
-        detections_co = self.model.transform.postprocess(detections_fw, images.image_size, original_image_sizes)
+        detections_co_op = self.model.transform.postprocess(detections_co, images.image_size, original_image_sizes)
 
-        return detections_fw, detections_co
+        return detections_fw_op, detections_co_op

--- a/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3.py
+++ b/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3.py
@@ -21,7 +21,7 @@ from forge.forge_property_utils import (
 from forge.verify.verify import verify
 
 from test.models.models_utils import print_cls_results
-from test.models.pytorch.vision.ssd300_vgg16.model_utils.model_utils import (
+from test.models.pytorch.vision.ssdlite320_mobilenetv3.model_utils.model_utils import (
     Postprocessor,
 )
 from test.models.pytorch.vision.vision_utils.utils import load_vision_model_and_input

--- a/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3.py
+++ b/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3.py
@@ -91,7 +91,7 @@ def test_ssdlite320_mobilenetv3(variant):
     )
 
     # Model Verification
-    verify(inputs, model, compiled_model)
+    fw_out, co_out = verify(inputs, model, compiled_model)
 
     # Post Processing
     postprocessor = Postprocessor(model)

--- a/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3.py
+++ b/forge/test/models/pytorch/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3.py
@@ -1,8 +1,12 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
+from collections import OrderedDict
+from typing import Optional
+
 import pytest
 import torch
+from torch import Tensor
 
 import forge
 from forge._C import DataFormat
@@ -16,11 +20,42 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
+from test.models.pytorch.vision.ssd300_vgg16.model_utils.model_utils import (
+    Postprocessor,
+)
 from test.models.pytorch.vision.vision_utils.utils import load_vision_model_and_input
 
 variants_with_weights = {
     "ssdlite320_mobilenet_v3_large": "SSDLite320_MobileNet_V3_Large_Weights",
 }
+
+
+class SSDWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        model.eval()
+        self.model = model
+
+    def forward(
+        self, images: list[Tensor], targets: Optional[list[dict[str, Tensor]]] = None
+    ) -> tuple[dict[str, Tensor], list[dict[str, Tensor]]]:
+
+        # transform the input
+        images, targets = self.model.transform(images, targets)
+
+        # get the features from the backbone
+        features = self.model.backbone(images.tensors)
+        if isinstance(features, torch.Tensor):
+            features = OrderedDict([("0", features)])
+
+        features = list(features.values())
+
+        # compute the ssd heads outputs using the features
+        head_outputs = self.model.head(features)
+        output = [head_outputs["bbox_regression"], head_outputs["cls_logits"], features[0]]
+
+        return output
 
 
 @pytest.mark.nightly
@@ -40,7 +75,8 @@ def test_ssdlite320_mobilenetv3(variant):
     # Load model and input
     weight_name = variants_with_weights[variant]
     framework_model, inputs = load_vision_model_and_input(variant, "detection", weight_name)
-    framework_model.to(torch.bfloat16)
+    model = SSDWrapper(framework_model)
+    model.to(torch.bfloat16)
     inputs = [inputs[0].to(torch.bfloat16)]
 
     data_format_override = DataFormat.Float16_b
@@ -48,11 +84,18 @@ def test_ssdlite320_mobilenetv3(variant):
 
     # Forge compile framework model
     compiled_model = forge.compile(
-        framework_model,
+        model,
         sample_inputs=inputs,
         module_name=module_name,
         compiler_cfg=compiler_cfg,
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    verify(inputs, model, compiled_model)
+
+    # Post Processing
+    postprocessor = Postprocessor(model)
+    detection_fw, detection_co = postprocessor.process(fw_out, co_out, inputs)
+
+    # Run model on sample data and print results
+    print_cls_results(detection_fw[0], detection_co[0])


### PR DESCRIPTION
Ticket
(https://github.com/tenstorrent/tt-forge-fe/issues/2033)

Problem description
The  RuntimeError: Couldn't load custom C++ ops. encountered during the execution of the framework model is due to an unsupported C++ operation. Specifically, the issue arises from the presence of the nms (Non-Maximum Suppression) operation in the model's forward pass, which is implemented in C++ and is currently not supported in this context.

What's changed
This PR includes the changes to make the postprocessing outside the model which resolves the issue.

Log:
[ssd_mobilenet.log](https://github.com/user-attachments/files/20500357/ssd_mobilenet.log)


