### PR TITLE
Fix gradient shape check in bwd pass

### DIFF
--- a/forge/forge/compiled_graph_state.py
+++ b/forge/forge/compiled_graph_state.py
@@ -384,14 +384,7 @@ class CompiledModel:
                     for idx, grad_output_name in enumerate(self.bwd_compiled_graph_state.ordered_output_names):
                         if name in grad_output_name:
                             grad_tensor = grads[idx].to_torch()
-                            if param.shape != grad_tensor.shape:
-                                # Our gradients have additional dimensions which PyTorch not expects (e.g. [1, 1, N, M] -> [N, M])
-                                grad_tensor_non_1_shape = [s for s in grad_tensor.shape if s != 1]
-                                param_non_1_shape = [s for s in param.shape if s != 1]
-                                if grad_tensor_non_1_shape != param_non_1_shape:
-                                    raise RuntimeError(f"Incompatible shapes: {grad_tensor.shape=} and {param.shape=}")
-                                grad_tensor = grad_tensor.reshape(param.shape)
-                                assert grad_tensor.shape == param.shape
+                            assert grad_tensor.shape == param.shape
 
                             if param.grad is not None:
                                 param.grad += grad_tensor


### PR DESCRIPTION
### Problem description
The current check we have fails for the edge case where we have [1, 1] as our grad shape and [1] as our param shape.
This edge case was encountered in NeRF training.

### What's changed
Generalize shape check, it removes the minimum number of dimensions of size 1 in the gradient.
