### PR TITLE
Removed op checks in cpp code that used pybind.

### DIFF
--- a/forge/csrc/graph_lib/node_types.hpp
+++ b/forge/csrc/graph_lib/node_types.hpp
@@ -586,6 +586,9 @@ class OpNode : public TaggedNode
 
     bool is_tm() const { return op_type_.is_tm(); };
     bool is_eltwise() const { return op_type_.is_eltwise(); };
+    bool is_eltwise_unary() const { return op_type_.is_eltwise_unary(); }
+    bool is_eltwise_binary() const { return op_type_.is_eltwise_binary(); }
+    bool is_eltwise_nary() const { return op_type_.is_eltwise_nary(); }
 
     bool should_pair_with_sparse(const OpNode *sparse_op_node, const Graph *graph) const;
     void set_output_df_from_operands(const Graph *graph);

--- a/forge/csrc/graph_lib/python_bindings.cpp
+++ b/forge/csrc/graph_lib/python_bindings.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include "graph_lib/python_bindings.hpp"
 
+#include <ATen/core/TensorBody.h>
 #include <pybind11/operators.h>
 #include <pybind11/stl.h>
 
@@ -714,57 +715,20 @@ void GraphModule(py::module &m_graph)
     m_graph_query.def("op_type", graphlib::query::op_type);
 }
 
-py::object eval_relu(py::object tensor, graphlib::OpType type);
-
-py::object eval_op(graphlib::OpType type, std::vector<py::object> inputs, bool evaluate_output_relu = true)
+py::object eval_op(graphlib::OpType type, std::vector<py::object> inputs)
 {
-    py::object eval_module = py::module_::import("forge.op.eval.forge");
-    py::function forge_eval = eval_module.attr("get_f_forge_eval")(std::ref(type));
+    std::vector<at::Tensor> tensors;
+
+    tensors.reserve(inputs.size());
+    for (const auto &tensor : inputs) tensors.emplace_back(tensor.cast<at::Tensor>());
+
+    py::object result = py::cast(type.eval(tensors));
 
     log_trace(LogEval, "  eval_op: {}", type);
-    bool has_requant =
-        type.forge_attrs.find("requant") != type.forge_attrs.end() and std::get<bool>(type.forge_attrs.at("requant"));
-
-    std::vector<py::object> inputs_;
-    if (has_requant)
-    {
-        inputs_.assign(inputs.begin(), inputs.end());
-        inputs_.erase(inputs_.end() - 1);  // skip requantization input (last input)
-    }
-    else
-    {
-        inputs_ = inputs;
-    }
-
-    py::object result = forge_eval(inputs_);
-
     py::object common_module = py::module_::import("forge.op.eval");
     common_module.attr("eval_debug_print")(type.op, inputs, result);
 
-    if (evaluate_output_relu)
-        result = eval_relu(result, type);
-
     return result;
-}
-
-py::object eval_relu(py::object tensor, graphlib::OpType type)
-{
-    auto relu_match = type.forge_attrs.find("relu_en");
-    if (relu_match != type.forge_attrs.end())
-    {
-        std::vector<py::object> inputs;
-        inputs.push_back(tensor);
-        float relu_threshold = (type.forge_attrs.find("relu_threshold") != type.forge_attrs.end())
-                                   ? std::get<float>(type.forge_attrs["relu_threshold"])
-                                   : 0.0;
-        std::string relu_mode = (type.forge_attrs.find("relu_mode") != type.forge_attrs.end())
-                                    ? std::get<std::string>(type.forge_attrs["relu_mode"])
-                                    : "min";
-
-        graphlib::OpType relu("relu", {relu_threshold, relu_mode});
-        tensor = eval_op(relu, inputs);
-    }
-    return tensor;
 }
 
 py::object eval_golden_transforms(graphlib::Node *node, py::object tensor, bool eval_for_output = false)
@@ -1479,7 +1443,7 @@ eval_graph(
 
             std::vector<py::object> inputs = eval_operand_tms(graph, node, node_outputs);
 
-            py::object obj = eval_op(op_node->op_type(), inputs, false);  // Don't Eval relu for intermediate checking
+            py::object obj = eval_op(op_node->op_type(), inputs);
 
             auto gradient_edges = graph->operand_edges(
                 node, [](const auto &edge) { return edge.edge_type == graphlib::EdgeType::kAutogradFwdToGradient; });
@@ -1558,8 +1522,6 @@ eval_graph(
                 }
             }
 
-            // Eval relu after checking intermediate tensors
-            obj = eval_relu(obj, op_node->op_type());
             node_outputs[node->id()].push_back(obj);
 
             std::vector<graphlib::Edge> loopback_edges = graph->user_edges(

--- a/forge/csrc/graph_lib/utils.cpp
+++ b/forge/csrc/graph_lib/utils.cpp
@@ -2016,8 +2016,7 @@ bool is_linked_queue(const graphlib::Graph *graph, const graphlib::Node *node)
                              not graph
                                      ->user_edges(
                                          node,
-                                         [](graphlib::Edge e)
-                                         {
+                                         [](graphlib::Edge e) {
                                              return e.edge_type == graphlib::EdgeType::kPartialDataCopy or
                                                     e.edge_type == graphlib::EdgeType::kSubgraphLink;
                                          })
@@ -2026,8 +2025,7 @@ bool is_linked_queue(const graphlib::Graph *graph, const graphlib::Node *node)
                             not graph
                                     ->operand_edges(
                                         node,
-                                        [](graphlib::Edge e)
-                                        {
+                                        [](graphlib::Edge e) {
                                             return e.edge_type == graphlib::EdgeType::kPartialDataCopy or
                                                    e.edge_type == graphlib::EdgeType::kSubgraphLink;
                                         })

--- a/forge/csrc/graph_lib/utils.cpp
+++ b/forge/csrc/graph_lib/utils.cpp
@@ -23,25 +23,6 @@ namespace tt
 
 namespace graphlib
 {
-
-bool is_eltwise_nary(const OpNode *op)
-{
-    static py::function fn_is_eltwise_nary = py::module_::import("forge.op.eval.forge").attr("is_eltwise_nary");
-    return fn_is_eltwise_nary(std::ref(op->op_type())).cast<bool>();
-}
-
-bool is_eltwise_unary(const OpNode *op)
-{
-    static py::function fn_is_eltwise_unary = py::module_::import("forge.op.eval.forge").attr("is_eltwise_unary");
-    return fn_is_eltwise_unary(std::ref(op->op_type())).cast<bool>();
-}
-
-bool is_eltwise_binary(const OpNode *op)
-{
-    static py::function fn_is_eltwise_binary = py::module_::import("forge.op.eval.forge").attr("is_eltwise_binary");
-    return fn_is_eltwise_binary(std::ref(op->op_type())).cast<bool>();
-}
-
 bool is_reduce_z(OpNode const *op)
 {
     return (op->op_name() == "reduce" and std::get<std::string>(op->forge_attrs().at("dim")) == "z") or
@@ -121,7 +102,7 @@ TileDim get_tile_dim_from_height_width(int tile_height, int tile_width)
 
 void validate_tile_dims(Graph *graph, graphlib::OpNode *op_node)
 {
-    if (graphlib::is_eltwise_binary(op_node))
+    if (op_node->is_eltwise_binary())
     {
         auto srcA_tile_dim = graph->operands(op_node)[0]->shape().get_tile_dim();
         auto srcB_tile_dim = graph->operands(op_node)[1]->shape().get_tile_dim();
@@ -2035,7 +2016,8 @@ bool is_linked_queue(const graphlib::Graph *graph, const graphlib::Node *node)
                              not graph
                                      ->user_edges(
                                          node,
-                                         [](graphlib::Edge e) {
+                                         [](graphlib::Edge e)
+                                         {
                                              return e.edge_type == graphlib::EdgeType::kPartialDataCopy or
                                                     e.edge_type == graphlib::EdgeType::kSubgraphLink;
                                          })
@@ -2044,7 +2026,8 @@ bool is_linked_queue(const graphlib::Graph *graph, const graphlib::Node *node)
                             not graph
                                     ->operand_edges(
                                         node,
-                                        [](graphlib::Edge e) {
+                                        [](graphlib::Edge e)
+                                        {
                                             return e.edge_type == graphlib::EdgeType::kPartialDataCopy or
                                                    e.edge_type == graphlib::EdgeType::kSubgraphLink;
                                         })

--- a/forge/csrc/graph_lib/utils.hpp
+++ b/forge/csrc/graph_lib/utils.hpp
@@ -49,9 +49,6 @@ bool default_node_filter(Node *);
 
 // Checks if given opnode is element-wise
 class OpNode;
-bool is_eltwise_nary(const OpNode *op);
-bool is_eltwise_unary(const OpNode *op);
-bool is_eltwise_binary(const OpNode *op);
 bool is_reduce_z(OpNode const *op);
 
 // Find Row/Col size of TileDim

--- a/forge/csrc/passes/constant_folding.cpp
+++ b/forge/csrc/passes/constant_folding.cpp
@@ -47,7 +47,7 @@ static graphlib::OpNode *get_producer_input(graphlib::Graph *graph, graphlib::Op
 
 bool is_constant_eltwise_binary(graphlib::Graph *graph, graphlib::OpNode *binary)
 {
-    if (not graphlib::is_eltwise_binary(binary))
+    if (not binary->is_eltwise_binary())
         return false;
 
     return bool(get_constant_input(graph, binary)) and bool(get_producer_input(graph, binary));

--- a/forge/csrc/passes/decomposing_context.cpp
+++ b/forge/csrc/passes/decomposing_context.cpp
@@ -52,13 +52,12 @@ NodeContext DecomposingContext::op(
     }
     new_node->set_golden_transforms(this->node_->get_golden_transforms());
 
-    py::module_ eval_module = py::module_::import("forge.op.eval.forge");
-    py::function forge_shape = eval_module.attr("get_f_forge_shape")(op_type);
     std::vector<std::vector<std::uint32_t>> operand_tuples;
     for (NodeContext const &op_node : operands) operand_tuples.push_back(op_node.shape.as_vector());
-    py::tuple ret = forge_shape(operand_tuples);
-    graphlib::Shape shape = graphlib::Shape::create(ret[0].cast<std::vector<std::uint32_t>>());
-    std::vector<graphlib::DimBroadcast> broadcasts = ret[1].cast<std::vector<graphlib::DimBroadcast>>();
+
+    auto ret = op_type.shape(operand_tuples);
+    graphlib::Shape shape = std::get<0>(ret);
+    std::vector<graphlib::DimBroadcast> broadcasts = std::get<1>(ret);
 
     new_node->set_shape(shape);
 

--- a/forge/csrc/passes/erase_consecutive_reshape.cpp
+++ b/forge/csrc/passes/erase_consecutive_reshape.cpp
@@ -82,7 +82,7 @@ static std::vector<graphlib::Node *> path_to_reshape_after_communable_unaries(
             path.clear();
             break;
         }
-        if (graphlib::is_eltwise_unary(user) or graphlib::is_eltwise_binary(user))
+        if (user->is_eltwise_unary() or user->is_eltwise_binary())
         {
             path.push_back(op);
         }
@@ -126,7 +126,7 @@ static void commute_eltwise_ops(graphlib::Graph *graph, std::vector<graphlib::No
             op->add_golden_transform(first->op_type());
 
             // Handle the other operand if it's eltwise-binary op  (taken from erase-inverse-ops)
-            if (graphlib::is_eltwise_binary(op))
+            if (op->is_eltwise_binary())
             {
                 std::vector<graphlib::Edge> edges = graph->operand_data_edges(op);
                 graphlib::Edge current_edge = (edges[0].producer_node_id == path[i - 1]->id()) ? edges[0] : edges[1];

--- a/forge/csrc/passes/explicate_unsqueeze.cpp
+++ b/forge/csrc/passes/explicate_unsqueeze.cpp
@@ -27,7 +27,7 @@ void explicate_unsqueeze(graphlib::Graph *graph)
         {
             continue;
         }
-        if (graphlib::is_eltwise_binary(op))
+        if (op->is_eltwise_binary())
         {
             auto operand_a = graph->operands(node)[0];
             auto operand_b = graph->operands(node)[1];

--- a/forge/csrc/passes/fuse_redundant_tm_sequence.cpp
+++ b/forge/csrc/passes/fuse_redundant_tm_sequence.cpp
@@ -34,18 +34,13 @@ bool equivalent_pattern(const TMPattern& pattern1, const TMPattern& pattern2)
 
 graphlib::Shape replacement_output_shape(graphlib::Shape input_shape, const TMPattern& pattern)
 {
-    py::object eval_module = py::module_::import("forge.op.eval.forge");
-
     for (uint i = 0; i < pattern.size(); i++)
     {
-        auto op_name = pattern[i].op_name;
-        auto attrs = pattern[i].attrs;
-
-        py::function forge_shape = eval_module.attr("get_f_forge_shape")(pattern[i].as_op_type());
         std::vector<std::vector<std::uint32_t>> operand_tuples;
         operand_tuples.push_back(input_shape.as_vector());
-        py::tuple ret = forge_shape(operand_tuples);
-        graphlib::Shape shape = graphlib::Shape::create(ret[0].cast<std::vector<std::uint32_t>>());
+
+        auto ret = pattern[i].as_op_type().shape(operand_tuples);
+        graphlib::Shape shape = std::get<0>(ret);
         input_shape = shape;
     }
     return input_shape;

--- a/forge/csrc/passes/fuse_redundant_tm_sequence.cpp
+++ b/forge/csrc/passes/fuse_redundant_tm_sequence.cpp
@@ -206,8 +206,6 @@ bool replace_pattern_with_new_pattern(
 bool fuse_tm_sequences(tt::graphlib::Graph* graph, TMPatternPairs& pattern_map)
 {
     bool updated = true;
-    py::object eval_module = py::module_::import("forge.op.eval.forge");
-    py::function is_tm = eval_module.attr("is_tm");
     bool updated_anything = false;
     while (updated)
     {

--- a/forge/csrc/passes/link_past_cache_ios.cpp
+++ b/forge/csrc/passes/link_past_cache_ios.cpp
@@ -135,7 +135,7 @@ graphlib::Node *detect_inputs_to_convert(graphlib::Graph *graph, graphlib::Node 
 {
     graphlib::Node *input_node = nullptr;
     graphlib::OpNode *output_producer = producer->as<graphlib::OpNode>();
-    if (not output_producer or not(output_producer->is_eltwise() or is_eltwise_nary(output_producer)))
+    if (not output_producer or not(output_producer->is_eltwise() or output_producer->is_eltwise_nary()))
         return input_node;
 
     auto is_input = [](graphlib::Node *n)

--- a/forge/forge/op/common.py
+++ b/forge/forge/op/common.py
@@ -6,7 +6,6 @@ from typing import Tuple, Union
 
 from ..tensor import Tensor
 from ..parameter import Parameter
-from forge.op.eval.forge import get_f_forge_eval, get_f_forge_shape
 from forge._C import DataFormat
 from forge._C.graph import OpType
 import forge

--- a/forge/forge/op/eval/forge/__init__.py
+++ b/forge/forge/op/eval/forge/__init__.py
@@ -201,12 +201,6 @@ def _get_module_or_class(op_name):
         return module_name_or_cls
 
 
-def get_f_instance(op_type):
-    module_or_class = _get_module_or_class(op_type.op)
-    assert not isinstance(module_or_class, ModuleType)
-    return module_or_class(op_type)
-
-
 def empty_function(*inputs):
     pass
 

--- a/forge/forge/tensor.py
+++ b/forge/forge/tensor.py
@@ -931,8 +931,8 @@ def consteval_tensor(consteval_trace, name: str, inputs: Dict[str, torch.Tensor]
         return inputs[name]
 
     def eval_op(op_type, inputs):
-        forge_eval = eval_module.get_f_forge_eval(OpType(op_type["type"], op_type["attrs"], op_type["named_attrs"]))
-        return forge_eval(inputs)
+        op = OpType(op_type["type"], op_type["attrs"], op_type["named_attrs"])
+        return op.eval(inputs)
 
     logger.debug("ConstEval graph: {}", name)
     node_to_tensor: Dict[str, torch.Tensor] = {}


### PR DESCRIPTION
Removed is_tm, is_eltwise[unary/binary] from cpp code that called python implementation.
It is replaced with new ops implementation.