### PR TITLE
Modify decomposition logic for pixel_shuffle op

### DIFF
--- a/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
+++ b/forge/test/mlir/operators/eltwise_unary/test_eltwise_unary.py
@@ -16,33 +16,18 @@ import os
 @pytest.mark.parametrize(
     "input_shape, scale_factor",
     [
-        pytest.param(
-            (1, 256, 4, 128),
-            2,
-            marks=pytest.mark.xfail(
-                reason="Unsupported operations while lowering from TTForge to TTIR in forward graph - narrow, pad_tile, sparse_matmul, vstack"
-            ),
-        ),
-        pytest.param(
+        ((1, 256, 4, 128), 2),
+        (
             (3, 32, 10, 10),
             4,
-            marks=pytest.mark.xfail(reason="NotImplementedError: Pixel shuffle decomposition only supports r=2"),
         ),
-        pytest.param(
-            (2, 98, 6, 6),
-            7,
-            marks=pytest.mark.xfail(reason="NotImplementedError: Pixel shuffle decomposition only supports r=2"),
-        ),
-        pytest.param(
-            (4, 18, 8, 8),
-            3,
-            marks=pytest.mark.xfail(reason="NotImplementedError: Pixel shuffle decomposition only supports r=2"),
-        ),
-        pytest.param(
-            (2, 50, 12, 12),
-            5,
-            marks=pytest.mark.xfail(reason="NotImplementedError: Pixel shuffle decomposition only supports r=2"),
-        ),
+        ((2, 98, 6, 6), 7),
+        ((4, 18, 8, 8), 3),
+        ((2, 50, 12, 12), 5),
+        ((2, 64, 7, 7), 8),
+        ((5, 100, 2, 4), 10),
+        ((1, 49, 4, 4), 7),
+        ((4, 36, 5, 5), 6),
     ],
 )
 @pytest.mark.push


### PR DESCRIPTION
Fixes #2319 
`forge/test/models/pytorch/vision/swin/test_swin.py::test_swin_v2_tiny_masked[microsoft/swinv2-tiny-patch4-window8-256]` test case fails with `NotImplementedError: Pixel shuffle decomposition only supports r=2`. 

This is because current decomposition only supports upscale factor = 2 as mentioned [here](https://github.com/tenstorrent/tt-forge-fe/blob/4d525545a5267abc099e65473112ede787b6738d/forge/forge/op/eval/forge/tm.py#L935).

This PR, rectifies the decomposition logic to support any upscale factor. Existing xfail markers has been removed from pixel_shuffle test for cases of upscale factor greater than 2, since these tests are passing now.

Swin test case was intially failing with this error from post_initial_graph_pass stage. After this fix, model fails in run_mlir_compiler stage with `loc("reciprocal_24"): error: 'ttir.reciprocal' op result shape (64, 3, 64, 32) doesn't match expected shape after broadcasting (64, 3, 64, 1)`

Logs:
[pixel_shuffle_test.log](https://github.com/user-attachments/files/20847410/pixel_shuffle_test.log)
[swin_before_fix.log](https://github.com/user-attachments/files/20847375/swin_before_fix.log)
[swin_after_fix.log](https://github.com/user-attachments/files/20847376/swin_after_fix.log)
