### PR TITLE
Replace runtime error with xfail

### DIFF
--- a/forge/test/models/onnx/text/phi3/test_phi3_5_vision.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3_5_vision.py
@@ -27,6 +27,7 @@ class Wrapper(torch.nn.Module):
 variants = ["microsoft/Phi-3.5-vision-instruct"]
 
 
+@pytest.mark.out_of_memory
 @pytest.mark.nightly
 @pytest.mark.skip("Segmentation Fault")
 @pytest.mark.parametrize("variant", variants)

--- a/forge/test/models/pytorch/multimodal/llava/test_llava.py
+++ b/forge/test/models/pytorch/multimodal/llava/test_llava.py
@@ -60,7 +60,7 @@ def test_llava(variant):
         priority=ModelPriority.P1,
     )
 
-    raise RuntimeError("Requires multi-chip support")
+    pytest.xfail(reason="Requires multi-chip support")
 
     framework_model, processor = load_model(variant)
     image = "https://www.ilankelman.org/stopsigns/australia.jpg"

--- a/forge/test/models/pytorch/multimodal/phi3/test_phi3_5_vision.py
+++ b/forge/test/models/pytorch/multimodal/phi3/test_phi3_5_vision.py
@@ -51,7 +51,7 @@ def test_phi3_5_vision(variant):
         priority=ModelPriority.P1,
     )
 
-    raise RuntimeError("Requires multi-chip support")
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and processor
     model = download_model(

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_v35.py
@@ -73,7 +73,7 @@ def test_stable_diffusion_v35(variant):
         priority=ModelPriority.P1,
     )
 
-    raise RuntimeError("Requires multi-chip support")
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load pipeline
     pipe = load_pipe(variant, variant_type="v35")

--- a/forge/test/models/pytorch/text/falcon/test_falcon.py
+++ b/forge/test/models/pytorch/text/falcon/test_falcon.py
@@ -109,7 +109,7 @@ def test_falcon_3(variant):
     )
 
     if variant != "tiiuae/Falcon3-1B-Base":
-        raise RuntimeError("Requires multi-chip support")
+        pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and tokenizer
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_2b.py
@@ -114,7 +114,7 @@ def test_gemma_pytorch_v2(variant):
         priority=ModelPriority.P1,
     )
     if variant == "google/gemma-2-9b-it":
-        raise RuntimeError("Requires multi-chip support")
+        pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and tokenizer from HuggingFace
     tokenizer = AutoTokenizer.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/gemma/test_gemma_v1.py
+++ b/forge/test/models/pytorch/text/gemma/test_gemma_v1.py
@@ -49,7 +49,7 @@ def test_gemma_pytorch_v1(variant):
         priority=ModelPriority.P1,
     )
 
-    raise RuntimeError("Requires multi-chip support")
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and tokenizer from HuggingFace
     tokenizer = AutoTokenizer.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/llama/test_llama3.py
+++ b/forge/test/models/pytorch/text/llama/test_llama3.py
@@ -204,9 +204,9 @@ def test_llama3_causal_lm(variant):
         "meta-llama/Llama-3.3-70B-Instruct",
         "meta-llama/Meta-Llama-3.1-8B-Instruct",
     ]:
-        raise RuntimeError("Requires multi-chip support")
+        pytest.xfail(reason="Requires multi-chip support")
     elif variant == "meta-llama/Llama-3.1-8B-Instruct":
-        raise RuntimeError("Segmentation Fault")
+        pytest.xfail(reason="Segmentation Fault")
 
     # Load model (with tokenizer)
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/ministral/test_ministral_3b.py
+++ b/forge/test/models/pytorch/text/ministral/test_ministral_3b.py
@@ -36,7 +36,7 @@ def test_ministral_3b(variant):
         priority=ModelPriority.P1,
     )
 
-    raise RuntimeError("Requires multi-chip support")
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/ministral/test_ministral_8b.py
+++ b/forge/test/models/pytorch/text/ministral/test_ministral_8b.py
@@ -38,7 +38,7 @@ def test_ministral_8b(variant):
         priority=ModelPriority.P1,
     )
 
-    raise RuntimeError("Requires multi-chip support")
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and tokenizer
     framework_model = download_model(AutoModelForCausalLM.from_pretrained, variant, return_dict=False, use_cache=False)

--- a/forge/test/models/pytorch/text/mistral/test_mistral.py
+++ b/forge/test/models/pytorch/text/mistral/test_mistral.py
@@ -85,7 +85,7 @@ def test_mistral_v0_3(variant):
         priority=ModelPriority.P1,
     )
 
-    raise RuntimeError("Requires multi-chip support")
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load tokenizer and model
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/phi2/test_phi2.py
+++ b/forge/test/models/pytorch/text/phi2/test_phi2.py
@@ -67,7 +67,7 @@ def test_phi2_clm(variant):
     )
 
     if variant == "microsoft/phi-2":
-        raise RuntimeError("Requires multi-chip support")
+        pytest.xfail(reason="Requires multi-chip support")
 
     # Load PhiConfig from pretrained variant, disable return_dict and caching.
     config = PhiConfig.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/phi3/test_phi3.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3.py
@@ -102,7 +102,7 @@ def test_phi3_causal_lm(variant):
         priority=ModelPriority.P1,
     )
 
-    raise RuntimeError("Requires multi-chip support")
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Phi3Config from pretrained variant, disable return_dict and caching.
     config = Phi3Config.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/phi3/test_phi3_5.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3_5.py
@@ -38,7 +38,7 @@ def test_phi3_5_causal_lm(variant):
         priority=ModelPriority.P1,
     )
 
-    raise RuntimeError("Segmentation Fault")
+    pytest.xfail(reason="Segmentation Fault")
 
     # Load model and tokenizer
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/text/phi4/test_phi4.py
+++ b/forge/test/models/pytorch/text/phi4/test_phi4.py
@@ -43,7 +43,7 @@ def test_phi_4_causal_lm_pytorch(variant):
         priority=ModelPriority.P1,
     )
 
-    raise RuntimeError("Requires multi-chip support")
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load tokenizer and model from HuggingFace
     framework_model = download_model(AutoModelForCausalLM.from_pretrained, variant, return_dict=False, use_cache=False)

--- a/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_coder.py
@@ -101,7 +101,7 @@ def test_qwen_clm(variant):
     )
 
     if variant == "Qwen/Qwen2.5-Coder-32B-Instruct":
-        raise RuntimeError("Requires multi-chip support")
+        pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and tokenizer
     framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu")

--- a/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_v2.py
@@ -81,7 +81,7 @@ def test_qwen_clm(variant):
         "Qwen/Qwen2.5-7B-Instruct-1M",
         "Qwen/Qwen2.5-14B-Instruct-1M",
     ]:
-        raise RuntimeError("Requires multi-chip support")
+        pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and tokenizer
     framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu")


### PR DESCRIPTION
In the model analysis, will execute skipped and xfailed tests to generate models ops tests by enabling `--runxfail `and `--no-skips` option in the tests command but for some xfailed tests we have added runtime exception raise inside the tests function to record properties alone which block the models analysis pipeline to execute the tests for generating ops tests so replacing runtime exception with pytest.xfail which helps to record those properties and stop the execution when it hit pytest.xfail statement and in the model analysis when we use `--runxfail `option, it will ignore the pytest.xfail statement present inside the tests function.