### PR TITLE
Fix: Add compatibility aliases for deprecated NumPy types (np.int, np.bool, etc.) to resolve dynamic shape regressions after NumPy upgrade

### DIFF
--- a/forge/forge/__init__.py
+++ b/forge/forge/__init__.py
@@ -2,6 +2,16 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import os
+import numpy as np
+
+np.bool = bool
+np.int = int
+np.float = float
+np.complex = complex
+np.object = object
+np.str = str
+np.long = int
+np.unicode = str
 
 # Set home directory paths for forge and forge
 def set_home_paths():

--- a/forge/test/models/pytorch/text/albert/test_albert.py
+++ b/forge/test/models/pytorch/text/albert/test_albert.py
@@ -72,17 +72,7 @@ def test_albert_masked_lm_pytorch(size, variant):
         return_tensors="pt",
     )
 
-    # Manually create token_type_ids and position_ids to avoid dynamic graph behavior
-    batch_size, seq_len = input_tokens["input_ids"].shape
-    input_tokens["token_type_ids"] = torch.zeros((batch_size, seq_len), dtype=torch.long)
-    input_tokens["position_ids"] = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
-
-    inputs = [
-        input_tokens["input_ids"],
-        input_tokens["attention_mask"],
-        input_tokens["token_type_ids"],
-        input_tokens["position_ids"],
-    ]
+    inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
 
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
@@ -156,17 +146,7 @@ def test_albert_token_classification_pytorch(size, variant):
         return_tensors="pt",
     )
 
-    # Manually create token_type_ids and position_ids to avoid dynamic graph behavior
-    batch_size, seq_len = input_tokens["input_ids"].shape
-    input_tokens["token_type_ids"] = torch.zeros((batch_size, seq_len), dtype=torch.long)
-    input_tokens["position_ids"] = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
-
-    inputs = [
-        input_tokens["input_ids"],
-        input_tokens["attention_mask"],
-        input_tokens["token_type_ids"],
-        input_tokens["position_ids"],
-    ]
+    inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
 
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
@@ -219,17 +199,8 @@ def test_albert_question_answering_pytorch(variant):
     # Data preprocessing
     input_tokens = tokenizer(question, text, return_tensors="pt")
 
-    # Manually create token_type_ids and position_ids to avoid dynamic graph behavior
-    batch_size, seq_len = input_tokens["input_ids"].shape
-    input_tokens["token_type_ids"] = torch.zeros((batch_size, seq_len), dtype=torch.long)
-    input_tokens["position_ids"] = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
-
-    inputs = [
-        input_tokens["input_ids"],
-        input_tokens["attention_mask"],
-        input_tokens["token_type_ids"],
-        input_tokens["position_ids"],
-    ]
+    # Load inputs
+    inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
 
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
@@ -269,17 +240,9 @@ def test_albert_sequence_classification_pytorch(variant):
 
     # Data preprocessing
     input_tokens = tokenizer(input_text, return_tensors="pt")
-    # Manually create token_type_ids and position_ids to avoid dynamic graph behavior
-    batch_size, seq_len = input_tokens["input_ids"].shape
-    input_tokens["token_type_ids"] = torch.zeros((batch_size, seq_len), dtype=torch.long)
-    input_tokens["position_ids"] = torch.arange(seq_len).unsqueeze(0).expand(batch_size, -1)
 
-    inputs = [
-        input_tokens["input_ids"],
-        input_tokens["attention_mask"],
-        input_tokens["token_type_ids"],
-        input_tokens["position_ids"],
-    ]
+    # Load inputs
+    inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
 
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)


### PR DESCRIPTION
### Issue:

- opt model faced `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'Any'. `

 
### Root cause :

- It is arising from [this slice operation](https://github.com/huggingface/transformers/blob/5d7739f15a6e50de416977fe2cc9cb516d67edda/src/transformers/models/opt/modeling_opt.py#L446C50-L446C70). This [PR](https://github.com/tenstorrent/tt-forge-fe/pull/1544) updates numpy version from 1.23.1 to 1.26.4. `np.int` is deprecated which executes [this](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/frontend/common.py#L629) exception block due to below reason. 
```
module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

- Due to this exception,  instead of returning the [fetched value](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/frontend/common.py#L628C9-L628C25) from [input expression](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/frontend/pytorch.py#L481C13-L481C22) it is returning the [input expression](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/frontend/common.py#L632C10-L632C26). 
- As [target_end](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/frontend/pytorch.py#L480C9-L480C19) is an expression not an int , [this block](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/frontend/pytorch.py#L547C9-L558C18) will execute instead of [this](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/frontend/pytorch.py#L527C9-L546C22). this makes [end](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/frontend/pytorch.py#L548C13-L548C16) variable also an [expression](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/frontend/pytorch.py#L548C19-L548C59) which maps slice to [dyn_make.strided_slice](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/op/transform.py#L1050C16-L1050C39) instead of _[make.strided_slice](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/op/transform.py#L1051C12-L1051C31) due to [this condition](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/op/transform.py#L1036C5-L1036C86) .
-  [dyn_make.strided_slice](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/op/transform.py#L1050C16-L1050C39) produces T.any() leads to `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'Any'. `

 
### Fix:

- Replacing [np.int](http://np.int/) with int [here](https://github.com/tenstorrent/tt-tvm/blob/48a71bc740f15e904013a5654c8e921b31ba8774/python/tvm/relay/frontend/pytorch.py#L481C47-L481C53) solved the issue in oft model.

- As there [many regressions](https://github.com/tenstorrent/tt-forge-fe/issues/2226) & [many deprecations](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) ,I added below changes in `forge/forge/__init__.py` to avoid manual changes across many functions in TVM to solve rest of the regressions.

- This PR also verifies the fix with sanity

```
np.bool = bool
np.int = int
np.float = float
np.complex = complex
np.object = object
np.str = str
np.long = int
np.unicode = str
```

### Logs

[jun11_sanity_before_fix.log](https://github.com/user-attachments/files/20689846/jun11_sanity_bf.log)
[jun11_sanity_after_fix.log](https://github.com/user-attachments/files/20689845/jun11_sanity_afff.log)
[jun11_opt_before_fix.log](https://github.com/user-attachments/files/20689844/jun11_opt_before_fix.log)
[jun11_opt_after_fix.log](https://github.com/user-attachments/files/20689856/test_opt.log)
[jun11_albert_after_fix.log.zip](https://github.com/user-attachments/files/20690978/jun11_albert_afetr_fix.log.zip)


