### PR TITLE
Add onnx support for generality pytorch models -set3

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -30,6 +30,10 @@ on:
   schedule:
     - cron: '0 22 * * *'  # Runs at 22:00 UTC every day
 
+# Set cache root to avoid IRD_LF_CACHE error when loading CenterNet ONNX model in CI
+env:
+  DOCKER_CACHE_ROOT: /mnt/dockercache
+
 permissions:
   packages: write
   checks: write

--- a/forge/test/models/onnx/text/bart/test_bart_onnx.py
+++ b/forge/test/models/onnx/text/bart/test_bart_onnx.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+# BART Demo Script - SQuADv1.1 QA
+import pytest
+import torch
+from transformers import BartForSequenceClassification, BartTokenizer
+from transformers.models.bart.modeling_bart import shift_tokens_right
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.utils import download_model
+from test.models.pytorch.text.bart.test_bart import BartWrapper
+import onnx
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "facebook/bart-large-mnli",
+            marks=pytest.mark.skip(reason="Hangs at generate initial graph stage."),
+        ),
+    ],
+)
+def test_bart_classifier_onnx(variant, forge_tmp_path):
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.BART,
+        variant=variant,
+        task=Task.SEQUENCE_CLASSIFICATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    model = download_model(BartForSequenceClassification.from_pretrained, variant, torchscript=True)
+    model.eval()
+    tokenizer = download_model(BartTokenizer.from_pretrained, variant, pad_to_max_length=True)
+    hypothesis = "Most of Mrinal Sen's work can be found in European collections."
+    premise = "Calcutta seems to be the only other production center having any pretensions to artistic creativity at all, but ironically you're actually more likely to see the works of Satyajit Ray or Mrinal Sen shown in Europe or North America than in India itself."
+
+    # generate inputs
+    inputs_dict = tokenizer(
+        premise,
+        hypothesis,
+        truncation="only_first",
+        padding="max_length",
+        max_length=256,
+        return_tensors="pt",
+    )
+    decoder_input_ids = shift_tokens_right(
+        inputs_dict["input_ids"], model.config.pad_token_id, model.config.decoder_start_token_id
+    )
+    inputs = [inputs_dict["input_ids"], inputs_dict["attention_mask"], decoder_input_ids]
+    torch_model = BartWrapper(model)
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    torch.onnx.export(torch_model, (inputs[0], inputs[1], inputs[2]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/text/bloom/test_bloom_onnx.py
+++ b/forge/test/models/onnx/text/bloom/test_bloom_onnx.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+from test.utils import download_model
+from test.models.pytorch.text.bloom.test_bloom import Wrapper
+import onnx
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "bigscience/bloom-1b1",
+            marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 26 GB"),
+        ),
+    ],
+)
+def test_bloom_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.BLOOM,
+        variant=variant,
+        source=Source.HUGGINGFACE,
+        task=Task.CAUSAL_LM,
+    )
+
+    # Load tokenizer and model from HuggingFace
+    tokenizer = download_model(AutoTokenizer.from_pretrained, variant, padding_side="left")
+    model = download_model(AutoModelForCausalLM.from_pretrained, variant, use_cache=False, return_dict=False)
+    model.eval()
+    torch_model = Wrapper(model)
+
+    # Prepare input
+    test_input = "This is a sample text from "
+    input_tokens = tokenizer.encode_plus(
+        test_input,
+        return_tensors="pt",
+        max_length=32,
+        padding="max_length",
+        add_special_tokens=True,
+        truncation=True,
+    )
+    inputs = [input_tokens["input_ids"], input_tokens["attention_mask"]]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    # passing model file instead of model proto due to size of the model(>2GB) - #https://github.com/onnx/onnx/issues/3775#issuecomment-943416925
+    onnx.checker.check_model(onnx_path)
+    framework_model = forge.OnnxModule(module_name, onnx_model, onnx_path)
+
+    # Compile model
+    compiled_model = forge.compile(framework_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/text/gpt2/test_gpt2_onnx.py
+++ b/forge/test/models/onnx/text/gpt2/test_gpt2_onnx.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+from transformers import (
+    AutoModelForSequenceClassification,
+    AutoTokenizer,
+)
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.utils import download_model
+import onnx
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize(
+    "variant",
+    [
+        "mnoukhov/gpt2-imdb-sentiment-classifier",
+    ],
+)
+def test_gpt2_sequence_classification_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.GPT,
+        variant=variant,
+        task=Task.SEQUENCE_CLASSIFICATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Load tokenizer and model from HuggingFace
+    tokenizer = download_model(AutoTokenizer.from_pretrained, variant, padding_side="left")
+    torch_model = download_model(
+        AutoModelForSequenceClassification.from_pretrained, variant, return_dict=False, use_cache=False
+    )
+    torch_model.eval()
+
+    # Prepare input
+    test_input = "This is a sample text from "
+    input_tokens = tokenizer(test_input, return_tensors="pt")
+    inputs = [input_tokens["input_ids"]]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # post processing
+    predicted_value = co_out[0].argmax(-1).item()
+    print(f"Predicted Sentiment: {torch_model.config.id2label[predicted_value]}")

--- a/forge/test/models/onnx/text/perceiver/test_perceiver_onnx.py
+++ b/forge/test/models/onnx/text/perceiver/test_perceiver_onnx.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Reference: https://huggingface.co/deepmind/language-perceiver
+
+import pytest
+from transformers import PerceiverForMaskedLM, PerceiverTokenizer
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.utils import download_model
+import torch
+import onnx
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", ["deepmind/language-perceiver"])
+def test_perceiverio_masked_lm_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.PERCEIVERIO,
+        variant=variant,
+        task=Task.MASKED_LM,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Load model and tokenizer
+    tokenizer = download_model(PerceiverTokenizer.from_pretrained, variant)
+    torch_model = download_model(PerceiverForMaskedLM.from_pretrained, variant, return_dict=False)
+    torch_model.eval()
+
+    # Prepare input
+    text = "This is an incomplete sentence where some words are missing."
+    encoding = tokenizer(text, padding="max_length", return_tensors="pt")
+    encoding.input_ids[0, 52:61] = tokenizer.mask_token_id
+    inputs = [encoding.input_ids, encoding.attention_mask]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # post processing
+    logits = co_out[0]
+    masked_tokens_predictions = logits[0, 51:61].argmax(dim=-1)
+    print(f"The predicted token for the [MASK] is: {tokenizer.decode(masked_tokens_predictions)}")

--- a/forge/test/models/onnx/text/roberta/test_roberta_onnx.py
+++ b/forge/test/models/onnx/text/roberta/test_roberta_onnx.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+from third_party.tt_forge_models.roberta import ModelLoader
+import onnx
+from forge.verify.config import VerifyConfig
+from forge.verify.value_checkers import AutomaticValueChecker
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", ["cardiffnlp/twitter-roberta-base-sentiment"])
+def test_roberta_sentiment_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.ROBERTA,
+        variant=variant,
+        task=Task.SEQUENCE_CLASSIFICATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Load model and input
+    loader = ModelLoader()
+    torch_model = loader.load_model()
+    input_tokens = loader.load_inputs()
+    inputs = [input_tokens]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+        verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.98)),
+    )
+
+    # post processing
+    predicted_value = co_out[0].argmax(-1).item()
+    print(f"Predicted Sentiment: {torch_model.config.id2label[predicted_value]}")

--- a/forge/test/models/onnx/text/squeezebert/test_squeezebert_onnx.py
+++ b/forge/test/models/onnx/text/squeezebert/test_squeezebert_onnx.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+from third_party.tt_forge_models.squeezebert import ModelLoader
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+import torch
+import onnx
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", ["squeezebert/squeezebert-mnli"])
+def test_squeezebert_sequence_classification_onnx(variant, forge_tmp_path):
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.SQUEEZEBERT,
+        variant=variant,
+        task=Task.SEQUENCE_CLASSIFICATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Load model and input
+    loader = ModelLoader()
+    torch_model = loader.load_model()
+    input_tokens = loader.load_inputs()
+    inputs = [input_tokens]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # post processing
+    predicted_class_id = co_out[0].argmax().item()
+    predicted_category = torch_model.config.id2label[predicted_class_id]
+    print(f"predicted category: {predicted_category}")

--- a/forge/test/models/onnx/vision/beit/test_beit_onnx.py
+++ b/forge/test/models/onnx/vision/beit/test_beit_onnx.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.models.pytorch.vision.beit.model_utils.utils import load_input, load_model
+import torch
+import onnx
+
+variants = [
+    "microsoft/beit-base-patch16-224",
+    "microsoft/beit-large-patch16-224",
+]
+
+
+@pytest.mark.xfail
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants)
+def test_beit_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.BEIT,
+        variant=variant,
+        source=Source.HUGGINGFACE,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load model and input
+    torch_model = load_model(variant)
+    inputs = load_input(variant)
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/vision/centernet/test_centernet_onnx.py
+++ b/forge/test/models/onnx/vision/centernet/test_centernet_onnx.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from third_party.tt_forge_models.centernet import ModelLoader
+import onnx
+import forge
+from forge.verify.verify import verify
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_centernet_onnx():
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.CENTERNET,
+        task=Task.OBJECT_DETECTION,
+        source=Source.GITHUB,
+    )
+
+    # Load model and input
+    loader = ModelLoader()
+    onnx_model = loader.load_model()
+    inputs = loader.load_inputs()
+
+    # Load framework model
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, [inputs], module_name=module_name)
+
+    # Model Verification and Inference
+    verify(
+        [inputs],
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/vision/monodle/test_monodle_onnx.py
+++ b/forge/test/models/onnx/vision/monodle/test_monodle_onnx.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.models.pytorch.vision.monodle.model_utils.model import CenterNet3D
+import onnx
+from test.models.models_utils import preprocess_inputs
+
+
+@pytest.mark.nightly
+@pytest.mark.skip(reason="Fatal Python error: Floating point exception")
+def test_monodle_onnx(forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX, model=ModelArch.MONODLE, source=Source.TORCHVISION, task=Task.OBJECT_DETECTION
+    )
+
+    # Load input
+    inputs = preprocess_inputs()
+
+    # Load Model
+    torch_model = CenterNet3D(backbone="dla34")
+    torch_model.eval()
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/monodle.onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/vision/resnext/test_resnext_onnx.py
+++ b/forge/test/models/onnx/vision/resnext/test_resnext_onnx.py
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+from pytorchcv.model_provider import get_model as ptcv_get_model
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.models.pytorch.vision.resnext.model_utils.utils import (
+    get_image_tensor,
+    post_processing,
+)
+from test.utils import download_model
+import onnx
+
+variants = ["resnext14_32x4d", "resnext26_32x4d", "resnext50_32x4d", "resnext101_64x4d"]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants)
+def test_resnext_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.RESNEXT,
+        source=Source.OSMR,
+        variant=variant,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load the model and prepare input data
+    torch_model = download_model(ptcv_get_model, variant, pretrained=True)
+    torch_model.eval()
+    input_batch = get_image_tensor()
+    inputs = [input_batch]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/{variant}.onnx"
+    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # Post processing
+    post_processing(co_out)


### PR DESCRIPTION
## Summary 

This PR adds ONNX support for below generality pytorch models 

- Bart
- Bloom
- GPT-2
- Perceiver
- Roberta
- Squeezebert
- Beit
- Centernet
- Monodle
- Resnext

## Logs
[jul22_bart_onnx.log](https://github.com/user-attachments/files/21372125/jul22_bart_onnx.log)
[jul22_beit.log](https://github.com/user-attachments/files/21372127/jul22_beit.log)
[jul22_bloom_onnx.log](https://github.com/user-attachments/files/21372145/jul22_bloom_onnx.log)
[jul22_centernet_onnx_1.log](https://github.com/user-attachments/files/21372161/jul22_centernet_onnx_1.log)
[jul22_gpt2_onnx.log](https://github.com/user-attachments/files/21372164/jul22_gpt2_onnx.log)
[jul22_perciever_onnx.log](https://github.com/user-attachments/files/21372171/jul22_perciever_onnx.log)
[jul22_resnext_onnx.log](https://github.com/user-attachments/files/21372192/jul22_resnext_onnx.log)
[jul22_roberta_onnx.log](https://github.com/user-attachments/files/21372197/jul22_roberta_onnx.log)
[jul22_sqbert_onnx.log](https://github.com/user-attachments/files/21372199/jul22_sqbert_onnx.log)
[jul22_monodle_onnx.log](https://github.com/user-attachments/files/21372237/jul22_monodle_onnx.log)

