### PR TITLE
Fix pytorch densenet, vgg, vovnet and yolo models

### DIFF
--- a/forge/test/models/pytorch/vision/densenet/test_densenet.py
+++ b/forge/test/models/pytorch/vision/densenet/test_densenet.py
@@ -1,6 +1,8 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
+import os
+
 import pytest
 import torch
 import torch.nn as nn
@@ -70,6 +72,7 @@ def test_densenet_121_pytorch(variant):
         framework_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "densenet121", pretrained=True)
         img_tensor = get_input_img()
     else:
+        os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"
         model_name = "densenet121-res224-all"
         model = download_model(xrv.models.get_model, model_name)
         framework_model = densenet_xray_wrapper(model)

--- a/forge/test/models/pytorch/vision/unet/test_vgg19_unet.py
+++ b/forge/test/models/pytorch/vision/unet/test_vgg19_unet.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+import torch
 
 import forge
 from forge._C import DataFormat
@@ -34,8 +35,8 @@ def test_vgg19_unet():
     )
 
     # Load model and input
-    framework_model = ModelLoader.load_model()
-    input_sample = ModelLoader.load_inputs()
+    framework_model = ModelLoader.load_model(dtype_override=torch.bfloat16)
+    input_sample = ModelLoader.load_inputs(dtype_override=torch.bfloat16)
 
     # Configurations
     compiler_cfg = CompilerConfig()

--- a/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/pytorch/vision/vovnet/test_vovnet.py
@@ -204,11 +204,11 @@ variants = [
 def test_vovnet_timm_pytorch(variant):
 
     if variant == "ese_vovnet19b_dw.ra_in1k":
-        group = (ModelGroup.RED,)
-        priority = (ModelPriority.P1,)
+        group = ModelGroup.RED
+        priority = ModelPriority.P1
     else:
-        group = (ModelGroup.GENERALITY,)
-        priority = (ModelPriority.P2,)
+        group = ModelGroup.GENERALITY
+        priority = ModelPriority.P2
 
     # Record Forge Property
     module_name = record_model_properties(

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v3.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v3.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+import torch
 
 import forge
 from forge._C import DataFormat
@@ -32,8 +33,8 @@ def test_yolo_v3():
     )
 
     # Load model and input
-    framework_model = ModelLoader.load_model()
-    input_sample = ModelLoader.load_inputs()
+    framework_model = ModelLoader.load_model(dtype_override=torch.bfloat16)
+    input_sample = ModelLoader.load_inputs(dtype_override=torch.bfloat16)
 
     # Configurations
     compiler_cfg = CompilerConfig()

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v4.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v4.py
@@ -49,9 +49,9 @@ def test_yolo_v4():
     )
 
     # Load model and input
-    framework_model = ModelLoader.load_model()
-    framework_model = Wrapper(framework_model)
-    input_sample = ModelLoader.load_inputs()
+    framework_model = ModelLoader.load_model(dtype_override=torch.bfloat16)
+    framework_model = Wrapper(framework_model).to(torch.bfloat16)
+    input_sample = ModelLoader.load_inputs(dtype_override=torch.bfloat16)
 
     # Configurations
     compiler_cfg = CompilerConfig()


### PR DESCRIPTION
Issues Fixed:

1. `RuntimeError: TT_ASSERT @ /proj_sw/user_dev/pchandrasekaran/Forge/tt-forge-fe/forge/csrc/passes/dataformat.cpp:312: node->output_df() == default_df_override || node_is_int Non integer Input activations should have output_df same as dataformat override which is: Float16_b, but node output_df is: Float32`

The below models tests contains conv ops but we have only passed compiler config with default_df_overide to compile function without converting models and inputs to bfloat16 which leads to above issues so converted the model and inputs to bfloat16

```
forge/test/models/pytorch/vision/yolo/test_yolo_v3.py::test_yolo_v3
forge/test/models/pytorch/vision/yolo/test_yolo_v4.py::test_yolo_v4
forge/test/models/pytorch/vision/unet/test_vgg19_unet.py::test_vgg19_unet
```

2. `AttributeError: 'tuple' object has no attribute 'value'`
Groups and priority are passed as tuple to record_model_properties which leads to above issues so fixed the recording in below models tests


```
forge/test/models/pytorch/vision/vovnet/test_vovnet.py::test_vovnet_timm_pytorch[ese_vovnet19b_dw.ra_in1k] forge/test/models/pytorch/vision/vovnet/test_vovnet.py::test_vovnet_timm_pytorch[ese_vovnet19b_dw]
forge/test/models/pytorch/vision/vovnet/test_vovnet.py::test_vovnet_timm_pytorch[ese_vovnet39b]
forge/test/models/pytorch/vision/vovnet/test_vovnet.py::test_vovnet_timm_pytorch[ese_vovnet99b]
```

3. `_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, [1mdo those steps only if you trust the source of the checkpoint(1) In PyTorch 2.6, we changed the default value of the `weights_only` argument in `torch.load` from `False` to `True`. Re-running `torch.load` with `weights_only` set to `False` will likely succeed, but it can result in arbitrary code execution. Do it only if you got the file from a trusted source. (2) Alternatively, to load with `weights_only=True` please check the recommended steps in the following error message.`


The above error was through while loading densenet model(i.e densenet121-res224-all ) weights in this [line](https://github.com/mlmed/torchxrayvision/blob/11c53a046ea7335cf3b132d61c22af81290748d5/torchxrayvision/models.py#L210) due to recent torch update. The densenet model class doesn't have argument to set weight_only argument to False so using the flag [TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD](https://docs.pytorch.org/docs/stable/miscellaneous_environment_variables.html#:~:text=TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD) to set weight_only to False 

`
forge/test/models/pytorch/vision/densenet/test_densenet.py::test_densenet_121_pytorch[densenet121_hf_xray]
`