### PR TITLE
Uplift third_party/tt-mlir to origin/main 2025-06-11

### DIFF
--- a/forge/test/mlir/operators/nn/test_nn.py
+++ b/forge/test/mlir/operators/nn/test_nn.py
@@ -742,10 +742,7 @@ def test_avgpool2d_decompose_to_conv2d(shape, padding):
     [
         pytest.param((1, 1, 1, 1)),
         pytest.param((1, 1, 2, 2)),
-        pytest.param(
-            (1, 2, 1, 2),
-            marks=pytest.mark.xfail(reason="error: failed to legalize operation 'ttir.conv2d'"),
-        ),
+        pytest.param((1, 2, 1, 2)),
     ],
 )
 @pytest.mark.push


### PR DESCRIPTION
This PR uplifts the third_party/tt-mlir submodule to the origin/main