### PR TITLE
Add support for surya OCR pytorch model

### DIFF
--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -52,3 +52,4 @@ hippynn==0.0.3
 bi-lstm-crf==0.2.1
 peft
 pyclipper==1.3.0
+surya-ocr==0.13.0

--- a/forge/test/models/models_utils.py
+++ b/forge/test/models/models_utils.py
@@ -11,6 +11,14 @@ from tabulate import tabulate
 import json
 from typing import Optional, Tuple
 from transformers import Cache
+from typing import List
+from surya.common.util import mark_step
+from tqdm import tqdm
+from surya.settings import settings
+from surya.detection import DetectionPredictor
+from surya.input.processing import convert_if_not_rgb
+from surya.recognition.schema import OCRResult
+import torch.nn.functional as F
 
 # Mean Pooling - Take attention mask into account for correct averaging
 def mean_pooling(model_output, attention_mask):
@@ -260,3 +268,167 @@ def Gemma2DecoderLayer_patched_forward(
         outputs += (present_key_value,)
 
     return outputs
+
+
+def __call__without_post_processing(
+    self,
+    images: List[Image.Image],
+    langs: List[List[str] | None],
+    det_predictor: DetectionPredictor | None = None,
+    detection_batch_size: int | None = None,
+    recognition_batch_size: int | None = None,
+    highres_images: List[Image.Image] | None = None,
+    bboxes: List[List[List[int]]] | None = None,
+    polygons: List[List[List[List[int]]]] | None = None,
+    sort_lines: bool = True,
+) -> List[OCRResult]:
+    assert len(images) == len(langs), "You need to pass in one list of languages for each image"
+    images = convert_if_not_rgb(images)
+    if highres_images is not None:
+        assert len(images) == len(highres_images), "You need to pass in one highres image for each image"
+
+    highres_images = convert_if_not_rgb(highres_images) if highres_images is not None else [None] * len(images)
+
+    if bboxes is None and polygons is None:
+        assert (
+            det_predictor is not None
+        ), "You need to pass in a detection predictor if you don't provide bboxes or polygons"
+
+        # Detect then slice
+        flat = self.detect_and_slice_bboxes(
+            images, langs, det_predictor, detection_batch_size=detection_batch_size, highres_images=highres_images
+        )
+    else:
+        if bboxes is not None:
+            assert len(images) == len(bboxes), "You need to pass in one list of bboxes for each image"
+        if polygons is not None:
+            assert len(images) == len(polygons), "You need to pass in one list of polygons for each image"
+
+        flat = self.slice_bboxes(images, langs, bboxes=bboxes, polygons=polygons)
+
+    output = self.batch_recognition(flat["slices"], flat["langs"], batch_size=recognition_batch_size)
+
+    return output
+
+
+def batch_recognition_without_post_processing(
+    self, images: List[Image.Image], languages: List[List[str] | None], batch_size=None
+):
+    assert all(isinstance(image, Image.Image) for image in images)
+    assert len(images) == len(languages)
+
+    if len(images) == 0:
+        return [], []
+
+    if batch_size is None:
+        batch_size = self.get_batch_size()
+
+    # Sort images by width, so similar length ones go together
+    sorted_pairs = sorted(enumerate(images), key=lambda x: x[1].width, reverse=False)
+    indices, images = zip(*sorted_pairs)
+    indices = list(indices)
+    images = list(images)
+
+    batch_predictions_all = []
+    sequence_scores_all = []
+
+    for i in tqdm(range(0, len(images), batch_size), desc="Recognizing Text", disable=self.disable_tqdm):
+        batch_images = images[i : i + batch_size]
+        batch_images = [image.convert("RGB") for image in batch_images]  # also copies the images
+        current_batch_size = len(batch_images)
+        batch_langs = languages[i : i + current_batch_size]
+        processed_batch = self.processor(text=[""] * len(batch_images), images=batch_images, langs=batch_langs)
+
+        batch_pixel_values = processed_batch["pixel_values"]
+        batch_langs = processed_batch["langs"]
+        batch_pixel_values, batch_decoder_input = self.prepare_input(batch_langs, batch_pixel_values, batch_size)
+
+        token_count = 0
+        inference_token_count = batch_decoder_input.shape[-1]
+
+        decoder_position_ids = (
+            torch.ones_like(batch_decoder_input[0, :], dtype=torch.int64, device=self.model.device).cumsum(0) - 1
+        )
+        self.model.decoder.model._setup_cache(self.model.config, batch_size, self.model.device, self.model.dtype)
+        self.model.text_encoder.model._setup_cache(self.model.config, batch_size, self.model.device, self.model.dtype)
+
+        # Batch pixel values is the real current batch size
+        sequence_scores = torch.zeros(
+            batch_pixel_values.shape[0], dtype=torch.bool, device=self.model.device
+        ).unsqueeze(1)
+        all_done = torch.zeros(batch_pixel_values.shape[0], dtype=torch.bool, device=self.model.device)
+        batch_predictions = torch.zeros(
+            batch_pixel_values.shape[0], dtype=torch.int64, device=self.model.device
+        ).unsqueeze(1)
+        device_pad_token = torch.tensor(self.processor.tokenizer.pad_token_id, device=self.model.device)
+
+        with settings.INFERENCE_MODE():
+            encoder_hidden_states = self.model.encoder(pixel_values=batch_pixel_values).last_hidden_state
+
+            text_encoder_input_ids = (
+                torch.arange(
+                    self.model.text_encoder.config.query_token_count,
+                    device=encoder_hidden_states.device,
+                    dtype=torch.long,
+                )
+                .unsqueeze(0)
+                .expand(encoder_hidden_states.size(0), -1)
+            )
+
+            encoder_text_hidden_states = self.model.text_encoder(
+                input_ids=text_encoder_input_ids,
+                cache_position=None,
+                attention_mask=None,
+                encoder_hidden_states=encoder_hidden_states,
+                encoder_attention_mask=None,
+                use_cache=False,
+            ).hidden_states
+
+            while token_count < settings.RECOGNITION_MAX_TOKENS - 1:
+                is_prefill = token_count == 0
+                # TODO: add attention mask
+                return_dict = self.model.decoder(
+                    input_ids=batch_decoder_input,
+                    encoder_hidden_states=encoder_text_hidden_states,
+                    cache_position=decoder_position_ids,
+                    use_cache=True,
+                    prefill=is_prefill,
+                )
+
+                decoder_position_ids = decoder_position_ids[-1:] + 1
+                logits = return_dict["logits"]  # Ignore batch padding
+
+                preds = torch.argmax(logits[:, -1], dim=-1)
+                scores = torch.max(F.softmax(logits[:, -1], dim=-1), dim=-1).values.unsqueeze(1)
+                done = (preds == self.processor.tokenizer.eos_id) | (preds == self.processor.tokenizer.pad_id)
+                all_done = all_done | done
+                all_done_cpu = all_done.cpu()
+
+                # Confidence score for the current token
+                scores = scores.masked_fill(all_done, 0)
+                sequence_scores = torch.cat([sequence_scores, scores], dim=1)
+
+                # Account for possible padding
+                if all_done_cpu[:current_batch_size].all():
+                    break
+
+                batch_decoder_input = preds.unsqueeze(1)
+
+                # If this batch item is done, input a pad token
+                batch_decoder_input = torch.where(all_done.unsqueeze(1), device_pad_token, batch_decoder_input)
+
+                batch_predictions = torch.cat([batch_predictions, batch_decoder_input], dim=1)
+                token_count += inference_token_count
+
+                inference_token_count = batch_decoder_input.shape[-1]
+                mark_step()
+
+        sequence_scores = torch.sum(sequence_scores, dim=-1) / torch.sum(sequence_scores != 0, dim=-1)
+
+        sequence_scores = sequence_scores.cpu()[:current_batch_size]
+        batch_predictions = batch_predictions.cpu()[:current_batch_size, 1:]  # Remove the start token
+
+        batch_predictions_all.append(batch_predictions)
+        sequence_scores_all.append(sequence_scores)
+
+    return (*batch_predictions_all, *sequence_scores_all)

--- a/forge/test/models/pytorch/vision/suryaocr/test_surya_ocr.py
+++ b/forge/test/models/pytorch/vision/suryaocr/test_surya_ocr.py
@@ -1,8 +1,19 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
 #
 # SPDX-License-Identifier: Apache-2.0
-import pytest
 
+from io import BytesIO
+
+import pytest
+import requests
+import torch
+import torch.nn as nn
+import torchvision.transforms as transforms
+from PIL import Image
+from surya.detection import DetectionPredictor
+from surya.recognition import RecognitionPredictor
+
+import forge
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -12,6 +23,47 @@ from forge.forge_property_utils import (
     Task,
     record_model_properties,
 )
+from forge.verify.verify import verify
+
+from test.models.models_utils import (
+    __call__without_post_processing,
+    batch_recognition_without_post_processing,
+)
+
+RecognitionPredictor.__call__ = __call__without_post_processing
+RecognitionPredictor.batch_recognition = batch_recognition_without_post_processing
+
+
+IMAGE_URL = "https://raw.githubusercontent.com/VikParuchuri/surya/master/static/images/excerpt_text.png"
+
+LANGUAGE_MAP = {"en": 0, "fr": 1, "de": 2}
+
+
+def preprocess_image(image):
+    transform = transforms.Compose(
+        [
+            transforms.ToTensor(),
+        ]
+    )
+    return transform(image)
+
+
+class SuryaOCRWrapper(nn.Module):
+    def __init__(self):
+        super(SuryaOCRWrapper, self).__init__()
+        self.recognition_predictor = RecognitionPredictor()
+        self.detection_predictor = DetectionPredictor()
+
+    def forward(self, images_tensor, languages_tensor):
+        batch_size = images_tensor.shape[0]
+        images_list = [transforms.ToPILImage()(images_tensor[i]) for i in range(batch_size)]
+        language_indices = languages_tensor.tolist()
+        languages_list = [[list(LANGUAGE_MAP.keys())[i] for i in batch] for batch in language_indices]
+
+        # Get OCR results
+        ocr_results = self.recognition_predictor(images_list, languages_list, self.detection_predictor)
+
+        return ocr_results
 
 
 @pytest.mark.nightly
@@ -22,10 +74,40 @@ def test_surya_ocr():
     module_name = record_model_properties(
         framework=Framework.PYTORCH,
         model=ModelArch.SURYAOCR,
+        variant="default",
         task=Task.OPTICAL_CHARACTER_RECOGNITION,
         source=Source.GITHUB,
         group=ModelGroup.RED,
         priority=ModelPriority.P1,
     )
 
-    raise RuntimeError("Test is currently not executable due to tricky dependencies.")
+    raise RuntimeError("Segmentation Fault")
+
+    # Load model
+    framework_model = SuryaOCRWrapper()
+    framework_model.eval()
+
+    for name, param in framework_model.recognition_predictor.model.named_parameters():
+        param.requires_grad = False
+
+    for name, param in framework_model.detection_predictor.model.named_parameters():
+        param.requires_grad = False
+
+    # Prepare input
+    response = requests.get(IMAGE_URL)
+    image = Image.open(BytesIO(response.content))
+    image_tensor = preprocess_image(image)
+    langs = [["en"]]
+    language_tensor = torch.tensor([[LANGUAGE_MAP[lang] for lang in batch] for batch in langs], dtype=torch.int64)
+    images = torch.stack([image_tensor])
+    inputs = [images, language_tensor]
+
+    # Forge compile framework model
+    compiled_model = forge.compile(
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+    )
+
+    # Model Verification
+    verify(inputs, framework_model, compiled_model)


### PR DESCRIPTION
### Summary

This PR adds support for the [Surya OCR](https://github.com/datalab-to/surya/tree/v0.13.0) PyTorch model.
The test script is taken from [this PR](https://github.com/tenstorrent/tt-forge-fe/pull/1463/files).
The CPU output of the model is structured as follows:

```
[OCRResult(text_lines=[TextLine(polygon=[[591.0, 8.0], [687.0, 8.0], [687.0, 15.0], [591.0, 15.0]], confidence=0.8464252948760986, text='LINDSEY WASSON/REUTERS', bbox=[591.0, 8.0, 687.0, 15.0]), TextLine(polygon=[[11.0, 19.0], [503.0, 19.0], [503.0, 28.0], [11.0, 28.0]], confidence=0.9991984367370605, text='After American Airlines neared a deal in 2011 to buy jets from Airbus, Boeing quickly decided to build the 737 Max, above.', bbox=[11.0, 19.0, 503.0, 28.0]), TextLine(polygon=[[60.0, 61.0], [238.0, 61.0], [238.0, 69.0], [60.0, 69.0]], ...
```

To enable proper ONNX export and inference, the following internal post-processing steps have been monkey-patched to return raw tensor outputs instead of OCRResult objects:

[RecognitionPredictor.__call__](https://github.com/datalab-to/surya/blob/7e5ac9d5afce743f503d453f09bcdb2552ebaaad/surya/recognition/__init__.py#L318C13-L330C40)
[RecognitionPredictor.batch_recognition](https://github.com/datalab-to/surya/blob/7e5ac9d5afce743f503d453f09bcdb2552ebaaad/surya/recognition/__init__.py#L81C13-L106C40)

### Log

[surya_ocr.log](https://github.com/user-attachments/files/20708566/jun12_surya_ocr_forge_inf_2.log)
