### PR TITLE
Add support for qwen3 embedding models

### DIFF
--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -25,7 +25,7 @@ scipy>=1.8.0
 tensorflow==2.15
 tensorboard==2.15
 tf2onnx==1.15.1
-transformers==4.47.0
+transformers==4.52.4
 # To avoid warning during the import
 requests==2.28.2
 tflite==2.10.0

--- a/forge/test/models/models_utils.py
+++ b/forge/test/models/models_utils.py
@@ -293,3 +293,7 @@ def preprocess_inputs():
     input_tensor = preprocess(input_image)
     input_batch = input_tensor.unsqueeze(0)
     return [input_batch]
+
+
+def get_detailed_instruct(task_description: str, query: str) -> str:
+    return f"Instruct: {task_description}\nQuery:{query}"

--- a/forge/test/models/pytorch/text/qwen/test_qwen_v3.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_v3.py
@@ -2,7 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+from transformers import AutoModel, AutoTokenizer
 
+import forge
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -12,6 +14,10 @@ from forge.forge_property_utils import (
     Task,
     record_model_properties,
 )
+from forge.verify.verify import verify
+
+from test.models.models_utils import get_detailed_instruct
+from test.utils import download_model
 
 variants = [
     "Qwen/Qwen3-32B",
@@ -42,3 +48,57 @@ def test_qwen3(variant):
     )
 
     pytest.xfail(reason="Requires upgrade of `transformers` version")
+
+
+variants = ["Qwen/Qwen3-Embedding-0.6B", "Qwen/Qwen3-Embedding-4B", "Qwen/Qwen3-Embedding-8B"]
+
+
+@pytest.mark.parametrize("variant", variants)
+def test_qwen3_embedding(variant):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.QWENV3,
+        variant=variant,
+        task=Task.SENTENCE_EMBEDDING_GENERATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    if variant in ["Qwen/Qwen3-Embedding-4B", "Qwen/Qwen3-Embedding-8B"]:
+        pytest.xfail(reason="Requires multi-chip support")
+
+    # Load model and tokenizer
+    tokenizer = download_model(AutoTokenizer.from_pretrained, variant)
+    framework_model = download_model(AutoModel.from_pretrained, variant, return_dict=False, use_cache=False)
+    framework_model.eval()
+
+    # prepare input
+    task = "Given a web search query, retrieve relevant passages that answer the query"
+
+    queries = [
+        get_detailed_instruct(task, "What is the capital of China?"),
+        get_detailed_instruct(task, "Explain gravity"),
+    ]
+    documents = [
+        "The capital of China is Beijing.",
+        "Gravity is a force that attracts two bodies towards each other. It gives weight to physical objects and is responsible for the movement of planets around the sun.",
+    ]
+    input_texts = queries + documents
+
+    # Tokenize the input texts
+    input_tokens = tokenizer(
+        input_texts,
+        padding=True,
+        truncation=True,
+        max_length=128,
+        return_tensors="pt",
+    )
+
+    inputs = [input_tokens["input_ids"]]
+
+    # Forge compile framework model
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
+
+    # Model Verification
+    verify(inputs, framework_model, compiled_model)


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2398

### Summary 

This PR adds support for qwen3 embedding models

### Default dtype(fp32) :

- **Qwen/Qwen3-Embedding-0.6B** - `Tensor mismatch. PCC = 0.7720792658668999, but required = 0.99`

- **Qwen/Qwen3-Embedding-4B** - `Out of Memory: Not enough space to allocate 99614720 B DRAM buffer across 12 banks, where each bank needs to store 8302592 B (assert.hpp:107)`

- **Qwen/Qwen3-Embedding-8B** - `Out of Memory: Not enough space to allocate 201326592 B DRAM buffer across 12 banks, where each bank needs to store 16777216 B (assert.hpp:107)`

we are skipping below variants due to high memory usage 

Test memory usage of `"Qwen/Qwen3-Embedding-4B"`:
```
FAILED2025-06-26 12:34:28.263 | INFO     | conftest:memory_usage_tracker:140 - Test memory usage:
2025-06-26 12:34:28.264 | INFO     | conftest:memory_usage_tracker:141 -     By test: 29358.25 MB
2025-06-26 12:34:28.264 | INFO     | conftest:memory_usage_tracker:142 -     Minimum: 6292.59 MB
2025-06-26 12:34:28.264 | INFO     | conftest:memory_usage_tracker:143 -     Maximum: 35650.84 MB
2025-06-26 12:34:28.264 | INFO     | conftest:memory_usage_tracker:144 -     Average: 17112.59 MB
```

Test memory usage of `"Qwen/Qwen3-Embedding-8B"`:
```
2025-06-26 12:45:46.276 | critical |          Always | Out of Memory: Not enough space to allocate 201326592 B DRAM buffer across 12 banks, where each bank needs to store 16777216 B (assert.hpp:107)
FAILED2025-06-26 12:45:46.447 | INFO     | conftest:memory_usage_tracker:140 - Test memory usage:
2025-06-26 12:45:46.448 | INFO     | conftest:memory_usage_tracker:141 -     By test: 31271.05 MB
2025-06-26 12:45:46.448 | INFO     | conftest:memory_usage_tracker:142 -     Minimum: 32881.46 MB
2025-06-26 12:45:46.448 | INFO     | conftest:memory_usage_tracker:143 -     Maximum: 64152.51 MB
2025-06-26 12:45:46.448 | INFO     | conftest:memory_usage_tracker:144 -     Average: 47022.16 MB
```

### Logs
- [jun26_qwenv3_embed_new.log](https://github.com/user-attachments/files/20926867/jun26_qwenv3_embed_new.log)


### bfp16 :

- **Qwen/Qwen3-Embedding-0.6B** - `Tensor mismatch. PCC = 0.7696317960138187, but required = 0.99`
- **Qwen/Qwen3-Embedding-4B** - `Tensor mismatch. PCC = 0.879476386011763, but required = 0.99`
- **Qwen/Qwen3-Embedding-8B** - `Out of Memory: Not enough space to allocate 100663296 B DRAM buffer across 12 banks, where each bank needs to store 8388608 B (assert.hpp:107)`

Test memory usage of `"Qwen/Qwen3-Embedding-8B"`:

```
Running model pt_qwen_v3_qwen_qwen3_embedding_8b_sentence_embed_gen_hf forward on device...
2025-06-26 13:43:49.604 | critical |          Always | Out of Memory: Not enough space to allocate 100663296 B DRAM buffer across 12 banks, where each bank needs to store 8388608 B (assert.hpp:107)
FAILED2025-06-26 13:43:49.730 | INFO     | conftest:memory_usage_tracker:140 - Test memory usage:
2025-06-26 13:43:49.730 | INFO     | conftest:memory_usage_tracker:141 -     By test: 45358.51 MB
2025-06-26 13:43:49.730 | INFO     | conftest:memory_usage_tracker:142 -     Minimum: 17453.22 MB
2025-06-26 13:43:49.730 | INFO     | conftest:memory_usage_tracker:143 -     Maximum: 62811.73 MB
2025-06-26 13:43:49.730 | INFO     | conftest:memory_usage_tracker:144 -     Average: 44343.52 MB

```

### Logs
[jun26_qwenv3_embed_new_bfp16.log](https://github.com/user-attachments/files/20927571/jun26_qwenv3_embed_new_bfp16.log)


