### PR TITLE
Fix CI import issues in paddlenlp

### DIFF
--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -39,6 +39,7 @@ ultralytics==8.3.91
 keras>=2.13.1
 paddlepaddle==2.6.2
 paddlenlp==2.8.1
+aistudio-sdk==0.2.6
 pytorch_forecasting==1.0.0
 patool
 openpyxl==3.1.5


### PR DESCRIPTION
The **aistudio-sdk** package version `0.3.0`, released this morning, removed the `download` function from hub.py, which is still used by the **paddlenlp** package. This caused an` ImportError: cannot import name 'download' from 'aistudio_sdk.hub'` in CI pipeline. During the installation of **paddlenlp** version` 2.8.1`, the latest aistudio-sdk was pulled due to the `aistudio-sdk>=0.1.3` requirement specified in its requirements.txt. To resolve the issue, we reverted aistudio-sdk from `0.3.0` back to version `0.2.6`.