### PR TITLE
Add post-processing for tests passing e2e

### DIFF
--- a/forge/test/models/pytorch/vision/inception/test_inception_v4.py
+++ b/forge/test/models/pytorch/vision/inception/test_inception_v4.py
@@ -20,6 +20,7 @@ from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
 from test.models.pytorch.vision.inception.model_utils.model_utils import (
     get_image,
     preprocess_timm_model,
@@ -62,7 +63,12 @@ def test_inception_v4_osmr_pytorch():
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.98)))
+    fw_out, co_out = verify(
+        inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.98))
+    )
+
+    # Post processing
+    print_cls_results(fw_out[0], co_out[0])
 
 
 def generate_model_inceptionV4_imgcls_timm_pytorch(variant):
@@ -108,4 +114,7 @@ def test_inception_v4_timm_pytorch(variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    fw_out, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post processing
+    print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
+++ b/forge/test/models/pytorch/vision/perceiverio/test_perceiverio.py
@@ -27,6 +27,8 @@ from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
+
 
 def get_sample_data(model_name):
     image_processor = AutoImageProcessor.from_pretrained(model_name)
@@ -105,6 +107,9 @@ def test_perceiverio_for_image_classification_pytorch(variant):
     )
 
     # Model Verification
-    verify(
+    fw_out, co_out = verify(
         inputs, framework_model, compiled_model, verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.98))
     )
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -28,6 +28,7 @@ from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
+from test.models.models_utils import print_cls_results
 from test.models.pytorch.vision.swin.model_utils.image_utils import load_image
 from test.models.pytorch.vision.vision_utils.utils import load_vision_model_and_input
 
@@ -239,9 +240,12 @@ def test_swin_torchvision(variant):
     )
 
     # Model Verification
-    verify(
+    fw_out, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
         VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)),
     )
+
+    # Post processing
+    print_cls_results(fw_out[0], co_out[0])


### PR DESCRIPTION
This PR adds post-processing for inceptionv4, perceiverio and swin torchvision variant.

Logs:
[inceptionv4_timm.log](https://github.com/user-attachments/files/21004069/inceptionv4_timm.log)
[swin_torchvision.log](https://github.com/user-attachments/files/21004071/swin_torchvision.log)
[perceiver_post_process.log](https://github.com/user-attachments/files/21030848/perceiver_post_process.log)

