### PR TITLE
Fix ttcore perf regression

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -423,7 +423,7 @@ class MLIRGenerator
             llvm::SmallVector<mlir::NamedAttribute, 1> named_attributes;
             named_attributes.push_back(
                 builder_.getNamedAttr("ttir.name", builder_.getStringAttr(argument_node->name())));
-            named_attributes.push_back(builder_.getNamedAttr("tt.argument_type", get_argument_type(argument_node)));
+            named_attributes.push_back(builder_.getNamedAttr("ttcore.argument_type", get_argument_type(argument_node)));
             func.setArgAttrs(i, named_attributes);
             log_trace(LogMLIRCompiler, "Set argument name {} for function argument {}.", argument_node->name(), i);
         }


### PR DESCRIPTION
### Problem description
In tt-mlir tt dialect was renamed to ttcore. The argument type created when lowering to mlir was not renamed casing args to not have proper input/constant/param types which leads to const-eval and fusing not working in tt-mlir.

### What's changed
Change argument_type named attr key from `tt.argument_type` to `ttcore.argument_type`. Why is this a hardcoded string in the first place?

Resnet is now back from 12fps to 320fps 🚀 