### PR TITLE
Add proper post-processing support for PyTorch models trained on ImageNet-21k

### DIFF
--- a/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
@@ -65,9 +65,7 @@ variants = [
     pytest.param("hf_hub:timm/efficientnet_b5.in12k_ft_in1k", id="hf_hub_timm_efficientnet_b5_in12k_ft_in1k"),
     pytest.param("hf_hub:timm/tf_efficientnet_b0.aa_in1k", id="hf_hub_timm_tf_efficientnet_b0_aa_in1k"),
     pytest.param("hf_hub:timm/efficientnetv2_rw_s.ra2_in1k", id="hf_hub_timm_efficientnetv2_rw_s_ra2_in1k"),
-    pytest.param(
-        "hf_hub:timm/tf_efficientnetv2_s.in21k", id="hf_hub_timm_tf_efficientnetv2_s_in21k", marks=[pytest.mark.xfail]
-    ),
+    pytest.param("hf_hub:timm/tf_efficientnetv2_s.in21k", id="hf_hub_timm_tf_efficientnetv2_s_in21k"),
 ]
 
 
@@ -98,10 +96,17 @@ def test_efficientnet_timm(variant):
 
     # Load and pre-process image
     try:
-        url, filename = (
-            "https://github.com/pytorch/hub/raw/master/images/dog.jpg",
-            "dog.jpg",
-        )
+        if variant == "hf_hub:timm/tf_efficientnetv2_s.in21k":
+            url = (
+                "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png"
+            )
+            filename = "beignets_with_coffee.png"
+            use_1k_labels = False
+        else:
+            url = "https://github.com/pytorch/hub/raw/master/images/dog.jpg"
+            filename = "dog.jpg"
+            use_1k_labels = True
+
         urllib.request.urlretrieve(url, filename)
         img = Image.open(filename).convert("RGB")
         config = resolve_data_config({}, model=framework_model)
@@ -130,7 +135,7 @@ def test_efficientnet_timm(variant):
     fw_out, co_out = verify(inputs, framework_model, compiled_model)
 
     # Run model on sample data and print results
-    print_cls_results(fw_out[0], co_out[0])
+    print_cls_results(fw_out[0], co_out[0], use_1k_labels=use_1k_labels)
 
 
 def get_state_dict(self, *args, **kwargs):

--- a/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
+++ b/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
@@ -81,7 +81,19 @@ def test_mlp_mixer_timm_pytorch(variant):
     transform = create_transform(**config)
 
     try:
-        url = "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
+        if variant in [
+            "mixer_b16_224_in21k",
+            "mixer_b16_224_miil_in21k",
+            "mixer_l16_224_in21k",
+            "mixer_b16_224.goog_in21k",
+        ]:
+            url = (
+                "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png"
+            )
+            use_1k_labels = False
+        else:
+            url = "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
+            use_1k_labels = True
         image = Image.open(requests.get(url, stream=True).raw).convert("RGB")
     except:
         logger.warning(
@@ -107,7 +119,7 @@ def test_mlp_mixer_timm_pytorch(variant):
     fw_out, co_out = verify(inputs, framework_model, compiled_model)
 
     # Run model on sample data and print results
-    print_cls_results(fw_out[0], co_out[0])
+    print_cls_results(fw_out[0], co_out[0], use_1k_labels=use_1k_labels)
 
 
 @pytest.mark.nightly


### PR DESCRIPTION
### Problem description

- For the models is trained on a larger label space (e.g., ImageNet-21k with 21,841 classes), but we initially loaded only the ImageNet-1k label file, which contains just 1,000 class labels.
- As a result, the model's top-1 prediction index (e.g., 2034) is valid within the model's label space, but it can't be mapped to a human-readable class name because the label file doesn't cover that range. This leads to an below IndexError.

```
def print_cls_results(fw_out, compiled_model_out):
    
        class_labels = load_class_labels(imagenet_class_index_path)
        fw_top1_probabilities, fw_top1_class_indices = torch.topk(fw_out.softmax(dim=1) * 100, k=1)
        compiled_model_top1_probabilities, compiled_model_top1_class_indices = torch.topk(
            compiled_model_out.softmax(dim=1) * 100, k=1
        )
    
        # Directly get the top 1 predicted class and its probability for both models
        fw_top1_class_idx = fw_top1_class_indices[0, 0].item()
        compiled_model_top1_class_idx = compiled_model_top1_class_indices[0, 0].item()
        fw_top1_class_prob = fw_top1_probabilities[0, 0].item()
        compiled_model_top1_class_prob = compiled_model_top1_probabilities[0, 0].item()
    
        # Get the class labels for top 1 class
>       fw_top1_class_label = class_labels[fw_top1_class_idx]
E       IndexError: list index out of range
```


### What's changed

- This PR adds proper post-processing support for PyTorch models trained on ImageNet-21k

### Logs

- [efficientnet_21k.log](https://github.com/user-attachments/files/20813747/jun19_eff_final.log)
