### PR TITLE
Remove xfail markers from repeat and multiply ops tests

### DIFF
--- a/forge/test/models_ops/test_multiply.py
+++ b/forge/test/models_ops/test_multiply.py
@@ -2818,19 +2818,16 @@ forge_modules_and_shapes_dtypes_list = [
             "pcc": 0.99,
         },
     ),
-    pytest.param(
-        (
-            Multiply0,
-            [((1, 100, 8, 32, 1), torch.float32), ((1, 1, 8, 32, 280), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                ],
-                "pcc": 0.99,
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Multiply0,
+        [((1, 100, 8, 32, 1), torch.float32), ((1, 1, 8, 32, 280), torch.float32)],
+        {
+            "model_names": [
+                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+            ],
+            "pcc": 0.99,
+        },
     ),
     (
         Multiply11,

--- a/forge/test/models_ops/test_repeat.py
+++ b/forge/test/models_ops/test_repeat.py
@@ -60,65 +60,53 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"repeats": "[1, 1, 1]"},
         },
     ),
-    pytest.param(
-        (
-            Repeat1,
-            [((1, 1, 32, 107, 160), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                ],
-                "pcc": 0.99,
-                "args": {"repeats": "[1, 100, 1, 1, 1]"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Repeat1,
+        [((1, 1, 32, 107, 160), torch.float32)],
+        {
+            "model_names": [
+                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+            ],
+            "pcc": 0.99,
+            "args": {"repeats": "[1, 100, 1, 1, 1]"},
+        },
     ),
-    pytest.param(
-        (
-            Repeat1,
-            [((1, 1, 64, 54, 80), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                ],
-                "pcc": 0.99,
-                "args": {"repeats": "[1, 100, 1, 1, 1]"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Repeat1,
+        [((1, 1, 64, 54, 80), torch.float32)],
+        {
+            "model_names": [
+                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+            ],
+            "pcc": 0.99,
+            "args": {"repeats": "[1, 100, 1, 1, 1]"},
+        },
     ),
-    pytest.param(
-        (
-            Repeat1,
-            [((1, 1, 128, 27, 40), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                ],
-                "pcc": 0.99,
-                "args": {"repeats": "[1, 100, 1, 1, 1]"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Repeat1,
+        [((1, 1, 128, 27, 40), torch.float32)],
+        {
+            "model_names": [
+                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+            ],
+            "pcc": 0.99,
+            "args": {"repeats": "[1, 100, 1, 1, 1]"},
+        },
     ),
-    pytest.param(
-        (
-            Repeat1,
-            [((1, 1, 256, 14, 20), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                    "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
-                ],
-                "pcc": 0.99,
-                "args": {"repeats": "[1, 100, 1, 1, 1]"},
-            },
-        ),
-        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
+    (
+        Repeat1,
+        [((1, 1, 256, 14, 20), torch.float32)],
+        {
+            "model_names": [
+                "onnx_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+                "pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf",
+            ],
+            "pcc": 0.99,
+            "args": {"repeats": "[1, 100, 1, 1, 1]"},
+        },
     ),
 ]
 


### PR DESCRIPTION
In the [latest models ops pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/15692931151/), the **data mismatch between framework and compiled model output** was resolved in the **repeat** and **multiply** ops tests in the below tests cases so removed xfail markers for those tests.

```
forge/test/models_ops/test_repeat.py::test_module[Repeat1-[((1, 1, 256, 14, 20), torch.float32)]]
forge/test/models_ops/test_multiply.py::test_module[Multiply0-[((1, 100, 8, 32, 1), torch.float32), ((1, 1, 8, 32, 280), torch.float32)]]
forge/test/models_ops/test_repeat.py::test_module[Repeat1-[((1, 1, 128, 27, 40), torch.float32)]]
forge/test/models_ops/test_repeat.py::test_module[Repeat1-[((1, 1, 64, 54, 80), torch.float32)]]
forge/test/models_ops/test_repeat.py::test_module[Repeat1-[((1, 1, 32, 107, 160), torch.float32)]]
```
