### PR TITLE
Add placeholder tests for missed red models and replace skip markers with xfail markers in skipped red models: Set1

### DIFF
--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -72,6 +72,9 @@ class Task(BaseEnum):
     SENTENCE_EMBEDDING_GENERATION = ("sentence_embed_gen", "Sentence Embedding Generation")
     MULTIMODAL_TEXT_GENERATION = ("multimodal_text_gen", "Multimodal Text Generation")
     ATOMIC_ML = ("atomic_ml", "Atomic Machine Learning")
+    REALTIME_MAP_CONSTRUCTION = ("realtime_map_construction", "Realtime Map Construction")
+    PLANNING_ORIENTED_DRIVING = ("planning_oriented_driving", "Planning-Oriented Driving")
+    OPTICAL_CHARACTER_RECOGNITION = ("optical_character_recognition", "Optical Character Recognition")
 
 
 class Source(BaseEnum):
@@ -208,6 +211,14 @@ class ModelArch(BaseEnum):
     VGG19UNET = ("VGG19 UNet", "VGG19 UNet")
     WIDERESNET = ("wideresnet", "Wide ResNet")
     XCEPTION = ("xception", "Xception")
+    MAPTR = ("maptr", "MapTR")
+    PHI3_5_MOE = ("phi3.5_moe", "Phi-3.5-MoE")
+    UNIAD = ("uniad", "UniAD")
+    MINIMAX = ("minimax", "MiniMax")
+    MPLUGOWL = ("mplug_owl", "mPLUG-Owl")
+    CENTERNET = ("centernet", "Centernet")
+    SURYAOCR = ("surya_ocr", "Surya_OCR")
+    TRANSFUSER = ("transfuser", "Transfuser")
 
 
 def build_module_name(

--- a/forge/test/models/pytorch/multimodal/llama3/test_llama3_pt.py
+++ b/forge/test/models/pytorch/multimodal/llama3/test_llama3_pt.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+variants = ["meta-llama/Llama-3.2-11B-Vision-Instruct"]
+
+
+@pytest.mark.parametrize("variant", variants)
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_llama_vision_Instruct(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.LLAMA3_2,
+        variant=variant,
+        task=Task.MULTIMODAL_TEXT_GENERATION,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+    )
+
+    raise RuntimeError("Requires multi-chip support")

--- a/forge/test/models/pytorch/multimodal/llava/test_llava.py
+++ b/forge/test/models/pytorch/multimodal/llava/test_llava.py
@@ -45,8 +45,8 @@ variants = ["llava-hf/llava-1.5-7b-hf"]
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.xfail
 def test_llava(variant):
-    pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 30 GB)")
 
     # Record Forge Property
     module_name = record_model_properties(
@@ -57,6 +57,8 @@ def test_llava(variant):
         source=Source.HUGGINGFACE,
         group=ModelGroup.RED,
     )
+
+    raise RuntimeError("Requires multi-chip support")
 
     framework_model, processor = load_model(variant)
     image = "https://www.ilankelman.org/stopsigns/australia.jpg"

--- a/forge/test/models/pytorch/multimodal/mplug_owl/test_mplug_owl.py
+++ b/forge/test/models/pytorch/multimodal/mplug_owl/test_mplug_owl.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+variants = ["mPLUG/mPLUG-Owl3-7B-240728"]
+
+
+@pytest.mark.parametrize("variant", variants)
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_mplug_owl(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.MPLUGOWL,
+        variant=variant,
+        task=Task.MULTIMODAL_TEXT_GENERATION,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+    )
+
+    raise RuntimeError("Requires multi-chip support")

--- a/forge/test/models/pytorch/multimodal/phi3/test_phi3_5_vision.py
+++ b/forge/test/models/pytorch/multimodal/phi3/test_phi3_5_vision.py
@@ -35,7 +35,7 @@ variants = ["microsoft/Phi-3.5-vision-instruct"]
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip("Test uses large amount of host memory (>30GB).")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_5_vision(variant):
 
@@ -48,6 +48,8 @@ def test_phi3_5_vision(variant):
         source=Source.HUGGINGFACE,
         group=ModelGroup.RED,
     )
+
+    raise RuntimeError("Requires multi-chip support")
 
     # Load model and processor
     model = download_model(

--- a/forge/test/models/pytorch/text/falcon/test_falcon.py
+++ b/forge/test/models/pytorch/text/falcon/test_falcon.py
@@ -64,24 +64,15 @@ variants = [
     pytest.param("tiiuae/Falcon3-1B-Base", marks=pytest.mark.xfail),
     pytest.param(
         "tiiuae/Falcon3-3B-Base",
-        marks=[
-            pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 25 GB)"),
-            pytest.mark.out_of_memory,
-        ],
+        marks=pytest.mark.xfail,
     ),
     pytest.param(
         "tiiuae/Falcon3-7B-Base",
-        marks=[
-            pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 36 GB)"),
-            pytest.mark.out_of_memory,
-        ],
+        marks=pytest.mark.xfail,
     ),
     pytest.param(
         "tiiuae/Falcon3-10B-Base",
-        marks=[
-            pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB)"),
-            pytest.mark.out_of_memory,
-        ],
+        marks=pytest.mark.xfail,
     ),
     pytest.param(
         "tiiuae/Falcon3-Mamba-7B-Base",
@@ -116,6 +107,9 @@ def test_falcon_3(variant):
         source=Source.HUGGINGFACE,
         group=group,
     )
+
+    if variant != "tiiuae/Falcon3-1B-Base":
+        raise RuntimeError("Requires multi-chip support")
 
     # Load model and tokenizer
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/llama/test_llama3.py
+++ b/forge/test/models/pytorch/text/llama/test_llama3.py
@@ -137,10 +137,7 @@ variants = [
     pytest.param(
         "meta-llama/Llama-3.1-8B", marks=[pytest.mark.skip(reason="Segmentation Fault"), pytest.mark.out_of_memory]
     ),
-    pytest.param(
-        "meta-llama/Llama-3.1-8B-Instruct",
-        marks=[pytest.mark.skip(reason="Segmentation Fault"), pytest.mark.out_of_memory],
-    ),
+    pytest.param("meta-llama/Llama-3.1-8B-Instruct", marks=pytest.mark.xfail),
     pytest.param("meta-llama/Llama-3.2-1B", marks=pytest.mark.xfail),
     pytest.param("meta-llama/Llama-3.2-1B-Instruct", marks=pytest.mark.xfail),
     pytest.param(
@@ -152,15 +149,7 @@ variants = [
             pytest.mark.out_of_memory,
         ],
     ),
-    pytest.param(
-        "meta-llama/Llama-3.2-3B-Instruct",
-        marks=[
-            pytest.mark.skip(
-                reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
-            ),
-            pytest.mark.out_of_memory,
-        ],
-    ),
+    pytest.param("meta-llama/Llama-3.2-3B-Instruct", marks=pytest.mark.xfail),
     pytest.param(
         "huggyllama/llama-7b",
         marks=[
@@ -170,6 +159,7 @@ variants = [
             pytest.mark.out_of_memory,
         ],
     ),
+    pytest.param("meta-llama/Meta-Llama-3.1-70B", marks=pytest.mark.xfail),
 ]
 
 
@@ -180,6 +170,7 @@ def test_llama3_causal_lm(variant):
         "meta-llama/Llama-3.1-8B-Instruct",
         "meta-llama/Llama-3.2-1B-Instruct",
         "meta-llama/Llama-3.2-3B-Instruct",
+        "meta-llama/Meta-Llama-3.1-70B",
     ]:
         group = ModelGroup.RED
     else:
@@ -194,6 +185,15 @@ def test_llama3_causal_lm(variant):
         source=Source.HUGGINGFACE,
         group=group,
     )
+
+    if variant in [
+        "meta-llama/Meta-Llama-3.1-70B",
+        "meta-llama/Llama-3.2-3B-Instruct",
+        "meta-llama/Llama-3.2-1B-Instruct",
+    ]:
+        raise RuntimeError("Requires multi-chip support")
+    elif variant == "meta-llama/Llama-3.1-8B-Instruct":
+        raise RuntimeError("Segmentation Fault")
 
     # Load model (with tokenizer)
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/minimax/test_minimax.py
+++ b/forge/test/models/pytorch/text/minimax/test_minimax.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+variants = ["MiniMaxAI/MiniMax-Text-01"]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", variants)
+def test_minimax_text(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.MINIMAX,
+        variant=variant,
+        task=Task.CAUSAL_LM,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+    )
+
+    raise RuntimeError("Requires multi-chip support")
+
+
+variants = ["MiniMaxAI/MiniMax-VL-01"]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", variants)
+def test_minimax_vl(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.MINIMAX,
+        variant=variant,
+        task=Task.CAUSAL_LM,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+    )
+
+    raise RuntimeError("Requires multi-chip support")

--- a/forge/test/models/pytorch/text/ministral/test_ministral_3b.py
+++ b/forge/test/models/pytorch/text/ministral/test_ministral_3b.py
@@ -9,6 +9,7 @@ from forge.forge_property_utils import (
     Framework,
     ModelArch,
     ModelGroup,
+    ModelPriority,
     Source,
     Task,
     record_model_properties,
@@ -21,9 +22,7 @@ variants = ["ministral/Ministral-3b-instruct"]
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
-@pytest.mark.skip(
-    reason="Insufficient host DRAM to run this model (requires a bit more than 26 GB during compile time)"
-)
+@pytest.mark.xfail
 def test_ministral_3b(variant):
 
     # Record Forge Property
@@ -34,7 +33,10 @@ def test_ministral_3b(variant):
         task=Task.CAUSAL_LM,
         source=Source.HUGGINGFACE,
         group=ModelGroup.RED,
+        priority=ModelPriority.P1,
     )
+
+    raise RuntimeError("Requires multi-chip support")
 
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/ministral/test_ministral_8b.py
+++ b/forge/test/models/pytorch/text/ministral/test_ministral_8b.py
@@ -9,6 +9,7 @@ from forge.forge_property_utils import (
     Framework,
     ModelArch,
     ModelGroup,
+    ModelPriority,
     Source,
     Task,
     record_model_properties,
@@ -23,7 +24,7 @@ variants = ["mistralai/Ministral-8B-Instruct-2410"]
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants, ids=variants)
-@pytest.mark.skip(reason="Transient test - Out of memory due to other tests in CI pipeline")
+@pytest.mark.xfail
 def test_ministral_8b(variant):
 
     # Record Forge Property
@@ -34,7 +35,10 @@ def test_ministral_8b(variant):
         source=Source.HUGGINGFACE,
         task=Task.CAUSAL_LM,
         group=ModelGroup.RED,
+        priority=ModelPriority.P1,
     )
+
+    raise RuntimeError("Requires multi-chip support")
 
     # Load model and tokenizer
     framework_model = download_model(AutoModelForCausalLM.from_pretrained, variant, return_dict=False, use_cache=False)

--- a/forge/test/models/pytorch/text/mistral/test_mistral.py
+++ b/forge/test/models/pytorch/text/mistral/test_mistral.py
@@ -69,7 +69,7 @@ variants = ["mistralai/Mistral-7B-Instruct-v0.3"]
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB)")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_mistral_v0_3(variant):
 
@@ -82,6 +82,8 @@ def test_mistral_v0_3(variant):
         source=Source.HUGGINGFACE,
         group=ModelGroup.RED,
     )
+
+    raise RuntimeError("Requires multi-chip support")
 
     # Load tokenizer and model
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
@@ -104,3 +106,45 @@ def test_mistral_v0_3(variant):
 
     # Model Verification
     verify(inputs, framework_model, compiled_model)
+
+
+variants = ["mistralai/Mistral-Nemo-Instruct-2407"]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", variants)
+def test_mistral_Nemo(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.MISTRAL,
+        variant=variant,
+        task=Task.CAUSAL_LM,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+    )
+
+    raise RuntimeError("Requires multi-chip support")
+
+
+variants = ["mistralai/Mixtral-8x7B-Instruct-v0.1"]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", variants)
+def test_mistral_8x7b(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.MISTRAL,
+        variant=variant,
+        task=Task.CAUSAL_LM,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+    )
+
+    raise RuntimeError("Requires multi-chip support")

--- a/forge/test/models/pytorch/text/phi3/test_phi3.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3.py
@@ -88,11 +88,8 @@ variants = ["microsoft/phi-3-mini-4k-instruct", "microsoft/phi-3-mini-128k-instr
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
+@pytest.mark.xfail
 def test_phi3_causal_lm(variant):
-    if variant == "microsoft/phi-3-mini-4k-instruct":
-        pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 31 GB)")
-    elif variant == "microsoft/phi-3-mini-128k-instruct":
-        pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 31 GB)")
 
     # Record Forge Property
     module_name = record_model_properties(
@@ -104,6 +101,8 @@ def test_phi3_causal_lm(variant):
         group=ModelGroup.RED,
         priority=ModelPriority.P1,
     )
+
+    raise RuntimeError("Requires multi-chip support")
 
     # Phi3Config from pretrained variant, disable return_dict and caching.
     config = Phi3Config.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/phi3/test_phi3_5.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3_5.py
@@ -23,7 +23,7 @@ variants = ["microsoft/Phi-3.5-mini-instruct"]
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Test skipped due to segmentation fault issue")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_5_causal_lm(variant):
 
@@ -37,6 +37,8 @@ def test_phi3_5_causal_lm(variant):
         group=ModelGroup.RED,
         priority=ModelPriority.P1,
     )
+
+    raise RuntimeError("Segmentation Fault")
 
     # Load model and tokenizer
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
@@ -61,3 +63,25 @@ def test_phi3_5_causal_lm(variant):
 
     # Model Verification
     verify(inputs, framework_model, compiled_model)
+
+
+variants = ["microsoft/Phi-3.5-MoE-instruct"]
+
+
+@pytest.mark.parametrize("variant", variants)
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_phi3_5_moe_causal_lm(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.PHI3_5_MOE,
+        variant=variant,
+        task=Task.CAUSAL_LM,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
+    )
+
+    raise RuntimeError("Requires multi-chip support")

--- a/forge/test/models/pytorch/text/phi4/test_phi4.py
+++ b/forge/test/models/pytorch/text/phi4/test_phi4.py
@@ -29,7 +29,7 @@ variants = ["microsoft/phi-4"]
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
-@pytest.mark.skip(reason="Skipped due to kill at consteval compilation stage")
+@pytest.mark.xfail
 def test_phi_4_causal_lm_pytorch(variant):
 
     # Record Forge Property
@@ -42,6 +42,8 @@ def test_phi_4_causal_lm_pytorch(variant):
         group=ModelGroup.RED,
         priority=ModelPriority.P1,
     )
+
+    raise RuntimeError("Requires multi-chip support")
 
     # Load tokenizer and model from HuggingFace
     framework_model = download_model(AutoModelForCausalLM.from_pretrained, variant, return_dict=False, use_cache=False)

--- a/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
@@ -69,6 +69,10 @@ variants = [
             pytest.mark.out_of_memory,
         ],
     ),
+    pytest.param(
+        "Qwen/Qwen2.5-Coder-32B-Instruct",
+        marks=[pytest.mark.xfail],
+    ),
 ]
 
 
@@ -84,6 +88,9 @@ def test_qwen_clm(variant):
         task=Task.CAUSAL_LM,
         source=Source.HUGGINGFACE,
     )
+
+    if variant == "Qwen/Qwen2.5-Coder-32B-Instruct":
+        raise RuntimeError("Requires multi-chip support")
 
     # Load model and tokenizer
     framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu")

--- a/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
@@ -53,6 +53,10 @@ variants = [
         "Qwen/Qwen2.5-7B-Instruct",
         marks=[pytest.mark.skip(reason="Insufficient host DRAM to run this model"), pytest.mark.out_of_memory],
     ),
+    pytest.param(
+        "Qwen/Qwen2.5-72B-Instruct",
+        marks=[pytest.mark.xfail],
+    ),
 ]
 
 
@@ -64,6 +68,7 @@ def test_qwen_clm(variant):
         "Qwen/Qwen2.5-1.5B-Instruct",
         "Qwen/Qwen2.5-3B-Instruct",
         "Qwen/Qwen2.5-7B-Instruct",
+        "Qwen/Qwen2.5-72B-Instruct",
     ]:
         group = ModelGroup.RED
     else:
@@ -78,6 +83,9 @@ def test_qwen_clm(variant):
         source=Source.HUGGINGFACE,
         group=group,
     )
+
+    if variant == "Qwen/Qwen2.5-72B-Instruct":
+        raise RuntimeError("Requires multi-chip support")
 
     # Load model and tokenizer
     framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu")

--- a/forge/test/models/pytorch/vision/centernet/test_centernet.py
+++ b/forge/test/models/pytorch/vision/centernet/test_centernet.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    ModelPriority,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_centernet():
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.CENTERNET,
+        task=Task.OBJECT_DETECTION,
+        source=Source.GITHUB,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
+    )
+
+    raise RuntimeError("Test is currently not executable due to model code dependency.")

--- a/forge/test/models/pytorch/vision/maptr/test_maptr.py
+++ b/forge/test/models/pytorch/vision/maptr/test_maptr.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    ModelPriority,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_maptr():
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.MAPTR,
+        task=Task.REALTIME_MAP_CONSTRUCTION,
+        source=Source.GITHUB,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
+    )
+
+    raise RuntimeError("Test is currently not executable due to mmdet3d and model code dependency.")

--- a/forge/test/models/pytorch/vision/suryaocr/test_surya_ocr.py
+++ b/forge/test/models/pytorch/vision/suryaocr/test_surya_ocr.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    ModelPriority,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_surya_ocr():
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.SURYAOCR,
+        task=Task.OPTICAL_CHARACTER_RECOGNITION,
+        source=Source.GITHUB,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
+    )
+
+    raise RuntimeError("Test is currently not executable due to tricky dependencies.")

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -84,7 +84,7 @@ def test_swin_v1_tiny_4_224_hf_pytorch(variant):
     [
         pytest.param(
             "microsoft/swinv2-tiny-patch4-window8-256",
-            marks=[pytest.mark.skip(reason="Transient failure - Segmentation fault")],
+            marks=pytest.mark.xfail,
         ),
     ],
 )
@@ -99,6 +99,8 @@ def test_swin_v2_tiny_4_256_hf_pytorch(variant):
         group=ModelGroup.RED,
         priority=ModelPriority.P1,
     )
+
+    raise RuntimeError("Transient failure - Segmentation fault")
 
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
     framework_model = Swinv2Model.from_pretrained(variant)

--- a/forge/test/models/pytorch/vision/transfuser/test_transfuser.py
+++ b/forge/test/models/pytorch/vision/transfuser/test_transfuser.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    ModelPriority,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_transfuser():
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.TRANSFUSER,
+        task=Task.PLANNING_ORIENTED_DRIVING,
+        source=Source.GITHUB,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
+    )
+
+    raise RuntimeError("Test is currently not executable due to model code dependency.")

--- a/forge/test/models/pytorch/vision/uniad/test_uniad.py
+++ b/forge/test/models/pytorch/vision/uniad/test_uniad.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    ModelPriority,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_uniad():
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.UNIAD,
+        task=Task.PLANNING_ORIENTED_DRIVING,
+        source=Source.GITHUB,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
+    )
+
+    raise RuntimeError("Test is currently not executable due to mmdet3d and model code dependency.")


### PR DESCRIPTION
### Summary 

- This PR adds placeholder tests for missed red models and replace skip markers with xfail markers in skipped models to record properties of red models except below models 

  - [Deepseek R1](https://huggingface.co/deepseek-ai/DeepSeek-R1), [Deepseek V3](https://huggingface.co/deepseek-ai/DeepSeek-V3) - target variant unknown
  - KLA K-SegNet, KLA Klassify , - Research Paper Need 




