### PR TITLE
Enable memory layout analysis in resnet.

### DIFF
--- a/forge/test/benchmark/benchmark/models/resnet_hf.py
+++ b/forge/test/benchmark/benchmark/models/resnet_hf.py
@@ -112,7 +112,7 @@ def test_resnet_hf(training, batch_size, data_format, input_size, channel_size, 
 
     # Turn on MLIR optimizations.
     compiler_cfg.mlir_config = (
-        MLIRConfig().set_enable_optimizer(True).set_enable_fusing(True).set_enable_memory_layout_analysis(False)
+        MLIRConfig().set_enable_optimizer(True).set_enable_fusing(True).set_enable_memory_layout_analysis(True)
     )
 
     compiled_model = forge.compile(framework_model, sample_inputs=inputs[0], compiler_cfg=compiler_cfg)


### PR DESCRIPTION
Enable memory layout analysis in resnet. Firware update resolved the problem with opening/closing the device.