### PR TITLE
Add xfail markers for conv2d regression tests and remove xfail marker for passing conv2d tests

### DIFF
--- a/forge/test/models_ops/test_conv2d.py
+++ b/forge/test/models_ops/test_conv2d.py
@@ -35200,20 +35200,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1,
-        [((1, 14, 14, 1024), torch.float32), ((256, 1024, 1, 1), torch.float32)],
-        {
-            "model_names": ["jax_resnet_50_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "1",
+    pytest.param(
+        (
+            Conv2D1,
+            [((1, 14, 14, 1024), torch.float32), ((256, 1024, 1, 1), torch.float32)],
+            {
+                "model_names": ["jax_resnet_50_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "1",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D2,
@@ -35230,20 +35233,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1,
-        [((1, 14, 14, 1024), torch.float32), ((512, 1024, 1, 1), torch.float32)],
-        {
-            "model_names": ["jax_resnet_50_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "1",
+    pytest.param(
+        (
+            Conv2D1,
+            [((1, 14, 14, 1024), torch.float32), ((512, 1024, 1, 1), torch.float32)],
+            {
+                "model_names": ["jax_resnet_50_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "1",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D3,
@@ -35293,20 +35299,23 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1,
-        [((1, 7, 7, 2048), torch.float32), ((512, 2048, 1, 1), torch.float32)],
-        {
-            "model_names": ["jax_resnet_50_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "1",
+    pytest.param(
+        (
+            Conv2D1,
+            [((1, 7, 7, 2048), torch.float32), ((512, 2048, 1, 1), torch.float32)],
+            {
+                "model_names": ["jax_resnet_50_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "1",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D2,
@@ -35603,32 +35612,9 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D19,
-            [((1, 512, 54, 80), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_detr_facebook_detr_resnet_50_obj_det_hf",
-                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_obj_det_hf",
-                ],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[0, 0, 0, 0]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
     (
-        Conv2D20,
-        [((1, 1024, 27, 40), torch.float32)],
+        Conv2D19,
+        [((1, 512, 54, 80), torch.float32)],
         {
             "model_names": [
                 "onnx_detr_facebook_detr_resnet_50_obj_det_hf",
@@ -35638,13 +35624,36 @@ forge_modules_and_shapes_dtypes_list = [
             ],
             "pcc": 0.99,
             "args": {
-                "stride": "[1, 1]",
+                "stride": "[2, 2]",
                 "padding": "[0, 0, 0, 0]",
                 "dilation": "1",
                 "groups": "1",
                 "channel_last": "0",
             },
         },
+    ),
+    pytest.param(
+        (
+            Conv2D20,
+            [((1, 1024, 27, 40), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_detr_facebook_detr_resnet_50_obj_det_hf",
+                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                    "pt_detr_facebook_detr_resnet_50_obj_det_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D21,
@@ -35666,25 +35675,28 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D22,
-        [((1, 1024, 27, 40), torch.float32)],
-        {
-            "model_names": [
-                "onnx_detr_facebook_detr_resnet_50_obj_det_hf",
-                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                "pt_detr_facebook_detr_resnet_50_obj_det_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D22,
+            [((1, 1024, 27, 40), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_detr_facebook_detr_resnet_50_obj_det_hf",
+                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                    "pt_detr_facebook_detr_resnet_50_obj_det_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D23,
@@ -35749,25 +35761,28 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D26,
-        [((1, 2048, 14, 20), torch.float32)],
-        {
-            "model_names": [
-                "onnx_detr_facebook_detr_resnet_50_obj_det_hf",
-                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                "pt_detr_facebook_detr_resnet_50_obj_det_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D26,
+            [((1, 2048, 14, 20), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_detr_facebook_detr_resnet_50_obj_det_hf",
+                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                    "pt_detr_facebook_detr_resnet_50_obj_det_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D27,
@@ -35789,25 +35804,28 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D28,
-        [((1, 2048, 14, 20), torch.float32)],
-        {
-            "model_names": [
-                "onnx_detr_facebook_detr_resnet_50_obj_det_hf",
-                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                "pt_detr_facebook_detr_resnet_50_obj_det_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D28,
+            [((1, 2048, 14, 20), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_detr_facebook_detr_resnet_50_obj_det_hf",
+                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                    "pt_detr_facebook_detr_resnet_50_obj_det_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D29,
@@ -35845,23 +35863,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D31,
-        [((1, 1024, 27, 40), torch.float32)],
-        {
-            "model_names": [
-                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D31,
+            [((1, 1024, 27, 40), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D32,
@@ -36586,28 +36607,31 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D69,
-        [((1, 672, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b4_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b0_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b1_img_cls_timm",
-                "pt_efficientnet_efficientnet_b4_img_cls_torchvision",
-                "pt_efficientnet_efficientnet_b0_img_cls_torchvision",
-                "pt_efficientnet_efficientnet_b4_img_cls_timm",
-                "pt_efficientnet_efficientnet_b0_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D69,
+            [((1, 672, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b4_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b0_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b1_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b4_img_cls_torchvision",
+                    "pt_efficientnet_efficientnet_b0_img_cls_torchvision",
+                    "pt_efficientnet_efficientnet_b4_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b0_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D70,
@@ -36632,23 +36656,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D71,
-        [((1, 672, 20, 20), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b4_img_cls_timm",
-                "pt_efficientnet_efficientnet_b4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D71,
+            [((1, 672, 20, 20), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b4_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D72,
@@ -36665,23 +36692,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D73,
-        [((1, 672, 20, 20), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b4_img_cls_timm",
-                "pt_efficientnet_efficientnet_b4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D73,
+            [((1, 672, 20, 20), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b4_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D74,
@@ -36731,24 +36761,27 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D77,
-        [((1, 960, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b4_img_cls_timm",
-                "pt_efficientnet_efficientnet_b4_img_cls_torchvision",
-                "pt_efficientnet_efficientnet_b4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D77,
+            [((1, 960, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b4_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b4_img_cls_torchvision",
+                    "pt_efficientnet_efficientnet_b4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D78,
@@ -36769,41 +36802,47 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D79,
-        [((1, 960, 20, 20), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b4_img_cls_timm",
-                "pt_efficientnet_efficientnet_b4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D79,
+            [((1, 960, 20, 20), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b4_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D80,
-        [((1, 960, 10, 10), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b4_img_cls_timm",
-                "pt_efficientnet_efficientnet_b4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D80,
+            [((1, 960, 10, 10), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b4_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D81,
@@ -36838,24 +36877,27 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D83,
-        [((1, 1632, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b4_img_cls_timm",
-                "pt_efficientnet_efficientnet_b4_img_cls_torchvision",
-                "pt_efficientnet_efficientnet_b4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D83,
+            [((1, 1632, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b4_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b4_img_cls_torchvision",
+                    "pt_efficientnet_efficientnet_b4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D84,
@@ -36876,23 +36918,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D85,
-        [((1, 1632, 10, 10), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b4_img_cls_timm",
-                "pt_efficientnet_efficientnet_b4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D85,
+            [((1, 1632, 10, 10), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b4_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D86,
@@ -36909,23 +36954,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D87,
-        [((1, 1632, 10, 10), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b4_img_cls_timm",
-                "pt_efficientnet_efficientnet_b4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D87,
+            [((1, 1632, 10, 10), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b4_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D88,
@@ -36945,39 +36993,45 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D89,
-        [((1, 2688, 10, 10), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b4_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "2688",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D89,
+            [((1, 2688, 10, 10), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b4_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "2688",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D90,
-        [((1, 2688, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b4_img_cls_timm",
-                "pt_efficientnet_efficientnet_b4_img_cls_torchvision",
-                "pt_efficientnet_efficientnet_b4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D90,
+            [((1, 2688, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b4_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b4_img_cls_torchvision",
+                    "pt_efficientnet_efficientnet_b4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D91,
@@ -36998,23 +37052,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D92,
-        [((1, 2688, 10, 10), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b4_img_cls_timm",
-                "pt_efficientnet_efficientnet_b4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D92,
+            [((1, 2688, 10, 10), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b4_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D93,
@@ -37719,23 +37776,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D130,
-        [((1, 720, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b2_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D130,
+            [((1, 720, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b2_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D131,
@@ -37755,41 +37815,47 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D132,
-        [((1, 720, 16, 16), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b2_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D132,
+            [((1, 720, 16, 16), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b2_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D133,
-        [((1, 720, 8, 8), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b2_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D133,
+            [((1, 720, 8, 8), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b2_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D134,
@@ -37827,23 +37893,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D136,
-        [((1, 1248, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b2_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D136,
+            [((1, 1248, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b2_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D137,
@@ -37863,23 +37932,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D138,
-        [((1, 1248, 8, 8), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b2_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D138,
+            [((1, 1248, 8, 8), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b2_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D139,
@@ -37899,23 +37971,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D140,
-        [((1, 1248, 8, 8), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b2_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D140,
+            [((1, 1248, 8, 8), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b2_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D141,
@@ -37935,41 +38010,47 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D142,
-        [((1, 2112, 8, 8), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b2_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "2112",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D142,
+            [((1, 2112, 8, 8), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b2_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "2112",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D143,
-        [((1, 2112, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b2_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D143,
+            [((1, 2112, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b2_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D144,
@@ -37989,23 +38070,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D145,
-        [((1, 2112, 8, 8), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b2_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D145,
+            [((1, 2112, 8, 8), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b2_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b2a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D146,
@@ -38421,23 +38505,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D156,
-        [((1, 576, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b3_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D156,
+            [((1, 576, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b3_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D157,
@@ -38565,23 +38652,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D164,
-        [((1, 816, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b3_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D164,
+            [((1, 816, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b3_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D165,
@@ -38619,23 +38709,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D167,
-        [((1, 816, 9, 9), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b3_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D167,
+            [((1, 816, 9, 9), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b3_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D168,
@@ -38673,23 +38766,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D170,
-        [((1, 1392, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b3_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D170,
+            [((1, 1392, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b3_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D171,
@@ -38709,23 +38805,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D172,
-        [((1, 1392, 9, 9), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b3_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D172,
+            [((1, 1392, 9, 9), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b3_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D173,
@@ -38745,23 +38844,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D174,
-        [((1, 1392, 9, 9), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b3_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D174,
+            [((1, 1392, 9, 9), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b3_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D175,
@@ -38781,41 +38883,47 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D176,
-        [((1, 2304, 9, 9), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b3_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "2304",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D176,
+            [((1, 2304, 9, 9), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b3_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "2304",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D177,
-        [((1, 2304, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b3_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D177,
+            [((1, 2304, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b3_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D178,
@@ -38835,23 +38943,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D179,
-        [((1, 2304, 9, 9), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b3_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D179,
+            [((1, 2304, 9, 9), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b3_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b3a_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D180,
@@ -39558,50 +39669,56 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D71,
-        [((1, 672, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b0_img_cls_timm",
-                "onnx_efficientnet_efficientnet_lite0_img_cls_timm",
-                "pt_efficientnet_efficientnet_b4_img_cls_torchvision",
-                "pt_efficientnet_efficientnet_b0_img_cls_torchvision",
-                "pt_efficientnet_efficientnet_b0_img_cls_timm",
-                "pt_efficientnet_lite_tf_efficientnet_lite0_in1k_img_cls_timm",
-                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D71,
+            [((1, 672, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b0_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_lite0_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b4_img_cls_torchvision",
+                    "pt_efficientnet_efficientnet_b0_img_cls_torchvision",
+                    "pt_efficientnet_efficientnet_b0_img_cls_timm",
+                    "pt_efficientnet_lite_tf_efficientnet_lite0_in1k_img_cls_timm",
+                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D198,
-        [((1, 672, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b0_img_cls_timm",
-                "onnx_efficientnet_efficientnet_lite0_img_cls_timm",
-                "pt_efficientnet_efficientnet_b0_img_cls_torchvision",
-                "pt_efficientnet_efficientnet_b0_img_cls_timm",
-                "pt_efficientnet_lite_tf_efficientnet_lite0_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D198,
+            [((1, 672, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b0_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_lite0_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b0_img_cls_torchvision",
+                    "pt_efficientnet_efficientnet_b0_img_cls_timm",
+                    "pt_efficientnet_lite_tf_efficientnet_lite0_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D199,
@@ -39642,25 +39759,28 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D201,
-        [((1, 1152, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b0_img_cls_timm",
-                "onnx_efficientnet_efficientnet_b1_img_cls_timm",
-                "pt_efficientnet_efficientnet_b0_img_cls_torchvision",
-                "pt_efficientnet_efficientnet_b0_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D201,
+            [((1, 1152, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b0_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_b1_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b0_img_cls_torchvision",
+                    "pt_efficientnet_efficientnet_b0_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D202,
@@ -39682,27 +39802,30 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D203,
-        [((1, 1152, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b0_img_cls_timm",
-                "onnx_efficientnet_efficientnet_lite0_img_cls_timm",
-                "pt_densenet_densenet161_img_cls_torchvision",
-                "pt_efficientnet_efficientnet_b0_img_cls_torchvision",
-                "pt_efficientnet_efficientnet_b0_img_cls_timm",
-                "pt_efficientnet_lite_tf_efficientnet_lite0_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D203,
+            [((1, 1152, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b0_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_lite0_img_cls_timm",
+                    "pt_densenet_densenet161_img_cls_torchvision",
+                    "pt_efficientnet_efficientnet_b0_img_cls_torchvision",
+                    "pt_efficientnet_efficientnet_b0_img_cls_timm",
+                    "pt_efficientnet_lite_tf_efficientnet_lite0_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D204,
@@ -39722,26 +39845,29 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D205,
-        [((1, 1152, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b0_img_cls_timm",
-                "onnx_efficientnet_efficientnet_lite0_img_cls_timm",
-                "pt_efficientnet_efficientnet_b0_img_cls_torchvision",
-                "pt_efficientnet_efficientnet_b0_img_cls_timm",
-                "pt_efficientnet_lite_tf_efficientnet_lite0_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D205,
+            [((1, 1152, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b0_img_cls_timm",
+                    "onnx_efficientnet_efficientnet_lite0_img_cls_timm",
+                    "pt_efficientnet_efficientnet_b0_img_cls_torchvision",
+                    "pt_efficientnet_efficientnet_b0_img_cls_timm",
+                    "pt_efficientnet_lite_tf_efficientnet_lite0_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D206,
@@ -40114,20 +40240,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D219,
-        [((1, 768, 1, 1), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D219,
+            [((1, 768, 1, 1), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D220,
@@ -40144,20 +40273,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D221,
-        [((1, 768, 28, 28), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D221,
+            [((1, 768, 28, 28), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D222,
@@ -40174,20 +40306,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D223,
-        [((1, 768, 28, 28), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D223,
+            [((1, 768, 28, 28), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D224,
@@ -40234,20 +40369,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D227,
-        [((1, 1056, 1, 1), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D227,
+            [((1, 1056, 1, 1), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D228,
@@ -40264,35 +40402,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D229,
-        [((1, 1056, 28, 28), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D229,
+            [((1, 1056, 28, 28), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D230,
-        [((1, 1056, 14, 14), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D230,
+            [((1, 1056, 14, 14), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D231,
@@ -40324,20 +40468,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D233,
-        [((1, 1824, 1, 1), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D233,
+            [((1, 1824, 1, 1), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D234,
@@ -40354,20 +40501,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D235,
-        [((1, 1824, 14, 14), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D235,
+            [((1, 1824, 14, 14), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D236,
@@ -40384,20 +40534,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D237,
-        [((1, 1824, 14, 14), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D237,
+            [((1, 1824, 14, 14), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D238,
@@ -40414,35 +40567,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D239,
-        [((1, 3072, 14, 14), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "3072",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D239,
+            [((1, 3072, 14, 14), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "3072",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D240,
-        [((1, 3072, 1, 1), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D240,
+            [((1, 3072, 1, 1), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D241,
@@ -40459,20 +40618,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D242,
-        [((1, 3072, 14, 14), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D242,
+            [((1, 3072, 14, 14), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b5_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D24,
@@ -40936,41 +41098,47 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D71,
-        [((1, 672, 15, 15), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b1_img_cls_timm",
-                "pt_efficientnet_lite_tf_efficientnet_lite1_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D71,
+            [((1, 672, 15, 15), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b1_img_cls_timm",
+                    "pt_efficientnet_lite_tf_efficientnet_lite1_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D198,
-        [((1, 672, 8, 8), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b1_img_cls_timm",
-                "pt_efficientnet_lite_tf_efficientnet_lite1_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D198,
+            [((1, 672, 8, 8), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b1_img_cls_timm",
+                    "pt_efficientnet_lite_tf_efficientnet_lite1_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D199,
@@ -41005,23 +41173,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D203,
-        [((1, 1152, 8, 8), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b1_img_cls_timm",
-                "pt_efficientnet_lite_tf_efficientnet_lite1_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D203,
+            [((1, 1152, 8, 8), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b1_img_cls_timm",
+                    "pt_efficientnet_lite_tf_efficientnet_lite1_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D204,
@@ -41038,23 +41209,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D205,
-        [((1, 1152, 8, 8), torch.float32)],
-        {
-            "model_names": [
-                "onnx_efficientnet_efficientnet_b1_img_cls_timm",
-                "pt_efficientnet_lite_tf_efficientnet_lite1_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D205,
+            [((1, 1152, 8, 8), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_efficientnet_efficientnet_b1_img_cls_timm",
+                    "pt_efficientnet_lite_tf_efficientnet_lite1_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D243,
@@ -41086,20 +41260,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D245,
-        [((1, 1920, 1, 1), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b1_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D245,
+            [((1, 1920, 1, 1), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b1_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D246,
@@ -41116,20 +41293,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D247,
-        [((1, 1920, 8, 8), torch.float32)],
-        {
-            "model_names": ["onnx_efficientnet_efficientnet_b1_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D247,
+            [((1, 1920, 8, 8), torch.float32)],
+            {
+                "model_names": ["onnx_efficientnet_efficientnet_b1_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D206,
@@ -41527,35 +41707,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D166,
-        [((1, 816, 14, 14), torch.float32)],
-        {
-            "model_names": ["onnx_mobilenetv2_mobilenetv2_140_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D166,
+            [((1, 816, 14, 14), torch.float32)],
+            {
+                "model_names": ["onnx_mobilenetv2_mobilenetv2_140_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D254,
-        [((1, 816, 7, 7), torch.float32)],
-        {
-            "model_names": ["onnx_mobilenetv2_mobilenetv2_140_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D254,
+            [((1, 816, 7, 7), torch.float32)],
+            {
+                "model_names": ["onnx_mobilenetv2_mobilenetv2_140_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D255,
@@ -41587,35 +41773,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D257,
-        [((1, 1344, 7, 7), torch.float32)],
-        {
-            "model_names": ["onnx_mobilenetv2_mobilenetv2_140_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D257,
+            [((1, 1344, 7, 7), torch.float32)],
+            {
+                "model_names": ["onnx_mobilenetv2_mobilenetv2_140_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D258,
-        [((1, 1344, 7, 7), torch.float32)],
-        {
-            "model_names": ["onnx_mobilenetv2_mobilenetv2_140_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D258,
+            [((1, 1344, 7, 7), torch.float32)],
+            {
+                "model_names": ["onnx_mobilenetv2_mobilenetv2_140_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D93,
@@ -42447,51 +42639,57 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D79,
-        [((1, 960, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "onnx_mobilenetv2_mobilenetv2_100_img_cls_timm",
-                "pd_mobilenetv2_basic_img_cls_paddlemodels",
-                "pt_mobilenetv2_mobilenet_v2_img_cls_torchvision",
-                "pt_mobilenetv2_mobilenetv2_100_img_cls_timm",
-                "pt_mobilenetv2_basic_img_cls_torchhub",
-                "pt_mobilenetv2_google_mobilenet_v2_1_0_224_img_cls_hf",
-                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D79,
+            [((1, 960, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_mobilenetv2_mobilenetv2_100_img_cls_timm",
+                    "pd_mobilenetv2_basic_img_cls_paddlemodels",
+                    "pt_mobilenetv2_mobilenet_v2_img_cls_torchvision",
+                    "pt_mobilenetv2_mobilenetv2_100_img_cls_timm",
+                    "pt_mobilenetv2_basic_img_cls_torchhub",
+                    "pt_mobilenetv2_google_mobilenet_v2_1_0_224_img_cls_hf",
+                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D275,
-        [((1, 960, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "onnx_mobilenetv2_mobilenetv2_100_img_cls_timm",
-                "pd_mobilenetv2_basic_img_cls_paddlemodels",
-                "pt_mobilenetv2_mobilenet_v2_img_cls_torchvision",
-                "pt_mobilenetv2_mobilenetv2_100_img_cls_timm",
-                "pt_mobilenetv2_basic_img_cls_torchhub",
-                "pt_mobilenetv2_google_mobilenet_v2_1_0_224_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D275,
+            [((1, 960, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_mobilenetv2_mobilenetv2_100_img_cls_timm",
+                    "pd_mobilenetv2_basic_img_cls_paddlemodels",
+                    "pt_mobilenetv2_mobilenet_v2_img_cls_torchvision",
+                    "pt_mobilenetv2_mobilenetv2_100_img_cls_timm",
+                    "pt_mobilenetv2_basic_img_cls_torchhub",
+                    "pt_mobilenetv2_google_mobilenet_v2_1_0_224_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D276,
@@ -42673,35 +42871,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D229,
-        [((1, 1056, 7, 7), torch.float32)],
-        {
-            "model_names": ["onnx_mobilenetv2_mobilenetv2_110d_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D229,
+            [((1, 1056, 7, 7), torch.float32)],
+            {
+                "model_names": ["onnx_mobilenetv2_mobilenetv2_110d_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D287,
-        [((1, 1056, 7, 7), torch.float32)],
-        {
-            "model_names": ["onnx_mobilenetv2_mobilenetv2_110d_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D287,
+            [((1, 1056, 7, 7), torch.float32)],
+            {
+                "model_names": ["onnx_mobilenetv2_mobilenetv2_110d_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D288,
@@ -43394,31 +43598,34 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D20,
-        [((1, 1024, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "onnx_resnet_50_img_cls_hf",
-                "pd_resnet_101_img_cls_paddlemodels",
-                "pd_resnet_152_img_cls_paddlemodels",
-                "pd_resnet_50_img_cls_paddlemodels",
-                "pt_resnet_resnet101_img_cls_torchvision",
-                "pt_resnet_resnet50_img_cls_torchvision",
-                "pt_resnet_resnet152_img_cls_torchvision",
-                "pt_resnet_50_img_cls_hf",
-                "pt_resnet_50_img_cls_timm",
-                "pt_unet_qubvel_img_seg_torchhub",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D20,
+            [((1, 1024, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_resnet_50_img_cls_hf",
+                    "pd_resnet_101_img_cls_paddlemodels",
+                    "pd_resnet_152_img_cls_paddlemodels",
+                    "pd_resnet_50_img_cls_paddlemodels",
+                    "pt_resnet_resnet101_img_cls_torchvision",
+                    "pt_resnet_resnet50_img_cls_torchvision",
+                    "pt_resnet_resnet152_img_cls_torchvision",
+                    "pt_resnet_50_img_cls_hf",
+                    "pt_resnet_50_img_cls_timm",
+                    "pt_unet_qubvel_img_seg_torchhub",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D21,
@@ -43453,41 +43660,44 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D22,
-        [((1, 1024, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "onnx_resnet_50_img_cls_hf",
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pd_resnet_101_img_cls_paddlemodels",
-                "pd_resnet_152_img_cls_paddlemodels",
-                "pd_resnet_50_img_cls_paddlemodels",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-                "pt_resnet_resnet101_img_cls_torchvision",
-                "pt_resnet_resnet50_img_cls_torchvision",
-                "pt_resnet_resnet152_img_cls_torchvision",
-                "pt_resnet_50_img_cls_hf",
-                "pt_resnet_50_img_cls_timm",
-                "pt_resnext_resnext50_32x4d_img_cls_osmr",
-                "pt_resnext_resnext50_32x4d_img_cls_torchhub",
-                "pt_resnext_resnext26_32x4d_img_cls_osmr",
-                "pt_unet_qubvel_img_seg_torchhub",
-                "pt_wideresnet_wide_resnet101_2_img_cls_timm",
-                "pt_wideresnet_wide_resnet101_2_img_cls_torchvision",
-                "pt_wideresnet_wide_resnet50_2_img_cls_torchvision",
-                "pt_wideresnet_wide_resnet50_2_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D22,
+            [((1, 1024, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_resnet_50_img_cls_hf",
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pd_resnet_101_img_cls_paddlemodels",
+                    "pd_resnet_152_img_cls_paddlemodels",
+                    "pd_resnet_50_img_cls_paddlemodels",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                    "pt_resnet_resnet101_img_cls_torchvision",
+                    "pt_resnet_resnet50_img_cls_torchvision",
+                    "pt_resnet_resnet152_img_cls_torchvision",
+                    "pt_resnet_50_img_cls_hf",
+                    "pt_resnet_50_img_cls_timm",
+                    "pt_resnext_resnext50_32x4d_img_cls_osmr",
+                    "pt_resnext_resnext50_32x4d_img_cls_torchhub",
+                    "pt_resnext_resnext26_32x4d_img_cls_osmr",
+                    "pt_unet_qubvel_img_seg_torchhub",
+                    "pt_wideresnet_wide_resnet101_2_img_cls_timm",
+                    "pt_wideresnet_wide_resnet101_2_img_cls_torchvision",
+                    "pt_wideresnet_wide_resnet50_2_img_cls_torchvision",
+                    "pt_wideresnet_wide_resnet50_2_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D23,
@@ -43618,50 +43828,56 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D292,
-        [((1, 1024, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_resnext_resnext101_32x8d_img_cls_torchhub",
-                "pt_resnext_resnext101_32x8d_wsl_img_cls_torchhub",
-                "pt_resnext_resnext101_64x4d_img_cls_osmr",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D292,
+            [((1, 1024, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_resnext_resnext101_32x8d_img_cls_torchhub",
+                    "pt_resnext_resnext101_32x8d_wsl_img_cls_torchhub",
+                    "pt_resnext_resnext101_64x4d_img_cls_osmr",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D26,
-        [((1, 2048, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "onnx_resnet_50_img_cls_hf",
-                "pd_resnet_101_img_cls_paddlemodels",
-                "pd_resnet_152_img_cls_paddlemodels",
-                "pd_resnet_50_img_cls_paddlemodels",
-                "pt_resnet_resnet101_img_cls_torchvision",
-                "pt_resnet_resnet50_img_cls_torchvision",
-                "pt_resnet_resnet152_img_cls_torchvision",
-                "pt_resnet_50_img_cls_hf",
-                "pt_resnet_50_img_cls_timm",
-                "pt_unet_qubvel_img_seg_torchhub",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D26,
+            [((1, 2048, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_resnet_50_img_cls_hf",
+                    "pd_resnet_101_img_cls_paddlemodels",
+                    "pd_resnet_152_img_cls_paddlemodels",
+                    "pd_resnet_50_img_cls_paddlemodels",
+                    "pt_resnet_resnet101_img_cls_torchvision",
+                    "pt_resnet_resnet50_img_cls_torchvision",
+                    "pt_resnet_resnet152_img_cls_torchvision",
+                    "pt_resnet_50_img_cls_hf",
+                    "pt_resnet_50_img_cls_timm",
+                    "pt_unet_qubvel_img_seg_torchhub",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D27,
@@ -44021,27 +44237,30 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D304,
-        [((1, 3072, 128, 128), torch.float32)],
-        {
-            "model_names": [
-                "onnx_segformer_nvidia_segformer_b2_finetuned_ade_512_512_sem_seg_hf",
-                "onnx_segformer_nvidia_segformer_b3_finetuned_ade_512_512_sem_seg_hf",
-                "onnx_segformer_nvidia_segformer_b4_finetuned_ade_512_512_sem_seg_hf",
-                "pt_segformer_nvidia_segformer_b3_finetuned_ade_512_512_sem_seg_hf",
-                "pt_segformer_nvidia_segformer_b2_finetuned_ade_512_512_sem_seg_hf",
-                "pt_segformer_nvidia_segformer_b4_finetuned_ade_512_512_sem_seg_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D304,
+            [((1, 3072, 128, 128), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_segformer_nvidia_segformer_b2_finetuned_ade_512_512_sem_seg_hf",
+                    "onnx_segformer_nvidia_segformer_b3_finetuned_ade_512_512_sem_seg_hf",
+                    "onnx_segformer_nvidia_segformer_b4_finetuned_ade_512_512_sem_seg_hf",
+                    "pt_segformer_nvidia_segformer_b3_finetuned_ade_512_512_sem_seg_hf",
+                    "pt_segformer_nvidia_segformer_b2_finetuned_ade_512_512_sem_seg_hf",
+                    "pt_segformer_nvidia_segformer_b4_finetuned_ade_512_512_sem_seg_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D305,
@@ -44065,25 +44284,28 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D20,
-        [((1, 1024, 128, 128), torch.float32)],
-        {
-            "model_names": [
-                "onnx_segformer_nvidia_segformer_b1_finetuned_ade_512_512_sem_seg_hf",
-                "onnx_segformer_nvidia_segformer_b0_finetuned_ade_512_512_sem_seg_hf",
-                "pt_segformer_nvidia_segformer_b0_finetuned_ade_512_512_sem_seg_hf",
-                "pt_segformer_nvidia_segformer_b1_finetuned_ade_512_512_sem_seg_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D20,
+            [((1, 1024, 128, 128), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_segformer_nvidia_segformer_b1_finetuned_ade_512_512_sem_seg_hf",
+                    "onnx_segformer_nvidia_segformer_b0_finetuned_ade_512_512_sem_seg_hf",
+                    "pt_segformer_nvidia_segformer_b0_finetuned_ade_512_512_sem_seg_hf",
+                    "pt_segformer_nvidia_segformer_b1_finetuned_ade_512_512_sem_seg_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D306,
@@ -44480,23 +44702,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D323,
-            [((1, 512, 32, 32), torch.float32)],
-            {
-                "model_names": ["onnx_unet_base_img_seg_torchhub", "pt_unet_base_img_seg_torchhub"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[1, 1]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D323,
+        [((1, 512, 32, 32), torch.float32)],
+        {
+            "model_names": ["onnx_unet_base_img_seg_torchhub", "pt_unet_base_img_seg_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D324,
@@ -44811,27 +45030,30 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D330,
-        [((1, 768, 56, 56), torch.float32)],
-        {
-            "model_names": [
-                "onnx_vovnet_vovnet_v1_57_obj_det_torchhub",
-                "onnx_vovnet_v1_vovnet39_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                "pt_vovnet_vovnet39_img_cls_osmr",
-                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                "pt_vovnet_vovnet57_img_cls_osmr",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D330,
+            [((1, 768, 56, 56), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_vovnet_vovnet_v1_57_obj_det_torchhub",
+                    "onnx_vovnet_v1_vovnet39_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                    "pt_vovnet_vovnet39_img_cls_osmr",
+                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                    "pt_vovnet_vovnet57_img_cls_osmr",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D331,
@@ -44877,27 +45099,30 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D333,
-        [((1, 1056, 28, 28), torch.float32)],
-        {
-            "model_names": [
-                "onnx_vovnet_vovnet_v1_57_obj_det_torchhub",
-                "onnx_vovnet_v1_vovnet39_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                "pt_vovnet_vovnet39_img_cls_osmr",
-                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                "pt_vovnet_vovnet57_img_cls_osmr",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D333,
+            [((1, 1056, 28, 28), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_vovnet_vovnet_v1_57_obj_det_torchhub",
+                    "onnx_vovnet_v1_vovnet39_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                    "pt_vovnet_vovnet39_img_cls_osmr",
+                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                    "pt_vovnet_vovnet57_img_cls_osmr",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D334,
@@ -44945,27 +45170,30 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D336,
-        [((1, 1472, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "onnx_vovnet_vovnet_v1_57_obj_det_torchhub",
-                "onnx_vovnet_v1_vovnet39_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                "pt_vovnet_vovnet39_img_cls_osmr",
-                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                "pt_vovnet_vovnet57_img_cls_osmr",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D336,
+            [((1, 1472, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_vovnet_vovnet_v1_57_obj_det_torchhub",
+                    "onnx_vovnet_v1_vovnet39_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                    "pt_vovnet_vovnet39_img_cls_osmr",
+                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                    "pt_vovnet_vovnet57_img_cls_osmr",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D337,
@@ -44989,27 +45217,30 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D338,
-        [((1, 1728, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "onnx_vovnet_vovnet_v1_57_obj_det_torchhub",
-                "onnx_vovnet_v1_vovnet39_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                "pt_vovnet_vovnet39_img_cls_osmr",
-                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                "pt_vovnet_vovnet57_img_cls_osmr",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D338,
+            [((1, 1728, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_vovnet_vovnet_v1_57_obj_det_torchhub",
+                    "onnx_vovnet_v1_vovnet39_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                    "pt_vovnet_vovnet39_img_cls_osmr",
+                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                    "pt_vovnet_vovnet57_img_cls_osmr",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D339,
@@ -45055,32 +45286,10 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D341,
-        [((1, 1888, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "onnx_vovnet_vovnet_v1_57_obj_det_torchhub",
-                "onnx_vovnet_v1_vovnet39_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                "pt_vovnet_vovnet39_img_cls_osmr",
-                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                "pt_vovnet_vovnet57_img_cls_osmr",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
     pytest.param(
         (
-            Conv2D342,
-            [((1, 1024, 7, 7), torch.float32)],
+            Conv2D341,
+            [((1, 1888, 7, 7), torch.float32)],
             {
                 "model_names": [
                     "onnx_vovnet_vovnet_v1_57_obj_det_torchhub",
@@ -45093,7 +45302,7 @@ forge_modules_and_shapes_dtypes_list = [
                 "pcc": 0.99,
                 "args": {
                     "stride": "[1, 1]",
-                    "padding": "[1, 1, 1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -45103,8 +45312,8 @@ forge_modules_and_shapes_dtypes_list = [
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
-        Conv2D343,
-        [((1, 2144, 7, 7), torch.float32)],
+        Conv2D342,
+        [((1, 1024, 7, 7), torch.float32)],
         {
             "model_names": [
                 "onnx_vovnet_vovnet_v1_57_obj_det_torchhub",
@@ -45117,12 +45326,37 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
             "args": {
                 "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
+                "padding": "[1, 1, 1, 1]",
                 "dilation": "1",
                 "groups": "1",
                 "channel_last": "0",
             },
         },
+    ),
+    pytest.param(
+        (
+            Conv2D343,
+            [((1, 2144, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_vovnet_vovnet_v1_57_obj_det_torchhub",
+                    "onnx_vovnet_v1_vovnet39_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                    "pt_vovnet_vovnet39_img_cls_osmr",
+                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                    "pt_vovnet_vovnet57_img_cls_osmr",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D35,
@@ -45249,20 +45483,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D351,
-        [((1, 736, 14, 14), torch.float32)],
-        {
-            "model_names": ["onnx_vovnet_vovnet27s_obj_det_osmr", "pt_vovnet_vovnet27s_img_cls_osmr"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D351,
+            [((1, 736, 14, 14), torch.float32)],
+            {
+                "model_names": ["onnx_vovnet_vovnet27s_obj_det_osmr", "pt_vovnet_vovnet27s_img_cls_osmr"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D352,
@@ -45578,24 +45815,27 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D365,
-        [((1, 736, 28, 28), torch.float32)],
-        {
-            "model_names": [
-                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D365,
+            [((1, 736, 28, 28), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D366,
@@ -45656,64 +45896,73 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D369,
-        [((1, 1088, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D369,
+            [((1, 1088, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D370,
-        [((1, 768, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D370,
+            [((1, 768, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D371,
-        [((1, 768, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D371,
+            [((1, 768, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D372,
@@ -45749,45 +45998,51 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D374,
-        [((1, 1440, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D374,
+            [((1, 1440, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D375,
-        [((1, 1024, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
-                "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D375,
+            [((1, 1024, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "onnx_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet39b_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet99b_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet19b_dw_ra_in1k_obj_det_torchhub",
+                    "pt_vovnet_ese_vovnet19b_dw_obj_det_torchhub",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D259,
@@ -46925,23 +47180,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D398,
-            [((1, 3, 224, 224), torch.float32)],
-            {
-                "model_names": ["pd_alexnet_base_img_cls_paddlemodels"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[4, 4]",
-                    "padding": "[2, 2, 2, 2]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D398,
+        [((1, 3, 224, 224), torch.float32)],
+        {
+            "model_names": ["pd_alexnet_base_img_cls_paddlemodels"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[4, 4]",
+                "padding": "[2, 2, 2, 2]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D399,
@@ -47635,278 +47887,317 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D415,
-        [((1, 608, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D415,
+            [((1, 608, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D416,
-        [((1, 640, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D416,
+            [((1, 640, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D417,
-        [((1, 672, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D417,
+            [((1, 672, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D418,
-        [((1, 704, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D418,
+            [((1, 704, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D419,
-        [((1, 736, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D419,
+            [((1, 736, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D221,
-        [((1, 768, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D221,
+            [((1, 768, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D420,
-        [((1, 800, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D420,
+            [((1, 800, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D421,
-        [((1, 832, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D421,
+            [((1, 832, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D422,
-        [((1, 864, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D422,
+            [((1, 864, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D423,
-        [((1, 896, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D423,
+            [((1, 896, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D424,
-        [((1, 928, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D424,
+            [((1, 928, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D425,
-        [((1, 960, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D425,
+            [((1, 960, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D426,
-        [((1, 992, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D426,
+            [((1, 992, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D14,
@@ -47986,269 +48277,308 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D415,
-        [((1, 608, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D415,
+            [((1, 608, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D416,
-        [((1, 640, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D416,
+            [((1, 640, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D417,
-        [((1, 672, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D417,
+            [((1, 672, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D418,
-        [((1, 704, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D418,
+            [((1, 704, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D419,
-        [((1, 736, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D419,
+            [((1, 736, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D221,
-        [((1, 768, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D221,
+            [((1, 768, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D420,
-        [((1, 800, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D420,
+            [((1, 800, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D421,
-        [((1, 832, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-                "pt_googlenet_base_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D421,
+            [((1, 832, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                    "pt_googlenet_base_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D422,
-        [((1, 864, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D422,
+            [((1, 864, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D423,
-        [((1, 896, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D423,
+            [((1, 896, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D424,
-        [((1, 928, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D424,
+            [((1, 928, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D425,
-        [((1, 960, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D425,
+            [((1, 960, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D426,
-        [((1, 992, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_densenet_121_img_cls_paddlemodels",
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-                "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
-                "pt_densenet_densenet121_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D426,
+            [((1, 992, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_densenet_121_img_cls_paddlemodels",
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                    "pt_densenet_densenet121_hf_xray_img_cls_torchvision",
+                    "pt_densenet_densenet121_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D6,
@@ -48700,20 +49030,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D421,
-        [((1, 832, 6, 6), torch.float32)],
-        {
-            "model_names": ["pd_googlenet_base_img_cls_paddlemodels"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D421,
+            [((1, 832, 6, 6), torch.float32)],
+            {
+                "model_names": ["pd_googlenet_base_img_cls_paddlemodels"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D428,
@@ -49052,25 +49385,28 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D375,
-        [((1, 1024, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pd_mobilenetv1_basic_img_cls_paddlemodels",
-                "pt_mobilenet_v1_mobilenetv1_100_ra4_e3600_r224_in1k_img_cls_timm",
-                "pt_mobilenet_v1_basic_img_cls_torchvision",
-                "pt_mobilnet_v1_google_mobilenet_v1_1_0_224_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D375,
+            [((1, 1024, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pd_mobilenetv1_basic_img_cls_paddlemodels",
+                    "pt_mobilenet_v1_mobilenetv1_100_ra4_e3600_r224_in1k_img_cls_timm",
+                    "pt_mobilenet_v1_basic_img_cls_torchvision",
+                    "pt_mobilnet_v1_google_mobilenet_v1_1_0_224_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D296,
@@ -49382,20 +49718,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D454,
-        [((1, 4096, 1, 6), torch.float32), ((4096, 1, 1, 4), torch.float32)],
-        {
-            "model_names": ["pt_mamba_state_spaces_mamba_1_4b_hf_clm_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 3, 0, 3]",
-                "dilation": "1",
-                "groups": "4096",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D454,
+            [((1, 4096, 1, 6), torch.float32), ((4096, 1, 1, 4), torch.float32)],
+            {
+                "model_names": ["pt_mamba_state_spaces_mamba_1_4b_hf_clm_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 3, 0, 3]",
+                    "dilation": "1",
+                    "groups": "4096",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D455,
@@ -49412,35 +49751,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D456,
-        [((1, 5120, 1, 6), torch.float32), ((5120, 1, 1, 4), torch.float32)],
-        {
-            "model_names": ["pt_mamba_state_spaces_mamba_2_8b_hf_clm_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 3, 0, 3]",
-                "dilation": "1",
-                "groups": "5120",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D456,
+            [((1, 5120, 1, 6), torch.float32), ((5120, 1, 1, 4), torch.float32)],
+            {
+                "model_names": ["pt_mamba_state_spaces_mamba_2_8b_hf_clm_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 3, 0, 3]",
+                    "dilation": "1",
+                    "groups": "5120",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D457,
-        [((1, 3072, 1, 6), torch.float32), ((3072, 1, 1, 4), torch.float32)],
-        {
-            "model_names": ["pt_mamba_state_spaces_mamba_790m_hf_clm_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 3, 0, 3]",
-                "dilation": "1",
-                "groups": "3072",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D457,
+            [((1, 3072, 1, 6), torch.float32), ((3072, 1, 1, 4), torch.float32)],
+            {
+                "model_names": ["pt_mamba_state_spaces_mamba_790m_hf_clm_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 3, 0, 3]",
+                    "dilation": "1",
+                    "groups": "3072",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D458,
@@ -49517,23 +49862,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D460,
-            [((1, 3, 224, 224), torch.float32)],
-            {
-                "model_names": ["pt_alexnet_base_img_cls_osmr"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[4, 4]",
-                    "padding": "[0, 0, 0, 0]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D460,
+        [((1, 3, 224, 224), torch.float32)],
+        {
+            "model_names": ["pt_alexnet_base_img_cls_osmr"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[4, 4]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D461,
@@ -49599,23 +49941,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D465,
-            [((1, 3, 224, 224), torch.float32)],
-            {
-                "model_names": ["pt_alexnet_base_img_cls_torchhub"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[4, 4]",
-                    "padding": "[2, 2, 2, 2]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D465,
+        [((1, 3, 224, 224), torch.float32)],
+        {
+            "model_names": ["pt_alexnet_base_img_cls_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[4, 4]",
+                "padding": "[2, 2, 2, 2]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D466,
@@ -49728,899 +50067,1061 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D31,
-        [((1, 1024, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D31,
+            [((1, 1024, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D471,
-        [((1, 1056, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D471,
+            [((1, 1056, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D472,
-        [((1, 1088, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D472,
+            [((1, 1088, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D473,
-        [((1, 1120, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D473,
+            [((1, 1120, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D474,
-        [((1, 1152, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D474,
+            [((1, 1152, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D475,
-        [((1, 1184, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D475,
+            [((1, 1184, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D476,
-        [((1, 1216, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D476,
+            [((1, 1216, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D477,
-        [((1, 1248, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D477,
+            [((1, 1248, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D478,
-        [((1, 1280, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D478,
+            [((1, 1280, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D479,
-        [((1, 1312, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D479,
+            [((1, 1312, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D480,
-        [((1, 1344, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D480,
+            [((1, 1344, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D481,
-        [((1, 1376, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D481,
+            [((1, 1376, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D482,
-        [((1, 1408, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D482,
+            [((1, 1408, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D483,
-        [((1, 1440, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D483,
+            [((1, 1440, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D484,
-        [((1, 1472, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D484,
+            [((1, 1472, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D485,
-        [((1, 1504, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D485,
+            [((1, 1504, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D486,
-        [((1, 1536, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D486,
+            [((1, 1536, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D487,
-        [((1, 1568, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D487,
+            [((1, 1568, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D488,
-        [((1, 1600, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D488,
+            [((1, 1600, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D489,
-        [((1, 1632, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D489,
+            [((1, 1632, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D490,
-        [((1, 1664, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D490,
+            [((1, 1664, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D491,
-        [((1, 1696, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D491,
+            [((1, 1696, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D492,
-        [((1, 1728, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D492,
+            [((1, 1728, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D493,
-        [((1, 1760, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D493,
+            [((1, 1760, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D494,
-        [((1, 1792, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D494,
+            [((1, 1792, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D31,
-        [((1, 1024, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D31,
+            [((1, 1024, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D471,
-        [((1, 1056, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D471,
+            [((1, 1056, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D472,
-        [((1, 1088, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D472,
+            [((1, 1088, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D473,
-        [((1, 1120, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D473,
+            [((1, 1120, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D474,
-        [((1, 1152, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D474,
+            [((1, 1152, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D475,
-        [((1, 1184, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D475,
+            [((1, 1184, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D476,
-        [((1, 1216, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D476,
+            [((1, 1216, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D477,
-        [((1, 1248, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D477,
+            [((1, 1248, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D478,
-        [((1, 1280, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D478,
+            [((1, 1280, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D479,
-        [((1, 1312, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D479,
+            [((1, 1312, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D480,
-        [((1, 1344, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D480,
+            [((1, 1344, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D481,
-        [((1, 1376, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D481,
+            [((1, 1376, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D482,
-        [((1, 1408, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D482,
+            [((1, 1408, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D483,
-        [((1, 1440, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D483,
+            [((1, 1440, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D484,
-        [((1, 1472, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D484,
+            [((1, 1472, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D485,
-        [((1, 1504, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D485,
+            [((1, 1504, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D486,
-        [((1, 1536, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D486,
+            [((1, 1536, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D487,
-        [((1, 1568, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D487,
+            [((1, 1568, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D488,
-        [((1, 1600, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D488,
+            [((1, 1600, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D489,
-        [((1, 1632, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_densenet_densenet201_img_cls_torchvision",
-                "pt_densenet_densenet169_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D489,
+            [((1, 1632, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_densenet_densenet201_img_cls_torchvision",
+                    "pt_densenet_densenet169_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D490,
-        [((1, 1664, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D490,
+            [((1, 1664, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D491,
-        [((1, 1696, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D491,
+            [((1, 1696, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D492,
-        [((1, 1728, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D492,
+            [((1, 1728, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D493,
-        [((1, 1760, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D493,
+            [((1, 1760, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D495,
-        [((1, 1792, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D495,
+            [((1, 1792, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D496,
-        [((1, 1824, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D496,
+            [((1, 1824, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D497,
-        [((1, 1856, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D497,
+            [((1, 1856, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D498,
-        [((1, 1888, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D498,
+            [((1, 1888, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet201_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D499,
-        [((1, 1280, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet169_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D499,
+            [((1, 1280, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet169_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D500,
@@ -50959,50 +51460,59 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D198,
-        [((1, 672, 28, 28), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D198,
+            [((1, 672, 28, 28), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D515,
-        [((1, 720, 28, 28), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D515,
+            [((1, 720, 28, 28), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D516,
-        [((1, 768, 28, 28), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D516,
+            [((1, 768, 28, 28), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D509,
@@ -51109,485 +51619,581 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D198,
-        [((1, 672, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D198,
+            [((1, 672, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D515,
-        [((1, 720, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D515,
+            [((1, 720, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D517,
-        [((1, 768, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D517,
+            [((1, 768, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D518,
-        [((1, 816, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D518,
+            [((1, 816, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D519,
-        [((1, 864, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D519,
+            [((1, 864, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D520,
-        [((1, 912, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D520,
+            [((1, 912, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D521,
-        [((1, 960, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D521,
+            [((1, 960, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D522,
-        [((1, 1008, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D522,
+            [((1, 1008, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D523,
-        [((1, 1056, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D523,
+            [((1, 1056, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D524,
-        [((1, 1104, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D524,
+            [((1, 1104, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D203,
-        [((1, 1152, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D203,
+            [((1, 1152, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D525,
-        [((1, 1200, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D525,
+            [((1, 1200, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D526,
-        [((1, 1248, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D526,
+            [((1, 1248, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D527,
-        [((1, 1296, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D527,
+            [((1, 1296, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D528,
-        [((1, 1344, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D528,
+            [((1, 1344, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D529,
-        [((1, 1392, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D529,
+            [((1, 1392, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D530,
-        [((1, 1440, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D530,
+            [((1, 1440, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D531,
-        [((1, 1488, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D531,
+            [((1, 1488, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D532,
-        [((1, 1536, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D532,
+            [((1, 1536, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D533,
-        [((1, 1584, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D533,
+            [((1, 1584, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D534,
-        [((1, 1632, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D534,
+            [((1, 1632, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D535,
-        [((1, 1680, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D535,
+            [((1, 1680, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D536,
-        [((1, 1728, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D536,
+            [((1, 1728, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D537,
-        [((1, 1776, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D537,
+            [((1, 1776, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D538,
-        [((1, 1824, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D538,
+            [((1, 1824, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D539,
-        [((1, 1872, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D539,
+            [((1, 1872, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D540,
-        [((1, 1920, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D540,
+            [((1, 1920, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D541,
-        [((1, 1968, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D541,
+            [((1, 1968, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D542,
-        [((1, 2016, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D542,
+            [((1, 2016, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D543,
-        [((1, 2064, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D543,
+            [((1, 2064, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D544,
-        [((1, 2112, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D544,
+            [((1, 2112, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D523,
-        [((1, 1056, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D523,
+            [((1, 1056, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D504,
@@ -51604,335 +52210,401 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D524,
-        [((1, 1104, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D524,
+            [((1, 1104, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D525,
-        [((1, 1200, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D525,
+            [((1, 1200, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D526,
-        [((1, 1248, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D526,
+            [((1, 1248, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D527,
-        [((1, 1296, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D527,
+            [((1, 1296, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D528,
-        [((1, 1344, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D528,
+            [((1, 1344, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D529,
-        [((1, 1392, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D529,
+            [((1, 1392, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D530,
-        [((1, 1440, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D530,
+            [((1, 1440, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D531,
-        [((1, 1488, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D531,
+            [((1, 1488, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D532,
-        [((1, 1536, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D532,
+            [((1, 1536, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D533,
-        [((1, 1584, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D533,
+            [((1, 1584, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D534,
-        [((1, 1632, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D534,
+            [((1, 1632, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D535,
-        [((1, 1680, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D535,
+            [((1, 1680, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D536,
-        [((1, 1728, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D536,
+            [((1, 1728, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D537,
-        [((1, 1776, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D537,
+            [((1, 1776, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D538,
-        [((1, 1824, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D538,
+            [((1, 1824, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D539,
-        [((1, 1872, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D539,
+            [((1, 1872, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D540,
-        [((1, 1920, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D540,
+            [((1, 1920, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D541,
-        [((1, 1968, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D541,
+            [((1, 1968, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D542,
-        [((1, 2016, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D542,
+            [((1, 2016, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D543,
-        [((1, 2064, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D543,
+            [((1, 2064, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D545,
-        [((1, 2112, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D545,
+            [((1, 2112, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D546,
-        [((1, 2160, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D546,
+            [((1, 2160, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_densenet_densenet161_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D428,
@@ -52099,20 +52771,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D548,
-        [((1, 896, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_dla_dla34_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D548,
+            [((1, 896, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_dla_dla34_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D290,
@@ -52129,20 +52804,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D549,
-        [((1, 1280, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_dla_dla34_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D549,
+            [((1, 1280, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_dla_dla34_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D550,
@@ -52443,20 +53121,23 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="RuntimeError: Failed to run MLIR compiler pass pipeline.")],
     ),
-    (
-        Conv2D73,
-        [((1, 672, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D73,
+            [((1, 672, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D74,
@@ -52503,35 +53184,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D79,
-        [((1, 960, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D79,
+            [((1, 960, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D80,
-        [((1, 960, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D80,
+            [((1, 960, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D81,
@@ -52563,20 +53250,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D85,
-        [((1, 1632, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D85,
+            [((1, 1632, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D566,
@@ -52593,20 +53283,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D87,
-        [((1, 1632, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D87,
+            [((1, 1632, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D88,
@@ -52623,35 +53316,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D567,
-        [((1, 2688, 7, 7), torch.float32), ((2688, 1, 3, 3), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "2688",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D567,
+            [((1, 2688, 7, 7), torch.float32), ((2688, 1, 3, 3), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "2688",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D92,
-        [((1, 2688, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D92,
+            [((1, 2688, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D568,
@@ -53156,20 +53855,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D567,
-        [((1, 2688, 10, 10), torch.float32), ((2688, 1, 3, 3), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "2688",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D567,
+            [((1, 2688, 10, 10), torch.float32), ((2688, 1, 3, 3), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_efficientnet_b4_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "2688",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     pytest.param(
         (
@@ -53540,35 +54242,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D166,
-        [((1, 816, 19, 19), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite3_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D166,
+            [((1, 816, 19, 19), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite3_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D167,
-        [((1, 816, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite3_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D167,
+            [((1, 816, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite3_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D168,
@@ -53600,20 +54308,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D172,
-        [((1, 1392, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite3_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D172,
+            [((1, 1392, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite3_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D590,
@@ -53630,20 +54341,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D174,
-        [((1, 1392, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite3_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D174,
+            [((1, 1392, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite3_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D591,
@@ -53939,20 +54653,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D71,
-        [((1, 672, 24, 24), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite4_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D71,
+            [((1, 672, 24, 24), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite4_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D560,
@@ -53969,20 +54686,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D73,
-        [((1, 672, 24, 24), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite4_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D73,
+            [((1, 672, 24, 24), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite4_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D74,
@@ -54032,35 +54752,41 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="RuntimeError: Failed to run MLIR compiler pass pipeline.")],
     ),
-    (
-        Conv2D79,
-        [((1, 960, 24, 24), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite4_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D79,
+            [((1, 960, 24, 24), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite4_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D80,
-        [((1, 960, 12, 12), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite4_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D80,
+            [((1, 960, 12, 12), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite4_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D81,
@@ -54092,20 +54818,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D85,
-        [((1, 1632, 12, 12), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite4_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D85,
+            [((1, 1632, 12, 12), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite4_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D566,
@@ -54122,20 +54851,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D87,
-        [((1, 1632, 12, 12), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite4_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D87,
+            [((1, 1632, 12, 12), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite4_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D594,
@@ -54518,35 +55250,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D132,
-        [((1, 720, 17, 17), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite2_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D132,
+            [((1, 720, 17, 17), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite2_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D133,
-        [((1, 720, 9, 9), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite2_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D133,
+            [((1, 720, 9, 9), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite2_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D134,
@@ -54578,20 +55316,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D138,
-        [((1, 1248, 9, 9), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite2_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D138,
+            [((1, 1248, 9, 9), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite2_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D601,
@@ -54608,20 +55349,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D140,
-        [((1, 1248, 9, 9), torch.float32)],
-        {
-            "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite2_in1k_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D140,
+            [((1, 1248, 9, 9), torch.float32)],
+            {
+                "model_names": ["pt_efficientnet_lite_tf_efficientnet_lite2_in1k_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D288,
@@ -54857,20 +55601,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D28,
-        [((1, 2048, 8, 8), torch.float32)],
-        {
-            "model_names": ["pt_fpn_base_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D28,
+            [((1, 2048, 8, 8), torch.float32)],
+            {
+                "model_names": ["pt_fpn_base_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D21,
@@ -55772,26 +56519,29 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D642,
-        [((1, 672, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_ghostnet_ghostnet_100_img_cls_timm",
-                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D642,
+            [((1, 672, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_ghostnet_ghostnet_100_img_cls_timm",
+                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D643,
@@ -55814,43 +56564,49 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D644,
-        [((1, 672, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_ghostnet_ghostnet_100_img_cls_timm",
-                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D644,
+            [((1, 672, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_ghostnet_ghostnet_100_img_cls_timm",
+                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D645,
-        [((1, 672, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_ghostnet_ghostnet_100_img_cls_timm",
-                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D645,
+            [((1, 672, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_ghostnet_ghostnet_100_img_cls_timm",
+                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D638,
@@ -55947,45 +56703,51 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D649,
-        [((1, 960, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_ghostnet_ghostnet_100_img_cls_timm",
-                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D649,
+            [((1, 960, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_ghostnet_ghostnet_100_img_cls_timm",
+                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D650,
-        [((1, 960, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_ghostnet_ghostnet_100_img_cls_timm",
-                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D650,
+            [((1, 960, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_ghostnet_ghostnet_100_img_cls_timm",
+                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D651,
@@ -56008,25 +56770,28 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D652,
-        [((1, 960, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_ghostnet_ghostnet_100_img_cls_timm",
-                "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
-                "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
-                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D652,
+            [((1, 960, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_ghostnet_ghostnet_100_img_cls_timm",
+                    "pt_ghostnet_ghostnetv2_100_in1k_img_cls_timm",
+                    "pt_ghostnet_ghostnet_100_in1k_img_cls_timm",
+                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D653,
@@ -57231,20 +57996,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D428,
-        [((1, 832, 7, 7), torch.float32), ((448, 832, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_googlenet_base_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D428,
+            [((1, 832, 7, 7), torch.float32), ((448, 832, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_googlenet_base_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D440,
@@ -57276,20 +58044,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D428,
-        [((1, 832, 7, 7), torch.float32), ((624, 832, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_googlenet_base_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D428,
+            [((1, 832, 7, 7), torch.float32), ((624, 832, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_googlenet_base_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D443,
@@ -58214,48 +58985,51 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D292,
-        [((1, 1024, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_hrnet_hrnet_w48_pose_estimation_timm",
-                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
-                "pt_hrnet_hrnet_w44_pose_estimation_timm",
-                "pt_hrnet_hrnet_w18_pose_estimation_timm",
-                "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
-                "pt_hrnet_hrnet_w40_pose_estimation_timm",
-                "pt_hrnet_hrnet_w32_pose_estimation_timm",
-                "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
-                "pt_hrnet_hrnetv2_w64_pose_estimation_osmr",
-                "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
-                "pt_hrnet_hrnetv2_w32_pose_estimation_osmr",
-                "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
-                "pt_hrnet_hrnetv2_w44_pose_estimation_osmr",
-                "pt_hrnet_hrnet_w30_pose_estimation_timm",
-                "pt_hrnet_hrnet_w64_pose_estimation_timm",
-                "pt_hrnet_hrnetv2_w40_pose_estimation_osmr",
-                "pt_hrnet_hrnetv2_w30_pose_estimation_osmr",
-                "pt_hrnet_hrnet_w18_ms_aug_in1k_pose_estimation_timm",
-                "pt_hrnet_hrnetv2_w48_pose_estimation_osmr",
-                "pt_resnext_resnext50_32x4d_img_cls_osmr",
-                "pt_resnext_resnext50_32x4d_img_cls_torchhub",
-                "pt_resnext_resnext26_32x4d_img_cls_osmr",
-                "pt_resnext_resnext14_32x4d_img_cls_osmr",
-                "pt_wideresnet_wide_resnet101_2_img_cls_timm",
-                "pt_wideresnet_wide_resnet101_2_img_cls_torchvision",
-                "pt_wideresnet_wide_resnet50_2_img_cls_torchvision",
-                "pt_wideresnet_wide_resnet50_2_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D292,
+            [((1, 1024, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_hrnet_hrnet_w48_pose_estimation_timm",
+                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_timm",
+                    "pt_hrnet_hrnet_w44_pose_estimation_timm",
+                    "pt_hrnet_hrnet_w18_pose_estimation_timm",
+                    "pt_hrnet_hrnet_w18_small_v2_pose_estimation_osmr",
+                    "pt_hrnet_hrnet_w40_pose_estimation_timm",
+                    "pt_hrnet_hrnet_w32_pose_estimation_timm",
+                    "pt_hrnet_hrnetv2_w18_pose_estimation_osmr",
+                    "pt_hrnet_hrnetv2_w64_pose_estimation_osmr",
+                    "pt_hrnet_hrnet_w18_small_v1_pose_estimation_osmr",
+                    "pt_hrnet_hrnetv2_w32_pose_estimation_osmr",
+                    "pt_hrnet_hrnet_w18_small_pose_estimation_timm",
+                    "pt_hrnet_hrnetv2_w44_pose_estimation_osmr",
+                    "pt_hrnet_hrnet_w30_pose_estimation_timm",
+                    "pt_hrnet_hrnet_w64_pose_estimation_timm",
+                    "pt_hrnet_hrnetv2_w40_pose_estimation_osmr",
+                    "pt_hrnet_hrnetv2_w30_pose_estimation_osmr",
+                    "pt_hrnet_hrnet_w18_ms_aug_in1k_pose_estimation_timm",
+                    "pt_hrnet_hrnetv2_w48_pose_estimation_osmr",
+                    "pt_resnext_resnext50_32x4d_img_cls_osmr",
+                    "pt_resnext_resnext50_32x4d_img_cls_torchhub",
+                    "pt_resnext_resnext26_32x4d_img_cls_osmr",
+                    "pt_resnext_resnext14_32x4d_img_cls_osmr",
+                    "pt_wideresnet_wide_resnet101_2_img_cls_timm",
+                    "pt_wideresnet_wide_resnet101_2_img_cls_torchvision",
+                    "pt_wideresnet_wide_resnet50_2_img_cls_torchvision",
+                    "pt_wideresnet_wide_resnet50_2_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D709,
@@ -59843,20 +60617,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D783,
-        [((1, 32, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[2, 2]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D783,
+            [((1, 32, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_hrnet_hrnet_w32_pose_estimation_timm", "pt_hrnet_hrnetv2_w32_pose_estimation_osmr"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[2, 2]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.skip(reason="Hang while executing on device")],
     ),
     (
         Conv2D784,
@@ -60798,20 +61575,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D813,
-        [((1, 30, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_hrnet_hrnet_w30_pose_estimation_timm", "pt_hrnet_hrnetv2_w30_pose_estimation_osmr"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[2, 2]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D813,
+            [((1, 30, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_hrnet_hrnet_w30_pose_estimation_timm", "pt_hrnet_hrnetv2_w30_pose_estimation_osmr"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[2, 2]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.skip(reason="Hang while executing on device")],
     ),
     (
         Conv2D814,
@@ -61307,24 +62087,27 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D428,
-        [((1, 1024, 17, 17), torch.float32), ((768, 1024, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_inception_v4_img_cls_osmr",
-                "pt_inception_inception_v4_tf_in1k_img_cls_timm",
-                "pt_inception_inception_v4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D428,
+            [((1, 1024, 17, 17), torch.float32), ((768, 1024, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_inception_v4_img_cls_osmr",
+                    "pt_inception_inception_v4_tf_in1k_img_cls_timm",
+                    "pt_inception_inception_v4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D835,
@@ -61421,43 +62204,49 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D31,
-        [((1, 1024, 17, 17), torch.float32)],
-        {
-            "model_names": [
-                "pt_inception_v4_img_cls_osmr",
-                "pt_inception_inception_v4_tf_in1k_img_cls_timm",
-                "pt_inception_inception_v4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D31,
+            [((1, 1024, 17, 17), torch.float32)],
+            {
+                "model_names": [
+                    "pt_inception_v4_img_cls_osmr",
+                    "pt_inception_inception_v4_tf_in1k_img_cls_timm",
+                    "pt_inception_inception_v4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D840,
-        [((1, 1024, 17, 17), torch.float32)],
-        {
-            "model_names": [
-                "pt_inception_v4_img_cls_osmr",
-                "pt_inception_inception_v4_tf_in1k_img_cls_timm",
-                "pt_inception_inception_v4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D840,
+            [((1, 1024, 17, 17), torch.float32)],
+            {
+                "model_names": [
+                    "pt_inception_v4_img_cls_osmr",
+                    "pt_inception_inception_v4_tf_in1k_img_cls_timm",
+                    "pt_inception_inception_v4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     pytest.param(
         (
@@ -61481,24 +62270,27 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D20,
-        [((1, 1024, 17, 17), torch.float32)],
-        {
-            "model_names": [
-                "pt_inception_v4_img_cls_osmr",
-                "pt_inception_inception_v4_tf_in1k_img_cls_timm",
-                "pt_inception_inception_v4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D20,
+            [((1, 1024, 17, 17), torch.float32)],
+            {
+                "model_names": [
+                    "pt_inception_v4_img_cls_osmr",
+                    "pt_inception_inception_v4_tf_in1k_img_cls_timm",
+                    "pt_inception_inception_v4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D841,
@@ -61560,24 +62352,27 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D428,
-        [((1, 1536, 8, 8), torch.float32), ((1024, 1536, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_inception_v4_img_cls_osmr",
-                "pt_inception_inception_v4_tf_in1k_img_cls_timm",
-                "pt_inception_inception_v4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D428,
+            [((1, 1536, 8, 8), torch.float32), ((1024, 1536, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_inception_v4_img_cls_osmr",
+                    "pt_inception_inception_v4_tf_in1k_img_cls_timm",
+                    "pt_inception_inception_v4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D844,
@@ -61693,24 +62488,27 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D850,
-        [((1, 1536, 8, 8), torch.float32)],
-        {
-            "model_names": [
-                "pt_inception_v4_img_cls_osmr",
-                "pt_inception_inception_v4_tf_in1k_img_cls_timm",
-                "pt_inception_inception_v4_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D850,
+            [((1, 1536, 8, 8), torch.float32)],
+            {
+                "model_names": [
+                    "pt_inception_v4_img_cls_osmr",
+                    "pt_inception_inception_v4_tf_in1k_img_cls_timm",
+                    "pt_inception_inception_v4_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D851,
@@ -61856,20 +62654,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D428,
-        [((1, 1024, 512, 1), torch.float32), ((256, 1024, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_mlp_mixer_base_img_cls_github"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D428,
+            [((1, 1024, 512, 1), torch.float32), ((256, 1024, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_mlp_mixer_base_img_cls_github"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D858,
@@ -63005,35 +63806,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D132,
-        [((1, 720, 5, 5), torch.float32)],
-        {
-            "model_names": ["pt_mobilenetv2_google_mobilenet_v2_0_75_160_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D132,
+            [((1, 720, 5, 5), torch.float32)],
+            {
+                "model_names": ["pt_mobilenetv2_google_mobilenet_v2_0_75_160_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D895,
-        [((1, 720, 5, 5), torch.float32)],
-        {
-            "model_names": ["pt_mobilenetv2_google_mobilenet_v2_0_75_160_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D895,
+            [((1, 720, 5, 5), torch.float32)],
+            {
+                "model_names": ["pt_mobilenetv2_google_mobilenet_v2_0_75_160_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D896,
@@ -63665,35 +64472,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D79,
-        [((1, 960, 28, 28), torch.float32)],
-        {
-            "model_names": ["pt_mobilnetv2_google_deeplabv3_mobilenet_v2_1_0_513_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D79,
+            [((1, 960, 28, 28), torch.float32)],
+            {
+                "model_names": ["pt_mobilnetv2_google_deeplabv3_mobilenet_v2_1_0_513_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D275,
-        [((1, 960, 28, 28), torch.float32)],
-        {
-            "model_names": ["pt_mobilnetv2_google_deeplabv3_mobilenet_v2_1_0_513_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D275,
+            [((1, 960, 28, 28), torch.float32)],
+            {
+                "model_names": ["pt_mobilnetv2_google_deeplabv3_mobilenet_v2_1_0_513_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D772,
@@ -64300,25 +65113,28 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D923,
-        [((1, 576, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
-                "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
-                "pt_regnet_regnet_y_3_2gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_064_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D923,
+            [((1, 576, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm",
+                    "pt_mobilenetv3_mobilenet_v3_small_img_cls_torchhub",
+                    "pt_regnet_regnet_y_3_2gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_064_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D924,
@@ -64358,20 +65174,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D925,
-        [((1, 576, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D925,
+            [((1, 576, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_mobilnetv3_mobilenetv3_small_100_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D103,
@@ -64661,23 +65480,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D73,
-        [((1, 672, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
-                "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D73,
+            [((1, 672, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_mobilenetv3_mobilenet_v3_large_img_cls_torchhub",
+                    "pt_mobilnetv3_mobilenetv3_large_100_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D563,
@@ -64965,25 +65787,28 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D20,
-        [((1, 1024, 20, 20), torch.float32)],
-        {
-            "model_names": [
-                "pt_mobilenetv3_ssd_resnet152_img_cls_torchvision",
-                "pt_mobilenetv3_ssd_resnet50_img_cls_torchvision",
-                "pt_mobilenetv3_ssd_resnet101_img_cls_torchvision",
-                "pt_yolox_yolox_l_obj_det_torchhub",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D20,
+            [((1, 1024, 20, 20), torch.float32)],
+            {
+                "model_names": [
+                    "pt_mobilenetv3_ssd_resnet152_img_cls_torchvision",
+                    "pt_mobilenetv3_ssd_resnet50_img_cls_torchvision",
+                    "pt_mobilenetv3_ssd_resnet101_img_cls_torchvision",
+                    "pt_yolox_yolox_l_obj_det_torchhub",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D21,
@@ -65009,27 +65834,30 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D22,
-        [((1, 1024, 20, 20), torch.float32)],
-        {
-            "model_names": [
-                "pt_mobilenetv3_ssd_resnet152_img_cls_torchvision",
-                "pt_mobilenetv3_ssd_resnet50_img_cls_torchvision",
-                "pt_mobilenetv3_ssd_resnet101_img_cls_torchvision",
-                "pt_yolox_yolox_s_obj_det_torchhub",
-                "pt_yolox_yolox_darknet_obj_det_torchhub",
-                "pt_yolox_yolox_l_obj_det_torchhub",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D22,
+            [((1, 1024, 20, 20), torch.float32)],
+            {
+                "model_names": [
+                    "pt_mobilenetv3_ssd_resnet152_img_cls_torchvision",
+                    "pt_mobilenetv3_ssd_resnet50_img_cls_torchvision",
+                    "pt_mobilenetv3_ssd_resnet101_img_cls_torchvision",
+                    "pt_yolox_yolox_s_obj_det_torchhub",
+                    "pt_yolox_yolox_darknet_obj_det_torchhub",
+                    "pt_yolox_yolox_l_obj_det_torchhub",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D23,
@@ -65106,24 +65934,27 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D26,
-        [((1, 2048, 10, 10), torch.float32)],
-        {
-            "model_names": [
-                "pt_mobilenetv3_ssd_resnet152_img_cls_torchvision",
-                "pt_mobilenetv3_ssd_resnet50_img_cls_torchvision",
-                "pt_mobilenetv3_ssd_resnet101_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D26,
+            [((1, 2048, 10, 10), torch.float32)],
+            {
+                "model_names": [
+                    "pt_mobilenetv3_ssd_resnet152_img_cls_torchvision",
+                    "pt_mobilenetv3_ssd_resnet50_img_cls_torchvision",
+                    "pt_mobilenetv3_ssd_resnet101_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D27,
@@ -66031,27 +66862,24 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    pytest.param(
-        (
-            Conv2D937,
-            [((1, 64, 82, 258), torch.float32)],
-            {
-                "model_names": [
-                    "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                    "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
-                ],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[1, 1]",
-                    "padding": "[0, 0, 0, 0]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D937,
+        [((1, 64, 82, 258), torch.float32)],
+        {
+            "model_names": [
+                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
+                "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
+            ],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     pytest.param(
         (
@@ -66098,43 +66926,57 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D940,
-        [((1, 16, 322, 1026), torch.float32)],
-        {
-            "model_names": [
-                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
-                "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D940,
+            [((1, 16, 322, 1026), torch.float32)],
+            {
+                "model_names": [
+                    "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
+                    "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
+                    "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:877: tt::exception info: Statically allocated circular buffers in program 31315 clash with L1 buffers on core range [(x=0,y=0) - (x=7,y=7)]. L1 buffer allocated at 351360 and static circular buffer region ends at 465952"
+            )
+        ],
     ),
-    (
-        Conv2D941,
-        [((1, 16, 322, 1026), torch.float32)],
-        {
-            "model_names": [
-                "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
-                "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
-                "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D941,
+            [((1, 16, 322, 1026), torch.float32)],
+            {
+                "model_names": [
+                    "pt_monodepth2_mono_1024x320_depth_prediction_torchvision",
+                    "pt_monodepth2_stereo_1024x320_depth_prediction_torchvision",
+                    "pt_monodepth2_mono_stereo_1024x320_depth_prediction_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:877: tt::exception info: Statically allocated circular buffers in program 31330 clash with L1 buffers on core range [(x=0,y=0) - (x=7,y=7)]. L1 buffer allocated at 351360 and static circular buffer region ends at 465952"
+            )
+        ],
     ),
     (
         Conv2D465,
@@ -66346,20 +67188,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D951,
-        [((1, 720, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_8gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D951,
+            [((1, 720, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_8gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D952,
@@ -66394,20 +67239,23 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D954,
-        [((1, 720, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_8gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D954,
+            [((1, 720, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_8gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D955,
@@ -66424,20 +67272,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D956,
-        [((1, 1920, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_8gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D956,
+            [((1, 1920, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_8gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D957,
@@ -66475,26 +67326,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D959,
-            [((1, 232, 112, 112), torch.float32)],
-            {
-                "model_names": [
-                    "pt_regnet_regnet_y_32gf_img_cls_torchvision",
-                    "pt_regnet_facebook_regnet_y_320_img_cls_hf",
-                ],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D959,
+        [((1, 232, 112, 112), torch.float32)],
+        {
+            "model_names": [
+                "pt_regnet_regnet_y_32gf_img_cls_torchvision",
+                "pt_regnet_facebook_regnet_y_320_img_cls_hf",
+            ],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D960,
@@ -66658,23 +67506,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D969,
-        [((1, 696, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_32gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_320_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D969,
+            [((1, 696, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_32gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_320_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D970,
@@ -66694,23 +67545,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D971,
-        [((1, 696, 28, 28), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_32gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_320_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D971,
+            [((1, 696, 28, 28), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_32gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_320_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D972,
@@ -66730,23 +67584,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D973,
-        [((1, 696, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_32gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_320_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D973,
+            [((1, 696, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_32gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_320_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D974,
@@ -66787,23 +67644,26 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D976,
-        [((1, 696, 28, 28), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_32gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_320_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D976,
+            [((1, 696, 28, 28), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_32gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_320_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D977,
@@ -66823,23 +67683,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D978,
-        [((1, 1392, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_32gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_320_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D978,
+            [((1, 1392, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_32gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_320_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D979,
@@ -66859,23 +67722,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D980,
-        [((1, 1392, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_32gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_320_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D980,
+            [((1, 1392, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_32gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_320_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D981,
@@ -66895,23 +67761,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D982,
-        [((1, 1392, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_32gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_320_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D982,
+            [((1, 1392, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_32gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_320_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D983,
@@ -66952,59 +67821,68 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D985,
-        [((1, 1392, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_32gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_320_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D985,
+            [((1, 1392, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_32gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_320_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D986,
-        [((1, 3712, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_32gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_320_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[2, 2]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "16",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D986,
+            [((1, 3712, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_32gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_320_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[2, 2]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "16",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D987,
-        [((1, 3712, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_32gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_320_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D987,
+            [((1, 3712, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_32gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_320_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D988,
@@ -67024,23 +67902,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D989,
-        [((1, 3712, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_32gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_320_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D989,
+            [((1, 3712, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_32gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_320_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D990,
@@ -67372,20 +68253,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1010,
-        [((1, 576, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_3_2gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1010,
+            [((1, 576, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_3_2gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1011,
@@ -67435,23 +68319,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1014,
-            [((1, 576, 14, 14), torch.float32)],
-            {
-                "model_names": ["pt_regnet_regnet_y_3_2gf_img_cls_torchvision"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[0, 0, 0, 0]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1014,
+        [((1, 576, 14, 14), torch.float32)],
+        {
+            "model_names": ["pt_regnet_regnet_y_3_2gf_img_cls_torchvision"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1015,
@@ -67483,20 +68364,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1017,
-        [((1, 1512, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_3_2gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1017,
+            [((1, 1512, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_3_2gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1018,
@@ -67513,20 +68397,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1019,
-        [((1, 1512, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_3_2gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1019,
+            [((1, 1512, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_3_2gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1020,
@@ -67765,25 +68652,28 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1031,
-        [((1, 448, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_16gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_160_img_cls_hf",
-                "pt_regnet_facebook_regnet_y_120_img_cls_hf",
-                "pt_regnet_regnet_y_8gf_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1031,
+            [((1, 448, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_16gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_160_img_cls_hf",
+                    "pt_regnet_facebook_regnet_y_120_img_cls_hf",
+                    "pt_regnet_regnet_y_8gf_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1032,
@@ -67941,23 +68831,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1040,
-        [((1, 1232, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_16gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_160_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1040,
+            [((1, 1232, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_16gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_160_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1041,
@@ -67977,23 +68870,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1042,
-        [((1, 1232, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_16gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_160_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1042,
+            [((1, 1232, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_16gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_160_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1043,
@@ -68013,23 +68909,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1044,
-        [((1, 1232, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_16gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_160_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1044,
+            [((1, 1232, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_16gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_160_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1045,
@@ -68070,59 +68969,68 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1047,
-        [((1, 1232, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_16gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_160_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1047,
+            [((1, 1232, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_16gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_160_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1048,
-        [((1, 3024, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_16gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_160_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[2, 2]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "27",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1048,
+            [((1, 3024, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_16gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_160_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[2, 2]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "27",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1049,
-        [((1, 3024, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_16gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_160_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1049,
+            [((1, 3024, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_16gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_160_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1050,
@@ -68142,23 +69050,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1051,
-        [((1, 3024, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_y_16gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_160_img_cls_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1051,
+            [((1, 3024, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_y_16gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_160_img_cls_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1052,
@@ -68595,20 +69506,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1077,
-        [((1, 888, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_1_6gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1077,
+            [((1, 888, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_1_6gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1078,
@@ -68625,20 +69539,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1079,
-        [((1, 888, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_1_6gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1079,
+            [((1, 888, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_1_6gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1080,
@@ -68655,20 +69572,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1081,
-        [((1, 888, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_1_6gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1081,
+            [((1, 888, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_1_6gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1082,
@@ -68963,24 +69883,27 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1101,
-        [((1, 896, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_facebook_regnet_y_080_img_cls_hf",
-                "pt_regnet_facebook_regnet_y_120_img_cls_hf",
-                "pt_regnet_regnet_y_8gf_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1101,
+            [((1, 896, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_facebook_regnet_y_080_img_cls_hf",
+                    "pt_regnet_facebook_regnet_y_120_img_cls_hf",
+                    "pt_regnet_regnet_y_8gf_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1102,
@@ -69001,25 +69924,28 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1103,
-        [((1, 896, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_facebook_regnet_y_080_img_cls_hf",
-                "pt_regnet_regnet_x_16gf_img_cls_torchvision",
-                "pt_regnet_facebook_regnet_y_120_img_cls_hf",
-                "pt_regnet_regnet_y_8gf_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1103,
+            [((1, 896, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_facebook_regnet_y_080_img_cls_hf",
+                    "pt_regnet_regnet_x_16gf_img_cls_torchvision",
+                    "pt_regnet_facebook_regnet_y_120_img_cls_hf",
+                    "pt_regnet_regnet_y_8gf_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1104,
@@ -69036,24 +69962,27 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1105,
-        [((1, 896, 1, 1), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_facebook_regnet_y_080_img_cls_hf",
-                "pt_regnet_facebook_regnet_y_120_img_cls_hf",
-                "pt_regnet_regnet_y_8gf_img_cls_torchvision",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1105,
+            [((1, 896, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_facebook_regnet_y_080_img_cls_hf",
+                    "pt_regnet_facebook_regnet_y_120_img_cls_hf",
+                    "pt_regnet_regnet_y_8gf_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1106,
@@ -69074,20 +70003,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1107,
-        [((1, 896, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_080_img_cls_hf", "pt_regnet_regnet_y_8gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1107,
+            [((1, 896, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_facebook_regnet_y_080_img_cls_hf",
+                    "pt_regnet_regnet_y_8gf_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     pytest.param(
         (
@@ -69125,20 +70060,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1110,
-        [((1, 2016, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_080_img_cls_hf", "pt_regnet_regnet_y_8gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1110,
+            [((1, 2016, 1, 1), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_facebook_regnet_y_080_img_cls_hf",
+                    "pt_regnet_regnet_y_8gf_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1111,
@@ -69155,20 +70096,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1112,
-        [((1, 2016, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_080_img_cls_hf", "pt_regnet_regnet_y_8gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1112,
+            [((1, 2016, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_facebook_regnet_y_080_img_cls_hf",
+                    "pt_regnet_regnet_y_8gf_img_cls_torchvision",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1113,
@@ -69200,23 +70147,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1115,
-            [((1, 336, 112, 112), torch.float32)],
-            {
-                "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "2",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1115,
+        [((1, 336, 112, 112), torch.float32)],
+        {
+            "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "2",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1070,
@@ -69293,20 +70237,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1120,
-        [((1, 672, 28, 28), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1120,
+            [((1, 672, 28, 28), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1121,
@@ -69341,20 +70288,23 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1123,
-        [((1, 672, 28, 28), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1123,
+            [((1, 672, 28, 28), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1124,
@@ -69371,20 +70321,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1125,
-        [((1, 1344, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1125,
+            [((1, 1344, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1126,
@@ -69419,50 +70372,59 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1128,
-        [((1, 1344, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1128,
+            [((1, 1344, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1129,
-        [((1, 2520, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[2, 2]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "15",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1129,
+            [((1, 2520, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[2, 2]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "15",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1130,
-        [((1, 2520, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1130,
+            [((1, 2520, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_32gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1131,
@@ -69688,20 +70650,23 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1141,
-        [((1, 896, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_16gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1141,
+            [((1, 896, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_16gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1142,
@@ -69718,25 +70683,28 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1143,
-        [((1, 2048, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_regnet_regnet_x_16gf_img_cls_torchvision",
-                "pt_resnext_resnext101_32x8d_img_cls_torchhub",
-                "pt_resnext_resnext101_32x8d_wsl_img_cls_torchhub",
-                "pt_resnext_resnext101_64x4d_img_cls_osmr",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1143,
+            [((1, 2048, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_regnet_regnet_x_16gf_img_cls_torchvision",
+                    "pt_resnext_resnext101_32x8d_img_cls_torchhub",
+                    "pt_resnext_resnext101_32x8d_wsl_img_cls_torchhub",
+                    "pt_resnext_resnext101_64x4d_img_cls_osmr",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1144,
@@ -69972,20 +70940,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1159,
-        [((1, 320, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_800mf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1159,
+            [((1, 320, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_800mf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1160,
@@ -70107,20 +71078,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1168,
-        [((1, 784, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_800mf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1168,
+            [((1, 784, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_800mf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1169,
@@ -70137,20 +71111,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1170,
-        [((1, 784, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_800mf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1170,
+            [((1, 784, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_800mf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1171,
@@ -70167,20 +71144,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1172,
-        [((1, 784, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_800mf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1172,
+            [((1, 784, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_800mf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1173,
@@ -70647,20 +71627,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1200,
-        [((1, 1008, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_3_2gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1200,
+            [((1, 1008, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_3_2gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1201,
@@ -70932,20 +71915,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1218,
-        [((1, 576, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_064_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1218,
+            [((1, 576, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_facebook_regnet_y_064_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1219,
@@ -70992,23 +71978,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1222,
-            [((1, 576, 14, 14), torch.float32)],
-            {
-                "model_names": ["pt_regnet_facebook_regnet_y_064_img_cls_hf"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[0, 0, 0, 0]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1222,
+        [((1, 576, 14, 14), torch.float32)],
+        {
+            "model_names": ["pt_regnet_facebook_regnet_y_064_img_cls_hf"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1223,
@@ -71025,20 +72008,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1224,
-        [((1, 1296, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_064_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1224,
+            [((1, 1296, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_facebook_regnet_y_064_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1225,
@@ -71055,20 +72041,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1226,
-        [((1, 1296, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_064_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1226,
+            [((1, 1296, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_regnet_facebook_regnet_y_064_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1227,
@@ -71085,20 +72074,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1228,
-        [((1, 1296, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_064_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1228,
+            [((1, 1296, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_facebook_regnet_y_064_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1229,
@@ -71145,20 +72137,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1232,
-        [((1, 896, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_120_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1232,
+            [((1, 896, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_regnet_facebook_regnet_y_120_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     pytest.param(
         (
@@ -71178,35 +72173,41 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1234,
-        [((1, 2240, 14, 14), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_120_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[2, 2]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "20",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1234,
+            [((1, 2240, 14, 14), torch.float32)],
+            {
+                "model_names": ["pt_regnet_facebook_regnet_y_120_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[2, 2]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "20",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1235,
-        [((1, 2240, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_120_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1235,
+            [((1, 2240, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_facebook_regnet_y_120_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1236,
@@ -71223,20 +72224,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1237,
-        [((1, 2240, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_120_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1237,
+            [((1, 2240, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_regnet_facebook_regnet_y_120_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1238,
@@ -71433,20 +72437,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1250,
-        [((1, 912, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_1_6gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1250,
+            [((1, 912, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_1_6gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1251,
@@ -71778,20 +72785,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1266,
-        [((1, 512, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_040_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1266,
+            [((1, 512, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_facebook_regnet_y_040_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1267,
@@ -71898,20 +72908,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D472,
-        [((1, 1088, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_040_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D472,
+            [((1, 1088, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_facebook_regnet_y_040_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1272,
@@ -71928,20 +72941,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1273,
-        [((1, 1088, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_040_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1273,
+            [((1, 1088, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_regnet_facebook_regnet_y_040_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1274,
@@ -71958,20 +72974,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1275,
-        [((1, 1088, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_facebook_regnet_y_040_img_cls_hf"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1275,
+            [((1, 1088, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_facebook_regnet_y_040_img_cls_hf"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1276,
@@ -72572,23 +73591,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1314,
-            [((1, 528, 96, 96), torch.float32)],
-            {
-                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[0, 0, 0, 0]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1314,
+        [((1, 528, 96, 96), torch.float32)],
+        {
+            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1315,
@@ -72627,20 +73643,23 @@ forge_modules_and_shapes_dtypes_list = [
             )
         ],
     ),
-    (
-        Conv2D1317,
-        [((1, 1056, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1317,
+            [((1, 1056, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1318,
@@ -72657,20 +73676,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1319,
-        [((1, 1056, 48, 48), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1319,
+            [((1, 1056, 48, 48), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1320,
@@ -72687,20 +73709,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1321,
-        [((1, 1056, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1321,
+            [((1, 1056, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1322,
@@ -72735,50 +73760,59 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1324,
-        [((1, 1056, 48, 48), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1324,
+            [((1, 1056, 48, 48), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1325,
-        [((1, 2904, 48, 48), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[2, 2]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "11",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1325,
+            [((1, 2904, 48, 48), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[2, 2]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "11",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1326,
-        [((1, 2904, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1326,
+            [((1, 2904, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1327,
@@ -72795,65 +73829,77 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1328,
-        [((1, 2904, 24, 24), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1328,
+            [((1, 2904, 24, 24), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1329,
-        [((1, 2904, 24, 24), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "11",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1329,
+            [((1, 2904, 24, 24), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "11",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1330,
-        [((1, 2904, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1330,
+            [((1, 2904, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1331,
-        [((1, 726, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1331,
+            [((1, 726, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     pytest.param(
         (
@@ -72873,35 +73919,41 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1333,
-        [((1, 2904, 24, 24), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1333,
+            [((1, 2904, 24, 24), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1334,
-        [((1, 7392, 24, 24), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[2, 2]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "28",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1334,
+            [((1, 7392, 24, 24), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[2, 2]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "28",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     pytest.param(
         (
@@ -72921,20 +73973,23 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1336,
-        [((1, 726, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1336,
+            [((1, 726, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_y_128gf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     pytest.param(
         (
@@ -73104,20 +74159,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1120,
-        [((1, 672, 7, 7), torch.float32)],
-        {
-            "model_names": ["pt_regnet_regnet_x_800mf_img_cls_torchvision"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1120,
+            [((1, 672, 7, 7), torch.float32)],
+            {
+                "model_names": ["pt_regnet_regnet_x_800mf_img_cls_torchvision"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1347,
@@ -73340,32 +74398,35 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D375,
-        [((1, 1024, 14, 14), torch.float32)],
-        {
-            "model_names": [
-                "pt_resnext_resnext50_32x4d_img_cls_osmr",
-                "pt_resnext_resnext50_32x4d_img_cls_torchhub",
-                "pt_resnext_resnext101_32x8d_img_cls_torchhub",
-                "pt_resnext_resnext101_32x8d_wsl_img_cls_torchhub",
-                "pt_resnext_resnext26_32x4d_img_cls_osmr",
-                "pt_resnext_resnext14_32x4d_img_cls_osmr",
-                "pt_resnext_resnext101_64x4d_img_cls_osmr",
-                "pt_wideresnet_wide_resnet101_2_img_cls_timm",
-                "pt_wideresnet_wide_resnet101_2_img_cls_torchvision",
-                "pt_wideresnet_wide_resnet50_2_img_cls_torchvision",
-                "pt_wideresnet_wide_resnet50_2_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D375,
+            [((1, 1024, 14, 14), torch.float32)],
+            {
+                "model_names": [
+                    "pt_resnext_resnext50_32x4d_img_cls_osmr",
+                    "pt_resnext_resnext50_32x4d_img_cls_torchhub",
+                    "pt_resnext_resnext101_32x8d_img_cls_torchhub",
+                    "pt_resnext_resnext101_32x8d_wsl_img_cls_torchhub",
+                    "pt_resnext_resnext26_32x4d_img_cls_osmr",
+                    "pt_resnext_resnext14_32x4d_img_cls_osmr",
+                    "pt_resnext_resnext101_64x4d_img_cls_osmr",
+                    "pt_wideresnet_wide_resnet101_2_img_cls_timm",
+                    "pt_wideresnet_wide_resnet101_2_img_cls_torchvision",
+                    "pt_wideresnet_wide_resnet50_2_img_cls_torchvision",
+                    "pt_wideresnet_wide_resnet50_2_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1353,
@@ -73405,28 +74466,31 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1355,
-        [((1, 2048, 7, 7), torch.float32)],
-        {
-            "model_names": [
-                "pt_resnext_resnext50_32x4d_img_cls_osmr",
-                "pt_resnext_resnext50_32x4d_img_cls_torchhub",
-                "pt_resnext_resnext26_32x4d_img_cls_osmr",
-                "pt_wideresnet_wide_resnet101_2_img_cls_timm",
-                "pt_wideresnet_wide_resnet101_2_img_cls_torchvision",
-                "pt_wideresnet_wide_resnet50_2_img_cls_torchvision",
-                "pt_wideresnet_wide_resnet50_2_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1355,
+            [((1, 2048, 7, 7), torch.float32)],
+            {
+                "model_names": [
+                    "pt_resnext_resnext50_32x4d_img_cls_osmr",
+                    "pt_resnext_resnext50_32x4d_img_cls_torchhub",
+                    "pt_resnext_resnext26_32x4d_img_cls_osmr",
+                    "pt_wideresnet_wide_resnet101_2_img_cls_timm",
+                    "pt_wideresnet_wide_resnet101_2_img_cls_torchvision",
+                    "pt_wideresnet_wide_resnet50_2_img_cls_torchvision",
+                    "pt_wideresnet_wide_resnet50_2_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1354,
@@ -74386,48 +75450,10 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D20,
-        [((1, 1024, 30, 40), torch.float32)],
-        {
-            "model_names": [
-                "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
-                "pt_retinanet_retinanet_rn50fpn_obj_det_hf",
-                "pt_retinanet_retinanet_rn152fpn_obj_det_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
-    (
-        Conv2D22,
-        [((1, 1024, 30, 40), torch.float32)],
-        {
-            "model_names": [
-                "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
-                "pt_retinanet_retinanet_rn50fpn_obj_det_hf",
-                "pt_retinanet_retinanet_rn152fpn_obj_det_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
     pytest.param(
         (
-            Conv2D23,
-            [((1, 512, 30, 40), torch.float32)],
+            Conv2D20,
+            [((1, 1024, 30, 40), torch.float32)],
             {
                 "model_names": [
                     "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
@@ -74436,8 +75462,8 @@ forge_modules_and_shapes_dtypes_list = [
                 ],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -74445,6 +75471,47 @@ forge_modules_and_shapes_dtypes_list = [
             },
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    ),
+    pytest.param(
+        (
+            Conv2D22,
+            [((1, 1024, 30, 40), torch.float32)],
+            {
+                "model_names": [
+                    "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
+                    "pt_retinanet_retinanet_rn50fpn_obj_det_hf",
+                    "pt_retinanet_retinanet_rn152fpn_obj_det_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    ),
+    (
+        Conv2D23,
+        [((1, 512, 30, 40), torch.float32)],
+        {
+            "model_names": [
+                "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
+                "pt_retinanet_retinanet_rn50fpn_obj_det_hf",
+                "pt_retinanet_retinanet_rn152fpn_obj_det_hf",
+            ],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
     ),
     (
         Conv2D24,
@@ -74487,47 +75554,9 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D26,
-        [((1, 2048, 15, 20), torch.float32)],
-        {
-            "model_names": [
-                "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
-                "pt_retinanet_retinanet_rn50fpn_obj_det_hf",
-                "pt_retinanet_retinanet_rn152fpn_obj_det_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
-    (
-        Conv2D28,
-        [((1, 2048, 15, 20), torch.float32)],
-        {
-            "model_names": [
-                "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
-                "pt_retinanet_retinanet_rn50fpn_obj_det_hf",
-                "pt_retinanet_retinanet_rn152fpn_obj_det_hf",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
     pytest.param(
         (
-            Conv2D1368,
+            Conv2D26,
             [((1, 2048, 15, 20), torch.float32)],
             {
                 "model_names": [
@@ -74537,8 +75566,8 @@ forge_modules_and_shapes_dtypes_list = [
                 ],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -74546,6 +75575,47 @@ forge_modules_and_shapes_dtypes_list = [
             },
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    ),
+    pytest.param(
+        (
+            Conv2D28,
+            [((1, 2048, 15, 20), torch.float32)],
+            {
+                "model_names": [
+                    "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
+                    "pt_retinanet_retinanet_rn50fpn_obj_det_hf",
+                    "pt_retinanet_retinanet_rn152fpn_obj_det_hf",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    ),
+    (
+        Conv2D1368,
+        [((1, 2048, 15, 20), torch.float32)],
+        {
+            "model_names": [
+                "pt_retinanet_retinanet_rn101fpn_obj_det_hf",
+                "pt_retinanet_retinanet_rn50fpn_obj_det_hf",
+                "pt_retinanet_retinanet_rn152fpn_obj_det_hf",
+            ],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
     ),
     (
         Conv2D863,
@@ -74944,31 +76014,16 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D20,
-        [((1, 1024, 38, 38), torch.float32)],
-        {
-            "model_names": ["pt_ssd300_resnet50_base_img_cls_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
     pytest.param(
         (
-            Conv2D1370,
+            Conv2D20,
             [((1, 1024, 38, 38), torch.float32)],
             {
                 "model_names": ["pt_ssd300_resnet50_base_img_cls_torchhub"],
                 "pcc": 0.99,
                 "args": {
                     "stride": "[1, 1]",
-                    "padding": "[1, 1, 1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -74976,6 +76031,21 @@ forge_modules_and_shapes_dtypes_list = [
             },
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    ),
+    (
+        Conv2D1370,
+        [((1, 1024, 38, 38), torch.float32)],
+        {
+            "model_names": ["pt_ssd300_resnet50_base_img_cls_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
     ),
     (
         Conv2D448,
@@ -75193,23 +76263,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1375,
-            [((1, 1024, 38, 38), torch.float32)],
-            {
-                "model_names": ["pt_ssd300_resnet50_base_img_cls_torchhub"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[1, 1]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1375,
+        [((1, 1024, 38, 38), torch.float32)],
+        {
+            "model_names": ["pt_ssd300_resnet50_base_img_cls_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1376,
@@ -75505,64 +76572,55 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1380,
-            [((1, 1024, 14, 14), torch.float32)],
-            {
-                "model_names": ["pt_unet_carvana_base_img_seg_github"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[1, 1]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1380,
+        [((1, 1024, 14, 14), torch.float32)],
+        {
+            "model_names": ["pt_unet_carvana_base_img_seg_github"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
-    pytest.param(
-        (
-            Conv2D1381,
-            [((1, 1024, 14, 14), torch.float32)],
-            {
-                "model_names": [
-                    "pt_wideresnet_wide_resnet101_2_img_cls_timm",
-                    "pt_wideresnet_wide_resnet101_2_img_cls_torchvision",
-                    "pt_wideresnet_wide_resnet50_2_img_cls_torchvision",
-                    "pt_wideresnet_wide_resnet50_2_img_cls_timm",
-                ],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1381,
+        [((1, 1024, 14, 14), torch.float32)],
+        {
+            "model_names": [
+                "pt_wideresnet_wide_resnet101_2_img_cls_timm",
+                "pt_wideresnet_wide_resnet101_2_img_cls_torchvision",
+                "pt_wideresnet_wide_resnet50_2_img_cls_torchvision",
+                "pt_wideresnet_wide_resnet50_2_img_cls_timm",
+            ],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
-    pytest.param(
-        (
-            Conv2D1382,
-            [((1, 1024, 28, 28), torch.float32)],
-            {
-                "model_names": ["pt_unet_carvana_base_img_seg_github"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[1, 1]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1382,
+        [((1, 1024, 28, 28), torch.float32)],
+        {
+            "model_names": ["pt_unet_carvana_base_img_seg_github"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     pytest.param(
         (
@@ -75582,23 +76640,20 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    pytest.param(
-        (
-            Conv2D324,
-            [((1, 256, 112, 112), torch.float32)],
-            {
-                "model_names": ["pt_unet_carvana_base_img_seg_github"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[1, 1]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D324,
+        [((1, 256, 112, 112), torch.float32)],
+        {
+            "model_names": ["pt_unet_carvana_base_img_seg_github"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     pytest.param(
         (
@@ -75651,23 +76706,20 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    pytest.param(
-        (
-            Conv2D1385,
-            [((1, 768, 28, 28), torch.float32)],
-            {
-                "model_names": ["pt_unet_qubvel_img_seg_torchhub"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[1, 1]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1385,
+        [((1, 768, 28, 28), torch.float32)],
+        {
+            "model_names": ["pt_unet_qubvel_img_seg_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1386,
@@ -75744,23 +76796,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1387,
-            [((1, 1024, 28, 28), torch.float32)],
-            {
-                "model_names": ["pt_unet_cityscape_img_seg_osmr"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[1, 1]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1387,
+        [((1, 1024, 28, 28), torch.float32)],
+        {
+            "model_names": ["pt_unet_cityscape_img_seg_osmr"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     pytest.param(
         (
@@ -75780,23 +76829,20 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    pytest.param(
-        (
-            Conv2D392,
-            [((1, 256, 112, 112), torch.float32)],
-            {
-                "model_names": ["pt_unet_cityscape_img_seg_osmr"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[1, 1]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D392,
+        [((1, 256, 112, 112), torch.float32)],
+        {
+            "model_names": ["pt_unet_cityscape_img_seg_osmr"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1389,
@@ -75831,20 +76877,23 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1391,
-        [((1, 4096, 1, 1), torch.float32)],
-        {
-            "model_names": ["pt_vgg_vgg19_bn_obj_det_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1391,
+            [((1, 4096, 1, 1), torch.float32)],
+            {
+                "model_names": ["pt_vgg_vgg19_bn_obj_det_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     pytest.param(
         (
@@ -75879,20 +76928,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1394,
-        [((1, 1312, 28, 28), torch.float32)],
-        {
-            "model_names": ["pt_vovnet_ese_vovnet99b_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1394,
+            [((1, 1312, 28, 28), torch.float32)],
+            {
+                "model_names": ["pt_vovnet_ese_vovnet99b_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1395,
@@ -75948,28 +77000,25 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1380,
-            [((1, 1024, 7, 7), torch.float32)],
-            {
-                "model_names": [
-                    "pt_wideresnet_wide_resnet101_2_img_cls_timm",
-                    "pt_wideresnet_wide_resnet101_2_img_cls_torchvision",
-                    "pt_wideresnet_wide_resnet50_2_img_cls_torchvision",
-                    "pt_wideresnet_wide_resnet50_2_img_cls_timm",
-                ],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[1, 1]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1380,
+        [((1, 1024, 7, 7), torch.float32)],
+        {
+            "model_names": [
+                "pt_wideresnet_wide_resnet101_2_img_cls_timm",
+                "pt_wideresnet_wide_resnet101_2_img_cls_torchvision",
+                "pt_wideresnet_wide_resnet50_2_img_cls_torchvision",
+                "pt_wideresnet_wide_resnet50_2_img_cls_timm",
+            ],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D311,
@@ -76376,35 +77425,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1402,
-        [((1, 728, 38, 38), torch.float32)],
-        {
-            "model_names": [
-                "pt_xception_xception71_img_cls_timm",
-                "pt_xception_xception65_img_cls_timm",
-                "pt_xception_xception41_img_cls_timm",
-                "pt_xception_xception71_tf_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
     pytest.param(
         (
-            Conv2D1403,
+            Conv2D1402,
             [((1, 728, 38, 38), torch.float32)],
             {
-                "model_names": ["pt_xception_xception71_img_cls_timm", "pt_xception_xception71_tf_in1k_img_cls_timm"],
+                "model_names": [
+                    "pt_xception_xception71_img_cls_timm",
+                    "pt_xception_xception65_img_cls_timm",
+                    "pt_xception_xception41_img_cls_timm",
+                    "pt_xception_xception71_tf_in1k_img_cls_timm",
+                ],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
+                    "stride": "[1, 1]",
                     "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
@@ -76415,25 +77449,43 @@ forge_modules_and_shapes_dtypes_list = [
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
-        Conv2D1402,
-        [((1, 728, 19, 19), torch.float32)],
+        Conv2D1403,
+        [((1, 728, 38, 38), torch.float32)],
         {
-            "model_names": [
-                "pt_xception_xception71_img_cls_timm",
-                "pt_xception_xception65_img_cls_timm",
-                "pt_xception_xception41_img_cls_timm",
-                "pt_xception_xception_img_cls_timm",
-                "pt_xception_xception71_tf_in1k_img_cls_timm",
-            ],
+            "model_names": ["pt_xception_xception71_img_cls_timm", "pt_xception_xception71_tf_in1k_img_cls_timm"],
             "pcc": 0.99,
             "args": {
-                "stride": "[1, 1]",
+                "stride": "[2, 2]",
                 "padding": "[0, 0, 0, 0]",
                 "dilation": "1",
                 "groups": "1",
                 "channel_last": "0",
             },
         },
+    ),
+    pytest.param(
+        (
+            Conv2D1402,
+            [((1, 728, 19, 19), torch.float32)],
+            {
+                "model_names": [
+                    "pt_xception_xception71_img_cls_timm",
+                    "pt_xception_xception65_img_cls_timm",
+                    "pt_xception_xception41_img_cls_timm",
+                    "pt_xception_xception_img_cls_timm",
+                    "pt_xception_xception71_tf_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1400,
@@ -76456,26 +77508,29 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1404,
-        [((1, 728, 19, 19), torch.float32)],
-        {
-            "model_names": [
-                "pt_xception_xception71_img_cls_timm",
-                "pt_xception_xception65_img_cls_timm",
-                "pt_xception_xception41_img_cls_timm",
-                "pt_xception_xception_img_cls_timm",
-                "pt_xception_xception71_tf_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1404,
+            [((1, 728, 19, 19), torch.float32)],
+            {
+                "model_names": [
+                    "pt_xception_xception71_img_cls_timm",
+                    "pt_xception_xception65_img_cls_timm",
+                    "pt_xception_xception41_img_cls_timm",
+                    "pt_xception_xception_img_cls_timm",
+                    "pt_xception_xception71_tf_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     pytest.param(
         (
@@ -76521,25 +77576,28 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D375,
-        [((1, 1024, 10, 10), torch.float32)],
-        {
-            "model_names": [
-                "pt_xception_xception71_img_cls_timm",
-                "pt_xception_xception65_img_cls_timm",
-                "pt_xception_xception41_img_cls_timm",
-                "pt_xception_xception71_tf_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D375,
+            [((1, 1024, 10, 10), torch.float32)],
+            {
+                "model_names": [
+                    "pt_xception_xception71_img_cls_timm",
+                    "pt_xception_xception65_img_cls_timm",
+                    "pt_xception_xception41_img_cls_timm",
+                    "pt_xception_xception71_tf_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D870,
@@ -76562,26 +77620,29 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1407,
-        [((1, 1024, 10, 10), torch.float32)],
-        {
-            "model_names": [
-                "pt_xception_xception71_img_cls_timm",
-                "pt_xception_xception65_img_cls_timm",
-                "pt_xception_xception41_img_cls_timm",
-                "pt_xception_xception_img_cls_timm",
-                "pt_xception_xception71_tf_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1407,
+            [((1, 1024, 10, 10), torch.float32)],
+            {
+                "model_names": [
+                    "pt_xception_xception71_img_cls_timm",
+                    "pt_xception_xception65_img_cls_timm",
+                    "pt_xception_xception41_img_cls_timm",
+                    "pt_xception_xception_img_cls_timm",
+                    "pt_xception_xception71_tf_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1408,
@@ -76604,46 +77665,52 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1409,
-        [((1, 1536, 10, 10), torch.float32)],
-        {
-            "model_names": [
-                "pt_xception_xception71_img_cls_timm",
-                "pt_xception_xception65_img_cls_timm",
-                "pt_xception_xception41_img_cls_timm",
-                "pt_xception_xception71_tf_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1409,
+            [((1, 1536, 10, 10), torch.float32)],
+            {
+                "model_names": [
+                    "pt_xception_xception71_img_cls_timm",
+                    "pt_xception_xception65_img_cls_timm",
+                    "pt_xception_xception41_img_cls_timm",
+                    "pt_xception_xception71_tf_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1410,
-        [((1, 1536, 10, 10), torch.float32)],
-        {
-            "model_names": [
-                "pt_xception_xception71_img_cls_timm",
-                "pt_xception_xception65_img_cls_timm",
-                "pt_xception_xception41_img_cls_timm",
-                "pt_xception_xception_img_cls_timm",
-                "pt_xception_xception71_tf_in1k_img_cls_timm",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1410,
+            [((1, 1536, 10, 10), torch.float32)],
+            {
+                "model_names": [
+                    "pt_xception_xception71_img_cls_timm",
+                    "pt_xception_xception65_img_cls_timm",
+                    "pt_xception_xception41_img_cls_timm",
+                    "pt_xception_xception_img_cls_timm",
+                    "pt_xception_xception71_tf_in1k_img_cls_timm",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D859,
@@ -76870,20 +77937,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1402,
-        [((1, 728, 37, 37), torch.float32)],
-        {
-            "model_names": ["pt_xception_xception_img_cls_timm"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1402,
+            [((1, 728, 37, 37), torch.float32)],
+            {
+                "model_names": ["pt_xception_xception_img_cls_timm"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D864,
@@ -77437,23 +78507,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1433,
-        [((1, 1024, 15, 15), torch.float32)],
-        {
-            "model_names": [
-                "pt_yolo_v5_yolov5s_img_cls_torchhub_480x480",
-                "pt_yolo_v5_yolov5l_img_cls_torchhub_480x480",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1433,
+            [((1, 1024, 15, 15), torch.float32)],
+            {
+                "model_names": [
+                    "pt_yolo_v5_yolov5s_img_cls_torchhub_480x480",
+                    "pt_yolo_v5_yolov5l_img_cls_torchhub_480x480",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1434,
@@ -77590,20 +78663,27 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1440,
-        [((1, 3, 640, 640), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[2, 2]",
-                "padding": "[2, 2, 2, 2]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1440,
+            [((1, 3, 640, 640), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[2, 2]",
+                    "padding": "[2, 2, 2, 2]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:877: tt::exception info: Statically allocated circular buffers in program 44101 clash with L1 buffers on core range [(x=0,y=0) - (x=7,y=7)]. L1 buffer allocated at 563456 and static circular buffer region ends at 568352"
+            )
+        ],
     ),
     pytest.param(
         (
@@ -77687,23 +78767,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1446,
-            [((1, 160, 160, 160), torch.float32)],
-            {
-                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1446,
+        [((1, 160, 160, 160), torch.float32)],
+        {
+            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1447,
@@ -77768,16 +78845,31 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
+    (
+        Conv2D1450,
+        [((1, 320, 80, 80), torch.float32)],
+        {
+            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
     pytest.param(
         (
-            Conv2D1450,
-            [((1, 320, 80, 80), torch.float32)],
+            Conv2D1451,
+            [((1, 640, 40, 40), torch.float32)],
             {
                 "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -77785,21 +78877,6 @@ forge_modules_and_shapes_dtypes_list = [
             },
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    (
-        Conv2D1451,
-        [((1, 640, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
     ),
     (
         Conv2D1449,
@@ -77849,31 +78926,16 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1454,
-        [((1, 640, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
     pytest.param(
         (
-            Conv2D1455,
+            Conv2D1454,
             [((1, 640, 40, 40), torch.float32)],
             {
                 "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -77883,37 +78945,58 @@ forge_modules_and_shapes_dtypes_list = [
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
-        Conv2D1456,
-        [((1, 1280, 20, 20), torch.float32)],
+        Conv2D1455,
+        [((1, 640, 40, 40), torch.float32)],
         {
             "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
             "pcc": 0.99,
             "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
                 "dilation": "1",
                 "groups": "1",
                 "channel_last": "0",
             },
         },
     ),
-    (
-        Conv2D1454,
-        [((1, 640, 20, 20), torch.float32)],
-        {
-            "model_names": [
-                "pt_yolo_v5_yolov5x_img_cls_torchhub_640x640",
-                "pt_yolo_v5_yolov5x_img_cls_torchhub_320x320",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1456,
+            [((1, 1280, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    ),
+    pytest.param(
+        (
+            Conv2D1454,
+            [((1, 640, 20, 20), torch.float32)],
+            {
+                "model_names": [
+                    "pt_yolo_v5_yolov5x_img_cls_torchhub_640x640",
+                    "pt_yolo_v5_yolov5x_img_cls_torchhub_320x320",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1457,
@@ -77945,50 +79028,59 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1459,
-        [((1, 1280, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1459,
+            [((1, 1280, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1460,
-        [((1, 2560, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1460,
+            [((1, 2560, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1461,
-        [((1, 1280, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1461,
+            [((1, 1280, 40, 40), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1462,
@@ -78020,23 +79112,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1453,
-            [((1, 320, 80, 80), torch.float32)],
-            {
-                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1453,
+        [((1, 320, 80, 80), torch.float32)],
+        {
+            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1464,
@@ -78053,16 +79142,31 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
+    (
+        Conv2D1458,
+        [((1, 640, 40, 40), torch.float32)],
+        {
+            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
     pytest.param(
         (
-            Conv2D1458,
-            [((1, 640, 40, 40), torch.float32)],
+            Conv2D1465,
+            [((1, 1280, 20, 20), torch.float32)],
             {
                 "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -78070,21 +79174,6 @@ forge_modules_and_shapes_dtypes_list = [
             },
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    (
-        Conv2D1465,
-        [((1, 1280, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
     ),
     pytest.param(
         (
@@ -78281,26 +79370,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1424,
-            [((1, 128, 160, 160), torch.float32)],
-            {
-                "model_names": [
-                    "pt_yolo_v5_yolov5s_img_cls_torchhub_1280x1280",
-                    "pt_yolo_v5_yolov5l_img_cls_torchhub_640x640",
-                ],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1424,
+        [((1, 128, 160, 160), torch.float32)],
+        {
+            "model_names": [
+                "pt_yolo_v5_yolov5s_img_cls_torchhub_1280x1280",
+                "pt_yolo_v5_yolov5l_img_cls_torchhub_640x640",
+            ],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1425,
@@ -78501,20 +79587,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1433,
-        [((1, 1024, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5s_img_cls_torchhub_1280x1280"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1433,
+            [((1, 1024, 40, 40), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5s_img_cls_torchhub_1280x1280"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1434,
@@ -78564,23 +79653,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1427,
-            [((1, 128, 160, 160), torch.float32)],
-            {
-                "model_names": ["pt_yolo_v5_yolov5s_img_cls_torchhub_1280x1280"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1427,
+        [((1, 128, 160, 160), torch.float32)],
+        {
+            "model_names": ["pt_yolo_v5_yolov5s_img_cls_torchhub_1280x1280"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1437,
@@ -78651,16 +79737,34 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
+    (
+        Conv2D1467,
+        [((1, 512, 40, 40), torch.float32)],
+        {
+            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_640x640"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
     pytest.param(
         (
-            Conv2D1467,
-            [((1, 512, 40, 40), torch.float32)],
+            Conv2D1433,
+            [((1, 1024, 20, 20), torch.float32)],
             {
-                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_640x640"],
+                "model_names": [
+                    "pt_yolo_v5_yolov5l_img_cls_torchhub_640x640",
+                    "pt_yolo_v5_yolov5s_img_cls_torchhub_640x640",
+                ],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -78668,24 +79772,6 @@ forge_modules_and_shapes_dtypes_list = [
             },
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    (
-        Conv2D1433,
-        [((1, 1024, 20, 20), torch.float32)],
-        {
-            "model_names": [
-                "pt_yolo_v5_yolov5l_img_cls_torchhub_640x640",
-                "pt_yolo_v5_yolov5s_img_cls_torchhub_640x640",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
     ),
     (
         Conv2D1432,
@@ -78736,61 +79822,52 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1470,
-        [((1, 1024, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
-    (
-        Conv2D1471,
-        [((1, 2048, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
-    (
-        Conv2D1472,
-        [((1, 1024, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
     pytest.param(
         (
-            Conv2D1469,
-            [((1, 512, 40, 40), torch.float32)],
+            Conv2D1470,
+            [((1, 1024, 20, 20), torch.float32)],
             {
                 "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_640x640"],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    ),
+    pytest.param(
+        (
+            Conv2D1471,
+            [((1, 2048, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    ),
+    pytest.param(
+        (
+            Conv2D1472,
+            [((1, 1024, 40, 40), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -78800,19 +79877,37 @@ forge_modules_and_shapes_dtypes_list = [
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
-        Conv2D1473,
-        [((1, 1024, 20, 20), torch.float32)],
+        Conv2D1469,
+        [((1, 512, 40, 40), torch.float32)],
         {
             "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_640x640"],
             "pcc": 0.99,
             "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
                 "dilation": "1",
                 "groups": "1",
                 "channel_last": "0",
             },
         },
+    ),
+    pytest.param(
+        (
+            Conv2D1473,
+            [((1, 1024, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1440,
@@ -78904,23 +79999,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1446,
-            [((1, 160, 120, 120), torch.float32)],
-            {
-                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D1446,
+        [((1, 160, 120, 120), torch.float32)],
+        {
+            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1447,
@@ -79042,31 +80134,16 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1454,
-        [((1, 640, 30, 30), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
     pytest.param(
         (
-            Conv2D1455,
+            Conv2D1454,
             [((1, 640, 30, 30), torch.float32)],
             {
                 "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -79076,19 +80153,37 @@ forge_modules_and_shapes_dtypes_list = [
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
-        Conv2D1456,
-        [((1, 1280, 15, 15), torch.float32)],
+        Conv2D1455,
+        [((1, 640, 30, 30), torch.float32)],
         {
             "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
             "pcc": 0.99,
             "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
                 "dilation": "1",
                 "groups": "1",
                 "channel_last": "0",
             },
         },
+    ),
+    pytest.param(
+        (
+            Conv2D1456,
+            [((1, 1280, 15, 15), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1454,
@@ -79120,50 +80215,59 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1459,
-        [((1, 1280, 15, 15), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1459,
+            [((1, 1280, 15, 15), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1460,
-        [((1, 2560, 15, 15), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1460,
+            [((1, 2560, 15, 15), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1461,
-        [((1, 1280, 30, 30), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1461,
+            [((1, 1280, 30, 30), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1462,
@@ -79225,16 +80329,31 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
+    (
+        Conv2D1458,
+        [((1, 640, 30, 30), torch.float32)],
+        {
+            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
     pytest.param(
         (
-            Conv2D1458,
-            [((1, 640, 30, 30), torch.float32)],
+            Conv2D1465,
+            [((1, 1280, 15, 15), torch.float32)],
             {
                 "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -79242,21 +80361,6 @@ forge_modules_and_shapes_dtypes_list = [
             },
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    (
-        Conv2D1465,
-        [((1, 1280, 15, 15), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
     ),
     (
         Conv2D1466,
@@ -79559,23 +80663,26 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1433,
-        [((1, 1024, 10, 10), torch.float32)],
-        {
-            "model_names": [
-                "pt_yolo_v5_yolov5l_img_cls_torchhub_320x320",
-                "pt_yolo_v5_yolov5s_img_cls_torchhub_320x320",
-            ],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1433,
+            [((1, 1024, 10, 10), torch.float32)],
+            {
+                "model_names": [
+                    "pt_yolo_v5_yolov5l_img_cls_torchhub_320x320",
+                    "pt_yolo_v5_yolov5s_img_cls_torchhub_320x320",
+                ],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1432,
@@ -79610,50 +80717,59 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1470,
-        [((1, 1024, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1470,
+            [((1, 1024, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1471,
-        [((1, 2048, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1471,
+            [((1, 2048, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1472,
-        [((1, 1024, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1472,
+            [((1, 1024, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1434,
@@ -79709,20 +80825,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1473,
-        [((1, 1024, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1473,
+            [((1, 1024, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1466,
@@ -79919,50 +81038,59 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1470,
-        [((1, 1024, 15, 15), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1470,
+            [((1, 1024, 15, 15), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1471,
-        [((1, 2048, 15, 15), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1471,
+            [((1, 2048, 15, 15), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1472,
-        [((1, 1024, 30, 30), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1472,
+            [((1, 1024, 30, 30), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1434,
@@ -80039,20 +81167,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1473,
-        [((1, 1024, 15, 15), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1473,
+            [((1, 1024, 15, 15), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1474,
@@ -80648,20 +81779,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1496,
-        [((1, 768, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1496,
+            [((1, 768, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1494,
@@ -80708,35 +81842,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1499,
-        [((1, 1536, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1499,
+            [((1, 1536, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1500,
-        [((1, 768, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1500,
+            [((1, 768, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1501,
@@ -80843,20 +81983,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1506,
-        [((1, 768, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1506,
+            [((1, 768, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1474,
@@ -81812,65 +82955,77 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1496,
-        [((1, 768, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1496,
+            [((1, 768, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1498,
-        [((1, 768, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1498,
+            [((1, 768, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1499,
-        [((1, 1536, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1499,
+            [((1, 1536, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1500,
-        [((1, 768, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1500,
+            [((1, 768, 40, 40), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1501,
@@ -81947,20 +83102,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1506,
-        [((1, 768, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_640x640"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1506,
+            [((1, 768, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_640x640"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1474,
@@ -82340,20 +83498,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1496,
-        [((1, 768, 15, 15), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1496,
+            [((1, 768, 15, 15), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1494,
@@ -82400,20 +83561,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1499,
-        [((1, 1536, 15, 15), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1499,
+            [((1, 1536, 15, 15), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1500,
@@ -82505,20 +83669,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1506,
-        [((1, 768, 15, 15), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1506,
+            [((1, 768, 15, 15), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5m_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1440,
@@ -82670,20 +83837,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1451,
-        [((1, 640, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1451,
+            [((1, 640, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1449,
@@ -82730,20 +83900,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1456,
-        [((1, 1280, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1456,
+            [((1, 1280, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1454,
@@ -82775,50 +83948,59 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1459,
-        [((1, 1280, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1459,
+            [((1, 1280, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1460,
-        [((1, 2560, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1460,
+            [((1, 2560, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1461,
-        [((1, 1280, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1461,
+            [((1, 1280, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1462,
@@ -82865,20 +84047,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1465,
-        [((1, 1280, 10, 10), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_320x320"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1465,
+            [((1, 1280, 10, 10), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5x_img_cls_torchhub_320x320"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1413,
@@ -83237,20 +84422,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1524,
-        [((1, 768, 14, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1524,
+            [((1, 768, 14, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1525,
@@ -83271,65 +84459,77 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1526,
-        [((1, 1024, 14, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1526,
+            [((1, 1024, 14, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1527,
-        [((1, 768, 14, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1527,
+            [((1, 768, 14, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1528,
-        [((1, 1536, 14, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1528,
+            [((1, 1536, 14, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1529,
-        [((1, 768, 14, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1529,
+            [((1, 768, 14, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v6_yolov6m_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1530,
@@ -84471,20 +85671,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1576,
-        [((1, 1024, 14, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v6_yolov6s_obj_det_torchhub", "pt_yolo_v6_yolov6l_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1576,
+            [((1, 1024, 14, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v6_yolov6s_obj_det_torchhub", "pt_yolo_v6_yolov6l_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1577,
@@ -84846,16 +86049,31 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
+    (
+        Conv2D1582,
+        [((1, 512, 28, 40), torch.float32)],
+        {
+            "model_names": ["pt_yolo_v6_yolov6l_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
     pytest.param(
         (
-            Conv2D1582,
-            [((1, 512, 28, 40), torch.float32)],
+            Conv2D1583,
+            [((1, 1024, 14, 20), torch.float32)],
             {
                 "model_names": ["pt_yolo_v6_yolov6l_obj_det_torchhub"],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -84864,50 +86082,41 @@ forge_modules_and_shapes_dtypes_list = [
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1583,
-        [((1, 1024, 14, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v6_yolov6l_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1584,
+            [((1, 1024, 14, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v6_yolov6l_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1584,
-        [((1, 1024, 14, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v6_yolov6l_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1585,
+            [((1, 2048, 14, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v6_yolov6l_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
-    ),
-    (
-        Conv2D1585,
-        [((1, 2048, 14, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v6_yolov6l_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1521,
@@ -85189,23 +86398,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D683,
-            [((1, 160, 160, 160), torch.float32)],
-            {
-                "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D683,
+        [((1, 160, 160, 160), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1592,
@@ -85267,16 +86473,31 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
+    (
+        Conv2D1593,
+        [((1, 320, 80, 80), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
     pytest.param(
         (
-            Conv2D1593,
-            [((1, 320, 80, 80), torch.float32)],
+            Conv2D1594,
+            [((1, 640, 40, 40), torch.float32)],
             {
                 "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -85284,21 +86505,6 @@ forge_modules_and_shapes_dtypes_list = [
             },
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    (
-        Conv2D1594,
-        [((1, 640, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
     ),
     (
         Conv2D1161,
@@ -85330,31 +86536,16 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1595,
-        [((1, 640, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
     pytest.param(
         (
-            Conv2D1596,
+            Conv2D1595,
             [((1, 640, 40, 40), torch.float32)],
             {
                 "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
                 "pcc": 0.99,
                 "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -85364,49 +86555,73 @@ forge_modules_and_shapes_dtypes_list = [
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
-        Conv2D499,
-        [((1, 1280, 20, 20), torch.float32)],
+        Conv2D1596,
+        [((1, 640, 40, 40), torch.float32)],
         {
             "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
             "pcc": 0.99,
             "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
                 "dilation": "1",
                 "groups": "1",
                 "channel_last": "0",
             },
         },
     ),
-    (
-        Conv2D1597,
-        [((1, 2560, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D499,
+            [((1, 1280, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1595,
-        [((1, 640, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1597,
+            [((1, 2560, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    ),
+    pytest.param(
+        (
+            Conv2D1595,
+            [((1, 640, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
+            },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1598,
@@ -85423,35 +86638,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1599,
-        [((1, 1280, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1599,
+            [((1, 1280, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1600,
-        [((1, 1280, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1600,
+            [((1, 1280, 40, 40), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1601,
@@ -85468,16 +86689,151 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
+    (
+        Conv2D769,
+        [((1, 320, 80, 80), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
+    (
+        Conv2D1602,
+        [((1, 320, 80, 80), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
+    (
+        Conv2D1603,
+        [((1, 320, 80, 80), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
+    (
+        Conv2D1604,
+        [((1, 320, 80, 80), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
+    (
+        Conv2D1163,
+        [((1, 320, 80, 80), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
+    (
+        Conv2D1603,
+        [((1, 320, 40, 40), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
+    (
+        Conv2D1604,
+        [((1, 320, 40, 40), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
+    (
+        Conv2D1163,
+        [((1, 320, 40, 40), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[1, 1]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
+    (
+        Conv2D1605,
+        [((1, 640, 40, 40), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
+            },
+        },
+    ),
     pytest.param(
         (
-            Conv2D769,
-            [((1, 320, 80, 80), torch.float32)],
+            Conv2D1600,
+            [((1, 1280, 20, 20), torch.float32)],
             {
                 "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
                 "pcc": 0.99,
                 "args": {
                     "stride": "[1, 1]",
-                    "padding": "[1, 1, 1, 1]",
+                    "padding": "[0, 0, 0, 0]",
                     "dilation": "1",
                     "groups": "1",
                     "channel_last": "0",
@@ -85485,147 +86841,6 @@ forge_modules_and_shapes_dtypes_list = [
             },
         ),
         marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    pytest.param(
-        (
-            Conv2D1602,
-            [((1, 320, 80, 80), torch.float32)],
-            {
-                "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    (
-        Conv2D1603,
-        [((1, 320, 80, 80), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
-    (
-        Conv2D1604,
-        [((1, 320, 80, 80), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
-    (
-        Conv2D1163,
-        [((1, 320, 80, 80), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
-    (
-        Conv2D1603,
-        [((1, 320, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
-    (
-        Conv2D1604,
-        [((1, 320, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
-    (
-        Conv2D1163,
-        [((1, 320, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
-    ),
-    pytest.param(
-        (
-            Conv2D1605,
-            [((1, 640, 40, 40), torch.float32)],
-            {
-                "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
-    ),
-    (
-        Conv2D1600,
-        [((1, 1280, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_x_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
-            },
-        },
     ),
     (
         Conv2D769,
@@ -85942,35 +87157,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D516,
-        [((1, 768, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_m_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D516,
+            [((1, 768, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_m_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D1608,
-        [((1, 1536, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_m_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1608,
+            [((1, 1536, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_m_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D881,
@@ -86002,35 +87223,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D370,
-        [((1, 768, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_m_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D370,
+            [((1, 768, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_m_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D517,
-        [((1, 768, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_m_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D517,
+            [((1, 768, 40, 40), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_m_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D271,
@@ -86182,20 +87409,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D517,
-        [((1, 768, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_m_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D517,
+            [((1, 768, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_m_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D335,
@@ -87236,20 +88466,27 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D95,
-        [((1, 3, 640, 640), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_darknet_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D95,
+            [((1, 3, 640, 640), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_darknet_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[
+            pytest.mark.xfail(
+                reason="RuntimeError: TT_THROW @ /proj_sw/user_dev/pchandrasekaran/Forge3/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/program/program.cpp:877: tt::exception info: Statically allocated circular buffers in program 55482 clash with L1 buffers on core range [(x=0,y=0) - (x=7,y=7)]. L1 buffer allocated at 400640 and static circular buffer region ends at 527392"
+            )
+        ],
     ),
     pytest.param(
         (
@@ -87318,23 +88555,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D395,
-            [((1, 128, 160, 160), torch.float32)],
-            {
-                "model_names": ["pt_yolox_yolox_darknet_obj_det_torchhub", "pt_yolox_yolox_l_obj_det_torchhub"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D395,
+        [((1, 128, 160, 160), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_darknet_obj_det_torchhub", "pt_yolox_yolox_l_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D448,
@@ -87351,23 +88585,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D707,
-            [((1, 512, 40, 40), torch.float32)],
-            {
-                "model_names": ["pt_yolox_yolox_darknet_obj_det_torchhub", "pt_yolox_yolox_l_obj_det_torchhub"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D707,
+        [((1, 512, 40, 40), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_darknet_obj_det_torchhub", "pt_yolox_yolox_l_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D708,
@@ -87384,35 +88615,41 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D26,
-        [((1, 2048, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_darknet_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D26,
+            [((1, 2048, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_darknet_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D330,
-        [((1, 768, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_darknet_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D330,
+            [((1, 768, 40, 40), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_darknet_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D216,
@@ -87864,20 +89101,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D516,
-        [((1, 768, 13, 13), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_tiny_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D516,
+            [((1, 768, 13, 13), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_tiny_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D368,
@@ -88239,50 +89479,59 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1355,
-        [((1, 2048, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_l_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D1355,
+            [((1, 2048, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_l_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D375,
-        [((1, 1024, 20, 20), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_l_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D375,
+            [((1, 1024, 20, 20), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_l_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
-    (
-        Conv2D20,
-        [((1, 1024, 40, 40), torch.float32)],
-        {
-            "model_names": ["pt_yolox_yolox_l_obj_det_torchhub"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "0",
+    pytest.param(
+        (
+            Conv2D20,
+            [((1, 1024, 40, 40), torch.float32)],
+            {
+                "model_names": ["pt_yolox_yolox_l_obj_det_torchhub"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "0",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D14,
@@ -88299,23 +89548,20 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D23,
-            [((1, 512, 40, 40), torch.float32)],
-            {
-                "model_names": ["pt_yolox_yolox_l_obj_det_torchhub"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[1, 1, 1, 1]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "0",
-                },
+    (
+        Conv2D23,
+        [((1, 512, 40, 40), torch.float32)],
+        {
+            "model_names": ["pt_yolox_yolox_l_obj_det_torchhub"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[1, 1, 1, 1]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "0",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1628,
@@ -88467,41 +89713,35 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    pytest.param(
-        (
-            Conv2D1631,
-            [((1, 28, 27, 512), torch.float32), ((1024, 512, 1, 1), torch.float32), ((1024,), torch.float32)],
-            {
-                "model_names": ["tf_resnet_resnet50_img_cls_keras"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[0, 0, 0, 0]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "1",
-                },
+    (
+        Conv2D1631,
+        [((1, 28, 27, 512), torch.float32), ((1024, 512, 1, 1), torch.float32), ((1024,), torch.float32)],
+        {
+            "model_names": ["tf_resnet_resnet50_img_cls_keras"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "1",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
-    pytest.param(
-        (
-            Conv2D1631,
-            [((1, 28, 27, 512), torch.float32), ((256, 512, 1, 1), torch.float32), ((256,), torch.float32)],
-            {
-                "model_names": ["tf_resnet_resnet50_img_cls_keras"],
-                "pcc": 0.99,
-                "args": {
-                    "stride": "[2, 2]",
-                    "padding": "[0, 0, 0, 0]",
-                    "dilation": "1",
-                    "groups": "1",
-                    "channel_last": "1",
-                },
+    (
+        Conv2D1631,
+        [((1, 28, 27, 512), torch.float32), ((256, 512, 1, 1), torch.float32), ((256,), torch.float32)],
+        {
+            "model_names": ["tf_resnet_resnet50_img_cls_keras"],
+            "pcc": 0.99,
+            "args": {
+                "stride": "[2, 2]",
+                "padding": "[0, 0, 0, 0]",
+                "dilation": "1",
+                "groups": "1",
+                "channel_last": "1",
             },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+        },
     ),
     (
         Conv2D1630,
@@ -88533,20 +89773,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1629,
-        [((1, 14, 14, 1024), torch.float32), ((256, 1024, 1, 1), torch.float32), ((256,), torch.float32)],
-        {
-            "model_names": ["tf_resnet_resnet50_img_cls_keras"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "1",
+    pytest.param(
+        (
+            Conv2D1629,
+            [((1, 14, 14, 1024), torch.float32), ((256, 1024, 1, 1), torch.float32), ((256,), torch.float32)],
+            {
+                "model_names": ["tf_resnet_resnet50_img_cls_keras"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "1",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     pytest.param(
         (
@@ -88614,20 +89857,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1629,
-        [((1, 7, 7, 2048), torch.float32), ((512, 2048, 1, 1), torch.float32), ((512,), torch.float32)],
-        {
-            "model_names": ["tf_resnet_resnet50_img_cls_keras"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[1, 1]",
-                "padding": "[0, 0, 0, 0]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "1",
+    pytest.param(
+        (
+            Conv2D1629,
+            [((1, 7, 7, 2048), torch.float32), ((512, 2048, 1, 1), torch.float32), ((512,), torch.float32)],
+            {
+                "model_names": ["tf_resnet_resnet50_img_cls_keras"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[1, 1]",
+                    "padding": "[0, 0, 0, 0]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "1",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
 ]
 


### PR DESCRIPTION
In the [latest models ops pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/15380838049/job/43304647062), 457 conv2d tests was regressed and 48 conv2d tests was xpassed. So Removed xfail markers for 48 XPASSED conv2d test and added xfail markers for 455 conv2d regression tests and below 2 regressed conv2d test was hanged in both CI and local machine while executing on device and so skipped the those 2 tests.
```

forge/test/models_ops/test_conv2d.py::test_module[Conv2D783-[((1, 32, 14, 14), torch.float32)]]
forge/test/models_ops/test_conv2d.py::test_module[Conv2D813-[((1, 30, 14, 14), torch.float32)]]
```

For more insight into conv2d regression and xpass tests, please take a look into this [conv2d models ops tests report](https://docs.google.com/spreadsheets/d/1BLuBF84UF7LGlyO4McgtsQVkSdqGXlFAt5loe05Yhjg/edit?usp=sharing)