### PR TITLE
Fix onnx and pytorch models

### DIFF
--- a/forge/test/models/onnx/text/deepcogito/test_cogito_v1_onnx.py
+++ b/forge/test/models/onnx/text/deepcogito/test_cogito_v1_onnx.py
@@ -6,8 +6,6 @@ import pytest
 import torch
 import onnx
 from onnx import external_data_helper
-from transformers import AutoModelForCausalLM, AutoTokenizer
-from torch import nn
 
 import forge
 from forge.verify.verify import verify
@@ -62,14 +60,14 @@ def test_cogito_generation_onnx(forge_tmp_path, variant):
 
     # Load and validate ONNX model
     loaded_model = onnx.load(str(final_onnx), load_external_data=True)
-    onnx.checker.check_model(loaded_model)
+    onnx.checker.check_model(str(final_onnx))
 
     # Create Forge ONNX model
-    framework_model = forge.OnnxModule(module_name, loaded_model)
+    framework_model = forge.OnnxModule(module_name, loaded_model, onnx_path=final_onnx)
 
     # Compile with Forge
     compiled_model = forge.compile(
-        loaded_model,
+        framework_model,
         sample_inputs=sample_inputs,
         module_name=module_name,
     )

--- a/forge/test/models/onnx/text/phi3/test_phi3_5.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3_5.py
@@ -59,10 +59,10 @@ def test_phi3_5_causal_lm_onnx(variant, forge_tmp_path):
 
     # passing model file instead of model proto due to size of the model(>2GB) - #https://github.com/onnx/onnx/issues/3775#issuecomment-943416925
     onnx.checker.check_model(onnx_path)
-    framework_model = forge.OnnxModule(module_name, onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model, onnx_path)
 
     # Compile model
-    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+    compiled_model = forge.compile(framework_model, inputs, module_name=module_name)
 
     # Model Verification
     verify(

--- a/forge/test/models/onnx/vision/sam/test_sam_onnx.py
+++ b/forge/test/models/onnx/vision/sam/test_sam_onnx.py
@@ -56,12 +56,12 @@ def test_sam_onnx(variant, forge_tmp_path):
 
     # Load framework model
     onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
-    framework_model = forge.OnnxModule(module_name, onnx_model)
+    onnx.checker.check_model(onnx_path)
+    framework_model = forge.OnnxModule(module_name, onnx_model, onnx_path)
 
     # Compile model
     compiled_model = forge.compile(
-        onnx_model,
+        framework_model,
         sample_inputs=sample_inputs,
         module_name=module_name,
     )

--- a/forge/test/models/pytorch/audio/whisper/test_whisper.py
+++ b/forge/test/models/pytorch/audio/whisper/test_whisper.py
@@ -70,7 +70,7 @@ def test_whisper(variant):
     model.config.use_cache = False
 
     # Load and preprocess sample audio
-    sample = torch.load("forge/test/models/files/samples/audio/1272-128104-0000.pt")
+    sample = torch.load("forge/test/models/files/samples/audio/1272-128104-0000.pt", weights_only=False)
     sample_audio = sample["audio"]["array"]
 
     inputs = processor(sample_audio, return_tensors="pt")

--- a/forge/test/models/pytorch/text/mistral/test_mistral.py
+++ b/forge/test/models/pytorch/text/mistral/test_mistral.py
@@ -75,7 +75,7 @@ variants = ["mistralai/Mistral-7B-Instruct-v0.3"]
 def test_mistral_v0_3(variant):
 
     # Record Forge Property
-    record_model_properties(
+    module_name = record_model_properties(
         framework=Framework.PYTORCH,
         model=ModelArch.MISTRAL,
         variant=variant,

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py
@@ -86,7 +86,7 @@ def test_mobilenetv1_192(variant):
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.PYTORCH,
-        model=ModelArch.MOBILENET_V1,
+        model=ModelArch.MOBILENETV1,
         variant=variant,
         source=Source.HUGGINGFACE,
         task=Task.IMAGE_CLASSIFICATION,
@@ -132,7 +132,7 @@ def test_mobilenetv1_224(variant):
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.PYTORCH,
-        model=ModelArch.MOBILENET_V1,
+        model=ModelArch.MOBILENETV1,
         variant=variant,
         source=Source.HUGGINGFACE,
         task=Task.IMAGE_CLASSIFICATION,


### PR DESCRIPTION
### Fixed Issues:

1.  `ValueError: Message onnx.ModelProto exceeds maximum protobuf size of 2GB`
The exported onnx model exceed 2GB which leads to above issues so passing onnx model file instead of model proto in below tests cases.

```
forge/test/models/onnx/text/deepcogito/test_cogito_v1_onnx.py::test_cogito_generation_onnx[deepcogito/cogito-v1-preview-llama-3B]
forge/test/models/onnx/text/phi3/test_phi3_5.py::test_phi3_5_causal_lm_onnx[microsoft/Phi-3.5-mini-instruct]
forge/test/models/onnx/vision/sam/test_sam_onnx.py::test_sam_onnx[facebook/sam-vit-huge]
```

2.` _pickle.UnpicklingError: Weights only load failed. `
While loading the sample audio in these line(i.e `sample = torch.load("forge/test/models/files/samples/audio/1272-128104-0000.pt")`), the above error was through due to torch update. In PyTorch 2.6,they have changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`  which leads to above error.
So set weights_only to False
`
forge/test/models/pytorch/audio/whisper/test_whisper.py::test_whisper[openai/whisper-large]
`

3. `AttributeError: MOBILENET_V1. Did you mean: 'MOBILENETV1'?`
Fixed model arch in below test cases
```
forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py::test_mobilenetv1_224[google/mobilenet_v1_1.0_224]
forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v1.py::test_mobilenetv1_192[google/mobilenet_v1_0.75_192]
```

5. Fixed module_name not found issues in mistral and removed model bfloat16 conversion in yolo world onnx model because the lower dataformat compilation is only supported in pytorch models

```
forge/test/models/onnx/vision/yolo/test_yolo_world.py::test_yolo_world_inference_onnx
forge/test/models/pytorch/text/mistral/test_mistral.py::test_mistral_v0_3[mistralai/Mistral-7B-Instruct-v0.3]
```
