### PR TITLE
Add logical_not op in lower_to_mlir and add skip_model_analysis marker in paddleocr model

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -745,6 +745,7 @@ class MLIRGenerator
         lowering_handler_map["leaky_relu"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::LeakyReluOp>;
         lowering_handler_map["less"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::LessEqualOp>;
         lowering_handler_map["log"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::LogOp>;
+        lowering_handler_map["logical_not"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::LogicalNotOp>;
         lowering_handler_map["matmul"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MatmulOp>;
         lowering_handler_map["max_pool2d"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MaxPool2dOp>;
         lowering_handler_map["maximum"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::MaximumOp>;

--- a/forge/test/models/paddlepaddle/multimodal/paddleocr/test_paddleocr.py
+++ b/forge/test/models/paddlepaddle/multimodal/paddleocr/test_paddleocr.py
@@ -35,6 +35,7 @@ cache_dir = os.path.join("forge/test/models/paddlepaddle/multimodal/paddleocr", 
 os.makedirs(cache_dir, exist_ok=True)
 
 
+@pytest.mark.skip_model_analysis
 @pytest.mark.nightly
 @pytest.mark.xfail
 @pytest.mark.parametrize("det_url,rec_url", [(urls["det"], urls["rec"]) for _, urls in model_urls.items()])

--- a/forge/test/models_ops/test_logicalnot.py
+++ b/forge/test/models_ops/test_logicalnot.py
@@ -37,17 +37,10 @@ def ids_func(param):
 
 
 forge_modules_and_shapes_dtypes_list = [
-    pytest.param(
-        (
-            Logicalnot0,
-            [((1, 25, 34), torch.bool)],
-            {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph"
-            )
-        ],
+    (
+        Logicalnot0,
+        [((1, 25, 34), torch.bool)],
+        {"model_names": ["pt_detr_facebook_detr_resnet_50_panoptic_sem_seg_hf"], "pcc": 0.99},
     ),
 ]
 


### PR DESCRIPTION
1. The models ops logical_not test cases(i.e `forge/test/models_ops/test_logicalnot.py`) was failing with `RuntimeError: Found Unsupported operations while lowering from TTForge to TTIR in forward graph` error but the logical_not was present in the TTIR(i.e [ttirlogical_not](https://docs.tenstorrent.com/tt-mlir/autogen/md/Dialect/TTIROp.html#ttirlogical_not-ttttirlogicalnotop)) so mapped it in lower to mlir and tested the logical_not models ops test and the test passed. so removed xfail marker.

2. Added `skip_model_analysis` pytest marker for `paddleocr` model because it contains two compile function and for these kind of cases will not generate models ops tests.