### PR TITLE
Removes xfail for [trend_basis], [generic_basis] variants

### DIFF
--- a/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
+++ b/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
@@ -58,7 +58,6 @@ def test_nbeats_with_seasonality_basis(variant):
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["generic_basis"])
 def test_nbeats_with_generic_basis(variant):
 
@@ -86,7 +85,6 @@ def test_nbeats_with_generic_basis(variant):
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["trend_basis"])
 def test_nbeats_with_trend_basis(variant):
 


### PR DESCRIPTION
- Removed xfail for the passing tests:
```
test_nbeats_with_trend_basis[trend_basis]
test_nbeats_with_generic_basis[generic_basis]
```