### PR TITLE
Remove xfail marker from passing stack op test

### DIFF
--- a/forge/test/models_ops/test_stack.py
+++ b/forge/test/models_ops/test_stack.py
@@ -57,26 +57,23 @@ def ids_func(param):
 
 
 forge_modules_and_shapes_dtypes_list = [
-    pytest.param(
-        (
-            Stack0,
-            [
-                ((2, 1, 2048), torch.float32),
-                ((2, 1, 2048), torch.float32),
-                ((2, 1, 2048), torch.float32),
-                ((2, 1, 2048), torch.float32),
+    (
+        Stack0,
+        [
+            ((2, 1, 2048), torch.float32),
+            ((2, 1, 2048), torch.float32),
+            ((2, 1, 2048), torch.float32),
+            ((2, 1, 2048), torch.float32),
+        ],
+        {
+            "model_names": [
+                "pt_stereo_facebook_musicgen_small_music_generation_hf",
+                "pt_stereo_facebook_musicgen_large_music_generation_hf",
+                "pt_stereo_facebook_musicgen_medium_music_generation_hf",
             ],
-            {
-                "model_names": [
-                    "pt_stereo_facebook_musicgen_small_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_large_music_generation_hf",
-                    "pt_stereo_facebook_musicgen_medium_music_generation_hf",
-                ],
-                "pcc": 0.99,
-                "args": {"axis": "-3"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+            "pcc": 0.99,
+            "args": {"axis": "-3"},
+        },
     ),
     (
         Stack1,


### PR DESCRIPTION
In the [latest models ops pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/15547255793/job/43803920123), `data mismatch between framework and compiled model output` issues was resolved in the **stack** op in the below mentioned test. So removing xfail marker for below passing stack op test.

```
forge/test/models_ops/test_stack.py::test_module[Stack0-[((2, 1, 2048), torch.float32), ((2, 1, 2048), torch.float32), ((2, 1, 2048), torch.float32), ((2, 1, 2048), torch.float32)]]
```