### PR TITLE
[watchdog] show timout exceeded message

### DIFF
--- a/forge/test/conftest.py
+++ b/forge/test/conftest.py
@@ -51,6 +51,11 @@ watchdog_test_durations = None
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_setup(item):
     def send_abort_signal():
+        # Suspend pytest capturing (if active) so that we can actually print out the message.
+        capmanager = item.session.config.pluginmanager.get_plugin("capturemanager")
+        if capmanager and capmanager.is_capturing():
+            capmanager.suspend()
+
         print("WATCHDOG timeout reached! Killing test process.")
         os.kill(os.getpid(), signal.SIGABRT)
 


### PR DESCRIPTION
When running the tests with pytest capture enabled, the watchdog timeout message is not being showed. This is because the watchdog will abort the process, so pytest doesn't print out the captured logs.

If capture enabled, suspend the capture allowing us to print out the message directly. Useful for CI, since i suspect there are watchdog timeouts occuring in recent nightlies...