### PR TITLE
Run perf benchmark in tt-forge

### DIFF
--- a/.github/workflows/perf-bench-tt-forge.yml
+++ b/.github/workflows/perf-bench-tt-forge.yml
@@ -15,6 +15,10 @@ on:
         description: 'Branch of tt-forge to run the benchmarks on (empty=main)'
         required: false
         type: string
+      test_filter:
+        description: "Only run tests with name that contains"
+        required: false
+        type: string
 
 permissions:
   packages: write
@@ -56,4 +60,4 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
           repository: tenstorrent/tt-forge
           event-type: trigger-workflow
-          client-payload: '{"project": "tt-forge-fe", "run_id": "${{ github.run_id }}", "ref": "${{ steps.set-inputs.outputs.ref }}"}'
+          client-payload: '{"project": "tt-forge-fe", "run_id": "${{ github.run_id }}", "ref": "${{ steps.set-inputs.outputs.ref }}", "test_filter": "${{ inputs.test_filter }}"}'


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge/issues/235

### Problem description
Developers should be able to run performance benchmarks in tt-forge with current development build

### What's changed
New perf benchmark workflow allows developers to build tt-forge-fe and run perf benchmarks in tt-forge with that build.
<img width="333" alt="Screenshot 2025-07-04 at 16 21 51" src="https://github.com/user-attachments/assets/868ca8f5-2168-4796-a3eb-87a233320639" />

When dispatched it allows:
- run from dev branch
- override mlir version
- choose branch from which perf benchmarks is run on tt-forge
- for use cases where development branches are used on both repos checkbox is provided to use branch with same name on both repos.

Addon:
- Filtering of benchmark tests is added. When dispatched through this workflow it will execute tt-forge-fe benchmarks only. Additionally, you can specify test name filter and only tests containing filter will be launched.  

### Checklist
- [ ] New/Existing tests provide coverage for changes
