### PR TITLE
Change generated .mlir files to output MLIR format

### DIFF
--- a/forge/csrc/reportify/reportify.cpp
+++ b/forge/csrc/reportify/reportify.cpp
@@ -407,27 +407,6 @@ json create_json_for_graph(const graphlib::Graph* graph, std::function<bool(grap
     return this_json;
 }
 
-json create_json_for_mlir(const std::string& module_name, mlir::Operation* operation)
-{
-    json this_json;
-
-    this_json["module"] = module_name;
-
-    std::string outputString;
-    llvm::raw_string_ostream outStream(outputString);
-
-    // Print the MLIR module
-    mlir::OpPrintingFlags printFlags;
-    printFlags.enableDebugInfo();
-
-    // Put data into string
-    operation->print(outStream, printFlags);
-    outStream.flush();
-    this_json["content"] = outputString;
-
-    return this_json;
-}
-
 JsonNamePairs create_jsons_for_graph(
     const std::string& graph_prefix, const graphlib::Graph* graph, std::function<bool(graphlib::Node*)> node_filter)
 {
@@ -435,19 +414,6 @@ JsonNamePairs create_jsons_for_graph(
 
     json this_json = create_json_for_graph(graph, node_filter);
     std::string this_name = graph_prefix + ".forge";
-    JsonNamePair this_json_name_pair = std::make_pair(this_json, this_name);
-    this_json_name_pairs.push_back(this_json_name_pair);
-
-    return this_json_name_pairs;
-}
-
-JsonNamePairs create_jsons_for_mlir(
-    const std::string& file_name, const std::string& module_name, mlir::Operation* operation)
-{
-    JsonNamePairs this_json_name_pairs;
-
-    json this_json = create_json_for_mlir(module_name, operation);
-    std::string this_name = file_name + ".mlir";
     JsonNamePair this_json_name_pair = std::make_pair(this_json, this_name);
     this_json_name_pairs.push_back(this_json_name_pair);
 

--- a/forge/csrc/reportify/reportify.cpp
+++ b/forge/csrc/reportify/reportify.cpp
@@ -276,13 +276,6 @@ void write_json_to_file(const std::string& path, json json_file, int width = 4)
     o << json_file;
 }
 
-void write_text_to_file(const std::string& path, const std::string& content)
-{
-    std::ofstream o(path);
-    o << content;
-    o.flush();
-}
-
 JsonNamePairs create_jsons_for_graph(
     const std::string& graph_prefix,
     const graphlib::Graph* graph,
@@ -473,7 +466,10 @@ void dump_mlir(const std::string& file_name, const std::string& module_name, mli
     std::string root_file_path = full_report_path + root_file_name;
 
     std::filesystem::create_directories(std::filesystem::path(full_report_path));
-    write_text_to_file(root_file_path, outputString);
+
+    std::ofstream o(root_file_path);
+    o << outputString;
+    o.flush();
 }
 
 }  // namespace reportify

--- a/forge/csrc/reportify/reportify.cpp
+++ b/forge/csrc/reportify/reportify.cpp
@@ -276,6 +276,13 @@ void write_json_to_file(const std::string& path, json json_file, int width = 4)
     o << json_file;
 }
 
+void write_text_to_file(const std::string& path, const std::string& content)
+{
+    std::ofstream o(path);
+    o << content;
+    o.flush();
+}
+
 JsonNamePairs create_jsons_for_graph(
     const std::string& graph_prefix,
     const graphlib::Graph* graph,
@@ -466,7 +473,7 @@ void dump_mlir(const std::string& file_name, const std::string& module_name, mli
     std::string root_file_path = full_report_path + root_file_name;
 
     std::filesystem::create_directories(std::filesystem::path(full_report_path));
-    write_json_to_file(root_file_path, outputString);
+    write_text_to_file(root_file_path, outputString);
 }
 
 }  // namespace reportify

--- a/forge/csrc/reportify/reportify.hpp
+++ b/forge/csrc/reportify/reportify.hpp
@@ -37,8 +37,6 @@ json create_json_for_graph(
     const graphlib::Graph* graph,
     std::function<bool(graphlib::Node*)> node_filter = [](graphlib::Node*) { return true; });
 
-json create_json_for_mlir(const std::string& module_name, mlir::Operation* operation);
-
 void dump_graph(
     const std::string& test_name,
     const std::string& graph_prefix,

--- a/forge/test/benchmark/device_perf.py
+++ b/forge/test/benchmark/device_perf.py
@@ -42,7 +42,7 @@ def create_device_perf(device_perf_path, perf_report_path):
 
 def create_ttir(ttir_path):
     """
-    Create a TTIR file from the given path. TTIR is a JSON file that contains the model's information.
+    Create a TTIR file from the given path. TTIR is a text file that contains the model's information.
 
     Parameters:
     ----------
@@ -55,30 +55,19 @@ def create_ttir(ttir_path):
 
     """
 
-    # Read the TTIR the JSON file
+    # Read the TTIR file
     try:
         with open(ttir_path, "r") as file:
-            data = json.load(file)
+            content = file.read()
     except FileNotFoundError:
         print(f"Error: TTIR file '{ttir_path}' not found.")
-        return
-    except json.JSONDecodeError:
-        print(f"Error: TTIR file '{ttir_path}' contains invalid JSON.")
         return
     except Exception as e:
         print(f"Unexpected error: {e}")
         return
 
-    # Make string from the JSON data
-    # This JSON has should have the following structure:
-    #   {
-    #       'content': 'string'
-    #       'module': 'string'
-    #   }
-
-    # Content is actually what we want to write to the TTIR file, module is the name of the module
-    # Content is a string separated by newlines, we will create a list of strings from it, and modify it
-    content = data["content"].split("\n")
+    # Content is a string separated by newlines
+    content = content.split("\n")
 
     # The first line of the content is system descriptor, we don't need it
     # The second line is the definition of the module with attrubutes, we need to empty the attributes field

--- a/forge/test/benchmark/device_perf.py
+++ b/forge/test/benchmark/device_perf.py
@@ -55,16 +55,8 @@ def create_ttir(ttir_path):
 
     """
 
-    # Read the TTIR file
-    try:
-        with open(ttir_path, "r") as file:
-            content = file.read()
-    except FileNotFoundError:
-        print(f"Error: TTIR file '{ttir_path}' not found.")
-        return
-    except Exception as e:
-        print(f"Unexpected error: {e}")
-        return
+    with open(ttir_path, "r") as file:
+        content = file.read()
 
     # Content is a string separated by newlines
     content = content.split("\n")

--- a/forge/test/benchmark/test_data/device_perf/ttir.mlir
+++ b/forge/test/benchmark/test_data/device_perf/ttir.mlir
@@ -1,4 +1,23 @@
-{
-    "content": "#system_desc = #tt.system_desc<[{role = host, target_triple = \"x86_64-pc-linux-gnu\"}], [{arch = <wormhole_b0>, grid = 8x8, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_cores = {worker = [ 0x0,  0x1,  0x2,  0x3,  0x4,  0x5,  0x6,  0x7,  1x0,  1x1,  1x2,  1x3,  1x4,  1x5,  1x6,  1x7,  2x0,  2x1,  2x2,  2x3,  2x4,  2x5,  2x6,  2x7,  3x0,  3x1,  3x2,  3x3,  3x4,  3x5,  3x6,  3x7,  4x0,  4x1,  4x2,  4x3,  4x4,  4x5,  4x6,  4x7,  5x0,  5x1,  5x2,  5x3,  5x4,  5x5,  5x6,  5x7,  6x0,  6x1,  6x2,  6x3,  6x4,  6x5,  6x6,  6x7,  7x0,  7x1,  7x2,  7x3,  7x4,  7x5,  7x6,  7x7] dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], num_cbs = 32}], [0], [3 : i32], [ 0x0x0x0]>\nmodule @MNISTLinear attributes {tt.system_desc = #system_desc} {\n  func.func @forward(%arg0: tensor<32x784xf32> {ttir.name = \"input_1\"}, %arg1: tensor<784x256xf32> {ttir.name = \"l1.weight\"}, %arg2: tensor<256xf32> {ttir.name = \"l1.bias\"}, %arg3: tensor<256x10xf32> {ttir.name = \"l2.weight\"}, %arg4: tensor<10xf32> {ttir.name = \"l2.bias\"}) -> (tensor<32x10xf32> {ttir.name = \"MNISTLinear.output_softmax_9\"}) {\n    %0 = tensor.empty() : tensor<32x256xf32>\n    %1 = \"ttir.matmul\"(%arg0, %arg1, %0) <{transpose_a = false, transpose_b = false}> : (tensor<32x784xf32>, tensor<784x256xf32>, tensor<32x256xf32>) -> tensor<32x256xf32>\n    %2 = tensor.empty() : tensor<32x256xf32>\n    %3 = \"ttir.add\"(%1, %arg2, %2) : (tensor<32x256xf32>, tensor<256xf32>, tensor<32x256xf32>) -> tensor<32x256xf32>\n    %4 = tensor.empty() : tensor<32x256xf32>\n    %5 = \"ttir.relu\"(%3, %4) : (tensor<32x256xf32>, tensor<32x256xf32>) -> tensor<32x256xf32>\n    %6 = tensor.empty() : tensor<32x10xf32>\n    %7 = \"ttir.matmul\"(%5, %arg3, %6) <{transpose_a = false, transpose_b = false}> : (tensor<32x256xf32>, tensor<256x10xf32>, tensor<32x10xf32>) -> tensor<32x10xf32>\n    %8 = tensor.empty() : tensor<32x10xf32>\n    %9 = \"ttir.add\"(%7, %arg4, %8) : (tensor<32x10xf32>, tensor<10xf32>, tensor<32x10xf32>) -> tensor<32x10xf32>\n    %10 = tensor.empty() : tensor<32x10xf32>\n    %11 = \"ttir.softmax\"(%9, %10) <{dimension = 1 : si32}> : (tensor<32x10xf32>, tensor<32x10xf32>) -> tensor<32x10xf32>\n    return %11 : tensor<32x10xf32>\n  }\n}\n",
-    "module": "MNISTLinear"
-}
+#loc = loc("AdvIndexWrapper":0:0)
+#system_desc = #tt.system_desc<[{role = host, target_triple = "x86_64-pc-linux-gnu"}], [{arch = <wormhole_b0>, grid = 8x8, coord_translation_offsets = 18x18, l1_size = 1499136, num_dram_channels = 12, dram_channel_size = 1073741824, noc_l1_address_align_bytes = 16, pcie_address_align_bytes = 32, noc_dram_address_align_bytes = 32, l1_unreserved_base = 1024, erisc_l1_unreserved_base = 1024, dram_unreserved_base = 1024, dram_unreserved_end = 1073741824, physical_helper_cores = {dram = [ 8x0,  9x0,  10x0,  8x1,  9x1,  10x1,  8x2,  9x2,  10x2,  8x3,  9x3,  10x3]}, supported_data_types = [<f32>, <f16>, <bf16>, <bfp_f8>, <bfp_bf8>, <bfp_f4>, <bfp_bf4>, <bfp_f2>, <bfp_bf2>, <u32>, <u16>, <u8>, <si32>], supported_tile_sizes = [ 4x16,  16x16,  32x16,  4x32,  16x32,  32x32], dst_register_size_tiles = 8, num_cbs = 32, num_compute_threads = 1, num_datamovement_threads = 2}], [0], [3 : i32], [ 0x0x0x0]>
+module @AdvIndexWrapper attributes {tt.system_desc = #system_desc} {
+  func.func @forward(%arg0: tensor<2x4x8x16xf32> {tt.argument_type = #tt.argument_type<input>, ttir.name = "advindex_input"} loc("AdvIndexWrapper":0:0), %arg1: tensor<2xi32> {tt.argument_type = #tt.argument_type<input>, ttir.name = "indeces"} loc("AdvIndexWrapper":0:0)) -> (tensor<2x2x8x16xf32> {ttir.name = "advindex_op.output_adv_index_17"}) {
+    %0 = ttir.empty() : tensor<4x2x8x16xf32> loc(#loc1)
+    %1 = "ttir.transpose"(%arg0, %0) <{dim0 = -3 : si32, dim1 = -4 : si32}> : (tensor<2x4x8x16xf32>, tensor<4x2x8x16xf32>) -> tensor<4x2x8x16xf32> loc(#loc1)
+    %2 = ttir.empty() : tensor<4x256xf32> loc(#loc2)
+    %3 = "ttir.reshape"(%1, %2) <{shape = [4 : i32, 256 : i32]}> : (tensor<4x2x8x16xf32>, tensor<4x256xf32>) -> tensor<4x256xf32> loc(#loc2)
+    %4 = ttir.empty() : tensor<2x256xf32> loc(#loc3)
+    %5 = "ttir.embedding"(%arg1, %3, %4) : (tensor<2xi32>, tensor<4x256xf32>, tensor<2x256xf32>) -> tensor<2x256xf32> loc(#loc3)
+    %6 = ttir.empty() : tensor<2x2x8x16xf32> loc(#loc4)
+    %7 = "ttir.reshape"(%5, %6) <{shape = [2 : i32, 2 : i32, 8 : i32, 16 : i32]}> : (tensor<2x256xf32>, tensor<2x2x8x16xf32>) -> tensor<2x2x8x16xf32> loc(#loc4)
+    %8 = ttir.empty() : tensor<2x2x8x16xf32> loc(#loc5)
+    %9 = "ttir.transpose"(%7, %8) <{dim0 = -4 : si32, dim1 = -3 : si32}> : (tensor<2x2x8x16xf32>, tensor<2x2x8x16xf32>) -> tensor<2x2x8x16xf32> loc(#loc5)
+    return %9 : tensor<2x2x8x16xf32> loc(#loc6)
+  } loc(#loc)
+} loc(#loc)
+#loc1 = loc("adv_index_17.dc.transpose.0.dc.transpose.0")
+#loc2 = loc("adv_index_17.dc.reshape.1")
+#loc3 = loc("adv_index_17.dc.embedding.2")
+#loc4 = loc("adv_index_17.dc.reshape.3")
+#loc5 = loc("adv_index_17.dc.transpose.4.dc.transpose.0")
+#loc6 = loc(unknown)


### PR DESCRIPTION
### Ticket
fixes: #1911 

### Problem description
We generate `ttir.mlir` and `ttnn.mlir` under the testify directory, and while these files have the `.mlir` extension, their actual content is in JSON format.

### What's changed
`ttir.mlir` and `ttnn.mlir` are now stored in MLIR format instead
