### PR TITLE
Added git-blame ignore file for formatting commits.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# Git has the ability to ignore provided commits in git-blame command (https://git-scm.com/docs/git-config#Documentation/git-config.txt-blameignoreRevsFile).
+# This is useful for large formatting/refactoring commits that hides initial changes.
+#
+# This file contains commits that are not important for blaming. You can set this file as a default git-blame ignore file with:
+# git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# format everything #405 (https://github.com/tenstorrent/tt-forge-fe/pull/405)
+5e3f03c0c1f445e12e42f1612f655e7c4c57d3bc


### PR DESCRIPTION
Git has the ability to ignore provided commits in git-blame command (https://git-scm.com/docs/git-config#Documentation/git-config.txt-blameignoreRevsFile). This is useful for large formatting/refactoring commits that hides initial changes.

This change adds a file that contains commits that are not important for blaming. We can set this file as a default git-blame ignore file with: $ git config blame.ignoreRevsFile .git-blame-ignore-revs