### PR TITLE
remove convert_broadcast_ops_to_tms pass

### DIFF
--- a/forge/csrc/forge_passes.cpp
+++ b/forge/csrc/forge_passes.cpp
@@ -206,10 +206,6 @@ graphlib::Graph *run_pre_lowering_passes(graphlib::Graph *graph, const std::opti
         fuse_gelu(graph);
     }
 
-    // Manually convert broadcast ops to tms, so insert tile broadcast ops can work generically
-    // Note this is not lowering, these are still forge tms
-    convert_broadcast_ops_to_tms(graph);
-
     passes::remove_nops(graph);
 
     // Recalculate shapes before lowering to MLIR

--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -116,6 +116,10 @@ class AttributeMapper
         // argmax
         add_op_mapping("argmax", "dim", AttributeRemap("dim_arg", TargetType::I32ArrayAttr));
 
+        // broadcast
+        add_op_mapping(
+            "broadcast", "broadcast_dimensions", AttributeRemap(std::nullopt, TargetType::DenseI64ArrayAttr));
+
         // conv2d_transpose
         add_op_mapping("conv2d_transpose", "dilation", AttributeRemap(std::nullopt, TargetType::DenseI32ArrayAttr));
         add_op_mapping("conv2d_transpose", "groups", AttributeRemap(std::nullopt, TargetType::I32Attr));
@@ -727,6 +731,7 @@ class MLIRGenerator
         lowering_handler_map["abs"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::AbsOp>;
         lowering_handler_map["add"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::AddOp>;
         lowering_handler_map["argmax"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ArgMaxOp>;
+        lowering_handler_map["broadcast"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::BroadcastOp>;
         lowering_handler_map["cast"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::TypecastOp>;
         lowering_handler_map["clip"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ClampScalarOp>;
         lowering_handler_map["concatenate"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ConcatOp>;

--- a/forge/csrc/passes/pre_lowering_passes.cpp
+++ b/forge/csrc/passes/pre_lowering_passes.cpp
@@ -15,32 +15,6 @@ using NodeType = graphlib::NodeType;
 using Edge = graphlib::Edge;
 using EdgeType = graphlib::EdgeType;
 
-void convert_broadcast_ops_to_tms(Graph *graph)
-{
-    std::vector<Node *> broadcast_ops = graph->nodes(
-        [](Node *node) -> bool
-        {
-            graphlib::OpNode *op = dynamic_cast<graphlib::OpNode *>(node);
-            return op and op->op_name() == "broadcast";
-        });
-
-    for (Node *node : broadcast_ops)
-    {
-        graphlib::OpNode *op = node->as<graphlib::OpNode>();
-        graphlib::OpType op_type = op->op_type();
-        constexpr bool remove_node = true;
-        graphlib::bypass_node(
-            graph,
-            node,
-            remove_node,
-            [graph, op_type](Edge new_edge, Edge)
-            {
-                auto attr = graph->get_edge_attributes(new_edge);
-                attr->prepend_tm(op_type);
-            });
-    }
-}
-
 void place_inter_subgraph_queues(graphlib::Graph *graph)
 {
     for (Node *n : graph->nodes_by_type(NodeType::kOutput))

--- a/forge/csrc/passes/pre_lowering_passes.hpp
+++ b/forge/csrc/passes/pre_lowering_passes.hpp
@@ -15,8 +15,6 @@ namespace tt
 using Graph = graphlib::Graph;
 using Node = graphlib::Node;
 
-void convert_broadcast_ops_to_tms(Graph *graph);
-
 bool safe_to_hoist_past(const Graph *graph, const Node *operand);
 
 void fuse_bias(Graph *graph);

--- a/forge/forge/op/tm.py
+++ b/forge/forge/op/tm.py
@@ -361,8 +361,11 @@ def Broadcast(name: str, operandA: Tensor, dim: int, shape: int) -> Tensor:
     Tensor
         Forge tensor
     """
-
-    return op("broadcast", name, operandA, attrs=(dim, shape, True)).get_tensor()
+    broadcast_dimensions = [1] * len(operandA.shape.dims)
+    broadcast_dimensions[dim] = shape
+    return op(
+        "broadcast", name, operandA, attrs=(dim, shape, True), broadcast_dimensions=broadcast_dimensions
+    ).get_tensor()
 
 
 def Repeat(name: str, operandA: Tensor, repeats: List[int]) -> Tensor:


### PR DESCRIPTION
### Ticket
fixes: #2326

### Problem description
We used to have `input_tms` as a concept where, instead of having a broadcast op, we had an `input_tm` that indicated one or more inputs should change dimensions. When lowering to MLIR, that field was simply ignored and left for the rest of the compiler to handle (implicit broadcasting, usually possible with elementwise binary ops). That worked fine until implicit broadcasting wasn't possible later on (for example, in unary ops).

### What's changed
With the removal of the `convert_broadcast_ops_to_tms` pass, we no longer create those `input_tms` and instead leave the broadcast op as is. Also added mapping for the broadcast op.
