### PR TITLE
Update nightly schedule time

### DIFF
--- a/.github/workflows/on-nightly-bh.yml
+++ b/.github/workflows/on-nightly-bh.yml
@@ -27,7 +27,7 @@ on:
           - 'Yes'
           - 'No'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 22 * * *'  # Runs at 22:00 UTC every day
 
 permissions:
   packages: write

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -28,7 +28,7 @@ on:
           - 'Yes'
           - 'No'
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 22 * * *'  # Runs at 22:00 UTC every day
 
 permissions:
   packages: write


### PR DESCRIPTION
This pull request shifts both the On nightly and On nightly Blackhole jobs two hours earlier to accelerate bisecting and issue resolution. Previously, they ran each day at 00:00 UTC (02:00 CEST/Serbia time). With this change, they will now trigger at 22:00 UTC (00:00 CEST/Serbia time)