### PR TITLE
Build link broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 -----
 # Quick Links
 - [Getting Started / How to Run a Model](docs/src/getting_started.md)
-- [Build](docs/src/build.md) - Use these instructions if you plan to do development work.
+- [Build](docs/src/getting_started_build_from_source.md) - Use these instructions if you plan to do development work.
 
 -----
 # What is this Repo?

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -8,7 +8,7 @@
 - [Architecture Overview](./architecture_overview.md)
 
 # Project setup
-- [Building](./build.md)
+- [Building](./getting_started_build_from_source.md)
 - [Testing](./test.md)
     - [Pytest](./pytest.md)
 - [Tools](./tools.md)


### PR DESCRIPTION
fixed build to point to  `docs/src/getting_started_build_from_source.md`