### PR TITLE
Added Support for UpdateCacheOp and FillCacheOp on Forge

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -152,6 +152,10 @@ class AttributeMapper
         add_op_mapping("pad", "padding", AttributeRemap("padding", TargetType::DenseI32ArrayAttr));
         add_op_mapping("pad", "value", AttributeRemap("value", TargetType::F32Attr));
 
+        // llm cache
+        add_op_mapping("update_cache", "batch_offset", AttributeRemap(std::nullopt, TargetType::I32Attr));
+        add_op_mapping("fill_cache", "batch_offset", AttributeRemap(std::nullopt, TargetType::I32Attr));
+
         // Add more default mappings here
     }
 };
@@ -501,6 +505,35 @@ class MLIRGenerator
         return opResult;
     }
 
+    /// Emit an MLIR operation for a Non DPS ttforge operation.
+    template <typename TTIROp>
+    mlir::Value emit_mlir_ttforge_non_dps_op(tt::graphlib::Graph *graph, tt::graphlib::OpNode *op_node)
+    {
+        // Evaluate operation return type
+        llvm::SmallVector<mlir::Type> return_types = get_mlir_type_range(op_node);
+
+        // Evaluate operation operands: inputs and outputs per DPS
+        llvm::SmallVector<mlir::Value> operands = get_mlir_operands(graph, op_node, false);
+
+        // Map forge to MLIR attributes for this operation.
+        llvm::SmallVector<mlir::NamedAttribute> mlir_attributes;
+        for (const auto &[name, value] : op_node->op_type().named_attrs)
+        {
+            auto [mapped_name, target_type] = attr_mapper_.get_mapped_name_and_type(op_node->op_name(), name);
+
+            mlir_attributes.push_back(
+                builder_.getNamedAttr(mapped_name, convert_to_mlir_attribute(value, target_type)));
+        }
+
+        auto op = builder_.create<TTIROp>(
+            get_tt_forge_operation_location(graph, op_node),
+            mlir::TypeRange(return_types),
+            mlir::ValueRange(operands),
+            mlir_attributes);
+
+        return op.getOperation()->getResult(0);
+    }
+
     /// Emit an MLIR operation for a ttforge operation.
     template <typename TTIROp>
     mlir::Value emit_mlir_ttforge_op(tt::graphlib::Graph *graph, tt::graphlib::OpNode *op_node)
@@ -542,7 +575,8 @@ class MLIRGenerator
     // traversing the TTForge graph using topological sort. We iterate over the
     // operands of the current node and retrieve their corresponding values
     // from the symbol table.
-    llvm::SmallVector<mlir::Value> get_mlir_operands(tt::graphlib::Graph *graph, tt::graphlib::OpNode *op_node)
+    llvm::SmallVector<mlir::Value> get_mlir_operands(
+        tt::graphlib::Graph *graph, tt::graphlib::OpNode *op_node, bool is_dps = true)
     {
         llvm::SmallVector<mlir::Value> operands;
 
@@ -563,7 +597,12 @@ class MLIRGenerator
             operands.push_back(symbolTable_.at(operand->name()).first);
         }
 
-        operands.push_back(emit_mlir_empty_tensor(graph, op_node));
+        if (is_dps)
+        {
+            // If this is a DPS operation, we need to add the output of the operation
+            // to the operands list as well.
+            operands.push_back(emit_mlir_empty_tensor(graph, op_node));
+        }
         return operands;
     }
 
@@ -776,6 +815,9 @@ class MLIRGenerator
         lowering_handler_map["upsample2d"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::Upsample2dOp>;
         lowering_handler_map["pad"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::PadOp>;
         lowering_handler_map["where"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::WhereOp>;
+        lowering_handler_map["fill_cache"] = &MLIRGenerator::emit_mlir_ttforge_non_dps_op<mlir::tt::ttir::FillCacheOp>;
+        lowering_handler_map["update_cache"] =
+            &MLIRGenerator::emit_mlir_ttforge_non_dps_op<mlir::tt::ttir::UpdateCacheOp>;
     }
 };
 

--- a/forge/forge/op/__init__.py
+++ b/forge/forge/op/__init__.py
@@ -75,4 +75,5 @@ from .resize import Resize1d, Resize2d, Resize3d, Upsample2d, Downsample2d
 from .embedding import Embedding
 from .dram_queue import DRAMQueue
 from .quantize import Quantize, Dequantize, Requantize, ForgeRequantize
+from .kv_cache import FillCache, UpdateCache
 import forge.op.loss

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -24,6 +24,8 @@ from .convolution import Conv2dTranspose
 from .pooling import MaxPool2d
 from .cast import Cast
 from .pad import Pad
+from .kv_cache import UpdateCache
+from .kv_cache import FillCache
 
 op_to_module_map = {
     "add": "eltwise_binary",
@@ -141,6 +143,8 @@ op_to_module_map = {
     "requantize": "quantize",
     "forge_requantize": "quantize",
     "forge_dequantize": "quantize",
+    "update_cache": UpdateCache,
+    "fill_cache": FillCache,
 }
 
 

--- a/forge/forge/op/eval/forge/kv_cache.py
+++ b/forge/forge/op/eval/forge/kv_cache.py
@@ -1,0 +1,126 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+from ..common import to_torch_operands
+from ..interface import PyOp
+
+
+class UpdateCache(PyOp):
+    @classmethod
+    def create(cls, batch_offset=0):
+        self = cls("update_cache")
+        self.batch_offset = batch_offset
+        return self
+
+    def eval(self, tensors):
+        cache, input, update_index = to_torch_operands(*tensors)
+
+        if update_index.ndim == 0:
+            update_index = update_index.unsqueeze(0)
+
+        assert cache.ndim == 4, "Expected 4D tensor for cache"
+        assert input.ndim == 4, "Expected 4D tensor for input"
+        assert update_index.ndim == 1, "Expected 1D tensor for update_index"
+
+        B_cache, H_cache, S_cache, D_cache = cache.shape
+        B_in, H_in, S_in, D_in = input.shape
+        # B is batch size, H is number of heads, S is sequence length, D is hidden dimension
+        assert (
+            S_in == 1
+        ), "UpdateCache operation requires input sequence length S=1, but received a different length. Cache update can update only one position at a time."
+        assert (H_cache, D_cache) == (
+            H_in,
+            D_in,
+        ), "Number of heads H and hidden dimension D have to match for cache and input for UpdateCache op"
+
+        assert (
+            update_index.shape[0] == B_in
+        ), f"Update index batch size {update_index.shape[0]} must match input batch size {B_in}"
+
+        batch_offset = self.batch_offset
+        assert (
+            batch_offset + B_in <= B_cache
+        ), f"batch_offset ({batch_offset}) + input batch size ({B_in}) exceeds cache batch size ({B_cache})"
+
+        for b in range(B_in):
+            idx = update_index[b].item()
+            assert 0 <= idx < S_cache, f"Invalid update index {idx} at batch {b}"
+            cache[b + batch_offset, :, idx : idx + S_in, :] = input[b]
+
+        return cache
+
+    def shape(self, tensor_shapes):
+        cache_shape, _, _ = tensor_shapes
+        return cache_shape, []
+
+    def is_tm(self) -> bool:
+        return False
+
+    def is_eltwise(self) -> bool:
+        return False
+
+    def is_eltwise_binary(self) -> bool:
+        return False
+
+    def is_eltwise_unary(self) -> bool:
+        return False
+
+    def is_eltwise_nary(self) -> bool:
+        return False
+
+
+class FillCache(PyOp):
+    @classmethod
+    def create(cls, update_idx, batch_offset=0):
+        self = cls("fill_cache")
+        self.update_idx = update_idx
+        self.batch_offset = batch_offset
+        return self
+
+    def eval(self, tensors):
+        cache, input = to_torch_operands(*tensors)
+
+        assert cache.ndim == 4, "Expected 4D tensor for cache"
+        assert input.ndim == 4, "Expected 4D tensor for input"
+
+        B_cache, H_cache, S_cache, D_cache = cache.shape
+        B_in, H_in, S_in, D_in = input.shape
+
+        # Ensure input shape aligns with cache shape
+        assert (H_in, D_in) == (
+            H_cache,
+            D_cache,
+        ), "Number of heads H and hidden dimension D must match for cache and input in FillCache"
+
+        batch_offset = self.batch_offset
+        assert (
+            batch_offset + B_in <= B_cache
+        ), f"batch_offset ({batch_offset}) + input batch size ({B_in}) exceeds cache batch size ({B_cache})"
+
+        for b in range(B_in):
+            assert S_in <= S_cache, f"Fill would write past the end of cache: S_in {S_in} > S_cache {S_cache}"
+            cache[b + batch_offset, :, 0:S_in, :] = input[b]
+
+        return cache
+
+    def shape(self, tensor_shapes):
+        (
+            cache_shape,
+            _,
+        ) = tensor_shapes
+        return cache_shape, []
+
+    def is_tm(self) -> bool:
+        return False
+
+    def is_eltwise(self) -> bool:
+        return False
+
+    def is_eltwise_binary(self) -> bool:
+        return False
+
+    def is_eltwise_unary(self) -> bool:
+        return False
+
+    def is_eltwise_nary(self) -> bool:
+        return False

--- a/forge/forge/op/kv_cache.py
+++ b/forge/forge/op/kv_cache.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+from ..tensor import Tensor
+from .common import ForgeOp as op
+
+
+def FillCache(
+    name: str,
+    cache: Tensor,
+    input: Tensor,
+    batch_offset: int = 0,
+) -> Tensor:
+    """
+    FillCache op writes the input into the cache tensor starting at the specified update index.
+
+    Parameters
+    ----------
+    name: str
+        Unique op name.
+
+    cache: Tensor
+        4D cache tensor of shape [B, H, S_total, D]
+
+    input: Tensor
+        4D input tensor of shape [B, H, S_input, D]
+
+    update_idx: int
+        The starting position in dim=2 to begin writing.
+
+    batch_offset: int
+        Offset in the batch dimension.
+    """
+    return op(
+        "fill_cache",
+        name,
+        cache,
+        input,
+        batch_offset=batch_offset,
+    ).get_tensor()
+
+
+def UpdateCache(
+    name: str,
+    cache: Tensor,
+    input: Tensor,
+    update_index: int,
+    batch_offset: int = 0,
+) -> Tensor:
+    """
+    UpdateCache writes a single token (S=1) slice into the cache tensor on specified index.
+
+    Parameters
+    ----------
+    name: str
+        Unique op name.
+
+    cache: Tensor
+        4D cache tensor of shape [B, H, S_total, D]
+
+    input: Tensor
+        4D input tensor of shape [B, H, 1, D]
+
+    update_idx: int
+        Position in dim=2 to write the input slice.
+
+    batch_offset: int
+        Offset in the batch dimension.
+    """
+    return op(
+        "update_cache",
+        name,
+        cache,
+        input,
+        update_index,
+        attrs=(batch_offset,),
+        batch_offset=batch_offset,
+    ).get_tensor()

--- a/forge/test/mlir/llama/tests/test_llama_decode.py
+++ b/forge/test/mlir/llama/tests/test_llama_decode.py
@@ -259,7 +259,10 @@ def test_llama_prefill_on_cpu_decode_on_tt_no_cache(model_path, run_on_tt_device
             "openlm-research/open_llama_3b",
             True,
             None,
-            marks=pytest.mark.nightly,
+            marks=[
+                pytest.mark.nightly,
+                pytest.mark.skip(reason="Temporarily skipping this nightly test because it takes 30GB of host memory"),
+            ],
         ),
         pytest.param(
             "meta-llama/Llama-3.2-1B",

--- a/forge/test/mlir/test_ops_forge.py
+++ b/forge/test/mlir/test_ops_forge.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import torch
+import random
+import pytest
+
+import forge.op
+from forge import ForgeModule
+from forge import Tensor, compile
+from forge.verify.verify import verify
+
+
+class UpdateCacheWrapper(ForgeModule):
+    def __init__(self, name):
+        super().__init__(name)
+
+    def forward(self, cache, input, update_index):
+        return forge.op.UpdateCache("", cache, input, update_index)
+
+
+class FillCacheWrapper(ForgeModule):
+    def __init__(self, name):
+        super().__init__(name)
+
+    def forward(self, cache, input):
+        return forge.op.FillCache("", cache, input)
+
+
+@pytest.mark.parametrize(
+    "shapes_and_types",
+    [
+        # cache: [B=1, H=2, S=4, D=3]
+        # input: [B=1, H=2, S=1, D=3]
+        # update_index: [1]
+        (
+            ((1, 2, 4, 3), torch.float32),  # cache
+            ((1, 2, 1, 3), torch.float32),  # input
+        ),
+    ],
+)
+@pytest.mark.push
+def test_update_cache(shapes_and_types):
+    cache_shape, cache_dtype = shapes_and_types[0]
+    input_shape, input_dtype = shapes_and_types[1]
+
+    max_update_index = cache_shape[2] - input_shape[2]
+    update_idx_value = random.randint(0, max_update_index)
+
+    cache_tensor = torch.zeros(cache_shape, dtype=cache_dtype)
+    input_tensor = torch.ones(input_shape, dtype=input_dtype)
+    update_index_tensor = torch.tensor([update_idx_value], dtype=torch.int32)
+
+    cache = Tensor.create_from_torch(cache_tensor)
+    input = Tensor.create_from_torch(input_tensor)
+    update_index = Tensor.create_from_torch(update_index_tensor)
+
+    inputs = [cache, input, update_index]
+
+    model = UpdateCacheWrapper("update_cache_op")
+    compiled = compile(model, sample_inputs=inputs)
+
+    verify(
+        inputs,
+        model,
+        compiled,
+    )
+
+
+@pytest.mark.parametrize(
+    "shapes_and_types",
+    [
+        # cache: [B=1, H=2, S=6, D=3]
+        # input: [B=1, H=2, S=3, D=3]
+        # update_index: int (start pos in dim=2 to write input)
+        (
+            ((1, 2, 6, 3), torch.float32),  # cache
+            ((1, 2, 3, 3), torch.float32),  # input
+        ),
+    ],
+)
+@pytest.mark.push
+def test_fill_cache(shapes_and_types):
+    cache_shape, cache_dtype = shapes_and_types[0]
+    input_shape, input_dtype = shapes_and_types[1]
+
+    cache_tensor = torch.zeros(cache_shape, dtype=cache_dtype)
+    input_tensor = torch.ones(input_shape, dtype=input_dtype)
+
+    cache = Tensor.create_from_torch(cache_tensor)
+    input = Tensor.create_from_torch(input_tensor)
+
+    inputs = [
+        cache,
+        input,
+    ]
+
+    model = FillCacheWrapper("fill_cache_op")
+    compiled = compile(model, sample_inputs=inputs)
+
+    verify(
+        inputs,
+        model,
+        compiled,
+    )


### PR DESCRIPTION
### Ticket
Closes #2356

### Problem description
We need KV cache on device. To reach that, first step was to implement Fill and Update cache ops in Forge and lower to tt-mlir.

### What's changed
  - Added Forge ops: FillCache and UpdateCache
  - Lower Forge ops to tt-mlir representations: Add emit_mlir_ttforge_non_dps_op as these ops are non dps and emit_mlir_ttforge_op assumed all ops are dps.
  - Add simple Forge op tests for fill and update cache.
  - Skip llama 3B decode nightly test since it takes 30Gb of host
        memory.
