### PR TITLE
Add placeholder tests for missed red models and replace skip markers with xfail markers in skipped models: Set2

### DIFF
--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -219,6 +219,13 @@ class ModelArch(BaseEnum):
     CENTERNET = ("centernet", "Centernet")
     SURYAOCR = ("surya_ocr", "Surya_OCR")
     TRANSFUSER = ("transfuser", "Transfuser")
+    BEVDEPTH = ("bevdepth", "Bevdepth")
+    POINTPILLARS = ("pointpillars", "Pointpillars")
+    BEVFORMER = ("bevformer", "Bevformer")
+    FLUX = ("flux", "Flux")
+    PIXTRAL = ("pixtral", "Pixtral")
+    SOLAR = ("solar", "Solar")
+    VADV2 = ("vadv2", "Vadv2")
 
 
 def build_module_name(

--- a/forge/test/models/pytorch/multimodal/pixtral/test_pixtral.py
+++ b/forge/test/models/pytorch/multimodal/pixtral/test_pixtral.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+variants = ["mistralai/Pixtral-12B-2409", "mistralai/Pixtral-Large-Instruct-2411"]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", variants)
+def test_pixtral(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.PIXTRAL,
+        variant=variant,
+        task=Task.IMAGE_TEXT_PAIRING,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+    )
+
+    raise RuntimeError("Requires multi-chip support")

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
@@ -45,26 +45,18 @@ class StableDiffusionWrapper(torch.nn.Module):
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize(
     "variant",
     [
         pytest.param(
             "stable-diffusion-3.5-medium",
-            marks=pytest.mark.skip(
-                reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
-            ),
         ),
         pytest.param(
             "stable-diffusion-3.5-large",
-            marks=pytest.mark.skip(
-                reason="Insufficient host DRAM to run this model (requires a bit more than 54 GB during compile time)"
-            ),
         ),
         pytest.param(
             "stable-diffusion-3.5-large-turbo",
-            marks=pytest.mark.skip(
-                reason="Insufficient host DRAM to run this model (requires a bit more than 54 GB during compile time)"
-            ),
         ),
     ],
 )
@@ -78,6 +70,8 @@ def test_stable_diffusion_v35(variant):
         source=Source.HUGGINGFACE,
         group=ModelGroup.RED,
     )
+
+    raise RuntimeError("Requires multi-chip support")
 
     # Load pipeline
     pipe = load_pipe(variant, variant_type="v35")

--- a/forge/test/models/pytorch/text/flux/test_flux.py
+++ b/forge/test/models/pytorch/text/flux/test_flux.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    ModelPriority,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+variants = ["black-forest-labs/FLUX.1-schnell", "black-forest-labs/FLUX.1-dev"]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", variants)
+def test_flux(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.FLUX,
+        variant=variant,
+        task=Task.CONDITIONAL_GENERATION,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
+    )
+
+    raise RuntimeError("Requires multi-chip support")

--- a/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
@@ -96,12 +96,7 @@ def test_gemma_2b(variant):
         ),
         pytest.param(
             "google/gemma-2-9b-it",
-            marks=[
-                pytest.mark.skip(
-                    reason="Insufficient host DRAM to run this model (requires a bit more than 50 GB during compile time)"
-                ),
-                pytest.mark.out_of_memory,
-            ],
+            marks=pytest.mark.xfail,
         ),
     ],
 )
@@ -116,6 +111,8 @@ def test_gemma_pytorch_v2(variant):
         source=Source.HUGGINGFACE,
         group=ModelGroup.RED,
     )
+    if variant == "google/gemma-2-9b-it":
+        raise RuntimeError("Requires multi-chip support")
 
     # Load model and tokenizer from HuggingFace
     tokenizer = AutoTokenizer.from_pretrained(variant)
@@ -142,3 +139,27 @@ def test_gemma_pytorch_v2(variant):
         max_new_tokens=max_new_tokens, model=compiled_model, inputs=padded_inputs, seq_len=seq_len, tokenizer=tokenizer
     )
     print(generated_text)
+
+
+variants = [
+    "google/gemma-2-27b-it",
+]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", variants)
+def test_gemma_pytorch_27b(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.FLUX,
+        variant=variant,
+        task=Task.QA,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+    )
+
+    # Force the test to fail explicitly
+    raise RuntimeError("Requires multi-chip support")

--- a/forge/test/models/pytorch/text/gemma/test_gemma_v1.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_v1.py
@@ -23,20 +23,15 @@ from test.models.pytorch.text.gemma.model_utils.model_utils import (
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize(
     "variant",
     [
         pytest.param(
             "google/gemma-1.1-2b-it",
-            marks=pytest.mark.skip(
-                reason="Insufficient host DRAM to run this model (requires a bit more than 21 GB during compile time)"
-            ),
         ),
         pytest.param(
             "google/gemma-1.1-7b-it",
-            marks=pytest.mark.skip(
-                reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
-            ),
         ),
     ],
 )
@@ -51,6 +46,8 @@ def test_gemma_pytorch_v1(variant):
         source=Source.HUGGINGFACE,
         group=ModelGroup.RED,
     )
+
+    raise RuntimeError("Requires multi-chip support")
 
     # Load model and tokenizer from HuggingFace
     tokenizer = AutoTokenizer.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/llama/test_llama3.py
+++ b/forge/test/models/pytorch/text/llama/test_llama3.py
@@ -357,3 +357,28 @@ def test_llama3_sequence_classification(variant):
     predicted_value = co_out[0].argmax(-1).item()
 
     print(f"Prediction : {framework_model.config.id2label[predicted_value]}")
+
+
+variants = [
+    "meta-llama/Llama-3.2-90B-Vision-Instruct",
+    "meta-llama/Llama-3.1-8B-Instruct",
+]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", variants)
+def test_llama3(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.LLAMA3,
+        variant=variant,
+        task=Task.SEQUENCE_CLASSIFICATION,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+    )
+
+    # Force the test to fail explicitly
+    raise RuntimeError("Requires multi-chip support")

--- a/forge/test/models/pytorch/text/mistral/test_mistral.py
+++ b/forge/test/models/pytorch/text/mistral/test_mistral.py
@@ -148,3 +148,25 @@ def test_mistral_8x7b(variant):
     )
 
     raise RuntimeError("Requires multi-chip support")
+
+
+variants = ["mistralai/Mistral-Small-24B-Instruct-2501"]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", variants)
+def test_mistral_small_24b(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.MISTRAL,
+        variant=variant,
+        task=Task.CAUSAL_LM,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+    )
+
+    # Force the test to fail explicitly
+    raise RuntimeError("Requires multi-chip support")

--- a/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
@@ -23,35 +23,33 @@ from forge.verify.verify import verify
 variants = [
     pytest.param(
         "Qwen/Qwen2.5-0.5B",
-        marks=[pytest.mark.xfail],
     ),
     pytest.param(
         "Qwen/Qwen2.5-0.5B-Instruct",
-        marks=[pytest.mark.xfail],
     ),
     pytest.param(
         "Qwen/Qwen2.5-1.5B",
-        marks=[pytest.mark.xfail],
     ),
     pytest.param(
         "Qwen/Qwen2.5-1.5B-Instruct",
-        marks=[pytest.mark.xfail],
     ),
     pytest.param(
         "Qwen/Qwen2.5-3B",
-        marks=[pytest.mark.skip(reason="Insufficient host DRAM to run this model"), pytest.mark.out_of_memory],
     ),
     pytest.param(
         "Qwen/Qwen2.5-3B-Instruct",
-        marks=[pytest.mark.skip(reason="Insufficient host DRAM to run this model"), pytest.mark.out_of_memory],
     ),
     pytest.param(
         "Qwen/Qwen2.5-7B",
-        marks=[pytest.mark.skip(reason="Insufficient host DRAM to run this model"), pytest.mark.out_of_memory],
     ),
     pytest.param(
         "Qwen/Qwen2.5-7B-Instruct",
-        marks=[pytest.mark.skip(reason="Insufficient host DRAM to run this model"), pytest.mark.out_of_memory],
+    ),
+    pytest.param(
+        "Qwen/Qwen2.5-14B-Instruct",
+    ),
+    pytest.param(
+        "Qwen/Qwen2.5-32B-Instruct",
     ),
     pytest.param(
         "Qwen/Qwen2.5-72B-Instruct",
@@ -61,6 +59,7 @@ variants = [
 
 
 @pytest.mark.parametrize("variant", variants)
+@pytest.mark.xfail
 @pytest.mark.nightly
 def test_qwen_clm(variant):
     if variant in [
@@ -84,7 +83,15 @@ def test_qwen_clm(variant):
         group=group,
     )
 
-    if variant == "Qwen/Qwen2.5-72B-Instruct":
+    if variant in [
+        "Qwen/Qwen2.5-3B",
+        "Qwen/Qwen2.5-3B-Instruct",
+        "Qwen/Qwen2.5-7B",
+        "Qwen/Qwen2.5-7B-Instruct",
+        "Qwen/Qwen2.5-14B-Instruct",
+        "Qwen/Qwen2.5-32B-Instruct",
+        "Qwen/Qwen2.5-72B-Instruct",
+    ]:
         raise RuntimeError("Requires multi-chip support")
 
     # Load model and tokenizer

--- a/forge/test/models/pytorch/text/solar/test_solar.py
+++ b/forge/test/models/pytorch/text/solar/test_solar.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+variants = ["upstage/SOLAR-10.7B-Instruct-v1.0"]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", variants)
+def test_solar(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.SOLAR,
+        variant=variant,
+        task=Task.CAUSAL_LM,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+    )
+
+    raise RuntimeError("Requires multi-chip support")

--- a/forge/test/models/pytorch/vision/bevdepth/test_bevdepth.py
+++ b/forge/test/models/pytorch/vision/bevdepth/test_bevdepth.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    ModelPriority,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_bevdepth():
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.BEVDEPTH,
+        source=Source.GITHUB,
+        task=Task.DEPTH_ESTIMATION,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
+    )
+
+    raise RuntimeError("Test is currently not executable due to mmdet3d and model code dependency.")

--- a/forge/test/models/pytorch/vision/bevformer/test_bevformer.py
+++ b/forge/test/models/pytorch/vision/bevformer/test_bevformer.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    ModelPriority,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_bevformer():
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.BEVFORMER,
+        source=Source.GITHUB,
+        task=Task.OBJECT_DETECTION,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
+    )
+
+    raise RuntimeError("Test is currently not executable due to mmdet3d and model code dependency.")

--- a/forge/test/models/pytorch/vision/pointpillars/test_pointpillars.py
+++ b/forge/test/models/pytorch/vision/pointpillars/test_pointpillars.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    ModelPriority,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_pointpillars():
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.POINTPILLARS,
+        source=Source.GITHUB,
+        task=Task.OBJECT_DETECTION,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
+    )
+
+    raise RuntimeError("Test is currently not executable due to mmdet3d and model code dependency.")

--- a/forge/test/models/pytorch/vision/vadv2/test_vadv2.py
+++ b/forge/test/models/pytorch/vision/vadv2/test_vadv2.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    ModelPriority,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_vadv2():
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.VADV2,
+        source=Source.GITHUB,
+        task=Task.OBJECT_DETECTION,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
+    )
+
+    raise RuntimeError("Test is currently not executable due to mmdet3d and model code dependency.")


### PR DESCRIPTION
Summary

- This PR adds placeholder tests for missed red models and replace skip markers with xfail markers in skipped models to record properties of all red models