### PR TITLE
Load model weights and add post-processing for yolov4

### DIFF
--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v3.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v3.py
@@ -33,8 +33,9 @@ def test_yolo_v3():
     )
 
     # Load model and input
-    framework_model = ModelLoader.load_model(dtype_override=torch.bfloat16)
-    input_sample = ModelLoader.load_inputs(dtype_override=torch.bfloat16)
+    loader = ModelLoader()
+    framework_model = loader.load_model(dtype_override=torch.bfloat16)
+    input_sample = loader.load_inputs(dtype_override=torch.bfloat16)
 
     # Configurations
     compiler_cfg = CompilerConfig()


### PR DESCRIPTION
### Problem description
Yolov4 model was returning poor post-processed results since model weights was not being loaded.

### What's changed
Yolov4 model loader is modified to load model weights , but this model now fails with runtime issue in latest main, cpu inference results has been attached which ensure model runs e2e with right post-processing steps and expected performace and Changes in yolov3 test has been made to initialise Model Loader class since latest main of tt_forge_models is tracked in tt-forge-fe now.

Logs:
[yolov4_cpu.log](https://github.com/user-attachments/files/21300608/yolov4_cpu.log)
