### PR TITLE
Remove xfail markers for xglm and roberta and fix llama prefill and skip whisper large

### DIFF
--- a/forge/test/mlir/llama/tests/test_llama_prefil.py
+++ b/forge/test/mlir/llama/tests/test_llama_prefil.py
@@ -96,7 +96,7 @@ def test_llama_prefil_on_device_decode_on_cpu(model_path):
 
     # This is the part of the model needed for prefill; model without the last Linear layer (lm_head)
     framework_model = LlamaPrefillModel(model)
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs, model_name=module_name)
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
 
     # Prefill Phase - Process the initial prompt on device
     # Validate prefill outputs between TT and CPU

--- a/forge/test/models/onnx/audio/test_whisper_large.py
+++ b/forge/test/models/onnx/audio/test_whisper_large.py
@@ -29,7 +29,7 @@ variants = ["openai/whisper-large-v3"]
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
+@pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB)")
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_whisper_large_v3_onnx(variant, tmp_path):
 

--- a/forge/test/models/paddlepaddle/text/roberta/test_roberta.py
+++ b/forge/test/models/paddlepaddle/text/roberta/test_roberta.py
@@ -21,7 +21,6 @@ variants = ["hfl/rbt4"]
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail()
 @pytest.mark.parametrize("variant", variants)
 def test_roberta_sequence_classification(variant):
     # Record Forge properties

--- a/forge/test/models/pytorch/text/xglm/test_xglm.py
+++ b/forge/test/models/pytorch/text/xglm/test_xglm.py
@@ -23,7 +23,6 @@ variants = [
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_xglm_causal_lm(variant):
 


### PR DESCRIPTION
In the [latest nightly pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/15336018082), **xglm** and **roberta** models test was passed so removed xfail markers and pytest process was killed while executing `whisper large v3 onnx` model test which takes around 31 GB so skipping the tests and changed the model_name to module_name argument in the compile function for **llama prefill** tests and below are the test cases for reference. To know more about the nightly failures checkout this chart - [nightly_failing_case](https://superset.tenstorrent.com/explore/?dashboard_page_id=p0-CSJ94STWfD3J-LFhGc&slice_id=1881)


```
forge/test/models/pytorch/text/xglm/test_xglm.py::test_xglm_causal_lm[facebook/xglm-1.7B]
forge/test/models/pytorch/text/xglm/test_xglm.py::test_xglm_causal_lm[facebook/xglm-564M] 
forge/test/models/paddlepaddle/text/roberta/test_roberta.py::test_roberta_sequence_classification[hfl/rbt4]
forge/test/models/onnx/audio/test_whisper_large.py::test_whisper_large_v3_onnx[openai/whisper-large-v3]
forge/test/mlir/llama/tests/test_llama_prefil.py::test_llama_prefil_on_device_decode_on_cpu[meta-llama/Llama-3.2-1B]
```

