### PR TITLE
Fixed build errors with g++12.

### DIFF
--- a/utils/assert.hpp
+++ b/utils/assert.hpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <tuple>
 #include <vector>
 
 #include "fmt/core.h"


### PR DESCRIPTION
Errors were coming from assert.h which did not have std::apply function.
Fixed by including missing <tuple> header which holds std::apply.