### PR TITLE
Remove P1 tags & bfp16 conversion from onnx models

### DIFF
--- a/forge/test/models/onnx/multimodal/oft/test_oft_onnx.py
+++ b/forge/test/models/onnx/multimodal/oft/test_oft_onnx.py
@@ -7,7 +7,7 @@ import forge
 from forge.verify.verify import verify
 
 from test.models.onnx.multimodal.oft.model_utils.oft_utils import get_inputs, get_models
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 
 
 @pytest.mark.skip_model_analysis
@@ -22,7 +22,6 @@ def test_oft(forge_tmp_path, variant):
         variant=variant.split("/")[-1],
         task=Task.CONDITIONAL_GENERATION,
         source=Source.HUGGINGFACE,
-        priority=ModelPriority.P1,
     )
 
     # Load model and inputs

--- a/forge/test/models/onnx/text/bert/test_bert.py
+++ b/forge/test/models/onnx/text/bert/test_bert.py
@@ -14,7 +14,7 @@ from transformers import (
 import forge
 from forge.verify.verify import verify
 
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 from test.models.models_utils import mean_pooling
 from test.utils import download_model
 
@@ -150,7 +150,6 @@ def test_bert_sentence_embedding_generation_onnx(variant, forge_tmp_path):
         variant=variant,
         task=Task.SENTENCE_EMBEDDING_GENERATION,
         source=Source.HUGGINGFACE,
-        priority=ModelPriority.P1,
     )
 
     # Load model and tokenizer

--- a/forge/test/models/onnx/text/bi_lstm_crf/test_bilstm_crf.py
+++ b/forge/test/models/onnx/text/bi_lstm_crf/test_bilstm_crf.py
@@ -10,7 +10,7 @@ import forge
 from forge.verify.verify import verify
 
 from test.models.onnx.text.bi_lstm_crf.model_utils.model import get_model
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 
 
 @pytest.mark.nightly
@@ -23,7 +23,6 @@ def test_birnn_crf(forge_tmp_path):
         model=ModelArch.BIRNNCRF,
         task=Task.TOKEN_CLASSIFICATION,
         source=Source.GITHUB,
-        priority=ModelPriority.P1,
     )
 
     test_sentence = ["apple", "corporation", "is", "in", "georgia"]

--- a/forge/test/models/onnx/text/ministral/test_ministral.py
+++ b/forge/test/models/onnx/text/ministral/test_ministral.py
@@ -7,7 +7,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 import forge
 from forge.verify.verify import verify
 from test.utils import download_model
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 from test.models.models_utils import build_optimum_cli_command
 import subprocess
 import onnx
@@ -28,7 +28,6 @@ def test_ministral(variant, forge_tmp_path):
         variant=variant,
         task=Task.CAUSAL_LM,
         source=Source.HUGGINGFACE,
-        priority=ModelPriority.P1,
     )
 
     # Load tokenizer and model

--- a/forge/test/models/onnx/text/phi1/test_phi1_5_onnx.py
+++ b/forge/test/models/onnx/text/phi1/test_phi1_5_onnx.py
@@ -7,7 +7,7 @@ from transformers import AutoTokenizer, PhiForCausalLM
 import forge
 from forge.verify.verify import verify
 
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 from test.models.models_utils import build_optimum_cli_command
 
 from test.utils import download_model
@@ -29,7 +29,6 @@ def test_phi1_5_clm_onnx(variant, forge_tmp_path):
         variant=variant,
         source=Source.HUGGINGFACE,
         task=Task.CAUSAL_LM,
-        priority=ModelPriority.P1,
     )
 
     # Load tokenizer and model

--- a/forge/test/models/onnx/text/phi1/test_phi1_onnx.py
+++ b/forge/test/models/onnx/text/phi1/test_phi1_onnx.py
@@ -14,7 +14,7 @@ from transformers import (
 import forge
 from forge.verify.verify import verify
 
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 from test.models.models_utils import build_optimum_cli_command
 from test.utils import download_model
 
@@ -34,7 +34,6 @@ def test_phi_causal_lm_onnx(variant, forge_tmp_path):
         variant=variant,
         source=Source.HUGGINGFACE,
         task=Task.CAUSAL_LM,
-        priority=ModelPriority.P1,
     )
 
     # Load tokenizer and model from HuggingFace

--- a/forge/test/models/onnx/text/phi2/test_phi2.py
+++ b/forge/test/models/onnx/text/phi2/test_phi2.py
@@ -7,7 +7,7 @@ from transformers import AutoTokenizer, PhiForCausalLM
 import forge
 from forge.verify.verify import verify
 
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 from test.models.models_utils import build_optimum_cli_command
 
 from test.utils import download_model
@@ -29,7 +29,6 @@ def test_phi2_clm_onnx(variant, forge_tmp_path):
         variant=variant,
         source=Source.HUGGINGFACE,
         task=Task.CAUSAL_LM,
-        priority=ModelPriority.P1,
     )
 
     # Load tokenizer and model

--- a/forge/test/models/onnx/text/phi3/test_phi3.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3.py
@@ -12,7 +12,7 @@ import subprocess
 import onnx
 from forge.verify.verify import verify
 from test.utils import download_model
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 from test.models.models_utils import build_optimum_cli_command
 
 variants = ["microsoft/phi-3-mini-4k-instruct", "microsoft/Phi-3-mini-128k-instruct"]
@@ -23,7 +23,6 @@ variants = ["microsoft/phi-3-mini-4k-instruct", "microsoft/Phi-3-mini-128k-instr
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.skip(reason="Transient test - Out of memory due to other tests in CI pipeline")
 def test_phi3_causal_lm_onnx(variant, forge_tmp_path):
-    priority = ModelPriority.P1 if variant == "microsoft/phi-3-mini-4k-instruct" else ModelPriority.P2
 
     # Record Forge Property
     module_name = record_model_properties(
@@ -32,7 +31,6 @@ def test_phi3_causal_lm_onnx(variant, forge_tmp_path):
         variant=variant,
         task=Task.CAUSAL_LM,
         source=Source.HUGGINGFACE,
-        priority=priority,
     )
 
     # Load tokenizer and model from HuggingFace

--- a/forge/test/models/onnx/vision/detr/test_detr.py
+++ b/forge/test/models/onnx/vision/detr/test_detr.py
@@ -12,7 +12,7 @@ import torch
 import onnx
 from forge.verify.verify import verify
 from test.utils import download_model
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 from test.models.models_utils import preprocess_input_data
 
 
@@ -27,7 +27,6 @@ def test_detr_detection_onnx(variant, forge_tmp_path):
         variant=variant,
         task=Task.OBJECT_DETECTION,
         source=Source.HUGGINGFACE,
-        priority=ModelPriority.P1,
     )
 
     # Load the model

--- a/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
+++ b/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
@@ -15,7 +15,7 @@ from test.models.onnx.vision.mobilenetv2.model_utils.utils import load_inputs
 from urllib.request import urlopen
 from PIL import Image
 from test.models.models_utils import print_cls_results
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 
 params = [
     pytest.param("mobilenetv2_050"),
@@ -29,8 +29,6 @@ params = [
 @pytest.mark.nightly
 def test_mobilenetv2_onnx(variant, forge_tmp_path):
 
-    priority = ModelPriority.P1 if variant == "mobilenetv2_050" else ModelPriority.P2
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
@@ -38,7 +36,6 @@ def test_mobilenetv2_onnx(variant, forge_tmp_path):
         variant=variant,
         source=Source.TIMM,
         task=Task.IMAGE_CLASSIFICATION,
-        priority=priority,
     )
 
     # Load mobilenetv2 model

--- a/forge/test/models/onnx/vision/segformer/test_segformer.py
+++ b/forge/test/models/onnx/vision/segformer/test_segformer.py
@@ -8,7 +8,7 @@ import pytest
 import onnx
 import torch
 from forge.verify.verify import verify
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 from transformers import SegformerForSemanticSegmentation, SegformerForImageClassification
 from test.models.models_utils import get_sample_data
 from test.utils import download_model
@@ -26,8 +26,6 @@ variants_img_classification = [
 @pytest.mark.nightly
 def test_segformer_image_classification_onnx(variant, forge_tmp_path):
 
-    priority = ModelPriority.P1 if variant == "nvidia/mit-b0" else ModelPriority.P2
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
@@ -35,7 +33,6 @@ def test_segformer_image_classification_onnx(variant, forge_tmp_path):
         variant=variant,
         task=Task.IMAGE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
-        priority=priority,
     )
 
     # Load the model from HuggingFace

--- a/forge/test/models/onnx/vision/swin/test_swin.py
+++ b/forge/test/models/onnx/vision/swin/test_swin.py
@@ -14,7 +14,7 @@ import forge
 
 from test.models.pytorch.vision.swin.model_utils.image_utils import load_image
 from test.models.pytorch.vision.vision_utils.utils import load_vision_model_and_input
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 
 
 @pytest.mark.skip(reason="Segmentation Fault at run_mlir_compiler compilation stage")
@@ -29,7 +29,6 @@ def test_swin_v2_tiny_image_classification_onnx(variant, forge_tmp_path):
         variant=variant,
         task=Task.IMAGE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
-        priority=ModelPriority.P1,
     )
 
     # Load the model

--- a/forge/test/models/onnx/vision/unet/test_unet.py
+++ b/forge/test/models/onnx/vision/unet/test_unet.py
@@ -7,7 +7,7 @@ import numpy as np
 import forge
 import onnx
 from forge.verify.verify import verify
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 from test.models.onnx.vision.unet.model_utils.utils import load_inputs
 
 
@@ -22,7 +22,6 @@ def test_unet_onnx(forge_tmp_path):
         variant="base",
         source=Source.TORCH_HUB,
         task=Task.IMAGE_SEGMENTATION,
-        priority=ModelPriority.P1,
     )
 
     # Load the torch model

--- a/forge/test/models/onnx/vision/vit/test_vit.py
+++ b/forge/test/models/onnx/vision/vit/test_vit.py
@@ -8,7 +8,7 @@ import onnx
 import forge
 from transformers import ViTForImageClassification, AutoImageProcessor
 from forge.verify.verify import verify
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 
 
 variants = [
@@ -26,7 +26,6 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_vit_classify_224(variant, forge_tmp_path):
-    priority = ModelPriority.P1 if variant in ["google/vit-base-patch16-224"] else ModelPriority.P2
 
     # Record Forge Property
     module_name = record_model_properties(
@@ -35,7 +34,6 @@ def test_vit_classify_224(variant, forge_tmp_path):
         variant=variant,
         task=Task.IMAGE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
-        priority=priority,
     )
 
     # Load torch model and processor

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v10.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v10.py
@@ -10,7 +10,7 @@ import forge
 from forge.verify.verify import verify
 
 from test.models.onnx.vision.yolo.model_utils.yolo_utils import load_yolo_model_and_image, YoloWrapper
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 
 
 @pytest.mark.xfail
@@ -23,7 +23,6 @@ def test_yolov10(forge_tmp_path):
         variant="default",
         task=Task.OBJECT_DETECTION,
         source=Source.GITHUB,
-        priority=ModelPriority.P1,
     )
 
     # Load  model and input

--- a/forge/test/models/onnx/vision/yolo/test_yolo_world.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_world.py
@@ -8,11 +8,10 @@ import torch
 import onnx
 
 import forge
-from forge.forge_property_utils import Framework, Source, Task
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.yolo.model_utils.yolovx_utils import WorldModelWrapper, get_test_input, load_world_model
-from forge.forge_property_utils import Framework, Source, Task, ModelPriority, ModelArch, record_model_properties
+from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 
 
 @pytest.mark.xfail
@@ -28,12 +27,11 @@ def test_yolo_world_inference_onnx(tmp_path):
         variant="default",
         task=Task.OBJECT_DETECTION,
         source=Source.GITHUB,
-        priority=ModelPriority.P1,
     )
 
     # Load framework_model and input
     framework_model = load_world_model(MODEL_URL)
-    framework_model = WorldModelWrapper(framework_model).to(torch.bfloat16)
+    framework_model = WorldModelWrapper(framework_model)
     inputs = get_test_input()
 
     # Export model to ONNX


### PR DESCRIPTION
### Summary 

- This PR removes P1 tags from onnx models as only pytorch models are red models now
- It also removes improper bfp16 conversion from yolox world ONNX model as we are doing bfp16 conversion only for pytorch models now.
