### PR TITLE
Crash/Hang detector fix

### DIFF
--- a/.github/workflows/test_runner.py
+++ b/.github/workflows/test_runner.py
@@ -52,13 +52,15 @@ def remove_test(test_path, restart=False):
             idx = next(i for i, line in enumerate(lines) if test_path in line) + 1
             filtered_lines = lines[idx:]
         except StopIteration:
-            print("error: test_path not found in .pytest_tests_to_run")
+            print(f"error: {test_path} not found in .pytest_tests_to_run")
             exit(8)
 
     # Write filtered lines back to file
     with open(file_path, "w") as f:
         for line in filtered_lines:
             f.write(line + "\n")
+
+    return len(filtered_lines)
 
 
 def main():
@@ -101,7 +103,9 @@ def main():
                 if test_path not in crashed_tests:
                     crashed_tests.append(test_path)
                     print(f"    Crashed test: {test_path}")
-                    remove_test(test_path, restart_afer_crash)
+                    if remove_test(test_path, restart_afer_crash) == 0:
+                        print("No tests left to run.")
+                        break
                 else:
                     # If the test is already in the crashed tests list, print a message and exit
                     print(f"    Test {test_path} already in crashed tests list\nInternal error, exiting.")
@@ -139,7 +143,7 @@ def main():
                     f.write(f"FAILED {test}\n")
 
             if exit_code == 0:
-                exit_code = 1
+                exit_code = 11
 
     # Delete .pytest_current_test_executing file if it exists
     Path(".pytest_current_test_executing").unlink(missing_ok=True)
@@ -163,7 +167,7 @@ def main():
 
             # If there are crashed tests change exit code to failure
             if exit_code == 0:
-                exit_code = 1
+                exit_code = 10
 
     exit(exit_code)
 

--- a/forge/test/conftest.py
+++ b/forge/test/conftest.py
@@ -6,7 +6,6 @@ from typing import List, Dict, Tuple
 from loguru import logger
 import subprocess
 import fnmatch
-import signal
 import threading
 
 import numpy as np
@@ -48,8 +47,9 @@ watchdog_abort_timer = None
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item):
     def send_abort_signal():
-        print("WATCHDOG timeout reached! Killing test process.")
-        os.kill(os.getpid(), signal.SIGABRT)
+        pytest.exit("WATCHDOG timeout reached! Killing test process.", -69)
+        # print("WATCHDOG timeout reached! Killing test process.")
+        # os.kill(os.getpid(), signal.SIGABRT)
 
     def reset_abort_timer():
         global watchdog_abort_timer

--- a/forge/test/conftest.py
+++ b/forge/test/conftest.py
@@ -2,11 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import os
-import signal
 from typing import List, Dict, Tuple
 from loguru import logger
 import subprocess
 import fnmatch
+import signal
 import threading
 
 import numpy as np
@@ -71,7 +71,7 @@ def pytest_runtest_setup(item):
             except (FileNotFoundError, json.JSONDecodeError):
                 watchdog_test_durations = {}
 
-        if tst.nodeid in watchdog_test_durations:
+        if tst in watchdog_test_durations:
             duration = watchdog_test_durations[tst] * 2
             if duration < watchdog_timer_minimum:
                 duration = watchdog_timer_minimum


### PR DESCRIPTION
### Ticket


### Problem description
A bug that restarts all of the tests if the only test in test crashes/hangs (or the last one if --continue-after-crash is used).
Noticed that some tests take much longer than hang detection watchdog's default expiration time.

### What's changed
Bug is fixed.
Added dynamic watchdog timer with expiration set to double of .test_durations time, with a minimum of 300s (5 mins) and default time doubled to 1800 sec (30 min).

### Checklist
Test run:
https://github.com/tenstorrent/tt-forge-fe/actions/runs/15999073227

- [ ] New/Existing tests provide coverage for changes
