### PR TITLE
Add xfail marker for Nightly failing cases

### DIFF
--- a/forge/test/models/pytorch/vision/densenet/test_densenet.py
+++ b/forge/test/models/pytorch/vision/densenet/test_densenet.py
@@ -194,6 +194,7 @@ def test_densenet_169_pytorch(variant):
     print_cls_results(fw_out[0], co_out[0])
 
 
+@pytest.mark.xfail
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["densenet201"])
 def test_densenet_201_pytorch(variant):

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -333,6 +333,7 @@ variants_with_weights = {
 }
 
 
+@pytest.mark.xfail
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_mobilenetv2_torchvision(variant):

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3.py
@@ -106,11 +106,13 @@ def generate_model_mobilenetV3_imgcls_timm_pytorch(variant):
     return model.to(torch.bfloat16), [image_tensor.to(torch.bfloat16)], {}
 
 
-variants = ["mobilenetv3_large_100", "mobilenetv3_small_100"]
+variants = [
+    "mobilenetv3_large_100",
+    pytest.param("mobilenetv3_small_100", marks=[pytest.mark.xfail]),
+]
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_mobilenetv3_timm(variant):
 

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3_ssd.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v3_ssd.py
@@ -22,6 +22,14 @@ from test.models.pytorch.vision.mobilenet.model_utils.mobilenet_v3_ssd_utils imp
     load_model,
 )
 
+variants = [
+    "resnet18",
+    "resnet34",
+    pytest.param("resnet50", marks=[pytest.mark.xfail]),
+    pytest.param("resnet101", marks=[pytest.mark.xfail]),
+    "resnet152",
+]
+
 variants_with_weights = {
     "resnet18": "ResNet18_Weights",
     "resnet34": "ResNet34_Weights",

--- a/forge/test/models/pytorch/vision/regnet/test_regnet.py
+++ b/forge/test/models/pytorch/vision/regnet/test_regnet.py
@@ -105,7 +105,7 @@ variants = [
     "regnet_x_800mf",
     "regnet_x_1_6gf",
     "regnet_x_3_2gf",
-    "regnet_x_8gf",
+    pytest.param("regnet_x_8gf", marks=[pytest.mark.xfail]),
     "regnet_x_16gf",
     "regnet_x_32gf",
 ]

--- a/forge/test/models/pytorch/vision/resnet/test_resnet.py
+++ b/forge/test/models/pytorch/vision/resnet/test_resnet.py
@@ -165,9 +165,15 @@ variants_with_weights = {
     "resnet152": "ResNet152_Weights",
 }
 
+xfail_variants = {"resnet50", "resnet152"}
+params = [
+    pytest.param(variant, marks=pytest.mark.xfail()) if variant in xfail_variants else pytest.param(variant)
+    for variant in variants_with_weights.keys()
+]
+
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants_with_weights.keys())
+@pytest.mark.parametrize("variant", params, ids=list(variants_with_weights.keys()))
 def test_resnet_torchvision(variant):
 
     # Record Forge Property

--- a/forge/test/models/pytorch/vision/vit/test_vit.py
+++ b/forge/test/models/pytorch/vision/vit/test_vit.py
@@ -101,7 +101,7 @@ variants = [
     "vit_b_32",
     "vit_l_16",
     "vit_l_32",
-    "vit_h_14",
+    pytest.param("vit_h_14", marks=[pytest.mark.xfail]),
 ]
 
 

--- a/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
@@ -102,6 +102,7 @@ def generate_model_vovnet39_imgcls_stigma_pytorch():
     return model.to(torch.bfloat16), [image_tensor.to(torch.bfloat16)], {}
 
 
+@pytest.mark.xfail
 @pytest.mark.nightly
 def test_vovnet_v1_39_stigma_pytorch():
 
@@ -143,6 +144,7 @@ def generate_model_vovnet57_imgcls_stigma_pytorch():
     return model.to(torch.bfloat16), [image_tensor.to(torch.bfloat16)], {}
 
 
+@pytest.mark.xfail
 @pytest.mark.nightly
 def test_vovnet_v1_57_stigma_pytorch():
 

--- a/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
+++ b/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
@@ -87,7 +87,7 @@ def generate_model_wideresnet_imgcls_timm(variant):
     return framework_model.to(torch.bfloat16), [img_tensor.to(torch.bfloat16)]
 
 
-variants = ["wide_resnet50_2", "wide_resnet101_2"]
+variants = [pytest.param("wide_resnet50_2", marks=[pytest.mark.xfail]), "wide_resnet101_2"]
 
 
 @pytest.mark.nightly

--- a/forge/test/models/pytorch/vision/yolo/test_yolox.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolox.py
@@ -43,12 +43,12 @@ from forge.verify.verify import VerifyConfig, verify
 from test.models.pytorch.vision.yolo.model_utils.yolox_utils import preprocess
 
 variants = [
-    pytest.param("yolox_nano"),
+    pytest.param("yolox_nano", marks=[pytest.mark.xfail]),
     pytest.param("yolox_tiny"),
     pytest.param("yolox_s"),
-    pytest.param("yolox_m"),
+    pytest.param("yolox_m", marks=[pytest.mark.xfail]),
     pytest.param("yolox_l"),
-    pytest.param("yolox_darknet"),
+    pytest.param("yolox_darknet", marks=[pytest.mark.xfail]),
     pytest.param("yolox_x"),
 ]
 


### PR DESCRIPTION
### Ticket  
[Issue Link 1](https://github.com/tenstorrent/tt-forge-fe/issues/2211)
[Issue Link 2](https://github.com/tenstorrent/tt-forge-fe/issues/2184)
[Issue Link 3](https://github.com/tenstorrent/tt-torch/issues/793)

### Problem description
Data Mismatch Issue on [nightly](https://github.com/tenstorrent/tt-forge-fe/actions/runs/15455193882) run

### What's changed
Added XFAIL marker for the failing cases
Removed one xfail marker for xpass case (test_mobilenetv3_timm[mobilenetv3_large_100])