### PR TITLE
Implemented missing decomposing functions in cpp ops.

### DIFF
--- a/forge/csrc/forge_passes.cpp
+++ b/forge/csrc/forge_passes.cpp
@@ -71,7 +71,7 @@ run_post_initial_graph_passes(
     passes::explicate_unsqueeze(graph);
     passes::fuse_conv2d_bias(graph);
 
-    auto inserted_node_id_mapping = decompose_tt_forge_graph(graph, "get_f_forge_decompose", compiler_cfg);
+    auto inserted_node_id_mapping = decompose_tt_forge_graph<DecomposeEpoch::Initial>(graph, compiler_cfg);
     auto chip_id_assignments = passes::fracture(graph, fracture_groups);
 
     passes::bypass_nop_tms(graph);
@@ -154,8 +154,7 @@ std::vector<std::pair<graphlib::NodeId, graphlib::NodeId>> run_post_optimize_dec
     std::shared_ptr<void> compiler_cfg = make_shared_py_object(compiler_cfg_object);
 
     passes::print_graph(graph, "POST_OPTIMIZE");
-    auto inserted_node_id_mapping =
-        decompose_tt_forge_graph(graph, "get_f_forge_decompose_post_optimize", compiler_cfg);
+    auto inserted_node_id_mapping = decompose_tt_forge_graph<DecomposeEpoch::PostOptimize>(graph, compiler_cfg);
 
     return inserted_node_id_mapping;
 }
@@ -168,7 +167,7 @@ std::vector<std::pair<graphlib::NodeId, graphlib::NodeId>> run_post_autograd_gra
 
     passes::print_graph(graph, "POST_AUTOGRAD");
     lower_bwd_gather_ops(graph);
-    return decompose_tt_forge_graph(graph, "get_f_forge_decompose_post_autograd", compiler_cfg);
+    return decompose_tt_forge_graph<DecomposeEpoch::PostAutograd>(graph, compiler_cfg);
 }
 
 // ********** Run pre-lowering passes **********

--- a/forge/csrc/graph_lib/node_types.hpp
+++ b/forge/csrc/graph_lib/node_types.hpp
@@ -22,6 +22,9 @@ namespace tt
 {
 class FusedOp;
 
+enum class DecomposeEpoch : uint8_t;
+class DecomposingContext;
+
 namespace graphlib
 {
 
@@ -492,8 +495,8 @@ struct OpType
         const tt::graphlib::NodeContext &output,
         const tt::graphlib::NodeContext &gradient) const;
 
-    void decompose(
-        const char *dispatch, DecomposingContext &dc, const std::vector<tt::graphlib::NodeContext> &inputs) const;
+    template <DecomposeEpoch epoch>
+    void decompose(DecomposingContext &dc, const std::vector<tt::graphlib::NodeContext> &inputs) const;
 
     long initial_flops_estimate(const std::vector<std::vector<std::uint32_t>> &inputs) const;
 

--- a/forge/csrc/graph_lib/python_bindings.cpp
+++ b/forge/csrc/graph_lib/python_bindings.cpp
@@ -297,9 +297,6 @@ void GraphModule(py::module &m_graph)
         .def_readonly("named_attrs", &tt::graphlib::OpType::named_attrs)
         .def("eval", &tt::graphlib::OpType::eval)
         .def("shape", &tt::graphlib::OpType::shape)
-        .def("backward", &tt::graphlib::OpType::backward)
-        .def("decompose", &tt::graphlib::OpType::decompose)
-        .def("initial_flops_estimate", &tt::graphlib::OpType::initial_flops_estimate)
         .def(
             "__getattr__",
             [](tt::graphlib::OpType const &op_type, std::string const &name) { return op_type.get_attr(name); })

--- a/forge/csrc/ops/op.cpp
+++ b/forge/csrc/ops/op.cpp
@@ -432,12 +432,24 @@ tt::graphlib::NodeContext Op::backward(
     }
 }
 
-/**
- * TODO: Fix this with proper dispatching based on provided string.
- */
+template <DecomposeEpoch epoch>
 void Op::decompose(
     const graphlib::OpType &old_op_type,
-    const char *dispatch,
+    DecomposingContext &dc,
+    const std::vector<tt::graphlib::NodeContext> &inputs) const
+{
+    if constexpr (epoch == DecomposeEpoch::Initial)
+        return decompose_initial(old_op_type, dc, inputs);
+    else if constexpr (epoch == DecomposeEpoch::PostOptimize)
+        return decompose_post_optimize(old_op_type, dc, inputs);
+    else if constexpr (epoch == DecomposeEpoch::PostAutograd)
+        return decompose_post_autograd(old_op_type, dc, inputs);
+    else
+        static_assert("Invalid decomposing epoch.");
+}
+
+void Op::decompose_initial(
+    const graphlib::OpType &old_op_type,
     DecomposingContext &dc,
     const std::vector<tt::graphlib::NodeContext> &inputs) const
 {
@@ -445,7 +457,33 @@ void Op::decompose(
     {
         case OpType::Abs: return;
         case OpType::Constant: return;
-        default: return base_decompose(old_op_type, dispatch, dc, inputs);
+        default: return base_decompose(old_op_type, "get_f_forge_decompose", dc, inputs);
+    }
+}
+
+void Op::decompose_post_optimize(
+    const graphlib::OpType &old_op_type,
+    DecomposingContext &dc,
+    const std::vector<tt::graphlib::NodeContext> &inputs) const
+{
+    switch (type_)
+    {
+        case OpType::Abs: return;
+        case OpType::Constant: return;
+        default: return base_decompose(old_op_type, "get_f_forge_decompose_post_optimize", dc, inputs);
+    }
+}
+
+void Op::decompose_post_autograd(
+    const graphlib::OpType &old_op_type,
+    DecomposingContext &dc,
+    const std::vector<tt::graphlib::NodeContext> &inputs) const
+{
+    switch (type_)
+    {
+        case OpType::Abs: return;
+        case OpType::Constant: return;
+        default: return base_decompose(old_op_type, "get_f_forge_decompose_post_autograd", dc, inputs);
     }
 }
 
@@ -508,6 +546,24 @@ bool Op::is_eltwise_nary(const graphlib::OpType &old_op_type) const
         default: return base_is_eltwise_nary(old_op_type);
     }
 }
+
+/**
+ * Explicit instantiations to enable pybind symbol resolution.
+ */
+template void Op::decompose<DecomposeEpoch::Initial>(
+    const graphlib::OpType &old_op_type,
+    DecomposingContext &dc,
+    const std::vector<tt::graphlib::NodeContext> &inputs) const;
+
+template void Op::decompose<DecomposeEpoch::PostOptimize>(
+    const graphlib::OpType &old_op_type,
+    DecomposingContext &dc,
+    const std::vector<tt::graphlib::NodeContext> &inputs) const;
+
+template void Op::decompose<DecomposeEpoch::PostAutograd>(
+    const graphlib::OpType &old_op_type,
+    DecomposingContext &dc,
+    const std::vector<tt::graphlib::NodeContext> &inputs) const;
 
 }  // namespace ops
 }  // namespace tt

--- a/forge/csrc/ops/op.hpp
+++ b/forge/csrc/ops/op.hpp
@@ -32,6 +32,7 @@ struct autograd_context;
 }
 
 class DecomposingContext;
+enum class DecomposeEpoch : uint8_t;
 
 namespace ops
 {
@@ -229,9 +230,24 @@ class Op
      * Optional implementations. *
      * --------------------------*/
 
+    template <DecomposeEpoch epoch>
     void decompose(
         const graphlib::OpType &old_op_type,
-        const char *dispatch,
+        DecomposingContext &dc,
+        const std::vector<tt::graphlib::NodeContext> &inputs) const;
+
+    void decompose_initial(
+        const graphlib::OpType &old_op_type,
+        DecomposingContext &dc,
+        const std::vector<tt::graphlib::NodeContext> &inputs) const;
+
+    void decompose_post_optimize(
+        const graphlib::OpType &old_op_type,
+        DecomposingContext &dc,
+        const std::vector<tt::graphlib::NodeContext> &inputs) const;
+
+    void decompose_post_autograd(
+        const graphlib::OpType &old_op_type,
         DecomposingContext &dc,
         const std::vector<tt::graphlib::NodeContext> &inputs) const;
 

--- a/forge/csrc/ops/op_interface.hpp
+++ b/forge/csrc/ops/op_interface.hpp
@@ -51,11 +51,14 @@ class Op;
         const tt::graphlib::NodeContext &output,                                                      \
         const tt::graphlib::NodeContext &gradient);                                                   \
                                                                                                       \
-    void decompose(                                                                                   \
-        const Op &op,                                                                                 \
-        const char *dispatch,                                                                         \
-        DecomposingContext &dc,                                                                       \
-        const std::vector<tt::graphlib::NodeContext> &inputs);                                        \
+    void decompose_initial(                                                                           \
+        const Op &op, DecomposingContext &dc, const std::vector<tt::graphlib::NodeContext> &inputs);  \
+                                                                                                      \
+    void decompose_post_optimize(                                                                     \
+        const Op &op, DecomposingContext &dc, const std::vector<tt::graphlib::NodeContext> &inputs);  \
+                                                                                                      \
+    void decompose_post_autograd(                                                                     \
+        const Op &op, DecomposingContext &dc, const std::vector<tt::graphlib::NodeContext> &inputs);  \
                                                                                                       \
     long initial_flops_estimate(const Op &op, const std::vector<std::vector<std::uint32_t>> &inputs); \
     }

--- a/forge/csrc/passes/decomposing_context.hpp
+++ b/forge/csrc/passes/decomposing_context.hpp
@@ -13,6 +13,13 @@ namespace tt
 using Graph = graphlib::Graph;
 using NodeContext = graphlib::NodeContext;
 
+enum class DecomposeEpoch : uint8_t
+{
+    Initial,
+    PostOptimize,
+    PostAutograd
+};
+
 class DecomposingContext
 {
     // Graph that's being decomposed
@@ -63,7 +70,8 @@ class DecomposingContext
     inline std::shared_ptr<void> get_compiler_cfg() { return compiler_cfg; }
 };
 
+template <DecomposeEpoch epoch>
 std::vector<std::pair<graphlib::NodeId, graphlib::NodeId>> decompose_tt_forge_graph(
-    Graph* graph, const char* dispatcher_name, std::shared_ptr<void> compiler_cfg);
+    Graph* graph, std::shared_ptr<void> compiler_cfg);
 
 }  // namespace tt


### PR DESCRIPTION
Added missing decomposing function in ops cpp code.

This change is part of ops migration from python to cpp.
For details check out: https://github.com/tenstorrent/tt-forge-fe/issues/2378