### PR TITLE
Add post processing steps for e2e passing ONNX models

### DIFF
--- a/forge/test/models/onnx/text/bert/test_bert.py
+++ b/forge/test/models/onnx/text/bert/test_bert.py
@@ -69,7 +69,13 @@ def test_bert_masked_lm_onnx(variant, forge_tmp_path, opset_version):
     compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    _, co_out = verify(inputs, framework_model, compiled_model)
+
+    # post processing
+    logits = co_out[0]
+    mask_token_index = (input_tokens.input_ids == tokenizer.mask_token_id)[0].nonzero(as_tuple=True)[0]
+    predicted_token_id = logits[0, mask_token_index].argmax(axis=-1)
+    print("The predicted token for the [MASK] is: ", tokenizer.decode(predicted_token_id))
 
 
 @pytest.mark.nightly

--- a/forge/test/models/onnx/text/minilm/test_minilm.py
+++ b/forge/test/models/onnx/text/minilm/test_minilm.py
@@ -11,6 +11,7 @@ from forge.verify.verify import verify
 
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 from test.utils import download_model
+from test.models.models_utils import mean_pooling
 
 
 @pytest.mark.nightly
@@ -49,5 +50,9 @@ def test_minilm_sequence_classification_onnx(variant, forge_tmp_path):
     # Forge compile framework model
     compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
 
-    # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post processing
+    sentence_embeddings = mean_pooling(co_out, input_tokens["attention_mask"])
+    print("Sentence embeddings:", sentence_embeddings)

--- a/forge/test/models/onnx/vision/resnet/test_resnet.py
+++ b/forge/test/models/onnx/vision/resnet/test_resnet.py
@@ -6,7 +6,7 @@ import random
 import onnx
 import torch
 from datasets import load_dataset
-from transformers import ResNetForImageClassification
+from transformers import ResNetForImageClassification, AutoImageProcessor
 
 import forge
 from forge.verify.verify import verify
@@ -14,7 +14,6 @@ from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
-
 
 variants = [
     "microsoft/resnet-50",
@@ -36,9 +35,17 @@ def test_resnet_onnx(variant, forge_tmp_path):
         task=Task.IMAGE_CLASSIFICATION,
     )
 
-    # Export model to ONNX
+    # Load processor and Model
+    processor = AutoImageProcessor.from_pretrained("microsoft/resnet-50")
     torch_model = ResNetForImageClassification.from_pretrained(variant)
-    input_sample = torch.randn(1, 3, 224, 224)
+
+    # Prepare input
+    dataset = load_dataset("huggingface/cats-image")
+    image = dataset["test"]["image"][0]
+    inputs = processor(image, return_tensors="pt")
+    input_sample = inputs["pixel_values"]
+
+    # Export model to ONNX
     onnx_path = f"{forge_tmp_path}/resnet50.onnx"
     torch.onnx.export(torch_model, input_sample, onnx_path, opset_version=17)
 
@@ -52,10 +59,14 @@ def test_resnet_onnx(variant, forge_tmp_path):
     input_sample = [input_sample]
     compiled_model = forge.compile(onnx_model, input_sample, module_name=module_name)
 
-    # Verify data on sample input
-    verify(
+    # Model Verification and Inference
+    _, co_out = verify(
         input_sample,
         framework_model,
         compiled_model,
         VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95)),
     )
+
+    # Post processing
+    predicted_label = co_out[0].argmax(-1).item()
+    print("Predicted class: ", torch_model.config.id2label[predicted_label])


### PR DESCRIPTION
### Summary 

This PR adds post processing steps for e2e passing ONNX models

### Logs
[jun4_bert_masked_lm_onnx.log](https://github.com/user-attachments/files/20592839/jun4_bert_masked_lm_onnx.log)
[jun4_minilm_onnx.log](https://github.com/user-attachments/files/20592840/jun4_minilm_onnx.log)
[jun4_resnet_onnx.log](https://github.com/user-attachments/files/20592841/jun4_resnet_onnx.log)
[jun4_vit_onnx.log](https://github.com/user-attachments/files/20592842/jun4_vit_onnx.log)


