### PR TITLE
Enable Metal DEBUG logs.

### DIFF
--- a/.github/workflows/test-sub.yml
+++ b/.github/workflows/test-sub.yml
@@ -153,6 +153,7 @@ jobs:
           FORGE_DISABLE_REPORTIFY_DUMP: 1
           OPERATORS: ${{ inputs.operators }}
           FILTERS: ${{ inputs.filters }}
+          TT_METAL_LOGGER_LEVEL: DEBUG
         shell: bash
         run: |
           source env/activate


### PR DESCRIPTION
Required to get more details when we hit hangs during our CI test runs.