### PR TITLE
Fix integer constant handling in Forge codegen

### DIFF
--- a/forge/csrc/lower_to_forge/common.hpp
+++ b/forge/csrc/lower_to_forge/common.hpp
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <fmt/ostream.h>
+
 #include <array>
 #include <cstdint>
 #include <map>
@@ -262,3 +264,11 @@ struct PytorchTensorDesc
 };
 
 }  // namespace tt
+
+namespace fmt
+{
+template <>
+struct formatter<tt::DataFormat> : ostream_formatter
+{
+};
+}  // namespace fmt

--- a/forge/forge/python_codegen.py
+++ b/forge/forge/python_codegen.py
@@ -399,10 +399,6 @@ class ForgeWriter(PythonWriter):
             self.wl("tensor = tensor.reshape((1, 1))")
             self.indent -= 1
             self.wl("tensor.requires_grad = False")
-            self.wl("if not torch.is_floating_point(tensor):")
-            self.indent += 1
-            self.wl("tensor = tensor.float()")
-            self.indent -= 1
             self.wl("self.set_constant(name, tensor)")
             self.indent -= 1
 


### PR DESCRIPTION
### Ticket
Closes #2219 

### Problem description
Data mismatch on embedding test with constant input was caused by constant int32 being casted to bfloat16 and therefore changing index of embedding.

This cast was added in data formats pass. I looked into why was cast added on integer input node - turns out Forge codegen casted all integer constants to float32, so input index node wasn't integer anymore...

### What's changed
- bugfix: Change Forge codegen for process_framework_parameters - don't cast integer constants to floats.
- Change assert in configure_output_data_formats to handle integer constant inputs.
- Add test that reproed the bug.
