### PR TITLE
Enable EmitC for all RED models

### DIFF
--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -1049,3 +1049,11 @@ def record_parallelism(parallelism: Parallelism):
         return
 
     fph.add("tags.parallelism", parallelism.value)
+
+
+def get_model_group():
+    fph = forge_property_handler_var.get()
+    if fph is None:
+        return None
+
+    return fph.get("tags.group")

--- a/forge/forge/verify/verify.py
+++ b/forge/forge/verify/verify.py
@@ -30,6 +30,8 @@ from forge.verify.compare import compare_tensor_to_golden
 from forge.verify.utils import convert_to_supported_pytorch_dtype
 from forge.forge_property_utils import (
     ExecutionStage,
+    ModelGroup,
+    get_model_group,
     record_execution,
     record_verify_config,
     record_consistency_limits,
@@ -370,6 +372,11 @@ def verify(
         tuple: (framework_outputs, compiled_outputs) - outputs from both models
                Returns (None, None) if verification is disabled
     """
+
+    # If model group is RED, turn on verify_emitc_correctness
+    model_group = get_model_group()
+    if model_group and model_group == ModelGroup.RED:
+        verify_cfg.verify_emitc_correctness = True
 
     record_verify_config(verify_cfg)
 

--- a/forge/test/models/pytorch/vision/resnet/test_resnet.py
+++ b/forge/test/models/pytorch/vision/resnet/test_resnet.py
@@ -79,7 +79,7 @@ def test_resnet_hf(variant):
         input_sample,
         framework_model,
         compiled_model,
-        VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95), verify_emitc_correctness=True),
+        VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95)),
     )
 
     # Run model on sample data and print results


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/issues/2869

### Problem description
EmitC tested only on resnet.

### What's changed
Changed `verify()` call to turn on EmitC testing for all RED models, as previously agreed. Currently, this is around 10-15 models.

### Checklist
- [x] New/Existing tests provide coverage for changes
