### PR TITLE
Enhance model analysis

### DIFF
--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -2801,19 +2801,17 @@ def compile_tvm_to_python(
                     "Both extract_tvm_unique_ops_config and tvm_generate_unique_ops_tests should not be enabled at the same time."
                 )
 
-            # Commenting the below verification between framework outputs and generated forge module outputs
-            # because most of the models are failing with the pcc issue which leads to skip the models in model analysis
+            # Running the inference to verify the generated forge module which helps
+            # to avoid extracting unique ops configuration for not properly traced models
+            file_path = os.path.join(writer.module_directory, writer.filename)
+            module = import_from_path(writer.module_name, file_path)
 
-            # file_path = os.path.join(writer.module_directory, writer.filename)
-            # module = import_from_path(writer.module_name, file_path)
+            TestClass = getattr(module, writer.class_name)
+            forge_mod = TestClass(writer.module_name)
+            forge_mod.process_framework_parameters(framework_mod.module)
 
-            # TestClass = getattr(module, writer.class_name)
-            # forge_mod = TestClass(writer.module_name)
-            # forge_mod.process_framework_parameters(framework_mod.module)
-
-            # framework_outputs = framework_mod.cpu_eval_forward(*inputs)
-            # forge_outputs = get_forge_outputs([forge_mod], ["TTDevice"], forge_inputs)
-            # verify_framework_vs_forge_codegen(framework_outputs, forge_outputs, verify_cfg=verify_cfg)
+            framework_mod.cpu_eval_forward(*inputs)
+            get_forge_outputs([forge_mod], ["TTDevice"], forge_inputs)
 
             extract_and_generate_unique_ops_tests(
                 framework_mod,

--- a/forge/test/conftest.py
+++ b/forge/test/conftest.py
@@ -592,16 +592,16 @@ def pytest_collection_modifyitems(config, items):
 
     yield
 
+    is_collect_enabled = config.getoption("--collect-only")
     marker = config.getoption("-m")
-    if marker and marker == "not skip_model_analysis":  # If a marker is specified
-        print("Automatic Model Analysis Collected tests: ")
+    if marker and "skip_model_analysis" in marker and is_collect_enabled:  # If a marker is specified
+        print("\nAutomatic Model Analysis Collected tests: ")
         test_count = 0
         for item in items:
-            if "skip_model_analysis" not in item.keywords:
-                test_file_path = item.location[0]
-                test_name = item.location[2]
-                print(f"{test_file_path}::{test_name}")
-                test_count += 1
+            test_file_path = item.location[0]
+            test_name = item.location[2]
+            print(f"{test_file_path}::{test_name}")
+            test_count += 1
         print(f"Automatic Model Analysis Collected test count: {test_count}")
         if test_count == 0:  # Warn if no tests match the marker
             print(f"Warning: No tests found with marker '{marker}'.")

--- a/scripts/model_analysis/generate_models_ops_test.py
+++ b/scripts/model_analysis/generate_models_ops_test.py
@@ -27,6 +27,13 @@ def main():
         help="Specify the directory or file path containing models test with model_analysis pytest marker",
     )
     parser.add_argument(
+        "--marker",
+        "-m",
+        type=str,
+        required=True,
+        help="Specify the marker to collect the model analysis tests and then extract and export the unique ops config",
+    )
+    parser.add_argument(
         "--unique_ops_output_directory_path",
         default=os.path.join(os.getcwd(), "models_unique_ops_output"),
         required=False,
@@ -88,6 +95,7 @@ def main():
 
     generate_and_export_unique_ops_tests(
         test_directory_or_file_path=args.test_directory_or_file_path,
+        marker=args.marker,
         unique_ops_output_directory_path=args.unique_ops_output_directory_path,
         extract_tvm_unique_ops_config=True,
         tests_to_filter=args.tests_to_filter,

--- a/scripts/model_analysis/remove_ops_tests.py
+++ b/scripts/model_analysis/remove_ops_tests.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import os
+import argparse
+from utils import create_python_package, run_precommit, remove_directory
+from unique_ops_utils import extract_existing_unique_ops_config
+from forge.tvm_unique_op_generation import generate_models_ops_test
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Remove the generated unique ops tests for specific models")
+    parser.add_argument(
+        "--unique_ops_output_directory_path",
+        default=os.path.join(os.getcwd(), "models_unique_ops_output"),
+        required=False,
+        help="Specify the output directory path for saving existing unique ops configs outputs",
+    )
+    parser.add_argument(
+        "--models_ops_test_output_directory_path",
+        default=os.path.join(os.getcwd(), "forge/test"),
+        required=False,
+        help="Specify the directory path of the generated models ops tests",
+    )
+    parser.add_argument(
+        "--models_ops_test_package_name",
+        default="models_ops",
+        required=False,
+        help="Specify the python package name of the generated models ops tests",
+    )
+    parser.add_argument(
+        "--model_names",
+        nargs="+",
+        type=str,
+        required=False,
+        help="Specify the list of model names to which the generate models ops tests need to be removed",
+    )
+
+    args = parser.parse_args()
+
+    models_ops_tests_directory_path = os.path.join(
+        args.models_ops_test_output_directory_path, args.models_ops_test_package_name
+    )
+
+    existing_unique_ops_config_file_path = os.path.join(
+        args.unique_ops_output_directory_path, "existing_unique_ops_config_across_all_models_ops_tests.log"
+    )
+    existing_unique_ops_config = extract_existing_unique_ops_config(
+        models_ops_tests_directory_path=models_ops_tests_directory_path,
+        existing_unique_ops_config_file_path=existing_unique_ops_config_file_path,
+        remove_model_names=args.model_names,
+    )
+    remove_directory(directory_path=models_ops_tests_directory_path)
+    create_python_package(
+        package_path=args.models_ops_test_output_directory_path, package_name=args.models_ops_test_package_name
+    )
+    generate_models_ops_test(
+        existing_unique_ops_config,
+        models_ops_tests_directory_path,
+    )
+    run_precommit(directory_path=models_ops_tests_directory_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/model_analysis/unique_ops_utils.py
+++ b/scripts/model_analysis/unique_ops_utils.py
@@ -29,18 +29,19 @@ from utils import (
 def generate_and_export_unique_ops_tests(
     test_directory_or_file_path: str,
     unique_ops_output_directory_path: str,
+    marker: str,
     extract_tvm_unique_ops_config: bool = False,
     timeout: int = 1200,
     tests_to_filter: Optional[List[str]] = None,
 ):
     """
-    Collect all the tests that doesn't contain skip_model_analysis marker in the test_directory_or_file_path specified by the user
+    Collect all the tests that matches with specified marker in the test_directory_or_file_path specified by the user
     and then generate unique op test for all the collected test and return the list of directory path
     containing exported models unique op configuration as xlsx file
     """
 
-    # Collect all the test that doesn't contain skip_model_analysis marker inside the test_directory_or_file_path specified by the user
-    test_list = collect_all_model_analysis_test(test_directory_or_file_path, unique_ops_output_directory_path)
+    # Collect all the test that matches with specified marker inside the test_directory_or_file_path specified by the user
+    test_list = collect_all_model_analysis_test(test_directory_or_file_path, marker, unique_ops_output_directory_path)
 
     assert test_list != [], f"No tests found in the {test_directory_or_file_path} path"
 
@@ -263,6 +264,7 @@ def extract_existing_unique_ops_config(
     models_ops_tests_directory_path: str,
     existing_unique_ops_config_file_path: str,
     ops_to_filter: Optional[List[str]] = None,
+    remove_model_names: Optional[List[str]] = None,
 ):
     """
     Traverse a directory of generated models ops pytest files, extract each
@@ -277,6 +279,8 @@ def extract_existing_unique_ops_config(
         ops_to_filter (Optional[List[str]]): List of forge operation names
             (as strings) to include. If provided, only test files matching these
             names (without 'test_' prefix) will be processed.
+        remove_model_names: (Optional[List[str]]): List of model names to which
+            the unique ops will not be extracted
 
     Returns:
         UniqueOperations: Consolidated unique operations configuration extracted from the generated models ops tests.
@@ -320,6 +324,8 @@ def extract_existing_unique_ops_config(
         # Process each extracted config dict into an Operation instance
         for config in unique_ops_configs:
             for model_variant in config["model_names"]:
+                if remove_model_names and (str(model_variant) in remove_model_names):
+                    continue
                 op_count += 1
 
                 # Convert operand types to NodeType enums

--- a/scripts/model_analysis/utils.py
+++ b/scripts/model_analysis/utils.py
@@ -187,9 +187,9 @@ def dump_logs(log_files: Union[str, List[str]], content: str):
             logger.info(f"Dumped test logs in {log_file}")
 
 
-def collect_all_model_analysis_test(directory_or_file_path: str, output_directory_path: str):
+def collect_all_model_analysis_test(directory_or_file_path: str, marker: str, output_directory_path: str):
     """
-    Collect all the tests that doesn't contains skip_model_analysis marker in a specified directory or file.
+    Collect all the tests that matches with the specified marker in a specified directory or file.
     """
 
     # Ensure the directory or file path exists
@@ -197,15 +197,13 @@ def collect_all_model_analysis_test(directory_or_file_path: str, output_director
         directory_or_file_path
     ), f"The directory path for collecting test {directory_or_file_path} doesn't exists"
 
-    logger.info(
-        f"Collecting all the tests that doesn't contains skip_model_analysis marker in {directory_or_file_path}"
-    )
+    logger.info(f"Collecting all the tests that matches with {marker} marker in {directory_or_file_path}")
 
     collected_test_outputs = ""
     try:
-        # Run pytest to collect tests with the `model_analysis` marker
+        # Run pytest to collect all the tests that matches with the specified marker
         result = subprocess.run(
-            ["pytest", directory_or_file_path, "-m", "not skip_model_analysis", "--collect-only"],
+            ["pytest", directory_or_file_path, "-m", marker, "--collect-only"],
             capture_output=True,
             text=True,
             check=True,
@@ -556,6 +554,9 @@ def extract_models_ops_test_params(pytest_file_path: str):
                 pcc_value = metadata.get("pcc", None)
                 max_int_value = metadata.get("max_int", None)
                 op_args = metadata.get("args", {})
+                default_df_override = metadata.get("default_df_override", None)
+                if default_df_override is not None:
+                    op_args["default_df_override"] = default_df_override
 
                 # Locate the forward() method to find the forge.op.* call
                 class_node = class_defs.get(module_class_name)


### PR DESCRIPTION
The PR will enhance the model analysis ops test generation script features,

1) Created option to pass marker as input argument to the `scripts/model_analysis/generate_models_ops_test.py` script which helps to extract the unique ops config for different cases 
eg: 
     Case 1: not (skip_model_analysis and out_of_memory) -> For generating models ops test excluding OOO cases in CI runners.
     Case 2: not skip_model_analysis and out_of_memory -> For generating models ops test for OOO cases in local machine.
  
 2. Removed the condition(i.e `not skip_model_analysis`)  in `pytest_collection_modifyitems` hook for printing collected model analysis tests in **test_file_path::test_case_name** format which will be utilized by `collect_all_model_analysis_test` function present in `scripts/model_analysis/utils.py ` since the condition is already applied and added the additional condition to print collected model analysis tests  only when the `--collect-only` option is provided in the pytest command
 
 
 3. Created utility script(i.e `scripts/model_analysis/remove_ops_tests.py`) for removing the generated models ops tests for specific list of model provided by the user
 
 4. Before extracting and exporting unique ops configuration will run the inference on the generate forge module which help to avoid extracting unique ops config for not properly traced models but still disabling the pcc verification because still some models like swin have lower pcc values so uncommented the inference run in the tvm_to_python.py file. 