### PR TITLE
Add tests and ops filter and existing config override option in models ops gen workflow

### DIFF
--- a/.github/workflows/model-analysis.yml
+++ b/.github/workflows/model-analysis.yml
@@ -22,9 +22,24 @@ on:
         type: choice
         options:
           - runner
+          - wormhole_b0
           - n150
           - n300
           - p150
+      tests_to_filter:
+        description: 'Filter specific tests (comma-separated): Generate models ops tests only for the specified test commands'
+        required: false
+        type: string
+      ops_to_filter:
+        description: 'Filter specific operations (comma-separated): Generate models ops tests only for the specified Forge operations'
+        required: false
+        type: string
+      override_existing_ops:
+        description: 'Merge with existing ops: Extract unique ops config from existing models ops tests directory, combine with new filtered tests config, then regenerate all models ops tests'
+        required: false
+        type: boolean
+        default: false
+
 
 permissions:
   packages: write
@@ -78,6 +93,7 @@ jobs:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
       runs-on: ${{ needs.set-inputs.outputs.runs-on }}
       run_id: ${{ needs.build.outputs.run_id }}
+      tests_to_filter: ${{ inputs.tests_to_filter }}
       allow-fail: true
 
   generate-models-ops-tests:
@@ -163,10 +179,27 @@ jobs:
         run: |
           source env/activate
           set -o pipefail # Ensures that the exit code reflects the first command that fails
-          python scripts/model_analysis/combine_and_generate_ops_tests.py \
-            --extracted_unique_ops_config_directory_path ${{ env.UNIQUE_OPS_OUTPUT_DIR_PATH }} \
-            --models_ops_test_output_directory_path ${{ env.MODELS_OPS_TEST_OUTPUT_DIR_PATH }} \
-            --models_ops_test_package_name ${{ env.MODELS_OPS_TEST_PACKAGE_NAME }} \
+
+          command_args=(
+            "--extracted_unique_ops_config_directory_path" "${{ env.UNIQUE_OPS_OUTPUT_DIR_PATH }}"
+            "--models_ops_test_output_directory_path" "${{ env.MODELS_OPS_TEST_OUTPUT_DIR_PATH }}"
+            "--models_ops_test_package_name" "${{ env.MODELS_OPS_TEST_PACKAGE_NAME }}"
+          )
+
+          if [ -n "${{ inputs.ops_to_filter }}" ]; then
+            # Split on commas and trim whitespace
+            IFS=',' read -r -a ops_filters <<< "${{ inputs.ops_to_filter }}"
+            command_args+=("--ops_to_filter")
+            for of in "${ops_filters[@]}"; do
+              command_args+=("$(echo "$of" | xargs)")
+            done
+          fi
+
+          if [[ "${{ inputs.override_existing_ops }}" == "true" && -n "${{ inputs.tests_to_filter }}" ]]; then
+            command_args+=("--override_existing_ops")
+          fi
+
+          python scripts/model_analysis/combine_and_generate_ops_tests.py "${command_args[@]}" \
             2>&1 | tee ${{ env.SCRIPT_OUTPUT_LOG }}
 
       - name: Upload Script Output Logs

--- a/.github/workflows/test-model-analysis-sub.yml
+++ b/.github/workflows/test-model-analysis-sub.yml
@@ -26,9 +26,13 @@ on:
         description: 'Runs on'
         required: false
         type: string
-        default: '[{"runs-on": "n150"}]'
+        default: '[{"runs-on": "runner"}]'
       run_id:
         description: 'Run id the workflow where to find installation (or else it will search)'
+        required: false
+        type: string
+      tests_to_filter:
+        description: 'Filter specific tests'
         required: false
         type: string
       allow-fail:
@@ -144,15 +148,27 @@ jobs:
         shell: bash
         run: |
           source env/activate
-          pytest forge/test/models/ --splits ${{ inputs.test_group_cnt }} \
-                 --group ${{ matrix.test_group_id }} \
-                 --splitting-algorithm least_duration \
-                 -m "${{ inputs.test_mark }}" \
-                 --log-memory-usage \
-                 --runxfail \
-                 --no-skips \
-                 -vss \
-                 2>&1 | tee pytest.log
+
+          pytest_args=(
+            "--splits" "${{ inputs.test_group_cnt }}"
+            "--group" "${{ matrix.test_group_id }}"
+            "--splitting-algorithm" "least_duration"
+            "-m" "${{ inputs.test_mark }}"
+            "--log-memory-usage"
+            "--runxfail"
+            "--no-skips"
+            "-vss"
+          )
+          if [ -n "${{ inputs.tests_to_filter }}" ]; then
+            # Split on commas and trim whitespace
+            IFS=',' read -r -a test_filters <<< "${{ inputs.tests_to_filter }}"
+            pytest_args+=("--tests_to_filter")
+            for tf in "${test_filters[@]}"; do
+              pytest_args+=("$(echo "$tf" | xargs)")
+            done
+          fi
+
+          pytest forge/test/models/ "${pytest_args[@]}" 2>&1 | tee pytest.log
 
       - name: Upload Test Log
         uses: actions/upload-artifact@v4

--- a/conftest.py
+++ b/conftest.py
@@ -23,6 +23,9 @@ def pytest_addoption(parser):
         default=False,
         help="log per-test memory usage into pytest-memory-usage.csv",
     )
+    parser.addoption(
+        "--tests_to_filter", nargs="+", type=str, help="List of test patterns to include (file paths or full test IDs)"
+    )
 
 
 @pytest.fixture(scope="function")

--- a/scripts/model_analysis/combine_and_generate_ops_tests.py
+++ b/scripts/model_analysis/combine_and_generate_ops_tests.py
@@ -36,12 +36,41 @@ def main():
         required=False,
         help="Specify the python package name for saving generated models ops test",
     )
+    parser.add_argument(
+        "--ops_to_filter",
+        nargs="+",
+        type=str,
+        required=False,
+        help=(
+            "Only generate ops test for the list of provided forge ops names (e.g. `Conv2d`, `Add`)"
+            "By default, every operator extracted across all the models will have tests generated."
+        ),
+    )
+    parser.add_argument(
+        "--override_existing_ops",
+        action="store_true",
+        help=(
+            "If set, it will extract unique ops configurations from existing generated models ops tests directory path(i.e forge/test/models_ops)"
+            "and then combine it with unique ops configuration extracted for the list of models tests specified in the tests_to_filter and then generate models ops tests"
+        ),
+    )
 
     args = parser.parse_args()
 
     models_ops_tests_directory_path = os.path.join(
         args.models_ops_test_output_directory_path, args.models_ops_test_package_name
     )
+    existing_unique_ops_config = None
+    if args.override_existing_ops:
+        existing_unique_ops_config_file_path = os.path.join(
+            args.extracted_unique_ops_config_directory_path,
+            "existing_unique_ops_config_across_all_models_ops_tests.log",
+        )
+        existing_unique_ops_config = extract_existing_unique_ops_config(
+            models_ops_tests_directory_path=models_ops_tests_directory_path,
+            existing_unique_ops_config_file_path=existing_unique_ops_config_file_path,
+            ops_to_filter=args.ops_to_filter,
+        )
 
     unique_ops_config_file_path = os.path.join(
         args.extracted_unique_ops_config_directory_path, "extracted_unique_ops_config_across_all_models_ops_tests.log"
@@ -51,11 +80,18 @@ def main():
         unique_ops_config_file_path=unique_ops_config_file_path,
         use_constant_value=False,
         convert_param_and_const_to_activation=True,
+        existing_unique_ops_config=existing_unique_ops_config,
     )
-    remove_directory(directory_path=models_ops_tests_directory_path)
-    create_python_package(
-        package_path=args.models_ops_test_output_directory_path, package_name=args.models_ops_test_package_name
+    unique_operations_across_all_models_ops_test = filter_unique_operations(
+        unique_operations=unique_operations_across_all_models_ops_test, ops_to_filter=args.ops_to_filter
     )
+    if (check_path(models_ops_tests_directory_path) and not args.override_existing_ops) or (
+        not check_path(models_ops_tests_directory_path)
+    ):
+        remove_directory(directory_path=models_ops_tests_directory_path)
+        create_python_package(
+            package_path=args.models_ops_test_output_directory_path, package_name=args.models_ops_test_package_name
+        )
     generate_models_ops_test(
         unique_operations_across_all_models_ops_test,
         models_ops_tests_directory_path,


### PR DESCRIPTION
This PR extends the Models Ops Tests Generation workflow by introducing three new inputs:

**Options:**
1. **tests_to_filter**
A comma‑separated list of test command strings. When provided, only those tests will be used to extract unique ops configurations and to generate corresponding models ops tests.
2. **ops_to_filter**
A comma‑separated list of Forge operation names. When provided, models ops tests will be generated only for the specified operations.
3. **override_existing_ops** 
If set, it will extract unique ops configurations from existing generated models ops tests directory path(i.e forge/test/models_ops) and then combine it with unique ops configuration extracted for the list of models tests specified in the **tests_to_filter** and then generate models ops tests