### PR TITLE
Enable lower dataformat support in models ops gen

### DIFF
--- a/forge/forge/python_codegen.py
+++ b/forge/forge/python_codegen.py
@@ -1078,7 +1078,13 @@ class ForgeWriter(PythonWriter):
         if module_metadata is not None and len(module_metadata) != 0:
             self.wl("record_single_op_operands_info(framework_model, inputs)")
             self.wl("")
-        self.wl("compiled_model = compile(framework_model, sample_inputs=inputs)")
+        self.wl("compiler_cfg = forge.config.CompilerConfig()")
+        self.wl('if "default_df_override" in metadata.keys():')
+        self.indent += 1
+        self.wl('compiler_cfg.default_df_override = forge.DataFormat.from_json(metadata["default_df_override"])')
+        self.indent -= 1
+        self.wl("")
+        self.wl("compiled_model = compile(framework_model, sample_inputs=inputs, compiler_cfg=compiler_cfg)")
         self.wl("")
         self.wl(
             "verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)))"


### PR DESCRIPTION
Currently we are running convolution based models in **lower dataformat(eg: float16_b)**. For running the models in lower dataformat, we will convert the **model** and **inputs** to **lower dataformat(eg: bfloa16)** and then pass it to compile function but the **tvm graph** is constructed on **float32** because the `ConvertEmulatedDtypes` convert the **weights**, **buffers** and **inputs** from **bfloat16** to **float32**. In the `post initial graph pass`, we will convert the **parameter** and **op node** dataformat to **lower dataformat(eg: float16_b)** and add **cast node** after the **constant** node if the dataformat is not **lower dataformat(eg: float16_b)** and we are already passing activation and parameter as bfloat16 so there is no need to lower.

Since the lower dataformat conversation is happening only in post intial graph pass there will be no change in **ForgeModule generated with/without lower dataformat** because it is constructed on the **TVM graph.**

Similarly there will be no change in the **models ops generation** because the **unique ops config** is extracted from the **TVM graph**.

The PR will enable **lower dataformat support** in the **models ops tests generation pipeline** to match the same config as convolution models.

It will convert all the **parameters**, **constant** and **activation** from **floating dtype(eg: float32)** to **lower dataformat(eg: float16_b/bfloat16**) and will also save the lower dataformat as metadata for setting the compiler config default_df_override so that `configure_output_data_formats` function in `post initial graph pass` will assert if the constant and activation are not in lower dataformat and convert the parameter and op node to lower dataformat if is missed.