### PR TITLE
[Bug Fix] Qwen models - removed attention_mask from the input

### DIFF
--- a/forge/test/models/pytorch/text/qwen/test_qwen.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import torch
 from transformers import Qwen2Config, Qwen2ForCausalLM, Qwen2Tokenizer
 
 import forge

--- a/forge/test/models/pytorch/text/qwen/test_qwen.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen.py
@@ -54,12 +54,9 @@ def test_qwen1_5_causal_lm(variant):
     batch_size = 1
     prompt = ["My name is Jim Keller and"] * batch_size
 
-    inputs = tokenizer(prompt)
+    inputs = tokenizer(prompt, return_tensors="pt")
 
-    input_ids = torch.tensor(inputs["input_ids"])
-    attention_mask = torch.tensor(inputs["attention_mask"])
-
-    inputs = [input_ids, attention_mask]
+    inputs = [inputs["input_ids"]]
 
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)

--- a/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 from transformers import AutoModelForCausalLM, AutoTokenizer
+from torch import nn
 
 import forge
 from forge.forge_property_utils import (
@@ -105,7 +106,6 @@ def test_qwen_clm(variant):
 
     # Load model and tokenizer
     framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu")
-    framework_model.config.return_dict = False
     tokenizer = AutoTokenizer.from_pretrained(variant)
 
     # Prepare input
@@ -118,9 +118,16 @@ def test_qwen_clm(variant):
 
     # Tokenize and prepare inputs
     model_inputs = tokenizer([text], return_tensors="pt")
-    input_ids = model_inputs["input_ids"]
-    attention_mask = model_inputs["attention_mask"]
-    inputs = [input_ids, attention_mask]
+    inputs = [model_inputs["input_ids"]]
+    
+    class Wrapper(nn.Module):
+        def __init__(self, model):
+            super().__init__()
+            self.model = model
+        def forward(self, input_ids):
+            return self.model(input_ids).logits
+        
+    framework_model = Wrapper(framework_model)
 
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)

--- a/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-from transformers import AutoModelForCausalLM, AutoTokenizer
 from torch import nn
+from transformers import AutoModelForCausalLM, AutoTokenizer
 
 import forge
 from forge.forge_property_utils import (
@@ -119,14 +119,15 @@ def test_qwen_clm(variant):
     # Tokenize and prepare inputs
     model_inputs = tokenizer([text], return_tensors="pt")
     inputs = [model_inputs["input_ids"]]
-    
+
     class Wrapper(nn.Module):
         def __init__(self, model):
             super().__init__()
             self.model = model
+
         def forward(self, input_ids):
             return self.model(input_ids).logits
-        
+
     framework_model = Wrapper(framework_model)
 
     # Forge compile framework model

--- a/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
@@ -2,13 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+from torch import nn
 from transformers import (
     AutoModelForCausalLM,
     AutoTokenizer,
     Qwen2ForTokenClassification,
 )
-
-from torch import nn
 
 import forge
 from forge.forge_property_utils import (
@@ -97,14 +96,15 @@ def test_qwen_clm(variant):
     # Tokenize and generate
     model_inputs = tokenizer([text], return_tensors="pt")
     inputs = [model_inputs["input_ids"]]
-        
+
     class Wrapper(nn.Module):
         def __init__(self, model):
             super().__init__()
             self.model = model
+
         def forward(self, input_ids):
             return self.model(input_ids).logits
-    
+
     framework_model = Wrapper(framework_model)
 
     # Forge compile framework model

--- a/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
@@ -8,6 +8,8 @@ from transformers import (
     Qwen2ForTokenClassification,
 )
 
+from torch import nn
+
 import forge
 from forge.forge_property_utils import (
     Framework,
@@ -85,7 +87,6 @@ def test_qwen_clm(variant):
 
     # Load model and tokenizer
     framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu")
-    framework_model.config.return_dict = False
     tokenizer = AutoTokenizer.from_pretrained(variant)
 
     # Prepare input
@@ -95,9 +96,16 @@ def test_qwen_clm(variant):
 
     # Tokenize and generate
     model_inputs = tokenizer([text], return_tensors="pt")
-    input_ids = model_inputs["input_ids"]
-    attention_mask = model_inputs["attention_mask"]
-    inputs = [input_ids, attention_mask]
+    inputs = [model_inputs["input_ids"]]
+        
+    class Wrapper(nn.Module):
+        def __init__(self, model):
+            super().__init__()
+            self.model = model
+        def forward(self, input_ids):
+            return self.model(input_ids).logits
+    
+    framework_model = Wrapper(framework_model)
 
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)


### PR DESCRIPTION
### Problem Description
We encountered issues with in-place operations when using Qwen models. A detailed description of the problem is available [here](https://github.com/tenstorrent/tt-forge-fe/issues/2065#event-17698778096).

### Changes Made
Removed `attention_mask` as the second input parameter. While this resolves the issue for single-sentence inputs, it is not a comprehensive solution since the underlying problem is fundamental for our compiler. 

Fixes #2065, but now these models have bad pcc.