### PR TITLE
Fix torch update related regressions by removing deprecated numpy dtypes from TVM framework frontend

### DIFF
--- a/forge/test/models/pytorch/text/dpr/test_dpr.py
+++ b/forge/test/models/pytorch/text/dpr/test_dpr.py
@@ -26,8 +26,8 @@ from forge.verify.verify import verify
 from test.utils import download_model
 
 params = [
-    pytest.param("facebook/dpr-ctx_encoder-single-nq-base", marks=[pytest.mark.xfail]),
-    pytest.param("facebook/dpr-ctx_encoder-multiset-base", marks=[pytest.mark.xfail]),
+    "facebook/dpr-ctx_encoder-single-nq-base",
+    "facebook/dpr-ctx_encoder-multiset-base",
 ]
 
 
@@ -80,8 +80,8 @@ def test_dpr_context_encoder_pytorch(variant):
 
 
 params = [
-    pytest.param("facebook/dpr-question_encoder-single-nq-base", marks=[pytest.mark.xfail]),
-    pytest.param("facebook/dpr-question_encoder-multiset-base", marks=[pytest.mark.xfail]),
+    "facebook/dpr-question_encoder-single-nq-base",
+    "facebook/dpr-question_encoder-multiset-base",
 ]
 
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge-fe/issues/2226

### Summary
This PR tracks [this fix](https://github.com/tenstorrent/tt-tvm/pull/89) & remove xfail markers from dpr

### Logs 

[jun12_dpr.log](https://github.com/user-attachments/files/20704065/jun12_dpr.log)
[jun12_opt.log.zip](https://github.com/user-attachments/files/20704098/jun12_opt.log.zip)


