### PR TITLE
Fix dla import issues and remove xfail marker from passing models tests

### DIFF
--- a/forge/test/models/onnx/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/onnx/vision/efficientnet/test_efficientnet.py
@@ -18,11 +18,11 @@ params = [
     pytest.param(
         "efficientnet_b1",
     ),
-    pytest.param("efficientnet_b2", marks=[pytest.mark.xfail]),
-    pytest.param("efficientnet_b2a", marks=[pytest.mark.xfail]),
-    pytest.param("efficientnet_b3", marks=[pytest.mark.xfail]),
-    pytest.param("efficientnet_b3a", marks=[pytest.mark.xfail]),
-    pytest.param("efficientnet_b4", marks=[pytest.mark.xfail]),
+    pytest.param("efficientnet_b2"),
+    pytest.param("efficientnet_b2a"),
+    pytest.param("efficientnet_b3"),
+    pytest.param("efficientnet_b3a"),
+    pytest.param("efficientnet_b4"),
     pytest.param(
         "efficientnet_b5",
         marks=[pytest.mark.skip(reason="Out of memory due - not enough space to allocate L1 buffer across banks")],

--- a/forge/test/models/onnx/vision/hrnet/test_hrnet_onnx.py
+++ b/forge/test/models/onnx/vision/hrnet/test_hrnet_onnx.py
@@ -27,7 +27,7 @@ variants = [
     "hrnet_w18_small_v2",
     "hrnetv2_w18",
     "hrnetv2_w30",
-    pytest.param("hrnetv2_w44", marks=[pytest.mark.xfail]),
+    "hrnetv2_w44",
     "hrnetv2_w48",
     "hrnetv2_w64",
 ]

--- a/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
+++ b/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
@@ -19,7 +19,7 @@ params = [
     pytest.param("mobilenetv2_050"),
     pytest.param("mobilenetv2_100", marks=[pytest.mark.push]),
     pytest.param("mobilenetv2_110d"),
-    pytest.param("mobilenetv2_140", marks=[pytest.mark.xfail]),
+    pytest.param("mobilenetv2_140"),
 ]
 
 

--- a/forge/test/models/onnx/vision/xception/test_xception_onnx.py
+++ b/forge/test/models/onnx/vision/xception/test_xception_onnx.py
@@ -22,7 +22,6 @@ variants = ["xception65", "xception71.tf_in1k"]
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_xception_onnx(variant, forge_tmp_path):
 

--- a/forge/test/models/pytorch/vision/dla/test_dla.py
+++ b/forge/test/models/pytorch/vision/dla/test_dla.py
@@ -14,10 +14,13 @@ from forge.forge_property_utils import (
     Task,
     record_model_properties,
 )
+from forge.verify.config import VerifyConfig
+from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
 from test.models.models_utils import print_cls_results
 from test.models.pytorch.vision.dla.model_utils.utils import load_dla_model
+from test.models.pytorch.vision.vision_utils.utils import load_timm_model_and_input
 
 variants = [
     "dla34",

--- a/forge/test/models/pytorch/vision/segformer/test_segformer.py
+++ b/forge/test/models/pytorch/vision/segformer/test_segformer.py
@@ -28,11 +28,11 @@ from test.models.pytorch.vision.segformer.model_utils.image_utils import get_sam
 
 variants_img_classification = [
     pytest.param("nvidia/mit-b0", marks=pytest.mark.push),
-    pytest.param("nvidia/mit-b1", marks=pytest.mark.xfail),
-    pytest.param("nvidia/mit-b2", marks=pytest.mark.xfail),
-    pytest.param("nvidia/mit-b3", marks=pytest.mark.xfail),
-    pytest.param("nvidia/mit-b4", marks=pytest.mark.xfail),
-    pytest.param("nvidia/mit-b5", marks=pytest.mark.xfail),
+    pytest.param("nvidia/mit-b1"),
+    pytest.param("nvidia/mit-b2"),
+    pytest.param("nvidia/mit-b3"),
+    pytest.param("nvidia/mit-b4"),
+    pytest.param("nvidia/mit-b5"),
 ]
 
 

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -35,7 +35,7 @@ size = [
     pytest.param("s", id="yolov5s"),
     pytest.param("m", id="yolov5m"),
     pytest.param("l", id="yolov5l"),
-    pytest.param("x", id="yolov5x", marks=[pytest.mark.xfail]),
+    pytest.param("x", id="yolov5x"),
 ]
 
 


### PR DESCRIPTION
In the [latest nightly pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/15888097884), 

1. The dla timm model tests was failing with import issues(i.e `NameError: name 'load_timm_model_and_input' is not defined`), so fixed the dla timm tests cases by importing missing functions.
Fixed tests cases:
`forge/test/models/pytorch/vision/dla/test_dla.py::test_dla_timm[dla34.in1k]`

2. Removed xfailed marker for passing yolov5, hrnet, effiecientnet, mobilenetv2, segformer and xception models and below is the tests cases

```
forge/test/models/pytorch/vision/yolo/test_yolo_v5.py::test_yolov5_320x320[yolov5x]
forge/test/models/onnx/vision/hrnet/test_hrnet_onnx.py::test_hrnet_onnx[hrnetv2_w44]
forge/test/models/onnx/vision/xception/test_xception_onnx.py::test_xception_onnx[xception65]
forge/test/models/onnx/vision/xception/test_xception_onnx.py::test_xception_onnx[xception71.tf_in1k]
forge/test/models/onnx/vision/efficientnet/test_efficientnet.py::test_efficientnet_onnx[efficientnet_b2]
forge/test/models/onnx/vision/efficientnet/test_efficientnet.py::test_efficientnet_onnx[efficientnet_b2a]
forge/test/models/onnx/vision/efficientnet/test_efficientnet.py::test_efficientnet_onnx[efficientnet_b3]
forge/test/models/onnx/vision/efficientnet/test_efficientnet.py::test_efficientnet_onnx[efficientnet_b3a]
forge/test/models/onnx/vision/efficientnet/test_efficientnet.py::test_efficientnet_onnx[efficientnet_b4]
forge/test/models/pytorch/vision/segformer/test_segformer.py::test_segformer_image_classification_pytorch[nvidia/mit-b3]
forge/test/models/pytorch/vision/segformer/test_segformer.py::test_segformer_image_classification_pytorch[nvidia/mit-b2]
forge/test/models/pytorch/vision/segformer/test_segformer.py::test_segformer_image_classification_pytorch[nvidia/mit-b5]
forge/test/models/pytorch/vision/segformer/test_segformer.py::test_segformer_image_classification_pytorch[nvidia/mit-b1]
forge/test/models/pytorch/vision/segformer/test_segformer.py::test_segformer_image_classification_pytorch[nvidia/mit-b4]
forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py::test_mobilenetv2_onnx[mobilenetv2_140]
```

