### PR TITLE
Clean Llama with LoRA training tests

### DIFF
--- a/forge/test/mlir/llama/utils/utils.py
+++ b/forge/test/mlir/llama/utils/utils.py
@@ -26,7 +26,9 @@ def load_model(model_path="openlm-research/open_llama_3b", **kwargs):
     if use_lora:
         lora_r = kwargs.get("lora_r", 4)
         lora_alpha = kwargs.get("lora_alpha", 8)
-        lora_config = LoraConfig(r=lora_r, lora_alpha=lora_alpha, task_type="CAUSAL_LM")
+        # Applying LoRA to the last half of all layers due to memory constraints, this should be configurable
+        ltt = range(framework_model.config.num_hidden_layers // 2, framework_model.config.num_hidden_layers)
+        lora_config = LoraConfig(r=lora_r, lora_alpha=lora_alpha, task_type="CAUSAL_LM", layers_to_transform=ltt)
         framework_model = get_peft_model(framework_model, lora_config)
 
     # Using AutoTokenizer for default tokenizers for both openllama and llama 3.2


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-blacksmith/issues/119
https://github.com/tenstorrent/tt-blacksmith/issues/128
https://github.com/tenstorrent/tt-blacksmith/issues/132

### Problem description
Clean and update Llama with LoRA training tests to reflect the final setup that enables training. 

### What's changed
Update training tests (`test_llama_lora_fwd_pass`, `test_llama_lora_bwd_pass`, `test_llama_lora_bfloat16`) and add comments to highlight constraints.

### Checklist
- [ ] New/Existing tests provide coverage for changes
