### PR TITLE
Remove deprecated numpy dtypes from nbeats model scripts

### DIFF
--- a/forge/test/models/pytorch/timeseries/nbeats/model_utils/dataset.py
+++ b/forge/test/models/pytorch/timeseries/nbeats/model_utils/dataset.py
@@ -157,7 +157,7 @@ class ElectricityDataset:
                 raw[ignored_first_values:],
             )
         )
-        data = np.array(parsed_values).astype(np.float)
+        data = np.array(parsed_values).astype(float)
 
         # aggregate to hourly
         aggregated = []

--- a/forge/test/models/pytorch/timeseries/nbeats/model_utils/model.py
+++ b/forge/test/models/pytorch/timeseries/nbeats/model_utils/model.py
@@ -114,7 +114,7 @@ class TrendBasis(t.nn.Module):
             t.tensor(
                 np.concatenate(
                     [
-                        np.power(np.arange(backcast_size, dtype=np.float) / backcast_size, i)[None, :]
+                        np.power(np.arange(backcast_size, dtype=float) / backcast_size, i)[None, :]
                         for i in range(self.polynomial_size)
                     ]
                 ),
@@ -126,7 +126,7 @@ class TrendBasis(t.nn.Module):
             t.tensor(
                 np.concatenate(
                     [
-                        np.power(np.arange(forecast_size, dtype=np.float) / forecast_size, i)[None, :]
+                        np.power(np.arange(forecast_size, dtype=float) / forecast_size, i)[None, :]
                         for i in range(self.polynomial_size)
                     ]
                 ),


### PR DESCRIPTION
### Summary

- Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2275
- Remove deprecated numpy dtypes from nbeats model scripts to avoid below error 

```
E           AttributeError: module 'numpy' has no attribute 'float'.
E           `np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
E           The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
E               https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'cfloat'?
```

### Logs

[Nbeats_after_fix.log](https://github.com/user-attachments/files/20721015/jun13_nbeats_3.log)
