### PR TITLE
Add Onnx support for generality models - set1

### DIFF
--- a/forge/test/models/models_utils.py
+++ b/forge/test/models/models_utils.py
@@ -12,6 +12,7 @@ import json
 from typing import Optional, Tuple
 from transformers import Cache
 from third_party.tt_forge_models.tools.utils import get_file
+from datasets import load_dataset
 
 # Mean Pooling - Take attention mask into account for correct averaging
 def mean_pooling(model_output, attention_mask):
@@ -272,3 +273,23 @@ def Gemma2DecoderLayer_patched_forward(
         outputs += (present_key_value,)
 
     return outputs
+
+
+def preprocess_inputs():
+
+    # Load Input
+    dataset = load_dataset("imagenet-1k", split="validation", streaming=True)
+    input_image = next(iter(dataset.skip(10)))["image"]
+
+    # Prepare input
+    preprocess = transforms.Compose(
+        [
+            transforms.Resize(256),
+            transforms.CenterCrop(224),
+            transforms.ToTensor(),
+            transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+        ]
+    )
+    input_tensor = preprocess(input_image)
+    input_batch = input_tensor.unsqueeze(0)
+    return [input_batch]

--- a/forge/test/models/onnx/vision/alexnet/test_alexnet_onnx.py
+++ b/forge/test/models/onnx/vision/alexnet/test_alexnet_onnx.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import onnx
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+from test.models.models_utils import print_cls_results, preprocess_inputs
+from test.utils import download_model
+
+
+@pytest.mark.nightly
+def test_alexnet_onnx(forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.ALEXNET,
+        source=Source.TORCH_HUB,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load model
+    torch_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", "alexnet", pretrained=True)
+    torch_model.eval()
+
+    # Load input
+    inputs = preprocess_inputs()
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/alexnet.onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    fw_out, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # Post processing
+    print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/onnx/vision/deit/test_deit_onnx.py
+++ b/forge/test/models/onnx/vision/deit/test_deit_onnx.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+from datasets import load_dataset
+from transformers import AutoFeatureExtractor, ViTForImageClassification
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.utils import download_model
+import onnx
+from forge.verify.config import VerifyConfig
+from forge.verify.value_checkers import AutomaticValueChecker
+
+variants = [
+    "facebook/deit-base-patch16-224",
+    "facebook/deit-small-patch16-224",
+    "facebook/deit-tiny-patch16-224",
+]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants)
+def test_deit_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.DEIT,
+        variant=variant,
+        task=Task.IMAGE_CLASSIFICATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Load model
+    image_processor = download_model(AutoFeatureExtractor.from_pretrained, variant)
+    torch_model = download_model(ViTForImageClassification.from_pretrained, variant, return_dict=False)
+    torch_model.eval()
+
+    # Prepare input
+    dataset = load_dataset("huggingface/cats-image")
+    image_1 = dataset["test"]["image"][0]
+    img_tensor = image_processor(image_1, return_tensors="pt").pixel_values
+    inputs = [img_tensor]
+
+    # Export model to ONNX
+    onnx_path = f'{forge_tmp_path}/{variant.split("/")[-1].replace("-", "_")}.onnx'
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    pcc = 0.99
+    if variant == "facebook/deit-base-patch16-224":
+        pcc = 0.96
+
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)),
+    )
+
+    # Post processing
+    logits = co_out[0]
+    predicted_class_idx = logits.argmax(-1).item()
+    print("Predicted class: ", torch_model.config.id2label[predicted_class_idx])

--- a/forge/test/models/onnx/vision/densenet/test_densenet_onnx.py
+++ b/forge/test/models/onnx/vision/densenet/test_densenet_onnx.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.models.models_utils import print_cls_results
+from test.models.pytorch.vision.densenet.model_utils.densenet_utils import (
+    get_input_img,
+)
+from test.utils import download_model
+import onnx
+import forge
+
+variants = ["densenet121", "densenet161", "densenet169"]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants)
+def test_densenet_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.DENSENET,
+        variant=variant,
+        source=Source.TORCHVISION,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load model
+    torch_model = download_model(torch.hub.load, "pytorch/vision:v0.10.0", variant, pretrained=True)
+    torch_model.eval()
+
+    # Load and pre-process image
+    img_tensor = get_input_img()
+    inputs = [img_tensor]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/{variant}.onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    fw_out, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # Post processing
+    print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/onnx/vision/ghostnet/test_ghostnet_onnx.py
+++ b/forge/test/models/onnx/vision/ghostnet/test_ghostnet_onnx.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.models.pytorch.vision.ghostnet.model_utils.utils import load_ghostnet_model, post_processing
+import onnx
+import torch
+
+variants = ["ghostnet_100", "ghostnet_100.in1k"]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants)
+def test_ghostnet_onnx(variant, forge_tmp_path):
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.GHOSTNET,
+        variant=variant,
+        source=Source.TIMM,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load the model and input
+    torch_model, inputs = load_ghostnet_model(variant)
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/{variant.replace('.', '_')}.onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # Post processing
+    post_processing(co_out)

--- a/forge/test/models/onnx/vision/hrnet/test_hrnet_onnx.py
+++ b/forge/test/models/onnx/vision/hrnet/test_hrnet_onnx.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from pytorchcv.model_provider import get_model as ptcv_get_model
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+from test.models.models_utils import print_cls_results, preprocess_inputs
+from test.utils import download_model
+import onnx
+from forge.verify.verify import verify
+from forge.verify.config import VerifyConfig
+from forge.verify.value_checkers import AutomaticValueChecker
+
+variants = [
+    "hrnet_w18_small_v1",
+    "hrnet_w18_small_v2",
+    "hrnetv2_w18",
+    "hrnetv2_w30",
+    pytest.param("hrnetv2_w44", marks=[pytest.mark.xfail]),
+    "hrnetv2_w48",
+    "hrnetv2_w64",
+]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants)
+def test_hrnet_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.HRNET,
+        variant=variant,
+        source=Source.OSMR,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load the model
+    torch_model = download_model(ptcv_get_model, variant, pretrained=True)
+    torch_model.eval()
+
+    # Load input
+    inputs = preprocess_inputs()
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/{variant}.onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    pcc = 0.99
+    if variant == "hrnetv2_w64":
+        pcc = 0.98
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    fw_out, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)),
+    )
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv1_onnx.py
+++ b/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv1_onnx.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.models.pytorch.vision.mobilenet.model_utils.utils import (
+    load_mobilenet_model,
+    post_processing,
+)
+import onnx
+
+variants = ["mobilenet_v1"]
+
+
+@pytest.mark.parametrize("variant", variants)
+@pytest.mark.nightly
+def test_mobilenetv1_onnx(forge_tmp_path, variant):
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.MOBILENETV1,
+        variant=variant,
+        source=Source.TORCHVISION,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load the model and prepare input data
+    torch_model, inputs = load_mobilenet_model(variant)
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/{variant}.onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # Post processing
+    post_processing(co_out)

--- a/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv3_onnx.py
+++ b/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv3_onnx.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.models.pytorch.vision.mobilenet.model_utils.utils import (
+    load_mobilenet_model,
+    post_processing,
+)
+import onnx
+import torch
+
+variants = ["mobilenet_v3_small"]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants)
+def test_mobilenetv3_basic(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.MOBILENETV3,
+        variant=variant,
+        source=Source.TORCH_HUB,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load the model and prepare input data
+    torch_model, inputs = load_mobilenet_model(variant)
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/{variant}.onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # Post processing
+    post_processing(co_out)

--- a/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv3_ssd_onnx.py
+++ b/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv3_ssd_onnx.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.models.models_utils import print_cls_results
+from test.models.pytorch.vision.mobilenet.model_utils.mobilenet_v3_ssd_utils import (
+    load_input,
+    load_model,
+)
+import onnx
+import torch
+
+variants_with_weights = {
+    "resnet50": "ResNet50_Weights",
+    "resnet101": "ResNet101_Weights",
+}
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants_with_weights.keys())
+def test_mobilenetv3_ssd_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.MOBILENETV3SSD,
+        variant=variant,
+        source=Source.TORCHVISION,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load model and input
+    weight_name = variants_with_weights[variant]
+    torch_model = load_model(variant, weight_name)
+    inputs = load_input()
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/{variant}.onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    fw_out, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # Post processing
+    print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/onnx/vision/wideresnet/test_wideresnet_onnx.py
+++ b/forge/test/models/onnx/vision/wideresnet/test_wideresnet_onnx.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.models.pytorch.vision.wideresnet.model_utils.utils import (
+    post_processing,
+    generate_model_wideresnet_imgcls_pytorch,
+)
+import onnx
+
+
+variants = ["wide_resnet50_2", "wide_resnet101_2"]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants, ids=variants)
+def test_wideresnet_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.WIDERESNET,
+        source=Source.TIMM,
+        variant=variant,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load Model and input
+    torch_model, inputs = generate_model_wideresnet_imgcls_pytorch(variant)
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/{variant.replace('.', '_')}.onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # Post processing
+    post_processing(co_out)

--- a/forge/test/models/onnx/vision/xception/test_xception_onnx.py
+++ b/forge/test/models/onnx/vision/xception/test_xception_onnx.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.models.pytorch.vision.xception.model_utils.utils import post_processing
+from test.models.pytorch.vision.xception.test_xception import generate_model_xception_imgcls_timm
+import onnx
+
+variants = ["xception65", "xception71.tf_in1k"]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", variants)
+def test_xception_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.XCEPTION,
+        variant=variant,
+        source=Source.TIMM,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load the model and input
+    torch_model, inputs = generate_model_xception_imgcls_timm(variant)
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/{variant.replace('.', '_')}.onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # Post Processing
+    post_processing(co_out)

--- a/forge/test/models/pytorch/vision/xception/test_xception.py
+++ b/forge/test/models/pytorch/vision/xception/test_xception.py
@@ -38,7 +38,7 @@ def generate_model_xception_imgcls_timm(variant):
     img = Image.open(file_path).convert("RGB")
     img_tensor = transform(img).unsqueeze(0)
 
-    return framework_model.to(torch.bfloat16), [img_tensor.to(torch.bfloat16)]
+    return framework_model, [img_tensor]
 
 
 params = [
@@ -67,6 +67,8 @@ def test_xception_timm(variant):
     )
 
     (framework_model, inputs) = generate_model_xception_imgcls_timm(variant)
+    framework_model.to(torch.bfloat16)
+    inputs = [inputs[0].to(torch.bfloat16)]
 
     data_format_override = DataFormat.Float16_b
     compiler_cfg = CompilerConfig(default_df_override=data_format_override)


### PR DESCRIPTION
### Summary 

This PR adds ONNX support for below generality models

- AlexNet
- Deit
- DenseNet
- Ghostnet
- HRnet
- Mobilenet3-ssd
- Mobilenet3
- Mobilenet1
- Wideresnet
- Xception

### Logs

[jun23_alexnet_onnx.log](https://github.com/user-attachments/files/20866690/jun23_alexnet_onnx.log)
[jun23_deit_onnx_1.log](https://github.com/user-attachments/files/20866697/jun23_deit_onnx_1.log)
[jun23_densenet_onnx.log](https://github.com/user-attachments/files/20866704/jun23_densenet_onnx.log)
[jun23_ghostnet_onnx.log](https://github.com/user-attachments/files/20866705/jun23_ghostnet_onnx.log)
[jun23_hrnet_onnx_1.log](https://github.com/user-attachments/files/20866708/jun23_hrnet_onnx_1.log)
[jun23_hrnet_onnx_2.log](https://github.com/user-attachments/files/20866711/jun23_hrnet_onnx_2.log)
[jun23_mobilenet3_ssd_onnx.log](https://github.com/user-attachments/files/20866713/jun23_mob23_ssd.log)
[jun23_mobilenetv3_onnx.log](https://github.com/user-attachments/files/20866865/jun23_mobv3_onnx.log)
[jun23_mobilenet1_onnx.log](https://github.com/user-attachments/files/20866716/jun23_mobv1_onnx.log)
[jun23_wideresnet_onnx.log](https://github.com/user-attachments/files/20866718/jun23_wideresnet_onnx.log)
[jun23_xception_onnx.log](https://github.com/user-attachments/files/20866720/jun23_xception_onnx.log)

### Logs (after reflecting suggestions)

[jun25_alexnet.log](https://github.com/user-attachments/files/20898654/jun25_alex_cc.log)
[jun25_ghostnet.log](https://github.com/user-attachments/files/20898655/jun25_ghostnet.log)
[jun25_hrnet_c1.log](https://github.com/user-attachments/files/20898656/jun25_hrnet_c1.log)
[jun25_mobilenet.log](https://github.com/user-attachments/files/20898657/jun25_mobilenet.log)
[jun25_wideresnet.log](https://github.com/user-attachments/files/20898658/jun25_wideres.log)
[jun25_xception.log](https://github.com/user-attachments/files/20902048/jun25_xception.log)


