### PR TITLE
Update test_durations workflow

### DIFF
--- a/.github/workflows/get_test_duration_from_junit_xmls.py
+++ b/.github/workflows/get_test_duration_from_junit_xmls.py
@@ -26,7 +26,7 @@ def extract_test_case_info(xml_file):
             # Iterate over all <testcase> elements within the current <testsuite>
             for testcase in testsuite.findall("testcase"):
                 try:
-                    path = testsuite.get("classname").replace(".", "/")
+                    path = testcase.get("classname").replace(".", "/")
                     name = testcase.get("name")
                     test_cases_info[f"{path}.py::{name}"] = float(testcase.get("time", 0))
                 except ValueError:

--- a/.github/workflows/get_test_duration_from_junit_xmls.py
+++ b/.github/workflows/get_test_duration_from_junit_xmls.py
@@ -26,7 +26,9 @@ def extract_test_case_info(xml_file):
             # Iterate over all <testcase> elements within the current <testsuite>
             for testcase in testsuite.findall("testcase"):
                 try:
-                    test_cases_info[testcase.get("name")] = float(testcase.get("time", 0))
+                    path = testsuite.get("classname").replace(".", "/")
+                    name = testcase.get("name")
+                    test_cases_info[f"{path}.py::{name}"] = float(testcase.get("time", 0))
                 except ValueError:
                     print(f"Warning: Non-numeric time value encountered in {xml_file} for test case '{name}'")
 

--- a/.github/workflows/get_test_duration_from_junit_xmls.py
+++ b/.github/workflows/get_test_duration_from_junit_xmls.py
@@ -56,8 +56,11 @@ def process_directory(directory):
     """
     all_test_cases = {}
 
+    print(f"Procees dir {directory}")
     for subdir, _, files in os.walk(directory):
+        print(f"Walk subdir: {subdir}")
         for file in files:
+            printf(f"File: {file}")
             if file.endswith(".xml"):
                 xml_file_path = os.path.join(subdir, file)
                 # Check if it's a JUnit XML report by looking for <testsuite> tag
@@ -76,11 +79,12 @@ def main():
         sys.exit(1)
 
     root_directory = sys.argv[1]
-    test_case_data = process_directory(root_directory)
+    output_file = sys.argv[2]
+    print(f"Dir to process {root_directory}, output file {output_file}")
 
+    test_case_data = process_directory(root_directory)
     json_output = json.dumps(test_case_data, indent=4)
 
-    output_file = sys.argv[2]
     with open(output_file, "w") as f:
         f.write(json_output)
 

--- a/.github/workflows/get_test_duration_from_junit_xmls.py
+++ b/.github/workflows/get_test_duration_from_junit_xmls.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import os
+import xml.etree.ElementTree as ET
+import json
+
+
+def extract_test_case_info(xml_file):
+    """
+    Extract test case names and their execution times from a JUnit XML report.
+
+    Args:
+        xml_file (str): Path to the XML file.
+
+    Returns:
+        dict: A dictionary with test case names as keys and their execution time in seconds as values.
+    """
+    try:
+        tree = ET.parse(xml_file)
+        root = tree.getroot()
+
+        # Namespace map for parsing JUnit XML
+        namespace = {"ns": "http://xmlns.jenkins.io/manifests/junit"}
+
+        test_cases_info = {}
+
+        # Iterate through each testcase element in the XML file
+        for testcase in root.findall("ns:testsuite/ns:testcase", namespace):
+            name = testcase.get("name")
+            time_str = testcase.get("time", "0")  # Default to 0 if time not specified
+
+            try:
+                time_seconds = float(time_str)
+                test_cases_info[name] = time_seconds
+            except ValueError:
+                print(f"Warning: Non-numeric time value encountered in {xml_file} for test case '{name}'")
+
+        return test_cases_info
+
+    except ET.ParseError as e:
+        print(f"Error parsing XML file {xml_file}: {e}")
+        return {}
+
+
+def process_directory(directory):
+    """
+    Process all JUnit XML files in the directory and subdirectories.
+
+    Args:
+        directory (str): Path to the root directory.
+
+    Returns:
+        dict: A dictionary with test case names as keys and their execution times as values across all files.
+    """
+    all_test_cases = {}
+
+    for subdir, _, files in os.walk(directory):
+        for file in files:
+            if file.endswith(".xml"):
+                xml_file_path = os.path.join(subdir, file)
+                # Check if it's a JUnit XML report by looking for <testsuite> tag
+                try:
+                    test_cases_info = extract_test_case_info(xml_file_path)
+                    all_test_cases.update(test_cases_info)
+                except Exception as e:
+                    print(f"Error reading file {xml_file_path}: {e}")
+
+    return all_test_cases
+
+
+def main():
+    if len(sys.argv) != 3:
+        print("Usage: python .github/workflows/get_test_duration_from_junit_xmls.py <directory> <json_output>")
+        sys.exit(1)
+
+    root_directory = sys.argv[1]
+    test_case_data = process_directory(root_directory)
+
+    json_output = json.dumps(test_case_data, indent=4)
+
+    output_file = sys.argv[2]
+    with open(output_file, "w") as f:
+        f.write(json_output)
+
+    print(f"Test case data has been written to {output_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/get_test_duration_from_junit_xmls.py
+++ b/.github/workflows/get_test_duration_from_junit_xmls.py
@@ -27,7 +27,7 @@ def extract_test_case_info(xml_file):
         test_cases_info = {}
 
         # Iterate through each testcase element in the XML file
-        for testcase in root.findall("ns:testsuite/ns:testcase", namespace):
+        for testcase in root.findall("ns:testsuites/ns:testsuite/ns:testcase", namespace):
             name = testcase.get("name")
             time_str = testcase.get("time", "0")  # Default to 0 if time not specified
 
@@ -56,11 +56,8 @@ def process_directory(directory):
     """
     all_test_cases = {}
 
-    print(f"Procees dir {directory}")
     for subdir, _, files in os.walk(directory):
-        print(f"Walk subdir: {subdir}")
         for file in files:
-            print(f"File: {file}")
             if file.endswith(".xml"):
                 xml_file_path = os.path.join(subdir, file)
                 # Check if it's a JUnit XML report by looking for <testsuite> tag

--- a/.github/workflows/get_test_duration_from_junit_xmls.py
+++ b/.github/workflows/get_test_duration_from_junit_xmls.py
@@ -4,6 +4,7 @@
 import os
 import xml.etree.ElementTree as ET
 import json
+import sys
 
 
 def extract_test_case_info(xml_file):

--- a/.github/workflows/get_test_duration_from_junit_xmls.py
+++ b/.github/workflows/get_test_duration_from_junit_xmls.py
@@ -66,6 +66,7 @@ def process_directory(directory):
                 # Check if it's a JUnit XML report by looking for <testsuite> tag
                 try:
                     test_cases_info = extract_test_case_info(xml_file_path)
+                    print(f"test cases info {test_cases_info}")
                     all_test_cases.update(test_cases_info)
                 except Exception as e:
                     print(f"Error reading file {xml_file_path}: {e}")

--- a/.github/workflows/get_test_duration_from_junit_xmls.py
+++ b/.github/workflows/get_test_duration_from_junit_xmls.py
@@ -20,28 +20,20 @@ def extract_test_case_info(xml_file):
     try:
         tree = ET.parse(xml_file)
         root = tree.getroot()
-
-        # Namespace map for parsing JUnit XML
-        namespace = {"ns": "http://xmlns.jenkins.io/manifests/junit"}
-
         test_cases_info = {}
 
-        # Iterate through each testcase element in the XML file
-        for testcase in root.findall("ns:testsuites/ns:testsuite/ns:testcase", namespace):
-            name = testcase.get("name")
-            time_str = testcase.get("time", "0")  # Default to 0 if time not specified
-
-            try:
-                time_seconds = float(time_str)
-                test_cases_info[name] = time_seconds
-            except ValueError:
-                print(f"Warning: Non-numeric time value encountered in {xml_file} for test case '{name}'")
-
-        return test_cases_info
+        for testsuite in root.findall("testsuite"):
+            # Iterate over all <testcase> elements within the current <testsuite>
+            for testcase in testsuite.findall("testcase"):
+                try:
+                    test_cases_info[testcase.get("name")] = float(time_str)
+                except ValueError:
+                    print(f"Warning: Non-numeric time value encountered in {xml_file} for test case '{name}'")
 
     except ET.ParseError as e:
         print(f"Error parsing XML file {xml_file}: {e}")
-        return {}
+
+    return test_cases_info
 
 
 def process_directory(directory):

--- a/.github/workflows/get_test_duration_from_junit_xmls.py
+++ b/.github/workflows/get_test_duration_from_junit_xmls.py
@@ -60,7 +60,7 @@ def process_directory(directory):
     for subdir, _, files in os.walk(directory):
         print(f"Walk subdir: {subdir}")
         for file in files:
-            printf(f"File: {file}")
+            print(f"File: {file}")
             if file.endswith(".xml"):
                 xml_file_path = os.path.join(subdir, file)
                 # Check if it's a JUnit XML report by looking for <testsuite> tag

--- a/.github/workflows/get_test_duration_from_junit_xmls.py
+++ b/.github/workflows/get_test_duration_from_junit_xmls.py
@@ -26,7 +26,7 @@ def extract_test_case_info(xml_file):
             # Iterate over all <testcase> elements within the current <testsuite>
             for testcase in testsuite.findall("testcase"):
                 try:
-                    test_cases_info[testcase.get("name")] = float(time_str)
+                    test_cases_info[testcase.get("name")] = float(testcase.get("time", 0))
                 except ValueError:
                     print(f"Warning: Non-numeric time value encountered in {xml_file} for test case '{name}'")
 

--- a/.github/workflows/get_test_duration_from_junit_xmls.py
+++ b/.github/workflows/get_test_duration_from_junit_xmls.py
@@ -57,7 +57,6 @@ def process_directory(directory):
                 # Check if it's a JUnit XML report by looking for <testsuite> tag
                 try:
                     test_cases_info = extract_test_case_info(xml_file_path)
-                    print(f"test cases info {test_cases_info}")
                     all_test_cases.update(test_cases_info)
                 except Exception as e:
                     print(f"Error reading file {xml_file_path}: {e}")

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -18,7 +18,9 @@ jobs:
           fetch-depth: 0
           # ref: main
       - uses: actions/setup-python@v5
-      - id: get-test-durations
+        with:
+          python-version: '3.10'
+    - id: get-test-durations
         run: |
           repo="tenstorrent/tt-forge-fe"
           wf_name="on-nightly.yml"

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -53,10 +53,6 @@ jobs:
           python .github/workflows/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations_new
           echo "----- NEW DURATIONS"
           cat .test_durations_new
-          echo "----- DIFF"
-          diff .test_durations .test_durations_new
 
           echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-          echo "curr_wf_id=$curr_wf_id" >> $GITHUB_OUTPUT
-          echo "curr_wf_att=$curr_wf_att" >> $GITHUB_OUTPUT
-          echo "curr_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> $GITHUB_OUTPUT
+          echo "curr_wf_link='https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att'" >> $GITHUB_OUTPUT

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -20,7 +20,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - id: get-test-durations
+      - name: Process nightly test durations
+        id: get-test-durations
         run: |
           repo="tenstorrent/tt-forge-fe"
           wf_name="on-nightly.yml"

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -78,9 +78,9 @@ jobs:
           committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
           base: main
-          commit-message: "Update test durations based on latest nightly ${{ steps.get-test-durations.output.TODAY }}"
-          title: "Update test durations based on latest nightly ${{ steps.get-test-durations.output.TODAY }}"
-          body: "This PR updates test durations based on latest nightly (${{ steps.get-test-durations.output.curr_nightly_wf_link }}) and latest push (${{ steps.get-test-durations.output.curr_push_wf_link }})"
+          commit-message: "Update test durations based on latest nightly ${{ steps.get-test-durations.outputs.TODAY }}"
+          title: "Update test durations based on latest nightly ${{ steps.get-test-durations.outputs.TODAY }}"
+          body: "This PR updates test durations based on latest nightly (${{ steps.get-test-durations.outputs.curr_nightly_wf_link }}) and latest push (${{ steps.get-test-durations.outputs.curr_push_wf_link }})"
           labels: tooling
           delete-branch: true
           token: ${{ secrets.GH_TOKEN }}
@@ -94,6 +94,6 @@ jobs:
       - name: Generate Summary
         run: |
           echo "## Test duration report" >> $GITHUB_STEP_SUMMARY
-          echo "Used [Nightly](${{ steps.get-test-durations.output.curr_nightly_wf_link }})" >> $GITHUB_STEP_SUMMARY
-          echo "And [Push](${{ steps.get-test-durations.output.curr_push_wf_link }})" >> $GITHUB_STEP_SUMMARY
-          echo "Generated test durations in [Pull Request](${{ steps.create-pr.output.pull-request-url }})" >> $GITHUB_STEP_SUMMARY
+          echo "Used [Nightly](${{ steps.get-test-durations.outputs.curr_nightly_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Push](${{ steps.get-test-durations.outputs.curr_push_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "Generated test durations in [Pull Request](${{ steps.create-pr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -33,7 +33,7 @@ jobs:
             # Check the status of 'conclusion'
             conclusion=$(jq -r ".[$counter].conclusion" runs.json)
 
-            if [ "$conclusion" != "success"] && [ "$conclusion" != "failure" ]; then
+            if [ "$conclusion" != "success" ] && [ "$conclusion" != "failure" ]; then
               ((counter++))
 
               # Exit if the counter reaches 5
@@ -46,7 +46,7 @@ jobs:
             fi
           done
           curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
-          curr_wf_att$(jq -r ".[$counter].attempt" runs.json)
+          curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
 
           gh run download $curr_wf_id --attempt $curr_wf_att --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
           python .github/workflows/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations_new

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -2,98 +2,57 @@ name: Performance benchmark
 
 on:
   workflow_dispatch:
+    inputs:
+      rebuild:
+        description: 'Rebuild the Forge'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   packages: write
   checks: write
 
 jobs:
-  update_test_durations:
+  docker-build:
+    uses: ./.github/workflows/build-image.yml
+    secrets: inherit
+
+  set-inputs:
     runs-on: ubuntu-latest
+    needs: docker-build
+    outputs:
+      buildtype: ${{ steps.set-inputs.outputs.buildtype }}
+      run-id: ${{ steps.set-inputs.outputs.runid }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          # ref: main
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-      - name: Process nightly test durations
-        id: get-test-durations
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      - name: Set Inputs
+        id: set-inputs
         run: |
-          repo="tenstorrent/tt-forge-fe"
+          if [ ${{ inputs.rebuild }} == 'true' ]; then
+            echo "buildtype=Release" >> $GITHUB_OUTPUT
+            echo "runid=${{ github.run_id }}" >> $GITHUB_OUTPUT
+          else
+            echo "buildtype=None" >> $GITHUB_OUTPUT
+          fi
 
-          get_test_results_from_wf() {
-            local wf_name="$1"
-            local conclusions="$2"
-            local num=5
+  build:
+    needs:
+      - docker-build
+      - set-inputs
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
+      build: ${{ needs.set-inputs.outputs.buildtype}}
 
-            # get json of the last $num workflow runs
-            gh run list --workflow $wf_name -R $repo -b main -L $num --status completed --json attempt,conclusion,databaseId >runs.json
-
-            counter=0
-            while true; do
-              # Check the status of 'conclusion'
-              conclusion=$(jq -r ".[$counter].conclusion" runs.json)
-
-              if echo "$conclusions" | grep -q -w "$conclusion"; then
-                break
-              else
-                ((counter++))
-
-                # Exit if the counter reaches $num
-                if [ $counter -ge $num ]; then
-                  echo "ERROR: Did not found good workflow within last $num. Exiting."
-                  exit 1
-                fi
-              fi
-            done
-            curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
-            curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
-            echo "curr_$3_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> "$GITHUB_OUTPUT"
-            rm -f runs.json
-
-            gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
-          }
-
-          # get test results from the last nightly that was success or failure
-          get_test_results_from_wf "on-nightly.yml" "success,failure" "nightly"
-
-          # get test results from the last successful push
-          get_test_results_from_wf "on-push.yml" "success" "push"
-
-          python .github/workflows/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations_new
-          echo "----- NEW DURATIONS"
-          cat .test_durations_new
-
-          echo "TODAY=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
-        id: create-pr
-        with:
-          branch: test-durations-update
-          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-          base: main
-          commit-message: "Update test durations based on latest nightly ${{ steps.get-test-durations.outputs.TODAY }}"
-          title: "Update test durations based on latest nightly ${{ steps.get-test-durations.outputs.TODAY }}"
-          body: "This PR updates test durations based on latest nightly (${{ steps.get-test-durations.outputs.curr_nightly_wf_link }}) and latest push (${{ steps.get-test-durations.outputs.curr_push_wf_link }})"
-          labels: tooling
-          delete-branch: true
-          token: ${{ secrets.GH_TOKEN }}
-
-      - name: Enable Pull Request Automerge
-        if: ${{ steps.create-pr.outputs.pull-request-number }}
-        run: gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
-        env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
-
-      - name: Generate Summary
-        run: |
-          echo "## Test duration report" >> $GITHUB_STEP_SUMMARY
-          echo "Used [Nightly](${{ steps.get-test-durations.outputs.curr_nightly_wf_link }})" >> $GITHUB_STEP_SUMMARY
-          echo "And [Push](${{ steps.get-test-durations.outputs.curr_push_wf_link }})" >> $GITHUB_STEP_SUMMARY
-          echo "Generated test durations in [Pull Request](${{ steps.create-pr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY
+  run-perf-benchmarks:
+    if: always()
+    needs:
+      - docker-build
+      - set-inputs
+      - build
+    uses: ./.github/workflows/perf-benchmark-sub.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
+      run_id: ${{ needs.set-inputs.outputs.run-id }}

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -52,7 +52,8 @@ jobs:
             done
             curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
             curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
-            echo "curr_$3_wf_link='https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att'" >> $GITHUB_OUTPUT
+            echo "curr_$3_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> $GITHUB_OUTPUT
+            rm -f runs.json
 
             gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
           }
@@ -79,7 +80,7 @@ jobs:
           base: main
           commit-message: "Update test durations based on latest nightly ${{ steps.get-test-durations.output.TODAY }}"
           title: "Update test durations based on latest nightly ${{ steps.get-test-durations.output.TODAY }}"
-          body: "This PR updates test durations based on latest nightly (${{steps.get-test-durations.output.curr_nightly_wf_link}}) and latest push (${{steps.get-test-durations.output.curr_push_wf_link}})"
+          body: "This PR updates test durations based on latest nightly (${{ steps.get-test-durations.output.curr_nightly_wf_link }}) and latest push (${{ steps.get-test-durations.output.curr_push_wf_link }})"
           labels: tooling
           delete-branch: true
           token: ${{ secrets.GH_TOKEN }}
@@ -93,6 +94,6 @@ jobs:
       - name: Generate Summary
         run: |
           echo "## Test duration report" >> $GITHUB_STEP_SUMMARY
-          echo "Used [Nightly](<${{steps.get-test-durations.output.curr_nightly_wf_link}}>)" >> $GITHUB_STEP_SUMMARY
-          echo "And [Push](<${{steps.get-test-durations.output.curr_push_wf_link}}>)" >> $GITHUB_STEP_SUMMARY
-          echo "Generated test durations in [Pull Request](<${{steps.create-pr.output.pull-request-url}}>)" >> $GITHUB_STEP_SUMMARY
+          echo "Used [Nightly](<${{ steps.get-test-durations.output.curr_nightly_wf_link }}>)" >> $GITHUB_STEP_SUMMARY
+          echo "And [Push](<${{ steps.get-test-durations.output.curr_push_wf_link }}>)" >> $GITHUB_STEP_SUMMARY
+          echo "Generated test durations in [Pull Request](<${{ steps.create-pr.output.pull-request-url }}>)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           repo="tenstorrent/tt-forge-fe"
           wf_name="on-nightly.yml"
+          $conclusions="success,failure"
 
           # get json of the last 10 workflow runs
           gh run list --workflow $wf_name -R $repo -b main -L 5 --status completed --json attempt,conclusion,databaseId >runs.json
@@ -34,7 +35,9 @@ jobs:
             # Check the status of 'conclusion'
             conclusion=$(jq -r ".[$counter].conclusion" runs.json)
 
-            if [ "$conclusion" != "success" ] && [ "$conclusion" != "failure" ]; then
+            if echo "$conclusions" | grep -q -w "$conclusion"; then
+              break
+            else
               ((counter++))
 
               # Exit if the counter reaches 5
@@ -42,8 +45,6 @@ jobs:
                 echo "Counter reached 5. Exiting with code 1."
                 exit 1
               fi
-            else
-              break
             fi
           done
           curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -24,8 +24,6 @@ jobs:
         id: get-test-durations
         run: |
           repo="tenstorrent/tt-forge-fe"
-          curr_wf_id=""
-          curr_wf_att=""
 
           get_test_results_from_wf() {
             local wf_name="$1"
@@ -54,17 +52,16 @@ jobs:
             done
             curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
             curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
+            echo "curr_$3_wf_link='https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att'" >> $GITHUB_OUTPUT
 
             gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
           }
 
           # get test results from the last nightly that was success or failure
-          get_test_results_from_wf "on-nightly.yml" "success,failure"
-          echo "curr_nightly_wf_link='https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att'" >> $GITHUB_OUTPUT
+          get_test_results_from_wf "on-nightly.yml" "success,failure" "nightly"
 
           # get test results from the last successful push
-          get_test_results_from_wf "on-push.yml" "success"
-          echo "curr_push_wf_link='https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att'" >> $GITHUB_OUTPUT
+          get_test_results_from_wf "on-push.yml" "success" "push"
 
           python .github/workflows/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations_new
           echo "----- NEW DURATIONS"
@@ -86,6 +83,12 @@ jobs:
           labels: tooling
           delete-branch: true
           token: ${{ secrets.GH_TOKEN }}
+
+      - name: Enable Pull Request Automerge
+        if: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
       - name: Generate Summary
         run: |

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-    - id: get-test-durations
+      - id: get-test-durations
         run: |
           repo="tenstorrent/tt-forge-fe"
           wf_name="on-nightly.yml"

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -2,57 +2,58 @@ name: Performance benchmark
 
 on:
   workflow_dispatch:
-    inputs:
-      rebuild:
-        description: 'Rebuild the Forge'
-        required: false
-        default: false
-        type: boolean
 
 permissions:
   packages: write
   checks: write
 
 jobs:
-  docker-build:
-    uses: ./.github/workflows/build-image.yml
-    secrets: inherit
-
-  set-inputs:
+  update_test_durations:
     runs-on: ubuntu-latest
-    needs: docker-build
-    outputs:
-      buildtype: ${{ steps.set-inputs.outputs.buildtype }}
-      run-id: ${{ steps.set-inputs.outputs.runid }}
+    env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
-      - name: Set Inputs
-        id: set-inputs
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # ref: main
+      - uses: actions/setup-python@v5
+      - id: get-test-durations
         run: |
-          if [ ${{ inputs.rebuild }} == 'true' ]; then
-            echo "buildtype=Release" >> $GITHUB_OUTPUT
-            echo "runid=${{ github.run_id }}" >> $GITHUB_OUTPUT
-          else
-            echo "buildtype=None" >> $GITHUB_OUTPUT
-          fi
+          repo="tenstorrent/tt-forge-fe"
+          wf_name="on-nightly.yml"
 
-  build:
-    needs:
-      - docker-build
-      - set-inputs
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      build: ${{ needs.set-inputs.outputs.buildtype}}
+          # get json of the last 10 workflow runs
+          gh run list --workflow $wf_name -R $repo -b main -L 5 --status completed --json attempt,conclusion,databaseId >runs.json
 
-  run-perf-benchmarks:
-    if: always()
-    needs:
-      - docker-build
-      - set-inputs
-      - build
-    uses: ./.github/workflows/perf-benchmark-sub.yml
-    secrets: inherit
-    with:
-      docker-image: ${{ needs.docker-build.outputs.docker-image }}
-      run_id: ${{ needs.set-inputs.outputs.run-id }}
+          counter=0
+          while true; do
+            # Check the status of 'conclusion'
+            conclusion=$(jq -r '.[$counter].conclusion' runs.json)
+
+            if [ "$conclusion" != "success"] && [ "$conclusion" != "failure" ]; then
+              ((counter++))
+
+              # Exit if the counter reaches 5
+              if [ $counter -ge 5 ]; then
+                echo "Counter reached 5. Exiting with code 1."
+                exit 1
+              fi
+            else
+              break
+            fi
+          done
+          curr_wf_id=$(jq -r '.[$counter].databaseId' runs.json)
+          curr_wf_att$(jq -r '.[$counter].attempt' runs.json)
+
+          gh run download $curr_wf_id --attempt $curr_wf_att --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
+          python .github/workflows/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations_new
+          echo "----- NEW DURATIONS"
+          cat .test_durations_new
+          echo "----- DIFF"
+          diff .test_durations .test_durations_new
+
+          echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "curr_wf_id=$curr_wf_id" >> $GITHUB_OUTPUT
+          echo "curr_wf_att=$curr_wf_att" >> $GITHUB_OUTPUT
+          echo "curr_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> $GITHUB_OUTPUT

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -10,8 +10,6 @@ permissions:
 jobs:
   update_test_durations:
     runs-on: ubuntu-latest
-    env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -22,6 +20,8 @@ jobs:
           python-version: '3.10'
       - name: Process nightly test durations
         id: get-test-durations
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           repo="tenstorrent/tt-forge-fe"
 
@@ -52,7 +52,7 @@ jobs:
             done
             curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
             curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
-            echo "curr_$3_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> $GITHUB_OUTPUT
+            echo "curr_$3_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> "$GITHUB_OUTPUT"
             rm -f runs.json
 
             gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
@@ -68,7 +68,7 @@ jobs:
           echo "----- NEW DURATIONS"
           cat .test_durations_new
 
-          echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "TODAY=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
@@ -94,6 +94,6 @@ jobs:
       - name: Generate Summary
         run: |
           echo "## Test duration report" >> $GITHUB_STEP_SUMMARY
-          echo "Used [Nightly](<${{ steps.get-test-durations.output.curr_nightly_wf_link }}>)" >> $GITHUB_STEP_SUMMARY
-          echo "And [Push](<${{ steps.get-test-durations.output.curr_push_wf_link }}>)" >> $GITHUB_STEP_SUMMARY
-          echo "Generated test durations in [Pull Request](<${{ steps.create-pr.output.pull-request-url }}>)" >> $GITHUB_STEP_SUMMARY
+          echo "Used [Nightly](${{ steps.get-test-durations.output.curr_nightly_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Push](${{ steps.get-test-durations.output.curr_push_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "Generated test durations in [Pull Request](${{ steps.create-pr.output.pull-request-url }})" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -48,7 +48,7 @@ jobs:
           curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
           curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
 
-          gh run download $curr_wf_id --attempt $curr_wf_att --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
+          gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
           python .github/workflows/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations_new
           echo "----- NEW DURATIONS"
           cat .test_durations_new

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -24,36 +24,50 @@ jobs:
         id: get-test-durations
         run: |
           repo="tenstorrent/tt-forge-fe"
-          wf_name="on-nightly.yml"
-          $conclusions="success,failure"
+          curr_wf_id=""
+          curr_wf_att=""
 
-          # get json of the last 10 workflow runs
-          gh run list --workflow $wf_name -R $repo -b main -L 5 --status completed --json attempt,conclusion,databaseId >runs.json
+          get_test_results_from_wf() {
+            local wf_name="$1"
+            local conclusions="$2"
+            local num=5
 
-          counter=0
-          while true; do
-            # Check the status of 'conclusion'
-            conclusion=$(jq -r ".[$counter].conclusion" runs.json)
+            # get json of the last $num workflow runs
+            gh run list --workflow $wf_name -R $repo -b main -L $num --status completed --json attempt,conclusion,databaseId >runs.json
 
-            if echo "$conclusions" | grep -q -w "$conclusion"; then
-              break
-            else
-              ((counter++))
+            counter=0
+            while true; do
+              # Check the status of 'conclusion'
+              conclusion=$(jq -r ".[$counter].conclusion" runs.json)
 
-              # Exit if the counter reaches 5
-              if [ $counter -ge 5 ]; then
-                echo "Counter reached 5. Exiting with code 1."
-                exit 1
+              if echo "$conclusions" | grep -q -w "$conclusion"; then
+                break
+              else
+                ((counter++))
+
+                # Exit if the counter reaches $num
+                if [ $counter -ge $num ]; then
+                  echo "ERROR: Did not found good workflow within last $num. Exiting."
+                  exit 1
+                fi
               fi
-            fi
-          done
-          curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
-          curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
+            done
+            curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
+            curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
 
-          gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
+            gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
+          }
+
+          # get test results from the last nightly that was success or failure
+          get_test_results_from_wf "on-nightly.yml" "success,failure"
+          echo "curr_nightly_wf_link='https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att'" >> $GITHUB_OUTPUT
+
+          # get test results from the last successful push
+          get_test_results_from_wf "on-push.yml" "success"
+          echo "curr_push_wf_link='https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att'" >> $GITHUB_OUTPUT
+
           python .github/workflows/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations_new
           echo "----- NEW DURATIONS"
           cat .test_durations_new
 
           echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-          echo "curr_wf_link='https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att'" >> $GITHUB_OUTPUT

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -71,3 +71,25 @@ jobs:
           cat .test_durations_new
 
           echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        id: create-pr
+        with:
+          branch: test-durations-update
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          base: main
+          commit-message: "Update test durations based on latest nightly ${{ steps.get-test-durations.output.TODAY }}"
+          title: "Update test durations based on latest nightly ${{ steps.get-test-durations.output.TODAY }}"
+          body: "This PR updates test durations based on latest nightly (${{steps.get-test-durations.output.curr_nightly_wf_link}}) and latest push (${{steps.get-test-durations.output.curr_push_wf_link}})"
+          labels: tooling
+          delete-branch: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Generate Summary
+        run: |
+          echo "## Test duration report" >> $GITHUB_STEP_SUMMARY
+          echo "Used [Nightly](<${{steps.get-test-durations.output.curr_nightly_wf_link}}>)" >> $GITHUB_STEP_SUMMARY
+          echo "And [Push](<${{steps.get-test-durations.output.curr_push_wf_link}}>)" >> $GITHUB_STEP_SUMMARY
+          echo "Generated test durations in [Pull Request](<${{steps.create-pr.output.pull-request-url}}>)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -29,7 +29,7 @@ jobs:
           counter=0
           while true; do
             # Check the status of 'conclusion'
-            conclusion=$(jq -r '.[$counter].conclusion' runs.json)
+            conclusion=$(jq -r ".[$counter].conclusion" runs.json)
 
             if [ "$conclusion" != "success"] && [ "$conclusion" != "failure" ]; then
               ((counter++))
@@ -43,8 +43,8 @@ jobs:
               break
             fi
           done
-          curr_wf_id=$(jq -r '.[$counter].databaseId' runs.json)
-          curr_wf_att$(jq -r '.[$counter].attempt' runs.json)
+          curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
+          curr_wf_att$(jq -r ".[$counter].attempt" runs.json)
 
           gh run download $curr_wf_id --attempt $curr_wf_att --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
           python .github/workflows/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations_new

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -1,0 +1,74 @@
+name: Update Test Durations
+
+on:
+  workflow_dispatch:
+
+permissions:
+  packages: write
+  checks: write
+
+jobs:
+  update_test_durations:
+    runs-on: ubuntu-latest
+    env:
+        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # ref: main
+      - uses: actions/setup-python@v5
+      - id: get-test-durations
+        run: |
+          repo="tenstorrent/tt-forge-fe"
+          wf_name="on-nightly.yml"
+
+          # get json of the last 10 workflow runs
+          gh run list --workflow $wf_name -R $repo -b main -L 5 --status completed --json attempt,conclusion,databaseId >runs.json
+
+          counter=0
+          while true; do
+            # Check the status of 'conclusion'
+            conclusion=$(jq -r '.[$counter].conclusion' runs.json)
+
+            if [ "$conclusion" != "success"] && [ "$conclusion" != "failure" ]; then
+              ((counter++))
+
+              # Exit if the counter reaches 5
+              if [ $counter -ge 5 ]; then
+                echo "Counter reached 5. Exiting with code 1."
+                exit 1
+              fi
+            else
+              break
+            fi
+          done
+          curr_wf_id=$(jq -r '.[$counter].databaseId' runs.json)
+          curr_wf_att$(jq -r '.[$counter].attempt' runs.json)
+
+          gh run download $curr_wf_id --attempt $curr_wf_att --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
+          python .github/workflows/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations_new
+          echo "----- NEW DURATIONS"
+          cat .test_durations_new
+          echo "----- DIFF"
+          diff .test_durations .test_durations_new
+
+          echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
+          echo "curr_wf_id=$curr_wf_id" >> $GITHUB_OUTPUT
+          echo "curr_wf_att=$curr_wf_att" >> $GITHUB_OUTPUT
+          echo "curr_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> $GITHUB_OUTPUT
+
+    #   - name: Create Pull Request
+    #     uses: peter-evans/create-pull-request@v7
+    #     id: create-pr
+    #     with:
+    #       branch: test-durations-update
+    #       committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+    #       author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+    #       base: main
+    #       commit-message: "Update test durations based on latest nightly ${{ steps.get-test-durations.output.TODAY }}"
+    #       title: "Update test durations based on latest nightly ${{ steps.get-test-durations.output.TODAY }}"
+    #       body: "This PR updates test durations based on latest nightly (${{steps.get-test-durations.output.curr_wf_link}})"
+    #       labels: tooling
+    #       delete-branch: true
+    #       token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -18,6 +18,8 @@ jobs:
           fetch-depth: 0
           # ref: main
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - id: get-test-durations
         run: |
           repo="tenstorrent/tt-forge-fe"

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -1,5 +1,10 @@
 name: Update Test Durations
 
+description: |
+  This workflow updates test durations based on the latest nightly and push workflow runs.
+  It processes the JUnit XML reports from the last successful nightly and push workflows,
+  calculates the test durations, and creates a pull request to update the `.test_durations` file.
+
 on:
   workflow_dispatch:
 
@@ -10,8 +15,6 @@ permissions:
 jobs:
   update_test_durations:
     runs-on: ubuntu-latest
-    env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,57 +23,82 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - id: get-test-durations
+      - name: Process nightly test durations
+        id: get-test-durations
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           repo="tenstorrent/tt-forge-fe"
-          wf_name="on-nightly.yml"
 
-          # get json of the last 10 workflow runs
-          gh run list --workflow $wf_name -R $repo -b main -L 5 --status completed --json attempt,conclusion,databaseId >runs.json
+          get_test_results_from_wf() {
+            local wf_name="$1"
+            local conclusions="$2"
+            local num=5
 
-          counter=0
-          while true; do
-            # Check the status of 'conclusion'
-            conclusion=$(jq -r '.[$counter].conclusion' runs.json)
+            # get json of the last $num workflow runs
+            gh run list --workflow $wf_name -R $repo -b main -L $num --status completed --json attempt,conclusion,databaseId >runs.json
 
-            if [ "$conclusion" != "success"] && [ "$conclusion" != "failure" ]; then
-              ((counter++))
+            counter=0
+            while true; do
+              # Check the status of 'conclusion'
+              conclusion=$(jq -r ".[$counter].conclusion" runs.json)
 
-              # Exit if the counter reaches 5
-              if [ $counter -ge 5 ]; then
-                echo "Counter reached 5. Exiting with code 1."
-                exit 1
+              if echo "$conclusions" | grep -q -w "$conclusion"; then
+                break
+              else
+                ((counter++))
+
+                # Exit if the counter reaches $num
+                if [ $counter -ge $num ]; then
+                  echo "ERROR: Did not found good workflow within last $num. Exiting."
+                  exit 1
+                fi
               fi
-            else
-              break
-            fi
-          done
-          curr_wf_id=$(jq -r '.[$counter].databaseId' runs.json)
-          curr_wf_att$(jq -r '.[$counter].attempt' runs.json)
+            done
+            curr_wf_id=$(jq -r ".[$counter].databaseId" runs.json)
+            curr_wf_att=$(jq -r ".[$counter].attempt" runs.json)
+            echo "curr_$3_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> "$GITHUB_OUTPUT"
+            rm -f runs.json
 
-          gh run download $curr_wf_id --attempt $curr_wf_att --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
+            gh run download $curr_wf_id --pattern "test-reports-*" -R $repo -D ${{runner.temp}}/reports
+          }
+
+          # get test results from the last nightly that was success or failure
+          get_test_results_from_wf "on-nightly.yml" "success,failure" "nightly"
+
+          # get test results from the last successful push
+          get_test_results_from_wf "on-push.yml" "success" "push"
+
           python .github/workflows/get_test_duration_from_junit_xmls.py ${{runner.temp}}/reports .test_durations_new
           echo "----- NEW DURATIONS"
-          cat .test_durations_new
-          echo "----- DIFF"
-          diff .test_durations .test_durations_new
+          cat .test_durations
 
-          echo "TODAY=$(date +'%Y-%m-%d')" >> $GITHUB_OUTPUT
-          echo "curr_wf_id=$curr_wf_id" >> $GITHUB_OUTPUT
-          echo "curr_wf_att=$curr_wf_att" >> $GITHUB_OUTPUT
-          echo "curr_wf_link=\"https://github.com/$repo/actions/runs/$curr_wf_id/attempts/$curr_wf_att\"" >> $GITHUB_OUTPUT
+          echo "TODAY=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
 
-    #   - name: Create Pull Request
-    #     uses: peter-evans/create-pull-request@v7
-    #     id: create-pr
-    #     with:
-    #       branch: test-durations-update
-    #       committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
-    #       author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
-    #       base: main
-    #       commit-message: "Update test durations based on latest nightly ${{ steps.get-test-durations.output.TODAY }}"
-    #       title: "Update test durations based on latest nightly ${{ steps.get-test-durations.output.TODAY }}"
-    #       body: "This PR updates test durations based on latest nightly (${{steps.get-test-durations.output.curr_wf_link}})"
-    #       labels: tooling
-    #       delete-branch: true
-    #       token: ${{ secrets.GH_TOKEN }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        id: create-pr
+        with:
+          branch: test-durations-update
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: ${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>
+          base: main
+          commit-message: "Update test durations based on latest nightly ${{ steps.get-test-durations.outputs.TODAY }}"
+          title: "Update test durations based on latest nightly ${{ steps.get-test-durations.outputs.TODAY }}"
+          body: "This PR updates test durations based on latest nightly (${{ steps.get-test-durations.outputs.curr_nightly_wf_link }}) and latest push (${{ steps.get-test-durations.outputs.curr_push_wf_link }})"
+          labels: tooling
+          delete-branch: true
+          token: ${{ secrets.GH_TOKEN }}
+
+      - name: Enable Pull Request Automerge
+        if: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: gh pr merge --squash --auto "${{ steps.create-pr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+      - name: Generate Summary
+        run: |
+          echo "## Test duration report" >> $GITHUB_STEP_SUMMARY
+          echo "Used [Nightly](${{ steps.get-test-durations.outputs.curr_nightly_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "And [Push](${{ steps.get-test-durations.outputs.curr_push_wf_link }})" >> $GITHUB_STEP_SUMMARY
+          echo "Generated test durations in [Pull Request](${{ steps.create-pr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge-fe/issues/2108

### Problem description
For better CI split balance, we need to record the latest execution durations for each test. To do so, we should update the details in the .test_durations file.

### What's changed
New "Update Test Durations" workflow is introduced that updates test durations based on the latest nightly and push workflow runs. It processes the gathered  XML test reports from the last successful nightly and push workflows, calculates the test durations, and creates a pull request to update the `.test_durations` file.

Workflow is NOT automated. It should be manually run when needed.

### Checklist
- [ ] New/Existing tests provide coverage for changes

Tested in Perf Benchmark workflow: https://github.com/tenstorrent/tt-forge-fe/actions/runs/15557474048
Resulting PR: https://github.com/tenstorrent/tt-forge-fe/pull/2244
