### PR TITLE
Replaced string comparison to op type comparison for ops.

### DIFF
--- a/forge/csrc/autograd/autograd.cpp
+++ b/forge/csrc/autograd/autograd.cpp
@@ -360,13 +360,13 @@ void autograd_engine::create_backward_graph(const grad_map &requires_grad_map)
             {
                 if (tm.type() == ops::OpType::Broadcast)
                 {
-                    TT_ASSERT(tm.attrs_.size() <= 3);
+                    TT_ASSERT(tm.attr.size() <= 3);
                     log_debug(
                         tt::LogAutograd,
                         "Edge has broadcast: dim={} size={}",
-                        std::get<int>(tm.attrs_[0]),
-                        std::get<int>(tm.attrs_[1]));
-                    int dim = std::get<int>(tm.attrs_[0]);
+                        std::get<int>(tm.attr[0]),
+                        std::get<int>(tm.attr[1]));
+                    int dim = std::get<int>(tm.attr[0]);
 
                     NodeContext src = last_out;
                     last_out = create_backward_op(

--- a/forge/csrc/graph_lib/node.cpp
+++ b/forge/csrc/graph_lib/node.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "autograd/binding.hpp"
+#include "ops/op.hpp"
 #include "utils/assert.hpp"
 
 namespace tt
@@ -55,7 +56,7 @@ Shape Node::shape_of_operand(const Graph* graph, const Node* operand, bool ignor
         std::vector<OpType> tms = graph->get_edge_attributes(e)->get_tms();
         for (OpType tm : tms)
         {
-            if (ignore_broadcasts and tm.op == "broadcast")
+            if (ignore_broadcasts and tm.type() == ops::OpType::Broadcast)
                 continue;
             std::vector<Shape> shapes = {operand_shape};
             std::tuple<Shape, std::vector<DimBroadcast>> shape_data = get_op_shape(tm, shapes);

--- a/forge/csrc/graph_lib/node_types.cpp
+++ b/forge/csrc/graph_lib/node_types.cpp
@@ -335,7 +335,7 @@ void EdgeAttributes::clear_broadcast_dims()
 void EdgeAttributes::remove_broadcast_dim(int dim)
 {
     auto filter = [=](const OpType &o)
-    { return o.type() == ops::OpType::Broadcast && std::get<int>(o.attrs_[0]) == dim; };
+    { return o.type() == ops::OpType::Broadcast && std::get<int>(o.attr[0]) == dim; };
     tms.erase(std::remove_if(tms.begin(), tms.end(), filter), tms.end());
 }
 

--- a/forge/csrc/graph_lib/node_types.hpp
+++ b/forge/csrc/graph_lib/node_types.hpp
@@ -374,15 +374,15 @@ struct OpType
     using Attrs = ForgeOpAttrs;
 
     std::string op_;
-    std::vector<Attr> attrs_;  // legacy path
-    Attrs named_attrs_;        // new path
+    std::vector<Attr> attr;  // legacy path
+    Attrs named_attrs_;      // new path
 
    private:
     ops::Op new_op_;
 
    public:
     OpType(std::string const &op, std::vector<Attr> const &attr = {}, Attrs named_attrs = {}) :
-        op_(op), attrs_(attr), named_attrs_(std::move(named_attrs)), new_op_(*this)
+        op_(op), attr(attr), named_attrs_(std::move(named_attrs)), new_op_(*this)
     {
     }
 
@@ -391,7 +391,7 @@ struct OpType
 
     bool operator==(const OpType &other) const
     {
-        return *this == other.type() and attrs_ == other.attrs_ and named_attrs_ == other.named_attrs_;
+        return *this == other.type() and attr == other.attr and named_attrs_ == other.named_attrs_;
     }
     bool operator!=(const OpType &other) const { return !(*this == other); }
 
@@ -421,30 +421,30 @@ struct OpType
     std::string as_string() const
     {
         std::string ret = op_;
-        if (attrs_.size() > 0)
+        if (attr.size() > 0)
         {
             ret += "(";
-            for (unsigned int i = 0; i < attrs_.size(); i++)
+            for (unsigned int i = 0; i < attr.size(); i++)
             {
-                if (std::holds_alternative<bool>(attrs_[i]))
+                if (std::holds_alternative<bool>(attr[i]))
                 {
-                    ret += std::to_string(std::get<bool>(attrs_[i])) + ",";
+                    ret += std::to_string(std::get<bool>(attr[i])) + ",";
                 }
-                else if (std::holds_alternative<int>(attrs_[i]))
+                else if (std::holds_alternative<int>(attr[i]))
                 {
-                    ret += std::to_string(std::get<int>(attrs_[i])) + ",";
+                    ret += std::to_string(std::get<int>(attr[i])) + ",";
                 }
-                else if (std::holds_alternative<float>(attrs_[i]))
+                else if (std::holds_alternative<float>(attr[i]))
                 {
-                    ret += std::to_string(std::get<float>(attrs_[i])) + ",";
+                    ret += std::to_string(std::get<float>(attr[i])) + ",";
                 }
-                else if (std::holds_alternative<std::string>(attrs_[i]))
+                else if (std::holds_alternative<std::string>(attr[i]))
                 {
-                    ret += std::get<std::string>(attrs_[i]) + ",";
+                    ret += std::get<std::string>(attr[i]) + ",";
                 }
-                else if (std::holds_alternative<std::vector<int>>(attrs_[i]))
+                else if (std::holds_alternative<std::vector<int>>(attr[i]))
                 {
-                    auto attr_val = std::get<std::vector<int>>(attrs_[i]);
+                    auto attr_val = std::get<std::vector<int>>(attr[i]);
                     size_t num_items = attr_val.size();
 
                     ret += "[";
@@ -549,7 +549,7 @@ class OpNode : public TaggedNode
     OpType const *op_type_ptr() const { return &op_type_; }
     IRLevel get_ir_level() const { return IRLevel::IR_TT_FORGE; }
     const std::string &op_name() const { return op_type_.name(); }
-    const std::vector<OpType::Attr> &op_attrs() const { return op_type_.attrs_; }
+    const std::vector<OpType::Attr> &op_attrs() const { return op_type_.attr; }
     const OpType::Attrs &named_attrs() { return op_type_.named_attrs_; }
     const OpType::Attr &op_attr(std::string const &name) const { return op_type_.get_attr(name); }
     template <typename T>

--- a/forge/csrc/graph_lib/node_types.hpp
+++ b/forge/csrc/graph_lib/node_types.hpp
@@ -375,14 +375,14 @@ struct OpType
 
     std::string op_;
     std::vector<Attr> attr;  // legacy path
-    Attrs named_attrs_;      // new path
+    Attrs named_attrs;       // new path
 
    private:
     ops::Op new_op_;
 
    public:
     OpType(std::string const &op, std::vector<Attr> const &attr = {}, Attrs named_attrs = {}) :
-        op_(op), attr(attr), named_attrs_(std::move(named_attrs)), new_op_(*this)
+        op_(op), attr(attr), named_attrs(std::move(named_attrs)), new_op_(*this)
     {
     }
 
@@ -391,14 +391,14 @@ struct OpType
 
     bool operator==(const OpType &other) const
     {
-        return *this == other.type() and attr == other.attr and named_attrs_ == other.named_attrs_;
+        return *this == other.type() and attr == other.attr and named_attrs == other.named_attrs;
     }
     bool operator!=(const OpType &other) const { return !(*this == other); }
 
     ops::OpType type() const { return new_op_.type(); }
     ops::Op const &new_op() const { return new_op_; }
-    Attr const &get_attr(std::string const &name) const { return named_attrs_.at(name); }
-    Attr &get_attr(std::string const &name) { return named_attrs_.at(name); }
+    Attr const &get_attr(std::string const &name) const { return named_attrs.at(name); }
+    Attr &get_attr(std::string const &name) { return named_attrs.at(name); }
     template <typename T>
     T const &get_attr_as(std::string const &name) const
     {
@@ -412,7 +412,7 @@ struct OpType
 
     void set_attr(std::string const &name, Attr attr)
     {
-        named_attrs_[name] = attr;
+        named_attrs[name] = attr;
         new_op_.set_attr(name, std::move(attr));
     }
 
@@ -466,13 +466,13 @@ struct OpType
             ret += ")";
         }
 
-        if (named_attrs_.size() > 0)
+        if (named_attrs.size() > 0)
         {
             using tt::operator<<;
             std::stringstream ss;
             bool first = true;
             ss << "{";
-            for (auto const &[name, value] : named_attrs_)
+            for (auto const &[name, value] : named_attrs)
             {
                 if (not first)
                     ss << ", ";
@@ -550,7 +550,7 @@ class OpNode : public TaggedNode
     IRLevel get_ir_level() const { return IRLevel::IR_TT_FORGE; }
     const std::string &op_name() const { return op_type_.name(); }
     const std::vector<OpType::Attr> &op_attrs() const { return op_type_.attr; }
-    const OpType::Attrs &named_attrs() { return op_type_.named_attrs_; }
+    const OpType::Attrs &named_attrs() { return op_type_.named_attrs; }
     const OpType::Attr &op_attr(std::string const &name) const { return op_type_.get_attr(name); }
     template <typename T>
     const T &op_attr_as(std::string const &name) const

--- a/forge/csrc/graph_lib/node_types.hpp
+++ b/forge/csrc/graph_lib/node_types.hpp
@@ -549,7 +549,6 @@ class OpNode : public TaggedNode
     OpType const *op_type_ptr() const { return &op_type_; }
     IRLevel get_ir_level() const { return IRLevel::IR_TT_FORGE; }
     const std::string &op_name() const { return op_type_.name(); }
-    // const ops::OpType op_type() const { return op_type_.type(); }
     const std::vector<OpType::Attr> &op_attrs() const { return op_type_.attrs_; }
     const OpType::Attrs &named_attrs() { return op_type_.named_attrs_; }
     const OpType::Attr &op_attr(std::string const &name) const { return op_type_.get_attr(name); }

--- a/forge/csrc/graph_lib/python_bindings.cpp
+++ b/forge/csrc/graph_lib/python_bindings.cpp
@@ -293,7 +293,7 @@ void GraphModule(py::module &m_graph)
             py::arg("attr") = std::vector<tt::graphlib::OpType::Attr>{},
             py::arg("named_attrs") = tt::graphlib::OpType::Attrs{})
         .def_readonly("op", &tt::graphlib::OpType::op_)
-        .def_readonly("attr", &tt::graphlib::OpType::attrs_)
+        .def_readonly("attr", &tt::graphlib::OpType::attr)
         .def_readonly("named_attrs", &tt::graphlib::OpType::named_attrs_)
         .def("eval", &tt::graphlib::OpType::eval)
         .def("shape", &tt::graphlib::OpType::shape)

--- a/forge/csrc/graph_lib/python_bindings.cpp
+++ b/forge/csrc/graph_lib/python_bindings.cpp
@@ -294,7 +294,7 @@ void GraphModule(py::module &m_graph)
             py::arg("named_attrs") = tt::graphlib::OpType::Attrs{})
         .def_readonly("op", &tt::graphlib::OpType::op_)
         .def_readonly("attr", &tt::graphlib::OpType::attr)
-        .def_readonly("named_attrs", &tt::graphlib::OpType::named_attrs_)
+        .def_readonly("named_attrs", &tt::graphlib::OpType::named_attrs)
         .def("eval", &tt::graphlib::OpType::eval)
         .def("shape", &tt::graphlib::OpType::shape)
         .def(

--- a/forge/csrc/graph_lib/utils.cpp
+++ b/forge/csrc/graph_lib/utils.cpp
@@ -1255,7 +1255,7 @@ void handle_change_rank(graphlib::Graph *graph, graphlib::Edge edge)
         return;
 
     graphlib::OpNode *consumer = dynamic_cast<graphlib::OpNode *>(graph->node_by_id(edge.consumer_node_id));
-    if (consumer and consumer->op_type().type() == ops::OpType::Embedding)
+    if (consumer and consumer->new_op_type() == ops::OpType::Embedding)
         return;
 
     // This is one of the few cases where we actually want to move tms downstream

--- a/forge/csrc/graph_lib/utils.cpp
+++ b/forge/csrc/graph_lib/utils.cpp
@@ -1148,7 +1148,7 @@ void convert_implicit_to_explicit_bcasts(Graph *graph, Edge edge)
         if (op_type.type() == ops::OpType::Broadcast)
         {
             constexpr bool explicit_bcast = true;
-            std::get<bool>(op_type.attrs_[2]) = explicit_bcast;
+            std::get<bool>(op_type.attr[2]) = explicit_bcast;
         }
     }
 }
@@ -1208,9 +1208,9 @@ bool swap_broadcast_dims(graphlib::Graph *graph, graphlib::Edge edge, int old_di
     {
         if (op_type.type() == ops::OpType::Broadcast)
         {
-            int dim = std::get<int>(op_type.attrs_[0]);
-            int size = std::get<int>(op_type.attrs_[1]);
-            bool explicit_bcast = std::get<bool>(op_type.attrs_[2]);
+            int dim = std::get<int>(op_type.attr[0]);
+            int size = std::get<int>(op_type.attr[1]);
+            bool explicit_bcast = std::get<bool>(op_type.attr[2]);
             if (dim == old_dim)
             {
                 graphlib::OpType updated_bcast("broadcast", {new_dim, size, explicit_bcast});
@@ -1310,8 +1310,8 @@ void handle_change_rank(graphlib::Graph *graph, graphlib::Edge edge)
     {
         if (op_type.type() == ops::OpType::Broadcast)
         {
-            if (std::get<int>(op_type.attrs_[0]) >= 0)
-                std::get<int>(op_type.attrs_[0]) += diff;
+            if (std::get<int>(op_type.attr[0]) >= 0)
+                std::get<int>(op_type.attr[0]) += diff;
         }
     }
     graph->get_edge_attributes(edge)->set_tms(tms);

--- a/forge/csrc/graph_lib/utils.hpp
+++ b/forge/csrc/graph_lib/utils.hpp
@@ -213,9 +213,6 @@ bool is_constant_input(const Node *node);
 bool is_recompute(const Graph *graph, const Node *node);
 Node *get_fwd_from_recompute(const Graph *graph, const Node *node);
 
-bool can_swap_operands(Graph *graph, Node *node);
-void swap_operands(Graph *graph, Node *node);
-
 Edge retrieve_between_edge(Graph *graph, Node *producer, Node *consumer);
 bool are_bcasts_between_ops(Graph *graph, Node *producer, Node *consumer);
 //

--- a/forge/csrc/ops/op.cpp
+++ b/forge/csrc/ops/op.cpp
@@ -300,7 +300,7 @@ static NewToOldOpType new_to_old_op_type_mapper;
 static OldToNewOpType old_to_new_op_type_mapper;
 
 Op::Op(const graphlib::OpType &old_op_type) :
-    type_(old_to_new_op_type_mapper[old_op_type.op]), attrs_(old_op_type.named_attrs)
+    type_(old_to_new_op_type_mapper[old_op_type.op_]), attrs_(old_op_type.named_attrs_)
 {
 }
 

--- a/forge/csrc/ops/op.cpp
+++ b/forge/csrc/ops/op.cpp
@@ -300,7 +300,7 @@ static NewToOldOpType new_to_old_op_type_mapper;
 static OldToNewOpType old_to_new_op_type_mapper;
 
 Op::Op(const graphlib::OpType &old_op_type) :
-    type_(old_to_new_op_type_mapper[old_op_type.op_]), attrs_(old_op_type.named_attrs_)
+    type_(old_to_new_op_type_mapper[old_op_type.op_]), attrs_(old_op_type.named_attrs)
 {
 }
 

--- a/forge/csrc/ops/op.hpp
+++ b/forge/csrc/ops/op.hpp
@@ -199,7 +199,7 @@ class Op
 
     bool has_attr(const std::string &attr_name) const { return attrs_.find(attr_name) != attrs_.end(); }
     void set_attrs(Attrs attrs) { attrs_ = std::move(attrs); }
-    void set_attr(std::string const &name, Attr attr) { attrs_[name] = attr; }
+    void set_attr(std::string const &name, Attr attr) { attrs_[name] = std::move(attr); }
 
     const std::string &as_string() const;
 

--- a/forge/csrc/passes/commute_utils.cpp
+++ b/forge/csrc/passes/commute_utils.cpp
@@ -5,6 +5,7 @@
 
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/utils.hpp"
+#include "ops/op.hpp"
 #include "passes/passes_utils.hpp"
 #include "utils/logger.hpp"
 
@@ -104,29 +105,29 @@ std::tuple<bool, int> can_commute_through_dim(
 
 bool match_unsqueeze(graphlib::OpType const &a, graphlib::OpType const &b)
 {
-    bool fns_match = a.op == "unsqueeze" and b.op == "squeeze";
+    bool fns_match = a.type() == ops::OpType::Unsqueeze and b.type() == ops::OpType::Squeeze;
 
     if (not fns_match)
         return false;
 
-    return std::get<int>(a.attr[0]) == std::get<int>(b.attr[0]);
+    return std::get<int>(a.attrs_[0]) == std::get<int>(b.attrs_[0]);
 }
 
 bool match_squeeze(graphlib::OpType const &a, graphlib::OpType const &b)
 {
-    bool fns_match = a.op == "squeeze" and b.op == "unsqueeze";
+    bool fns_match = a.type() == ops::OpType::Unsqueeze and b.type() == ops::OpType::Squeeze;
 
     if (not fns_match)
         return false;
 
-    return std::get<int>(a.attr[0]) == std::get<int>(b.attr[0]);
+    return std::get<int>(a.attrs_[0]) == std::get<int>(b.attrs_[0]);
 }
 
-bool match_reshape(graphlib::OpType const &a, graphlib::OpType const &) { return a.op == "reshape"; }
+bool match_reshape(graphlib::OpType const &a, graphlib::OpType const &) { return a.type() == ops::OpType::Reshape; }
 
 bool match_transpose(graphlib::OpType const &a, graphlib::OpType const &b)
 {
-    if (a.op != "transpose")
+    if (a.type() != ops::OpType::Transpose)
         return false;
 
     int a_dim0 = a.get_attr_as<int>("dim0");
@@ -148,9 +149,9 @@ size_t total_broadcast_volume(graphlib::Graph *graph, graphlib::Edge edge)
     size_t volume = 1;
     for (graphlib::OpType &op_type : tms)
     {
-        if (op_type.op == "broadcast")
+        if (op_type.type() == ops::OpType::Broadcast)
         {
-            volume *= std::get<int>(op_type.attr[1]);
+            volume *= std::get<int>(op_type.attrs_[1]);
         }
     }
     return volume;
@@ -403,8 +404,8 @@ bool commute_through_select(
 
     auto concat_golden_transform = *golden_transform;
 
-    if (concat_golden_transform.op == "reshape")
-        concat_golden_transform.attr[select_dim] = concat_output_len;
+    if (concat_golden_transform.type() == ops::OpType::Reshape)
+        concat_golden_transform.attrs_[select_dim] = concat_output_len;
     op->add_golden_transform(concat_golden_transform);
     update_select_attr(op, new_dim);
 
@@ -538,8 +539,9 @@ bool commute_through_concat(
 
     auto concat_golden_transform = *golden_transform;
 
-    if (concat_golden_transform.op == "reshape")
-        concat_golden_transform.attr[concat_dim >= 0 ? concat_dim : concat_dim + concat_golden_transform.attr.size()] =
+    if (concat_golden_transform.type() == ops::OpType::Reshape)
+        concat_golden_transform
+            .attrs_[concat_dim >= 0 ? concat_dim : concat_dim + concat_golden_transform.attrs_.size()] =
             concat_output_len;
     op->add_golden_transform(concat_golden_transform);
     std::vector<graphlib::OpType::Attr> concat_attr;
@@ -775,10 +777,10 @@ bool commute_through_reduce(
         reduce_shape = graphlib::Shape::create(reduce_vec);
 
         auto reduce_golden_transform = *golden_transform;
-        if (reduce_golden_transform.op == "reshape")
+        if (reduce_golden_transform.type() == ops::OpType::Reshape)
         {
-            reduce_golden_transform.attr[op_reduce_dim] = 1;
-            reduce_golden_transform.attr[producer_reduce_dim] = 1;
+            reduce_golden_transform.attrs_[op_reduce_dim] = 1;
+            reduce_golden_transform.attrs_[producer_reduce_dim] = 1;
         }
 
         op->add_golden_transform(reduce_golden_transform);
@@ -818,8 +820,8 @@ bool commute_through_reduce(
         op->set_shape(reduce_shape);
 
         auto reduce_golden_transform = *golden_transform;
-        if (reduce_golden_transform.op == "reshape")
-            reduce_golden_transform.attr[reduce_dim] = 1;
+        if (reduce_golden_transform.type() == ops::OpType::Reshape)
+            reduce_golden_transform.attrs_[reduce_dim] = 1;
 
         op->add_golden_transform(reduce_golden_transform);
 
@@ -1074,10 +1076,10 @@ std::pair<bool, std::pair<std::vector<int>, std::vector<int>>> handle_shape_chan
     bool can_commute = true;
     for (graphlib::OpType &op_type : tms)
     {
-        if (op_type.op == "broadcast")
+        if (op_type.type() == ops::OpType::Broadcast)
         {
-            int bcast_dim = std::get<int>(op_type.attr[0]);
-            int volume = std::get<int>(op_type.attr[1]);
+            int bcast_dim = std::get<int>(op_type.attrs_[0]);
+            int volume = std::get<int>(op_type.attrs_[1]);
             if (bcast_dim < 0)
                 bcast_dim += clone_shape->size();
             auto [can_commute_bcast_through_dim, new_dim] = can_commute_through_dim(initial_op, graph, bcast_dim);
@@ -1112,11 +1114,11 @@ void add_or_compound_bcast(graphlib::Graph *graph, graphlib::Edge edge, int dim,
     bool compounded_bcast = false;
     for (graphlib::OpType &op_type : tms)
     {
-        if (op_type.op == "broadcast")
+        if (op_type.type() == ops::OpType::Broadcast)
         {
-            int existing_dim = std::get<int>(op_type.attr[0]);
+            int existing_dim = std::get<int>(op_type.attrs_[0]);
 
-            int existing_volume = std::get<int>(op_type.attr[1]);
+            int existing_volume = std::get<int>(op_type.attrs_[1]);
             if (existing_dim == dim)
             {
                 compounded_bcast = true;
@@ -1124,7 +1126,7 @@ void add_or_compound_bcast(graphlib::Graph *graph, graphlib::Edge edge, int dim,
             }
 
             graph->get_edge_attributes(edge)->set_broadcast_dim(
-                existing_dim, existing_volume, std::get<bool>(op_type.attr[2]));
+                existing_dim, existing_volume, std::get<bool>(op_type.attrs_[2]));
         }
     }
 
@@ -1144,10 +1146,10 @@ void restore_bcast_on_condition(
     // auto tms = graph->get_edge_attributes(edge)->get_tms();
     for (graphlib::OpType &op_type : orig_tms)
     {
-        if (op_type.op == "broadcast")
+        if (op_type.type() == ops::OpType::Broadcast)
         {
-            int dim = std::get<int>(op_type.attr[0]);
-            int volume = std::get<int>(op_type.attr[1]);
+            int dim = std::get<int>(op_type.attrs_[0]);
+            int volume = std::get<int>(op_type.attrs_[1]);
             if (dim < 0)
                 dim += operand_shape.size();
 
@@ -1205,13 +1207,13 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
     std::vector<int> bcast_dims;
     for (graphlib::OpType &op_type : tms)
     {
-        if (op_type.op == "broadcast")
+        if (op_type.type() == ops::OpType::Broadcast)
         {
             has_bcasts = true;
             num_bcasts++;
-            int dim = std::get<int>(op_type.attr[0]);
+            int dim = std::get<int>(op_type.attrs_[0]);
             bcast_dims.push_back(dim);
-            int volume = std::get<int>(op_type.attr[1]);
+            int volume = std::get<int>(op_type.attrs_[1]);
             if (dim < 0)
             {
                 while (-dim > (int)operand_shape.size())
@@ -1297,7 +1299,7 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
 
             if (is_transpose_reshape)
             {
-                int bcast_dim = std::get<int>(tms[0].attr[0]);
+                int bcast_dim = std::get<int>(tms[0].attrs_[0]);
                 if (bcast_dim < 0)
                     bcast_dim += operand_shape.size();
                 int bcast_volume = op->shape()[bcast_dim];
@@ -1416,14 +1418,14 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
 
                 for (auto &t : tms)
                 {
-                    if (t.op == "broadcast")
+                    if (t.type() == ops::OpType::Broadcast)
                     {
-                        int dim = std::get<int>(t.attr[0]);
+                        int dim = std::get<int>(t.attrs_[0]);
                         if (dim >= 0)
                         {
                             dim -= operand_shape.size();
                         }
-                        int volume = std::get<int>(t.attr[1]);
+                        int volume = std::get<int>(t.attrs_[1]);
                         add_or_compound_bcast(graph, user_edge, dim, volume);
                     }
                 }
@@ -1444,9 +1446,9 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
         for (int i = 0; i < (int)tms.size(); ++i)
         {
             graphlib::OpType op_type = tms[i];
-            if (op_type.op == "broadcast")
+            if (op_type.type() == ops::OpType::Broadcast)
             {
-                int dim = std::get<int>(op_type.attr[0]);
+                int dim = std::get<int>(op_type.attrs_[0]);
                 if (dim > 0)
                     dim -= operand_shape.size();
 
@@ -1455,7 +1457,7 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
                 erase_tms.push_back(i);
                 int updated_bcast_dim = update_bcast_dim_commuted_through_transpose(dim, op);
                 updated_shape[updated_bcast_dim] = operand_dim_size;
-                std::get<int>(op_type.attr[0]) = updated_bcast_dim;
+                std::get<int>(op_type.attrs_[0]) = updated_bcast_dim;
                 for (graphlib::Edge user_edge : graph->user_data_edges(op))
                     graph->get_edge_attributes(user_edge)->prepend_tm(op_type);
             }
@@ -1490,14 +1492,14 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
 
         for (auto &t : tms)
         {
-            if (t.op == "broadcast")
+            if (t.type() == ops::OpType::Broadcast)
             {
-                int dim = std::get<int>(t.attr[0]);
+                int dim = std::get<int>(t.attrs_[0]);
                 if (dim >= 0)
                 {
                     dim -= operand_shape.size();
                 }
-                int volume = std::get<int>(t.attr[1]);
+                int volume = std::get<int>(t.attrs_[1]);
                 add_or_compound_bcast(graph, user_edge, dim, volume);
             }
         }

--- a/forge/csrc/passes/commute_utils.cpp
+++ b/forge/csrc/passes/commute_utils.cpp
@@ -110,7 +110,7 @@ bool match_unsqueeze(graphlib::OpType const &a, graphlib::OpType const &b)
     if (not fns_match)
         return false;
 
-    return std::get<int>(a.attrs_[0]) == std::get<int>(b.attrs_[0]);
+    return std::get<int>(a.attr[0]) == std::get<int>(b.attr[0]);
 }
 
 bool match_squeeze(graphlib::OpType const &a, graphlib::OpType const &b)
@@ -120,7 +120,7 @@ bool match_squeeze(graphlib::OpType const &a, graphlib::OpType const &b)
     if (not fns_match)
         return false;
 
-    return std::get<int>(a.attrs_[0]) == std::get<int>(b.attrs_[0]);
+    return std::get<int>(a.attr[0]) == std::get<int>(b.attr[0]);
 }
 
 bool match_reshape(graphlib::OpType const &a, graphlib::OpType const &) { return a.type() == ops::OpType::Reshape; }
@@ -151,7 +151,7 @@ size_t total_broadcast_volume(graphlib::Graph *graph, graphlib::Edge edge)
     {
         if (op_type.type() == ops::OpType::Broadcast)
         {
-            volume *= std::get<int>(op_type.attrs_[1]);
+            volume *= std::get<int>(op_type.attr[1]);
         }
     }
     return volume;
@@ -405,7 +405,7 @@ bool commute_through_select(
     auto concat_golden_transform = *golden_transform;
 
     if (concat_golden_transform.type() == ops::OpType::Reshape)
-        concat_golden_transform.attrs_[select_dim] = concat_output_len;
+        concat_golden_transform.attr[select_dim] = concat_output_len;
     op->add_golden_transform(concat_golden_transform);
     update_select_attr(op, new_dim);
 
@@ -540,8 +540,7 @@ bool commute_through_concat(
     auto concat_golden_transform = *golden_transform;
 
     if (concat_golden_transform.type() == ops::OpType::Reshape)
-        concat_golden_transform
-            .attrs_[concat_dim >= 0 ? concat_dim : concat_dim + concat_golden_transform.attrs_.size()] =
+        concat_golden_transform.attr[concat_dim >= 0 ? concat_dim : concat_dim + concat_golden_transform.attr.size()] =
             concat_output_len;
     op->add_golden_transform(concat_golden_transform);
     std::vector<graphlib::OpType::Attr> concat_attr;
@@ -779,8 +778,8 @@ bool commute_through_reduce(
         auto reduce_golden_transform = *golden_transform;
         if (reduce_golden_transform.type() == ops::OpType::Reshape)
         {
-            reduce_golden_transform.attrs_[op_reduce_dim] = 1;
-            reduce_golden_transform.attrs_[producer_reduce_dim] = 1;
+            reduce_golden_transform.attr[op_reduce_dim] = 1;
+            reduce_golden_transform.attr[producer_reduce_dim] = 1;
         }
 
         op->add_golden_transform(reduce_golden_transform);
@@ -821,7 +820,7 @@ bool commute_through_reduce(
 
         auto reduce_golden_transform = *golden_transform;
         if (reduce_golden_transform.type() == ops::OpType::Reshape)
-            reduce_golden_transform.attrs_[reduce_dim] = 1;
+            reduce_golden_transform.attr[reduce_dim] = 1;
 
         op->add_golden_transform(reduce_golden_transform);
 
@@ -1078,8 +1077,8 @@ std::pair<bool, std::pair<std::vector<int>, std::vector<int>>> handle_shape_chan
     {
         if (op_type.type() == ops::OpType::Broadcast)
         {
-            int bcast_dim = std::get<int>(op_type.attrs_[0]);
-            int volume = std::get<int>(op_type.attrs_[1]);
+            int bcast_dim = std::get<int>(op_type.attr[0]);
+            int volume = std::get<int>(op_type.attr[1]);
             if (bcast_dim < 0)
                 bcast_dim += clone_shape->size();
             auto [can_commute_bcast_through_dim, new_dim] = can_commute_through_dim(initial_op, graph, bcast_dim);
@@ -1116,9 +1115,9 @@ void add_or_compound_bcast(graphlib::Graph *graph, graphlib::Edge edge, int dim,
     {
         if (op_type.type() == ops::OpType::Broadcast)
         {
-            int existing_dim = std::get<int>(op_type.attrs_[0]);
+            int existing_dim = std::get<int>(op_type.attr[0]);
 
-            int existing_volume = std::get<int>(op_type.attrs_[1]);
+            int existing_volume = std::get<int>(op_type.attr[1]);
             if (existing_dim == dim)
             {
                 compounded_bcast = true;
@@ -1126,7 +1125,7 @@ void add_or_compound_bcast(graphlib::Graph *graph, graphlib::Edge edge, int dim,
             }
 
             graph->get_edge_attributes(edge)->set_broadcast_dim(
-                existing_dim, existing_volume, std::get<bool>(op_type.attrs_[2]));
+                existing_dim, existing_volume, std::get<bool>(op_type.attr[2]));
         }
     }
 
@@ -1148,8 +1147,8 @@ void restore_bcast_on_condition(
     {
         if (op_type.type() == ops::OpType::Broadcast)
         {
-            int dim = std::get<int>(op_type.attrs_[0]);
-            int volume = std::get<int>(op_type.attrs_[1]);
+            int dim = std::get<int>(op_type.attr[0]);
+            int volume = std::get<int>(op_type.attr[1]);
             if (dim < 0)
                 dim += operand_shape.size();
 
@@ -1211,9 +1210,9 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
         {
             has_bcasts = true;
             num_bcasts++;
-            int dim = std::get<int>(op_type.attrs_[0]);
+            int dim = std::get<int>(op_type.attr[0]);
             bcast_dims.push_back(dim);
-            int volume = std::get<int>(op_type.attrs_[1]);
+            int volume = std::get<int>(op_type.attr[1]);
             if (dim < 0)
             {
                 while (-dim > (int)operand_shape.size())
@@ -1299,7 +1298,7 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
 
             if (is_transpose_reshape)
             {
-                int bcast_dim = std::get<int>(tms[0].attrs_[0]);
+                int bcast_dim = std::get<int>(tms[0].attr[0]);
                 if (bcast_dim < 0)
                     bcast_dim += operand_shape.size();
                 int bcast_volume = op->shape()[bcast_dim];
@@ -1420,12 +1419,12 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
                 {
                     if (t.type() == ops::OpType::Broadcast)
                     {
-                        int dim = std::get<int>(t.attrs_[0]);
+                        int dim = std::get<int>(t.attr[0]);
                         if (dim >= 0)
                         {
                             dim -= operand_shape.size();
                         }
-                        int volume = std::get<int>(t.attrs_[1]);
+                        int volume = std::get<int>(t.attr[1]);
                         add_or_compound_bcast(graph, user_edge, dim, volume);
                     }
                 }
@@ -1448,7 +1447,7 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
             graphlib::OpType op_type = tms[i];
             if (op_type.type() == ops::OpType::Broadcast)
             {
-                int dim = std::get<int>(op_type.attrs_[0]);
+                int dim = std::get<int>(op_type.attr[0]);
                 if (dim > 0)
                     dim -= operand_shape.size();
 
@@ -1457,7 +1456,7 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
                 erase_tms.push_back(i);
                 int updated_bcast_dim = update_bcast_dim_commuted_through_transpose(dim, op);
                 updated_shape[updated_bcast_dim] = operand_dim_size;
-                std::get<int>(op_type.attrs_[0]) = updated_bcast_dim;
+                std::get<int>(op_type.attr[0]) = updated_bcast_dim;
                 for (graphlib::Edge user_edge : graph->user_data_edges(op))
                     graph->get_edge_attributes(user_edge)->prepend_tm(op_type);
             }
@@ -1494,12 +1493,12 @@ bool try_commute_bcast_through_clone(graphlib::Graph *graph, graphlib::OpNode *n
         {
             if (t.type() == ops::OpType::Broadcast)
             {
-                int dim = std::get<int>(t.attrs_[0]);
+                int dim = std::get<int>(t.attr[0]);
                 if (dim >= 0)
                 {
                     dim -= operand_shape.size();
                 }
-                int volume = std::get<int>(t.attrs_[1]);
+                int volume = std::get<int>(t.attr[1]);
                 add_or_compound_bcast(graph, user_edge, dim, volume);
             }
         }

--- a/forge/csrc/passes/constant_folding.cpp
+++ b/forge/csrc/passes/constant_folding.cpp
@@ -78,11 +78,11 @@ static void insert_pad_within_tile(graphlib::Graph *graph, graphlib::Edge edge, 
             break;
         }
 
-        int tm_dim = consumer->shape().negative_index(std::get<int>(tm.attrs_[0]));
+        int tm_dim = consumer->shape().negative_index(std::get<int>(tm.attr[0]));
         if (tm_dim == dim)
         {
-            std::get<int>(tm.attrs_[0]) = tm_dim;
-            std::get<int>(tm.attrs_[1]) = size;
+            std::get<int>(tm.attr[0]) = tm_dim;
+            std::get<int>(tm.attr[1]) = size;
             return;
         }
     }
@@ -129,7 +129,7 @@ static bool try_hoist_above_narrow(graphlib::Graph *graph, graphlib::OpNode *nar
         return false;
 
     auto shape = narrow->shape();
-    auto attr = narrow->op_type().attrs_;
+    auto attr = narrow->op_type().attr;
     TT_ASSERT(attr.size() == 4);
     int dim = shape.negative_index(std::get<int>(attr[0]));
     int start = std::get<int>(attr[1]);
@@ -270,10 +270,10 @@ static bool try_fold_constant_multiply_into_matmul_rhs(
         {
             if (tm.type() == ops::OpType::Broadcast)
             {
-                int tm_dim = multiply->shape().negative_index(std::get<int>(tm.attrs_[0]));
+                int tm_dim = multiply->shape().negative_index(std::get<int>(tm.attr[0]));
                 if (tm_dim == -2)
                 {
-                    std::get<int>(tm.attrs_[1]) = matmul_rhs->shape()[-2];
+                    std::get<int>(tm.attr[1]) = matmul_rhs->shape()[-2];
                 }
             }
         }

--- a/forge/csrc/passes/constant_folding.cpp
+++ b/forge/csrc/passes/constant_folding.cpp
@@ -9,6 +9,7 @@
 
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/utils.hpp"
+#include "ops/op.hpp"
 #include "passes/commute_utils.hpp"
 #include "passes/passes_utils.hpp"
 #include "utils/logger.hpp"
@@ -71,17 +72,17 @@ static void insert_pad_within_tile(graphlib::Graph *graph, graphlib::Edge edge, 
     auto &tms = graph->get_edge_attributes(edge)->get_tms();
     for (auto &tm : tms)
     {
-        if (tm.op != "broadcast")
+        if (tm.type() != ops::OpType::Broadcast)
         {
             only_bcast = false;
             break;
         }
 
-        int tm_dim = consumer->shape().negative_index(std::get<int>(tm.attr[0]));
+        int tm_dim = consumer->shape().negative_index(std::get<int>(tm.attrs_[0]));
         if (tm_dim == dim)
         {
-            std::get<int>(tm.attr[0]) = tm_dim;
-            std::get<int>(tm.attr[1]) = size;
+            std::get<int>(tm.attrs_[0]) = tm_dim;
+            std::get<int>(tm.attrs_[1]) = size;
             return;
         }
     }
@@ -128,7 +129,7 @@ static bool try_hoist_above_narrow(graphlib::Graph *graph, graphlib::OpNode *nar
         return false;
 
     auto shape = narrow->shape();
-    auto attr = narrow->op_type().attr;
+    auto attr = narrow->op_type().attrs_;
     TT_ASSERT(attr.size() == 4);
     int dim = shape.negative_index(std::get<int>(attr[0]));
     int start = std::get<int>(attr[1]);
@@ -267,12 +268,12 @@ static bool try_fold_constant_multiply_into_matmul_rhs(
         // Fixup broadcast
         for (auto &tm : constant_attr->get_tms())
         {
-            if (tm.op == "broadcast")
+            if (tm.type() == ops::OpType::Broadcast)
             {
-                int tm_dim = multiply->shape().negative_index(std::get<int>(tm.attr[0]));
+                int tm_dim = multiply->shape().negative_index(std::get<int>(tm.attrs_[0]));
                 if (tm_dim == -2)
                 {
-                    std::get<int>(tm.attr[1]) = matmul_rhs->shape()[-2];
+                    std::get<int>(tm.attrs_[1]) = matmul_rhs->shape()[-2];
                 }
             }
         }

--- a/forge/csrc/passes/dataformat.cpp
+++ b/forge/csrc/passes/dataformat.cpp
@@ -8,6 +8,7 @@
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/utils.hpp"
 #include "lower_to_forge/common.hpp"
+#include "ops/op.hpp"
 #include "passes/amp.hpp"
 #include "utils/logger.hpp"
 
@@ -105,7 +106,7 @@ void configure_output_data_formats(graphlib::Graph *graph, std::optional<DataFor
                     consumers.size());
                 // check if consumer is cast node
                 bool consumer_is_cast = consumers[0]->node_type() == graphlib::NodeType::kPyOp &&
-                                        consumers[0]->as<graphlib::PyOpNode>()->op_type().op == "cast";
+                                        consumers[0]->as<graphlib::PyOpNode>()->op_type().type() == ops::OpType::Cast;
                 TT_ASSERT(
                     (consumer_is_cast && consumers[0]->output_df() == default_df_override.value()) || node_is_int,
                     "Non integer constant input node that doesn't have data format same as default_df_override {}, "

--- a/forge/csrc/passes/dataformat.cpp
+++ b/forge/csrc/passes/dataformat.cpp
@@ -106,7 +106,7 @@ void configure_output_data_formats(graphlib::Graph *graph, std::optional<DataFor
                     consumers.size());
                 // check if consumer is cast node
                 bool consumer_is_cast = consumers[0]->node_type() == graphlib::NodeType::kPyOp &&
-                                        consumers[0]->as<graphlib::PyOpNode>()->op_type().type() == ops::OpType::Cast;
+                                        consumers[0]->as<graphlib::PyOpNode>()->new_op_type() == ops::OpType::Cast;
                 TT_ASSERT(
                     (consumer_is_cast && consumers[0]->output_df() == default_df_override.value()) || node_is_int,
                     "Non integer constant input node that doesn't have data format same as default_df_override {}, "

--- a/forge/csrc/passes/decompose_nd_reshape_split.cpp
+++ b/forge/csrc/passes/decompose_nd_reshape_split.cpp
@@ -174,7 +174,7 @@ void decompose_nd_reshape_split(graphlib::Graph *graph)
 
             auto op_type_ = op->op_type();
             TT_ASSERT(op_type_.type() == ops::OpType::Index);
-            int start = std::get<int>(op->op_type().attrs_[1]);
+            int start = std::get<int>(op->op_type().attr[1]);
 
             // Update index attributes to slice the original tensor directly.
             // NOTE: since the old op infrastructure is used we need to set both the vector of attributes and the named

--- a/forge/csrc/passes/decompose_nd_reshape_split.cpp
+++ b/forge/csrc/passes/decompose_nd_reshape_split.cpp
@@ -4,6 +4,7 @@
 #include <pybind11/pybind11.h>
 
 #include "graph_lib/utils.hpp"
+#include "ops/op.hpp"
 #include "passes/passes_utils.hpp"
 
 namespace tt::passes
@@ -172,8 +173,8 @@ void decompose_nd_reshape_split(graphlib::Graph *graph)
             auto op = dynamic_cast<graphlib::OpNode *>(consumers[i]);
 
             auto op_type_ = op->op_type();
-            TT_ASSERT(op_type_.op == "index");
-            int start = std::get<int>(op->op_type().attr[1]);
+            TT_ASSERT(op_type_.type() == ops::OpType::Index);
+            int start = std::get<int>(op->op_type().attrs_[1]);
 
             // Update index attributes to slice the original tensor directly.
             // NOTE: since the old op infrastructure is used we need to set both the vector of attributes and the named

--- a/forge/csrc/passes/decomposing_context.cpp
+++ b/forge/csrc/passes/decomposing_context.cpp
@@ -23,7 +23,7 @@ NodeContext DecomposingContext::op(
     bool optimize_hoist,
     DataFormat output_df)
 {
-    std::string suffix = ".dc." + op_type.op + "." + std::to_string(op_index);
+    std::string suffix = ".dc." + op_type.name() + "." + std::to_string(op_index);
 
     graphlib::PyOpNode *new_node = this->graph->add_node(
         graphlib::create_node<graphlib::PyOpNode>(this->node_->name() + suffix, op_type), subgraph_idx);

--- a/forge/csrc/passes/erase_consecutive_reshape.cpp
+++ b/forge/csrc/passes/erase_consecutive_reshape.cpp
@@ -137,8 +137,8 @@ static void commute_eltwise_ops(graphlib::Graph *graph, std::vector<graphlib::No
                 {
                     if (op_type.type() == ops::OpType::Broadcast)
                     {
-                        int bcast_dim = std::get<int>(op_type.attrs_[0]);
-                        int volume = std::get<int>(op_type.attrs_[1]);
+                        int bcast_dim = std::get<int>(op_type.attr[0]);
+                        int volume = std::get<int>(op_type.attr[1]);
                         if (bcast_dim < 0)
                             bcast_dim += commute_shape.size();
 

--- a/forge/csrc/passes/erase_consecutive_reshape.cpp
+++ b/forge/csrc/passes/erase_consecutive_reshape.cpp
@@ -7,6 +7,7 @@
 
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/utils.hpp"
+#include "ops/op.hpp"
 #include "passes/commute_utils.hpp"
 #include "passes/passes_utils.hpp"
 #include "utils/logger.hpp"
@@ -134,10 +135,10 @@ static void commute_eltwise_ops(graphlib::Graph *graph, std::vector<graphlib::No
 
                 for (graphlib::OpType &op_type : current_edge_tms)
                 {
-                    if (op_type.op == "broadcast")
+                    if (op_type.type() == ops::OpType::Broadcast)
                     {
-                        int bcast_dim = std::get<int>(op_type.attr[0]);
-                        int volume = std::get<int>(op_type.attr[1]);
+                        int bcast_dim = std::get<int>(op_type.attrs_[0]);
+                        int volume = std::get<int>(op_type.attrs_[1]);
                         if (bcast_dim < 0)
                             bcast_dim += commute_shape.size();
 

--- a/forge/csrc/passes/erase_inverse_ops.cpp
+++ b/forge/csrc/passes/erase_inverse_ops.cpp
@@ -91,7 +91,7 @@ bool has_broadcast_on_dim(graphlib::Graph *graph, graphlib::Edge edge, int neede
     {
         if (op_type.type() == ops::OpType::Broadcast)
         {
-            int dim = std::get<int>(op_type.attrs_[0]);
+            int dim = std::get<int>(op_type.attr[0]);
             if (dim == needed_dim)
             {
                 return true;
@@ -188,10 +188,10 @@ void commute_and_bypass(graphlib::Graph *graph, std::vector<graphlib::Node *> co
                         .second;
                 if (golden_transform.type() == ops::OpType::Reshape)
                 {
-                    for (std::size_t i = 0; i < golden_transform.attrs_.size(); i++)
+                    for (std::size_t i = 0; i < golden_transform.attr.size(); i++)
                     {
-                        int current_dim = std::get<int>(golden_transform.attrs_[i]);
-                        golden_transform.attrs_[i] = clone_bcasts[i] * current_dim;
+                        int current_dim = std::get<int>(golden_transform.attr[i]);
+                        golden_transform.attr[i] = clone_bcasts[i] * current_dim;
                     }
                 }
 
@@ -335,8 +335,8 @@ void commute_and_bypass(graphlib::Graph *graph, std::vector<graphlib::Node *> co
                 {
                     if (tm.type() == ops::OpType::Broadcast)
                     {
-                        int dim = std::get<int>(tm.attrs_[0]);
-                        int volume = std::get<int>(tm.attrs_[1]);
+                        int dim = std::get<int>(tm.attr[0]);
+                        int volume = std::get<int>(tm.attr[1]);
                         op_shape[dim] *= volume;
                     }
                 }

--- a/forge/csrc/passes/erase_inverse_ops.cpp
+++ b/forge/csrc/passes/erase_inverse_ops.cpp
@@ -7,6 +7,7 @@
 
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/utils.hpp"
+#include "ops/op.hpp"
 #include "passes/commute_utils.hpp"
 #include "passes/passes_utils.hpp"
 #include "reportify/reportify.hpp"
@@ -88,9 +89,9 @@ bool has_broadcast_on_dim(graphlib::Graph *graph, graphlib::Edge edge, int neede
     auto tms = graph->get_edge_attributes(edge)->get_tms();
     for (graphlib::OpType &op_type : tms)
     {
-        if (op_type.op == "broadcast")
+        if (op_type.type() == ops::OpType::Broadcast)
         {
-            int dim = std::get<int>(op_type.attr[0]);
+            int dim = std::get<int>(op_type.attrs_[0]);
             if (dim == needed_dim)
             {
                 return true;
@@ -185,12 +186,12 @@ void commute_and_bypass(graphlib::Graph *graph, std::vector<graphlib::Node *> co
                 auto [commute_bcasts, clone_bcasts] =
                     handle_shape_change_through_bcast(graph, first, producer_as_op, op, &commute_shape, &clone_shape)
                         .second;
-                if (golden_transform.op == "reshape")
+                if (golden_transform.type() == ops::OpType::Reshape)
                 {
-                    for (std::size_t i = 0; i < golden_transform.attr.size(); i++)
+                    for (std::size_t i = 0; i < golden_transform.attrs_.size(); i++)
                     {
-                        int current_dim = std::get<int>(golden_transform.attr[i]);
-                        golden_transform.attr[i] = clone_bcasts[i] * current_dim;
+                        int current_dim = std::get<int>(golden_transform.attrs_[i]);
+                        golden_transform.attrs_[i] = clone_bcasts[i] * current_dim;
                     }
                 }
 
@@ -332,10 +333,10 @@ void commute_and_bypass(graphlib::Graph *graph, std::vector<graphlib::Node *> co
 
                 for (graphlib::OpType &tm : tms)
                 {
-                    if (tm.op == "broadcast")
+                    if (tm.type() == ops::OpType::Broadcast)
                     {
-                        int dim = std::get<int>(tm.attr[0]);
-                        int volume = std::get<int>(tm.attr[1]);
+                        int dim = std::get<int>(tm.attrs_[0]);
+                        int volume = std::get<int>(tm.attrs_[1]);
                         op_shape[dim] *= volume;
                     }
                 }

--- a/forge/csrc/passes/extract_unique_op_configuration.cpp
+++ b/forge/csrc/passes/extract_unique_op_configuration.cpp
@@ -129,7 +129,7 @@ void print_unique_op_configuration(const UniqueOpShapesAttrsType &unique_op_shap
             {
                 for (size_t i = 0; i < op_attrs.size(); i++)
                 {
-                    if (op_attrs[i].attr.size() > 0 or op_attrs[i].named_attrs_.size() > 0)
+                    if (op_attrs[i].attr.size() > 0 or op_attrs[i].named_attrs.size() > 0)
                     {
                         std::cout << "\t\t\t\t\t Attributes: " << op_attrs[i].as_string() << std::endl;
                     }
@@ -189,7 +189,7 @@ void export_unique_op_configuration_to_csv_file(
                         fs << op_shapes[j] << ", ";
                     }
                     fs << "]" << delimiter;
-                    if (op_attrs[i].attr.size() > 0 or op_attrs[i].named_attrs_.size() > 0)
+                    if (op_attrs[i].attr.size() > 0 or op_attrs[i].named_attrs.size() > 0)
                     {
                         fs << op_attrs[i].as_string();
                     }
@@ -246,7 +246,7 @@ void export_unique_op_configuration_to_xlsx_file(
             {
                 for (graphlib::OpType attr : attrs)
                 {
-                    if (attr.attr.size() > 0 or attr.named_attrs_.size() > 0)
+                    if (attr.attr.size() > 0 or attr.named_attrs.size() > 0)
                         py_attrs.append(attr.as_string());
                 }
             }

--- a/forge/csrc/passes/extract_unique_op_configuration.cpp
+++ b/forge/csrc/passes/extract_unique_op_configuration.cpp
@@ -49,7 +49,7 @@ UniqueOpShapesAttrsType extract_unique_op_configuration(
         // otherwise it will extract all the unique op configurations in the graph
         if (!supported_opnames.empty())
         {
-            if (std::find(supported_opnames.begin(), supported_opnames.end(), current_node_optype.op) !=
+            if (std::find(supported_opnames.begin(), supported_opnames.end(), current_node_optype.name()) !=
                 supported_opnames.end())
                 continue;
         }
@@ -64,9 +64,9 @@ UniqueOpShapesAttrsType extract_unique_op_configuration(
         // If the op is present in the unique_op_shapes_attrs map, then list of operand shapes
         // of the matched op is compared with the current node operand shapes otherwise the
         // current node operand_shapes and attributes(i.e OpTypes) are added to the unique_op_shapes_attrs map.
-        if (unique_op_shapes_attrs.find(current_node_optype.op) != unique_op_shapes_attrs.end())
+        if (unique_op_shapes_attrs.find(current_node_optype.name()) != unique_op_shapes_attrs.end())
         {
-            auto unique_shapes_attrs_list = unique_op_shapes_attrs.at(current_node_optype.op);
+            auto unique_shapes_attrs_list = unique_op_shapes_attrs.at(current_node_optype.name());
             bool operand_shapes_matched = false;
             for (size_t idx = 0; idx < unique_shapes_attrs_list.size(); idx++)
             {
@@ -85,19 +85,19 @@ UniqueOpShapesAttrsType extract_unique_op_configuration(
                     if (std::find(unique_attrs.begin(), unique_attrs.end(), current_node_optype) == unique_attrs.end())
                     {
                         unique_attrs.push_back(current_node_optype);
-                        unique_op_shapes_attrs[current_node_optype.op].at(idx) = {unique_shapes, unique_attrs};
+                        unique_op_shapes_attrs[current_node_optype.name()].at(idx) = {unique_shapes, unique_attrs};
                         break;
                     }
                 }
             }
             if (!operand_shapes_matched)
             {
-                unique_op_shapes_attrs[current_node_optype.op].push_back({operand_shapes, {current_node_optype}});
+                unique_op_shapes_attrs[current_node_optype.name()].push_back({operand_shapes, {current_node_optype}});
             }
         }
         else
         {
-            unique_op_shapes_attrs[current_node_optype.op] = {{operand_shapes, {current_node_optype}}};
+            unique_op_shapes_attrs[current_node_optype.name()] = {{operand_shapes, {current_node_optype}}};
         }
     }
 
@@ -129,7 +129,7 @@ void print_unique_op_configuration(const UniqueOpShapesAttrsType &unique_op_shap
             {
                 for (size_t i = 0; i < op_attrs.size(); i++)
                 {
-                    if (op_attrs[i].attr.size() > 0 or op_attrs[i].named_attrs.size() > 0)
+                    if (op_attrs[i].attrs_.size() > 0 or op_attrs[i].named_attrs_.size() > 0)
                     {
                         std::cout << "\t\t\t\t\t Attributes: " << op_attrs[i].as_string() << std::endl;
                     }
@@ -189,7 +189,7 @@ void export_unique_op_configuration_to_csv_file(
                         fs << op_shapes[j] << ", ";
                     }
                     fs << "]" << delimiter;
-                    if (op_attrs[i].attr.size() > 0 or op_attrs[i].named_attrs.size() > 0)
+                    if (op_attrs[i].attrs_.size() > 0 or op_attrs[i].named_attrs_.size() > 0)
                     {
                         fs << op_attrs[i].as_string();
                     }
@@ -246,7 +246,7 @@ void export_unique_op_configuration_to_xlsx_file(
             {
                 for (graphlib::OpType attr : attrs)
                 {
-                    if (attr.attr.size() > 0 or attr.named_attrs.size() > 0)
+                    if (attr.attrs_.size() > 0 or attr.named_attrs_.size() > 0)
                         py_attrs.append(attr.as_string());
                 }
             }

--- a/forge/csrc/passes/extract_unique_op_configuration.cpp
+++ b/forge/csrc/passes/extract_unique_op_configuration.cpp
@@ -129,7 +129,7 @@ void print_unique_op_configuration(const UniqueOpShapesAttrsType &unique_op_shap
             {
                 for (size_t i = 0; i < op_attrs.size(); i++)
                 {
-                    if (op_attrs[i].attrs_.size() > 0 or op_attrs[i].named_attrs_.size() > 0)
+                    if (op_attrs[i].attr.size() > 0 or op_attrs[i].named_attrs_.size() > 0)
                     {
                         std::cout << "\t\t\t\t\t Attributes: " << op_attrs[i].as_string() << std::endl;
                     }
@@ -189,7 +189,7 @@ void export_unique_op_configuration_to_csv_file(
                         fs << op_shapes[j] << ", ";
                     }
                     fs << "]" << delimiter;
-                    if (op_attrs[i].attrs_.size() > 0 or op_attrs[i].named_attrs_.size() > 0)
+                    if (op_attrs[i].attr.size() > 0 or op_attrs[i].named_attrs_.size() > 0)
                     {
                         fs << op_attrs[i].as_string();
                     }
@@ -246,7 +246,7 @@ void export_unique_op_configuration_to_xlsx_file(
             {
                 for (graphlib::OpType attr : attrs)
                 {
-                    if (attr.attrs_.size() > 0 or attr.named_attrs_.size() > 0)
+                    if (attr.attr.size() > 0 or attr.named_attrs_.size() > 0)
                         py_attrs.append(attr.as_string());
                 }
             }

--- a/forge/csrc/passes/fracture.cpp
+++ b/forge/csrc/passes/fracture.cpp
@@ -6,6 +6,7 @@
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/query.hpp"
 #include "graph_lib/utils.hpp"
+#include "ops/op.hpp"
 #include "passes/nd_slice.hpp"
 #include "utils/assert.hpp"
 #include "utils/logger.hpp"
@@ -230,7 +231,7 @@ static std::unique_ptr<graphlib::PyOpNode> create_gather(
         (dim == NDSlice::k_dim) ? graphlib::OpType("add", {}, {}) : graphlib::OpType("concatenate", {dim}, {});
 
     graphlib::Shape shape = operand_shape;
-    if (gather_op.op == "concatenate")
+    if (gather_op.type() == ops::OpType::Concatenate)
     {
         shape[dim] *= factor;
     }

--- a/forge/csrc/passes/fuse_conv2d_bias.cpp
+++ b/forge/csrc/passes/fuse_conv2d_bias.cpp
@@ -22,7 +22,7 @@ static bool has_fusable_upstream_conv2d(graphlib::Graph *graph, graphlib::PyOpNo
     if (op == nullptr)
         return false;
 
-    if (op->op_type().type() != ops::OpType::Conv2d)
+    if (op->new_op_type() != ops::OpType::Conv2d)
         return false;
     // If conv2d has more outputs than just to bias, we can't merge
     if (graph->user_data_edges(op).size() > 1)
@@ -41,7 +41,7 @@ void fuse_conv2d_bias(graphlib::Graph *graph)
     {
         // Look for bias
         if ((node->node_type() != graphlib::kPyOp) ||
-            (node->as<graphlib::PyOpNode>()->op_type().type() != ops::OpType::Add))
+            (node->as<graphlib::PyOpNode>()->new_op_type() != ops::OpType::Add))
             continue;
 
         graphlib::PyOpNode *op = node->as<graphlib::PyOpNode>();

--- a/forge/csrc/passes/fuse_conv2d_bias.cpp
+++ b/forge/csrc/passes/fuse_conv2d_bias.cpp
@@ -10,6 +10,7 @@
 #include "graph_lib/node.hpp"
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/utils.hpp"
+#include "ops/op.hpp"
 #include "python_bindings_common.hpp"
 #include "utils/logger.hpp"
 
@@ -21,7 +22,7 @@ static bool has_fusable_upstream_conv2d(graphlib::Graph *graph, graphlib::PyOpNo
     if (op == nullptr)
         return false;
 
-    if (op->op_type().op != "conv2d")
+    if (op->op_type().type() != ops::OpType::Conv2d)
         return false;
     // If conv2d has more outputs than just to bias, we can't merge
     if (graph->user_data_edges(op).size() > 1)
@@ -39,7 +40,8 @@ void fuse_conv2d_bias(graphlib::Graph *graph)
     for (tt::graphlib::Node *node : graphlib::topological_sort(*graph))
     {
         // Look for bias
-        if ((node->node_type() != graphlib::kPyOp) || (node->as<graphlib::PyOpNode>()->op_type().op != "add"))
+        if ((node->node_type() != graphlib::kPyOp) ||
+            (node->as<graphlib::PyOpNode>()->op_type().type() != ops::OpType::Add))
             continue;
 
         graphlib::PyOpNode *op = node->as<graphlib::PyOpNode>();
@@ -53,7 +55,7 @@ void fuse_conv2d_bias(graphlib::Graph *graph)
         auto tms = graph->get_edge_attributes(graph->operand_data_edges(op)[1])->get_tms();
         bool broadcast = false;
         for (auto tm : tms)
-            if (tm.op == "broadcast")
+            if (tm.type() == ops::OpType::Broadcast)
             {
                 broadcast = true;
                 break;

--- a/forge/csrc/passes/fuse_redundant_tm_sequence.cpp
+++ b/forge/csrc/passes/fuse_redundant_tm_sequence.cpp
@@ -113,7 +113,7 @@ bool replace_pattern_with_new_pattern(
                     return false;
                 }
 
-                if (user->as<graphlib::OpNode>()->op_type().op != op_type.op)
+                if (user->as<graphlib::OpNode>()->op_type().type() != op_type.type())
                 {
                     // All users should be the same op
                     log_debug(

--- a/forge/csrc/passes/fuse_redundant_tm_sequence.cpp
+++ b/forge/csrc/passes/fuse_redundant_tm_sequence.cpp
@@ -113,7 +113,7 @@ bool replace_pattern_with_new_pattern(
                     return false;
                 }
 
-                if (user->as<graphlib::OpNode>()->op_type().type() != op_type.type())
+                if (user->as<graphlib::OpNode>()->new_op_type() != op_type.type())
                 {
                     // All users should be the same op
                     log_debug(

--- a/forge/csrc/passes/fuse_redundant_tm_sequence.hpp
+++ b/forge/csrc/passes/fuse_redundant_tm_sequence.hpp
@@ -6,7 +6,9 @@
 #include <string>
 #include <unordered_map>
 
+#include "ops/op.hpp"
 #include "passes/passes_utils.hpp"
+
 namespace tt::passes
 {
 using OpType = tt::graphlib::OpType;
@@ -16,11 +18,11 @@ struct OpTypeItem
     std::vector<OpType::Attr> attrs;
     bool check_attrs;
     OpTypeItem(OpType const& op_type, bool check_attrs) :
-        op_name(op_type.op),
+        op_name(op_type.name()),
         attrs(
-            op_type.op == "transpose"
+            op_type.type() == ops::OpType::Transpose
                 ? std::vector<OpType::Attr>({op_type.get_attr_as<int>("dim0"), op_type.get_attr_as<int>("dim1")})
-                : op_type.attr),
+                : op_type.attrs_),
         check_attrs(check_attrs)
     {
     }

--- a/forge/csrc/passes/fuse_redundant_tm_sequence.hpp
+++ b/forge/csrc/passes/fuse_redundant_tm_sequence.hpp
@@ -22,7 +22,7 @@ struct OpTypeItem
         attrs(
             op_type.type() == ops::OpType::Transpose
                 ? std::vector<OpType::Attr>({op_type.get_attr_as<int>("dim0"), op_type.get_attr_as<int>("dim1")})
-                : op_type.attrs_),
+                : op_type.attr),
         check_attrs(check_attrs)
     {
     }

--- a/forge/csrc/passes/generate_initial_flops_estimate.cpp
+++ b/forge/csrc/passes/generate_initial_flops_estimate.cpp
@@ -29,14 +29,15 @@ void generate_initial_flops_estimate(graphlib::Graph *graph)
 
         long flops = op->op_type().initial_flops_estimate(operand_tuples);
 
-        if (macs_per_op.find(op->op_type().op) == macs_per_op.end())
+        if (macs_per_op.find(op->op_type().name()) == macs_per_op.end())
         {
-            macs_per_op[op->op_type().op] = std::make_pair(flops, 1);
+            macs_per_op[op->op_type().name()] = std::make_pair(flops, 1);
         }
         else
         {
-            macs_per_op[op->op_type().op] = std::make_pair(
-                std::get<0>(macs_per_op[op->op_type().op]) + flops, std::get<1>(macs_per_op[op->op_type().op]) + 1);
+            macs_per_op[op->op_type().name()] = std::make_pair(
+                std::get<0>(macs_per_op[op->op_type().name()]) + flops,
+                std::get<1>(macs_per_op[op->op_type().name()]) + 1);
         }
         total_flops += flops;
         total_ops += 1;

--- a/forge/csrc/passes/hoist_transforms_to_inputs.cpp
+++ b/forge/csrc/passes/hoist_transforms_to_inputs.cpp
@@ -46,10 +46,10 @@ void hoist_transforms_to_inputs(tt::graphlib::Graph *graph)
         runtime_tensor_transform.original_shape = input->shape();
         runtime_tensor_transform.reinterpreted_shape = op_node->shape();
 
-        runtime_tensor_transform.stride_height = std::get<int>(op_type.attr[0]);
-        runtime_tensor_transform.stride_width = std::get<int>(op_type.attr[1]);
-        runtime_tensor_transform.kernel_height = std::get<int>(op_type.attr[2]);
-        runtime_tensor_transform.kernel_width = std::get<int>(op_type.attr[3]);
+        runtime_tensor_transform.stride_height = std::get<int>(op_type.attrs_[0]);
+        runtime_tensor_transform.stride_width = std::get<int>(op_type.attrs_[1]);
+        runtime_tensor_transform.kernel_height = std::get<int>(op_type.attrs_[2]);
+        runtime_tensor_transform.kernel_width = std::get<int>(op_type.attrs_[3]);
 
         input->set_runtime_tensor_transform(runtime_tensor_transform);
         input->set_shape(runtime_tensor_transform.reinterpreted_shape);

--- a/forge/csrc/passes/hoist_transforms_to_inputs.cpp
+++ b/forge/csrc/passes/hoist_transforms_to_inputs.cpp
@@ -46,10 +46,10 @@ void hoist_transforms_to_inputs(tt::graphlib::Graph *graph)
         runtime_tensor_transform.original_shape = input->shape();
         runtime_tensor_transform.reinterpreted_shape = op_node->shape();
 
-        runtime_tensor_transform.stride_height = std::get<int>(op_type.attrs_[0]);
-        runtime_tensor_transform.stride_width = std::get<int>(op_type.attrs_[1]);
-        runtime_tensor_transform.kernel_height = std::get<int>(op_type.attrs_[2]);
-        runtime_tensor_transform.kernel_width = std::get<int>(op_type.attrs_[3]);
+        runtime_tensor_transform.stride_height = std::get<int>(op_type.attr[0]);
+        runtime_tensor_transform.stride_width = std::get<int>(op_type.attr[1]);
+        runtime_tensor_transform.kernel_height = std::get<int>(op_type.attr[2]);
+        runtime_tensor_transform.kernel_width = std::get<int>(op_type.attr[3]);
 
         input->set_runtime_tensor_transform(runtime_tensor_transform);
         input->set_shape(runtime_tensor_transform.reinterpreted_shape);

--- a/forge/csrc/passes/link_past_cache_ios.cpp
+++ b/forge/csrc/passes/link_past_cache_ios.cpp
@@ -18,7 +18,7 @@ bool shape_compatible(graphlib::OpNode *output_producer, graphlib::Node *input_c
     auto c_shape = input_consumer->shape().canonical();
     if (output_producer->new_op_type() == ops::OpType::Concatenate)
     {
-        int dim = std::get<int>(output_producer->op_type().attrs_[0]);
+        int dim = std::get<int>(output_producer->op_type().attr[0]);
         c_shape[dim] = p_shape[dim];
     }
     return (p_shape == c_shape);
@@ -250,7 +250,7 @@ std::map<std::string, std::size_t> convert_inputs_to_params(
                 continue;
 
             // select out the last tile to stream to dram
-            slice_factor = (slice != nullptr) ? std::get<int>(slice->as<graphlib::OpNode>()->op_type().attrs_[0]) : 1;
+            slice_factor = (slice != nullptr) ? std::get<int>(slice->as<graphlib::OpNode>()->op_type().attr[0]) : 1;
 
             // if we're only producing a single tile, we don't need to select anything
             bool control_edge_needed = false;

--- a/forge/csrc/passes/link_past_cache_ios.cpp
+++ b/forge/csrc/passes/link_past_cache_ios.cpp
@@ -16,7 +16,7 @@ bool shape_compatible(graphlib::OpNode *output_producer, graphlib::Node *input_c
 {
     auto p_shape = output_producer->shape().canonical();
     auto c_shape = input_consumer->shape().canonical();
-    if (output_producer->op_type().type() == ops::OpType::Concatenate)
+    if (output_producer->new_op_type() == ops::OpType::Concatenate)
     {
         int dim = std::get<int>(output_producer->op_type().attrs_[0]);
         c_shape[dim] = p_shape[dim];
@@ -46,7 +46,7 @@ std::unordered_map<graphlib::Node *, graphlib::Node *> link_cache_outputs_to_par
         // get the parameter, if the producer is a transpose, we need to go one more back
         graphlib::Node *operand = graph->data_operands(producer_mm)[1];
         if (operand->node_type() == graphlib::NodeType::kPyOp and
-            operand->as<graphlib::OpNode>()->op_type().type() == ops::OpType::Transpose)
+            operand->as<graphlib::OpNode>()->new_op_type() == ops::OpType::Transpose)
         {
             operand = graph->data_operands(operand)[0];
         }
@@ -159,7 +159,7 @@ graphlib::Node *detect_inputs_to_convert(graphlib::Graph *graph, graphlib::Node 
 
     // 2.5 handle the case that output-producer is 'nop' first, since it does not have span tag
     // currently only accept input -> nop -> output pattern for pt1.x
-    if (output_producer->op_type().type() == ops::OpType::Nop)
+    if (output_producer->new_op_type() == ops::OpType::Nop)
     {
         if (producer_input_nodes.size() == 1 and graph->data_users(producer_input_nodes[0])[0] == output_producer)
         {
@@ -225,8 +225,8 @@ std::map<std::string, std::size_t> convert_inputs_to_params(
             continue;
 
         // handle slice-op in producer chain of concatenate op
-        bool output_all = (producers[0]->as<graphlib::OpNode>()->op_type().type() != ops::OpType::Nop);
-        bool is_concat = (producers[0]->as<graphlib::OpNode>()->op_type().type() == ops::OpType::Concatenate);
+        bool output_all = (producers[0]->as<graphlib::OpNode>()->new_op_type() != ops::OpType::Nop);
+        bool is_concat = (producers[0]->as<graphlib::OpNode>()->new_op_type() == ops::OpType::Concatenate);
         int slice_factor = 1;
         std::vector<graphlib::Edge> edges;
         if (is_concat)

--- a/forge/csrc/passes/link_past_cache_ios.cpp
+++ b/forge/csrc/passes/link_past_cache_ios.cpp
@@ -5,6 +5,7 @@
 
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/utils.hpp"
+#include "ops/op.hpp"
 #include "passes/passes_utils.hpp"
 #include "utils/logger.hpp"
 
@@ -15,9 +16,9 @@ bool shape_compatible(graphlib::OpNode *output_producer, graphlib::Node *input_c
 {
     auto p_shape = output_producer->shape().canonical();
     auto c_shape = input_consumer->shape().canonical();
-    if (output_producer->op_type().op == "concatenate")
+    if (output_producer->op_type().type() == ops::OpType::Concatenate)
     {
-        int dim = std::get<int>(output_producer->op_type().attr[0]);
+        int dim = std::get<int>(output_producer->op_type().attrs_[0]);
         c_shape[dim] = p_shape[dim];
     }
     return (p_shape == c_shape);
@@ -45,7 +46,7 @@ std::unordered_map<graphlib::Node *, graphlib::Node *> link_cache_outputs_to_par
         // get the parameter, if the producer is a transpose, we need to go one more back
         graphlib::Node *operand = graph->data_operands(producer_mm)[1];
         if (operand->node_type() == graphlib::NodeType::kPyOp and
-            operand->as<graphlib::OpNode>()->op_type().op == "transpose")
+            operand->as<graphlib::OpNode>()->op_type().type() == ops::OpType::Transpose)
         {
             operand = graph->data_operands(operand)[0];
         }
@@ -158,7 +159,7 @@ graphlib::Node *detect_inputs_to_convert(graphlib::Graph *graph, graphlib::Node 
 
     // 2.5 handle the case that output-producer is 'nop' first, since it does not have span tag
     // currently only accept input -> nop -> output pattern for pt1.x
-    if (output_producer->op_type().op == "nop")
+    if (output_producer->op_type().type() == ops::OpType::Nop)
     {
         if (producer_input_nodes.size() == 1 and graph->data_users(producer_input_nodes[0])[0] == output_producer)
         {
@@ -224,8 +225,8 @@ std::map<std::string, std::size_t> convert_inputs_to_params(
             continue;
 
         // handle slice-op in producer chain of concatenate op
-        bool output_all = (producers[0]->as<graphlib::OpNode>()->op_type().op != "nop");
-        bool is_concat = (producers[0]->as<graphlib::OpNode>()->op_type().op == "concatenate");
+        bool output_all = (producers[0]->as<graphlib::OpNode>()->op_type().type() != ops::OpType::Nop);
+        bool is_concat = (producers[0]->as<graphlib::OpNode>()->op_type().type() == ops::OpType::Concatenate);
         int slice_factor = 1;
         std::vector<graphlib::Edge> edges;
         if (is_concat)
@@ -249,7 +250,7 @@ std::map<std::string, std::size_t> convert_inputs_to_params(
                 continue;
 
             // select out the last tile to stream to dram
-            slice_factor = (slice != nullptr) ? std::get<int>(slice->as<graphlib::OpNode>()->op_type().attr[0]) : 1;
+            slice_factor = (slice != nullptr) ? std::get<int>(slice->as<graphlib::OpNode>()->op_type().attrs_[0]) : 1;
 
             // if we're only producing a single tile, we don't need to select anything
             bool control_edge_needed = false;

--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -521,7 +521,7 @@ class MLIRGenerator
 
         // Map forge to MLIR attributes for this operation.
         llvm::SmallVector<mlir::NamedAttribute> mlir_attributes;
-        for (const auto &[name, value] : op_node->op_type().named_attrs_)
+        for (const auto &[name, value] : op_node->op_type().named_attrs)
         {
             auto [mapped_name, target_type] = attr_mapper_.get_mapped_name_and_type(op_node->op_name(), name);
 
@@ -550,7 +550,7 @@ class MLIRGenerator
 
         // Map forge to MLIR attributes for this operation.
         llvm::SmallVector<mlir::NamedAttribute> mlir_attributes;
-        for (const auto &[name, value] : op_node->op_type().named_attrs_)
+        for (const auto &[name, value] : op_node->op_type().named_attrs)
         {
             auto [mapped_name, target_type] = attr_mapper_.get_mapped_name_and_type(op_node->op_name(), name);
 

--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -521,7 +521,7 @@ class MLIRGenerator
 
         // Map forge to MLIR attributes for this operation.
         llvm::SmallVector<mlir::NamedAttribute> mlir_attributes;
-        for (const auto &[name, value] : op_node->op_type().named_attrs)
+        for (const auto &[name, value] : op_node->op_type().named_attrs_)
         {
             auto [mapped_name, target_type] = attr_mapper_.get_mapped_name_and_type(op_node->op_name(), name);
 
@@ -550,7 +550,7 @@ class MLIRGenerator
 
         // Map forge to MLIR attributes for this operation.
         llvm::SmallVector<mlir::NamedAttribute> mlir_attributes;
-        for (const auto &[name, value] : op_node->op_type().named_attrs)
+        for (const auto &[name, value] : op_node->op_type().named_attrs_)
         {
             auto [mapped_name, target_type] = attr_mapper_.get_mapped_name_and_type(op_node->op_name(), name);
 

--- a/forge/csrc/passes/move_requantize.cpp
+++ b/forge/csrc/passes/move_requantize.cpp
@@ -9,6 +9,7 @@
 #include "graph_lib/node.hpp"
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/utils.hpp"
+#include "ops/op.hpp"
 #include "passes/commute_utils.hpp"
 #include "passes/passes_utils.hpp"
 #include "python_bindings_common.hpp"
@@ -98,12 +99,12 @@ void commute_through_requant(graphlib::Graph *graph, std::vector<graphlib::Node 
                 auto [commute_bcasts, clone_bcasts] =
                     handle_shape_change_through_bcast(graph, first, producer_as_op, op, &commute_shape, &clone_shape)
                         .second;
-                if (golden_transform.op == "reshape")
+                if (golden_transform.type() == ops::OpType::Reshape)
                 {
-                    for (std::size_t i = 0; i < golden_transform.attr.size(); i++)
+                    for (std::size_t i = 0; i < golden_transform.attrs_.size(); i++)
                     {
-                        int current_dim = std::get<int>(golden_transform.attr[i]);
-                        golden_transform.attr[i] = clone_bcasts[i] * current_dim;
+                        int current_dim = std::get<int>(golden_transform.attrs_[i]);
+                        golden_transform.attrs_[i] = clone_bcasts[i] * current_dim;
                     }
                 }
 

--- a/forge/csrc/passes/move_requantize.cpp
+++ b/forge/csrc/passes/move_requantize.cpp
@@ -101,10 +101,10 @@ void commute_through_requant(graphlib::Graph *graph, std::vector<graphlib::Node 
                         .second;
                 if (golden_transform.type() == ops::OpType::Reshape)
                 {
-                    for (std::size_t i = 0; i < golden_transform.attrs_.size(); i++)
+                    for (std::size_t i = 0; i < golden_transform.attr.size(); i++)
                     {
-                        int current_dim = std::get<int>(golden_transform.attrs_[i]);
-                        golden_transform.attrs_[i] = clone_bcasts[i] * current_dim;
+                        int current_dim = std::get<int>(golden_transform.attr[i]);
+                        golden_transform.attr[i] = clone_bcasts[i] * current_dim;
                     }
                 }
 

--- a/forge/csrc/passes/pad_output_buffer.cpp
+++ b/forge/csrc/passes/pad_output_buffer.cpp
@@ -5,6 +5,7 @@
 
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/utils.hpp"
+#include "ops/op.hpp"
 #include "passes/passes_utils.hpp"
 
 namespace tt::passes
@@ -84,12 +85,14 @@ void pad_output_buffer(graphlib::Graph *graph, const DeviceConfig &device_config
         bool padded_ct = false;
 
         // If un-squeeze and matmul are preceding the output, we need to pad the second matmul operand
-        if (graph->node_by_id(edges[0].producer_node_id)->as<graphlib::OpNode>()->op_type().op == "unsqueeze")
+        if (graph->node_by_id(edges[0].producer_node_id)->as<graphlib::OpNode>()->op_type().type() ==
+            ops::OpType::Unsqueeze)
         {
             edges = graph->operand_data_edges(graph->node_by_id(edges[0].producer_node_id));
             TT_ASSERT(edges.size() == 1);
         }
-        if (graph->node_by_id(edges[0].producer_node_id)->as<graphlib::OpNode>()->op_type().op == "matmul")
+        if (graph->node_by_id(edges[0].producer_node_id)->as<graphlib::OpNode>()->op_type().type() ==
+            ops::OpType::Matmul)
         {
             graphlib::Node *matmul = graph->node_by_id(edges[0].producer_node_id);
             edges = graph->operand_data_edges(matmul);
@@ -102,7 +105,7 @@ void pad_output_buffer(graphlib::Graph *graph, const DeviceConfig &device_config
                 {
                     padded_inputs.push_back(producer);
                 }
-                else if (producer->as<graphlib::OpNode>()->op_type().op == "transpose")
+                else if (producer->as<graphlib::OpNode>()->op_type().type() == ops::OpType::Transpose)
                 {
                     if (graph->data_operands(producer)[0]->node_type() == graphlib::NodeType::kInput)
                         padded_inputs.push_back(graph->data_operands(producer)[0]);

--- a/forge/csrc/passes/pad_output_buffer.cpp
+++ b/forge/csrc/passes/pad_output_buffer.cpp
@@ -85,14 +85,13 @@ void pad_output_buffer(graphlib::Graph *graph, const DeviceConfig &device_config
         bool padded_ct = false;
 
         // If un-squeeze and matmul are preceding the output, we need to pad the second matmul operand
-        if (graph->node_by_id(edges[0].producer_node_id)->as<graphlib::OpNode>()->op_type().type() ==
+        if (graph->node_by_id(edges[0].producer_node_id)->as<graphlib::OpNode>()->new_op_type() ==
             ops::OpType::Unsqueeze)
         {
             edges = graph->operand_data_edges(graph->node_by_id(edges[0].producer_node_id));
             TT_ASSERT(edges.size() == 1);
         }
-        if (graph->node_by_id(edges[0].producer_node_id)->as<graphlib::OpNode>()->op_type().type() ==
-            ops::OpType::Matmul)
+        if (graph->node_by_id(edges[0].producer_node_id)->as<graphlib::OpNode>()->new_op_type() == ops::OpType::Matmul)
         {
             graphlib::Node *matmul = graph->node_by_id(edges[0].producer_node_id);
             edges = graph->operand_data_edges(matmul);
@@ -105,7 +104,7 @@ void pad_output_buffer(graphlib::Graph *graph, const DeviceConfig &device_config
                 {
                     padded_inputs.push_back(producer);
                 }
-                else if (producer->as<graphlib::OpNode>()->op_type().type() == ops::OpType::Transpose)
+                else if (producer->as<graphlib::OpNode>()->new_op_type() == ops::OpType::Transpose)
                 {
                     if (graph->data_operands(producer)[0]->node_type() == graphlib::NodeType::kInput)
                         padded_inputs.push_back(graph->data_operands(producer)[0]);

--- a/forge/csrc/passes/pre_lowering_passes.cpp
+++ b/forge/csrc/passes/pre_lowering_passes.cpp
@@ -90,7 +90,7 @@ bool safe_to_hoist_past(const Graph *graph, const Node *operand)
     if (operand->node_type() != NodeType::kPyOp)
         return false;
 
-    const std::string &op_type = operand->as<graphlib::PyOpNode>()->op_type().op;
+    const std::string &op_type = operand->as<graphlib::PyOpNode>()->op_type().name();
 
     // Any unary op that doesn't change shape, and not transpose (which could keep the same shape)
     if (op_type == "transpose")

--- a/forge/csrc/passes/replace_incommutable_patterns.cpp
+++ b/forge/csrc/passes/replace_incommutable_patterns.cpp
@@ -34,10 +34,10 @@ static bool hoist_bcast_through_path(graphlib::Graph *graph, std::vector<graphli
     {
         if (op_type.type() == ops::OpType::Broadcast)
         {
-            int dim = std::get<int>(op_type.attrs_[0]);
+            int dim = std::get<int>(op_type.attr[0]);
             if (dim == bcast_dim)
             {
-                bcast_volume = std::get<int>(op_type.attrs_[1]);
+                bcast_volume = std::get<int>(op_type.attr[1]);
 
                 // Just incase, remove both
                 graph->get_edge_attributes(last_user_edge)->remove_broadcast_dim(bcast_dim);
@@ -116,9 +116,9 @@ static bool is_incommutable_reduce_avg_reduce_avg_bcast_on_incommutable_dim(
             {
                 if (op_type.type() == ops::OpType::Broadcast)
                 {
-                    int bcast_dim = std::get<int>(op_type.attrs_[0]);
+                    int bcast_dim = std::get<int>(op_type.attr[0]);
                     contains_y_bcast |=
-                        bcast_dim == reduce_dim and std::get<int>(op_type.attrs_[1]) == (int)clone_shape[reduce_dim];
+                        bcast_dim == reduce_dim and std::get<int>(op_type.attr[1]) == (int)clone_shape[reduce_dim];
                 }
             }
             if (contains_y_bcast)
@@ -236,8 +236,8 @@ static bool attempt_replace_downward_pattern(
             {
                 if (op_type.type() == ops::OpType::Broadcast)
                 {
-                    int bcast_dim = std::get<int>(op_type.attrs_[0]);
-                    int volume = std::get<int>(op_type.attrs_[1]);
+                    int bcast_dim = std::get<int>(op_type.attr[0]);
+                    int volume = std::get<int>(op_type.attr[1]);
                     if (bcast_dim == reduce_dim)
                     {
                         continue;

--- a/forge/csrc/reportify/reportify.cpp
+++ b/forge/csrc/reportify/reportify.cpp
@@ -178,7 +178,7 @@ json node_to_json(const graphlib::Node* node, const graphlib::Graph* graph)
         const graphlib::PyOpNode* opnode = node->as<graphlib::PyOpNode>();
         ret_json["ir"] = "forge";
         ret_json["class"] = opnode->op_type().as_string();
-        ret_json["type"] = opnode->op_type().op;
+        ret_json["type"] = opnode->op_type().name();
         to_json(ret_json, opnode->op_type());
         ret_json["gradient_op"] = opnode->is_gradient_op();
     }

--- a/forge/csrc/reportify/to_json.cpp
+++ b/forge/csrc/reportify/to_json.cpp
@@ -22,9 +22,9 @@ void to_json(json& j, UBlockOrder const& ublock_order)
 void to_json(json& j, OpType const& op_type)
 {
     j["op_type"] = {};
-    j["op_type"]["type"] = op_type.op;
-    j["op_type"]["attrs"] = op_type.attr;
-    j["op_type"]["named_attrs"] = op_type.named_attrs;
+    j["op_type"]["type"] = op_type.name();
+    j["op_type"]["attrs"] = op_type.attrs_;
+    j["op_type"]["named_attrs"] = op_type.named_attrs_;
 }
 
 void to_json(json& j, EdgeAttributes const& attrs)

--- a/forge/csrc/reportify/to_json.cpp
+++ b/forge/csrc/reportify/to_json.cpp
@@ -24,7 +24,7 @@ void to_json(json& j, OpType const& op_type)
     j["op_type"] = {};
     j["op_type"]["type"] = op_type.name();
     j["op_type"]["attrs"] = op_type.attr;
-    j["op_type"]["named_attrs"] = op_type.named_attrs_;
+    j["op_type"]["named_attrs"] = op_type.named_attrs;
 }
 
 void to_json(json& j, EdgeAttributes const& attrs)

--- a/forge/csrc/reportify/to_json.cpp
+++ b/forge/csrc/reportify/to_json.cpp
@@ -23,7 +23,7 @@ void to_json(json& j, OpType const& op_type)
 {
     j["op_type"] = {};
     j["op_type"]["type"] = op_type.name();
-    j["op_type"]["attrs"] = op_type.attrs_;
+    j["op_type"]["attrs"] = op_type.attr;
     j["op_type"]["named_attrs"] = op_type.named_attrs_;
 }
 

--- a/forge/csrc/test/common.hpp
+++ b/forge/csrc/test/common.hpp
@@ -109,7 +109,7 @@ class GraphTest : public ::testing::Test
     OpType* create_op(
         std::string const& name, graphlib::OpType const& op_type, std::vector<graphlib::Node*> const& operands)
     {
-        return tt::add_node<OpType>(*graph, name, op_type.name(), op_type.attr, operands, {}, {}, op_type.named_attrs_);
+        return tt::add_node<OpType>(*graph, name, op_type.name(), op_type.attr, operands, {}, {}, op_type.named_attrs);
     }
 
     OpType* create_op(graphlib::OpType const& op_type, std::vector<graphlib::Node*> const& operands)

--- a/forge/csrc/test/common.hpp
+++ b/forge/csrc/test/common.hpp
@@ -109,8 +109,7 @@ class GraphTest : public ::testing::Test
     OpType* create_op(
         std::string const& name, graphlib::OpType const& op_type, std::vector<graphlib::Node*> const& operands)
     {
-        return tt::add_node<OpType>(
-            *graph, name, op_type.name(), op_type.attrs_, operands, {}, {}, op_type.named_attrs_);
+        return tt::add_node<OpType>(*graph, name, op_type.name(), op_type.attr, operands, {}, {}, op_type.named_attrs_);
     }
 
     OpType* create_op(graphlib::OpType const& op_type, std::vector<graphlib::Node*> const& operands)

--- a/forge/csrc/test/common.hpp
+++ b/forge/csrc/test/common.hpp
@@ -109,12 +109,13 @@ class GraphTest : public ::testing::Test
     OpType* create_op(
         std::string const& name, graphlib::OpType const& op_type, std::vector<graphlib::Node*> const& operands)
     {
-        return tt::add_node<OpType>(*graph, name, op_type.op, op_type.attr, operands, {}, {}, op_type.named_attrs);
+        return tt::add_node<OpType>(
+            *graph, name, op_type.name(), op_type.attrs_, operands, {}, {}, op_type.named_attrs_);
     }
 
     OpType* create_op(graphlib::OpType const& op_type, std::vector<graphlib::Node*> const& operands)
     {
-        auto name = op_type.op + std::to_string(op_name_id[op_type.op]++);
+        auto name = op_type.name() + std::to_string(op_name_id[op_type.name()]++);
         return create_op(name, op_type, operands);
     }
 

--- a/forge/csrc/test/passes/test_erase_inverse_ops.cpp
+++ b/forge/csrc/test/passes/test_erase_inverse_ops.cpp
@@ -277,8 +277,8 @@ TEST_F(CommuteBroadcastThroughTranspose, commute_broadcast_through_transpose)
     EXPECT_EQ(tms[1].type(), ops::OpType::Broadcast);
     // Broadcast along dimension -2 should become broadcast along -3
     // after commuting through transpose.
-    EXPECT_EQ(std::get<int>(tms[1].attrs_[0]), -3);
-    EXPECT_EQ(std::get<int>(tms[1].attrs_[1]), 112);
+    EXPECT_EQ(std::get<int>(tms[1].attr[0]), -3);
+    EXPECT_EQ(std::get<int>(tms[1].attr[1]), 112);
 }
 
 struct UpdateReshapeNamedAttrsTest : testing::Test

--- a/forge/csrc/test/passes/test_erase_inverse_ops.cpp
+++ b/forge/csrc/test/passes/test_erase_inverse_ops.cpp
@@ -55,7 +55,7 @@ TEST_F(EraseInverseOps, erase_transpose)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Transpose);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->new_op_type(), ops::OpType::Transpose);
         }
     }
     EXPECT_EQ(graph->nodes().size(), 8);
@@ -90,7 +90,7 @@ TEST_F(EraseInverseOps, erase_transpose_fork)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            if (node->as<graphlib::PyOpNode>()->op_type().type() == ops::OpType::Transpose)
+            if (node->as<graphlib::PyOpNode>()->new_op_type() == ops::OpType::Transpose)
                 transpose_count++;
         }
     }
@@ -137,7 +137,7 @@ TEST_F(EraseInverseOps, erase_inverse_ops_transpose_fork_join)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            if (node->as<graphlib::PyOpNode>()->op_type().type() == ops::OpType::Transpose)
+            if (node->as<graphlib::PyOpNode>()->new_op_type() == ops::OpType::Transpose)
                 transpose_count++;
         }
     }
@@ -185,11 +185,11 @@ TEST_F(EraseInverseOps, erase_inverse_ops_dual_reduce)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            if (node->as<graphlib::PyOpNode>()->op_type().type() == ops::OpType::Transpose)
+            if (node->as<graphlib::PyOpNode>()->new_op_type() == ops::OpType::Transpose)
                 transpose_count++;
-            else if (node->as<graphlib::PyOpNode>()->op_type().type() == ops::OpType::ReduceSum)
+            else if (node->as<graphlib::PyOpNode>()->new_op_type() == ops::OpType::ReduceSum)
                 reduce_count++;
-            else if (node->as<graphlib::PyOpNode>()->op_type().type() == ops::OpType::Reshape)
+            else if (node->as<graphlib::PyOpNode>()->new_op_type() == ops::OpType::Reshape)
                 reshape_count++;
         }
     }
@@ -221,7 +221,7 @@ TEST_F(EraseInverseOps, replace_x_y_change_concat_pattern)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            if (node->as<graphlib::PyOpNode>()->op_type().type() == ops::OpType::Reshape)
+            if (node->as<graphlib::PyOpNode>()->new_op_type() == ops::OpType::Reshape)
                 reshape_count++;
         }
     }

--- a/forge/csrc/test/passes/test_erase_inverse_ops.cpp
+++ b/forge/csrc/test/passes/test_erase_inverse_ops.cpp
@@ -310,7 +310,7 @@ TEST_F(UpdateReshapeNamedAttrsTest, update_named_attrs)
     op_node_reshape->set_shape(new_shape);
     passes::update_reshape_attr(op_node_reshape, new_shape);
 
-    auto updated_attrs = op_node_reshape->op_type().named_attrs_;
+    auto updated_attrs = op_node_reshape->op_type().named_attrs;
     EXPECT_TRUE(updated_attrs.count("shape")) << "Shape attribute not found.";
     auto shape_vector = std::get<std::vector<int>>(updated_attrs["shape"]);
 

--- a/forge/csrc/test/passes/test_erase_unnecessary_4d_tm_sequence.cpp
+++ b/forge/csrc/test/passes/test_erase_unnecessary_4d_tm_sequence.cpp
@@ -46,8 +46,8 @@ TEST_F(EraseUnnecessary4DSeqTwoOps, two_operands)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Reshape);
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Transpose);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->new_op_type(), ops::OpType::Reshape);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->new_op_type(), ops::OpType::Transpose);
         }
     }
     EXPECT_EQ(graph->nodes().size(), 5);
@@ -63,8 +63,8 @@ TEST_F(EraseUnnecessary4DSeqThreeOps, three_operands)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Reshape);
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Transpose);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->new_op_type(), ops::OpType::Reshape);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->new_op_type(), ops::OpType::Transpose);
         }
     }
     EXPECT_EQ(graph->nodes().size(), 6);
@@ -84,8 +84,8 @@ TEST_F(EraseUnnecessary4DSeqTwoOps, na1)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Select);
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Interleave);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->new_op_type(), ops::OpType::Select);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->new_op_type(), ops::OpType::Interleave);
         }
     }
     EXPECT_EQ(graph->nodes().size(), 6);
@@ -106,8 +106,8 @@ TEST_F(EraseUnnecessary4DSeqTwoOps, na2)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Select);
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Interleave);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->new_op_type(), ops::OpType::Select);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->new_op_type(), ops::OpType::Interleave);
         }
     }
     EXPECT_EQ(graph->nodes().size(), 7);

--- a/forge/csrc/test/passes/test_erase_unnecessary_4d_tm_sequence.cpp
+++ b/forge/csrc/test/passes/test_erase_unnecessary_4d_tm_sequence.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include "gtest/gtest.h"
+#include "ops/op.hpp"
 #include "passes/erase_unnecessary_4d_tm_sequence.hpp"
 #include "test/graph_api.hpp"
 
@@ -45,8 +46,8 @@ TEST_F(EraseUnnecessary4DSeqTwoOps, two_operands)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().op, "reshape");
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().op, "transpose");
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Reshape);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Transpose);
         }
     }
     EXPECT_EQ(graph->nodes().size(), 5);
@@ -62,8 +63,8 @@ TEST_F(EraseUnnecessary4DSeqThreeOps, three_operands)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().op, "reshape");
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().op, "transpose");
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Reshape);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Transpose);
         }
     }
     EXPECT_EQ(graph->nodes().size(), 6);
@@ -83,8 +84,8 @@ TEST_F(EraseUnnecessary4DSeqTwoOps, na1)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().op, "select");
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().op, "interleave");
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Select);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Interleave);
         }
     }
     EXPECT_EQ(graph->nodes().size(), 6);
@@ -105,8 +106,8 @@ TEST_F(EraseUnnecessary4DSeqTwoOps, na2)
     {
         if (node->node_type() == tt::graphlib::kPyOp)
         {
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().op, "select");
-            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().op, "interleave");
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Select);
+            EXPECT_NE(node->as<graphlib::PyOpNode>()->op_type().type(), ops::OpType::Interleave);
         }
     }
     EXPECT_EQ(graph->nodes().size(), 7);

--- a/forge/csrc/test/passes/test_link_past_cache_ios.cpp
+++ b/forge/csrc/test/passes/test_link_past_cache_ios.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <stdlib.h>
 
+#include "ops/op.hpp"
 #include "passes/link_past_cache_ios.hpp"
 #include "test/common.hpp"
 
@@ -93,7 +94,8 @@ TEST_F(WhisperPastCacheBase, whisper_past_cache_base)
     auto cache_users = graph->user_edges(cache);
     EXPECT_EQ(cache_users.size(), 2);
     for (auto user : cache_users)
-        EXPECT_EQ(graph->node_by_id(user.consumer_node_id)->as<graphlib::OpNode>()->op_type().op, "hslice");
+        EXPECT_EQ(
+            graph->node_by_id(user.consumer_node_id)->as<graphlib::OpNode>()->op_type().type(), ops::OpType::Hslice);
 }
 
 // test past-cache pass of Whisper models (V2)
@@ -182,7 +184,8 @@ TEST_F(WhisperPastCacheSubGraph, whisper_past_cache_subgraph)
     auto cache = graph->node_by_id(graph->user_edges(output_nodes[0])[0].consumer_node_id);
     auto cache_users = graph->user_edges(cache);
     EXPECT_EQ(cache_users.size(), 1);
-    EXPECT_EQ(graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->op_type().op, "nop");
+    EXPECT_EQ(
+        graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->op_type().type(), ops::OpType::Nop);
 }
 
 // test past-cache with rotate of T5 models
@@ -284,18 +287,22 @@ TEST_F(T5PastCacheRotate, t5_past_cache_rotate)
     auto cache = graph->node_by_id(graph->user_edges(output_nodes[0])[0].consumer_node_id);
     auto cache_users = graph->user_edges(cache);
     EXPECT_EQ(cache_users.size(), 4);
-    EXPECT_EQ(graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->op_type().op, "hslice");
-    EXPECT_EQ(graph->node_by_id(cache_users[1].consumer_node_id)->as<graphlib::OpNode>()->op_type().op, "hslice");
+    EXPECT_EQ(
+        graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->op_type().type(),
+        ops::OpType::Hslice);
+    EXPECT_EQ(
+        graph->node_by_id(cache_users[1].consumer_node_id)->as<graphlib::OpNode>()->op_type().type(),
+        ops::OpType::Hslice);
 
     // check the node connection in rotated parts
     auto left_sel = graph->node_by_id(cache_users[2].consumer_node_id);
     auto right_sel = graph->node_by_id(cache_users[3].consumer_node_id);
-    EXPECT_EQ(left_sel->as<graphlib::OpNode>()->op_type().op, "index");
-    EXPECT_EQ(right_sel->as<graphlib::OpNode>()->op_type().op, "index");
+    EXPECT_EQ(left_sel->as<graphlib::OpNode>()->op_type().type(), ops::OpType::Index);
+    EXPECT_EQ(right_sel->as<graphlib::OpNode>()->op_type().type(), ops::OpType::Index);
     EXPECT_EQ(single_user_operand(graph, left_sel), true);
     EXPECT_EQ(single_user_operand(graph, right_sel), true);
     auto rotate_concat_op = graph->data_users(left_sel)[0];
-    EXPECT_EQ(rotate_concat_op->as<graphlib::OpNode>()->op_type().op, "concatenate");
+    EXPECT_EQ(rotate_concat_op->as<graphlib::OpNode>()->op_type().type(), ops::OpType::Concatenate);
     EXPECT_EQ(single_user_operand(graph, graph->data_users(rotate_concat_op)[0]), true);
     EXPECT_EQ(graph->data_users(graph->data_users(rotate_concat_op)[0])[0], output_nodes[2]);
 }
@@ -408,8 +415,12 @@ TEST_F(Falcon40bPastCache, falcon40b_past_cache)
     auto cache = graph->node_by_id(graph->user_edges(output_nodes[0])[0].consumer_node_id);
     auto cache_users = graph->user_edges(cache);
     EXPECT_EQ(cache_users.size(), 2);
-    EXPECT_EQ(graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->op_type().op, "multiply");
-    EXPECT_EQ(graph->node_by_id(cache_users[1].consumer_node_id)->as<graphlib::OpNode>()->op_type().op, "reshape");
+    EXPECT_EQ(
+        graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->op_type().type(),
+        ops::OpType::Multiply);
+    EXPECT_EQ(
+        graph->node_by_id(cache_users[1].consumer_node_id)->as<graphlib::OpNode>()->op_type().type(),
+        ops::OpType::Reshape);
 }
 
 // test past-cache pass of Fuyu-8b
@@ -498,7 +509,9 @@ TEST_F(Fuyu8bPastCache, fuyu8b_past_cache)
     auto cache = graph->node_by_id(graph->user_edges(output_nodes[0])[0].consumer_node_id);
     auto cache_users = graph->user_edges(cache);
     EXPECT_EQ(cache_users.size(), 1);
-    EXPECT_EQ(graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->op_type().op, "hslice");
+    EXPECT_EQ(
+        graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->op_type().type(),
+        ops::OpType::Hslice);
 }
 
 }  // namespace tt::test

--- a/forge/csrc/test/passes/test_link_past_cache_ios.cpp
+++ b/forge/csrc/test/passes/test_link_past_cache_ios.cpp
@@ -94,8 +94,7 @@ TEST_F(WhisperPastCacheBase, whisper_past_cache_base)
     auto cache_users = graph->user_edges(cache);
     EXPECT_EQ(cache_users.size(), 2);
     for (auto user : cache_users)
-        EXPECT_EQ(
-            graph->node_by_id(user.consumer_node_id)->as<graphlib::OpNode>()->op_type().type(), ops::OpType::Hslice);
+        EXPECT_EQ(graph->node_by_id(user.consumer_node_id)->as<graphlib::OpNode>()->new_op_type(), ops::OpType::Hslice);
 }
 
 // test past-cache pass of Whisper models (V2)
@@ -185,7 +184,7 @@ TEST_F(WhisperPastCacheSubGraph, whisper_past_cache_subgraph)
     auto cache_users = graph->user_edges(cache);
     EXPECT_EQ(cache_users.size(), 1);
     EXPECT_EQ(
-        graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->op_type().type(), ops::OpType::Nop);
+        graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->new_op_type(), ops::OpType::Nop);
 }
 
 // test past-cache with rotate of T5 models
@@ -288,21 +287,19 @@ TEST_F(T5PastCacheRotate, t5_past_cache_rotate)
     auto cache_users = graph->user_edges(cache);
     EXPECT_EQ(cache_users.size(), 4);
     EXPECT_EQ(
-        graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->op_type().type(),
-        ops::OpType::Hslice);
+        graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->new_op_type(), ops::OpType::Hslice);
     EXPECT_EQ(
-        graph->node_by_id(cache_users[1].consumer_node_id)->as<graphlib::OpNode>()->op_type().type(),
-        ops::OpType::Hslice);
+        graph->node_by_id(cache_users[1].consumer_node_id)->as<graphlib::OpNode>()->new_op_type(), ops::OpType::Hslice);
 
     // check the node connection in rotated parts
     auto left_sel = graph->node_by_id(cache_users[2].consumer_node_id);
     auto right_sel = graph->node_by_id(cache_users[3].consumer_node_id);
-    EXPECT_EQ(left_sel->as<graphlib::OpNode>()->op_type().type(), ops::OpType::Index);
-    EXPECT_EQ(right_sel->as<graphlib::OpNode>()->op_type().type(), ops::OpType::Index);
+    EXPECT_EQ(left_sel->as<graphlib::OpNode>()->new_op_type(), ops::OpType::Index);
+    EXPECT_EQ(right_sel->as<graphlib::OpNode>()->new_op_type(), ops::OpType::Index);
     EXPECT_EQ(single_user_operand(graph, left_sel), true);
     EXPECT_EQ(single_user_operand(graph, right_sel), true);
     auto rotate_concat_op = graph->data_users(left_sel)[0];
-    EXPECT_EQ(rotate_concat_op->as<graphlib::OpNode>()->op_type().type(), ops::OpType::Concatenate);
+    EXPECT_EQ(rotate_concat_op->as<graphlib::OpNode>()->new_op_type(), ops::OpType::Concatenate);
     EXPECT_EQ(single_user_operand(graph, graph->data_users(rotate_concat_op)[0]), true);
     EXPECT_EQ(graph->data_users(graph->data_users(rotate_concat_op)[0])[0], output_nodes[2]);
 }
@@ -416,10 +413,10 @@ TEST_F(Falcon40bPastCache, falcon40b_past_cache)
     auto cache_users = graph->user_edges(cache);
     EXPECT_EQ(cache_users.size(), 2);
     EXPECT_EQ(
-        graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->op_type().type(),
+        graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->new_op_type(),
         ops::OpType::Multiply);
     EXPECT_EQ(
-        graph->node_by_id(cache_users[1].consumer_node_id)->as<graphlib::OpNode>()->op_type().type(),
+        graph->node_by_id(cache_users[1].consumer_node_id)->as<graphlib::OpNode>()->new_op_type(),
         ops::OpType::Reshape);
 }
 
@@ -510,8 +507,7 @@ TEST_F(Fuyu8bPastCache, fuyu8b_past_cache)
     auto cache_users = graph->user_edges(cache);
     EXPECT_EQ(cache_users.size(), 1);
     EXPECT_EQ(
-        graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->op_type().type(),
-        ops::OpType::Hslice);
+        graph->node_by_id(cache_users[0].consumer_node_id)->as<graphlib::OpNode>()->new_op_type(), ops::OpType::Hslice);
 }
 
 }  // namespace tt::test


### PR DESCRIPTION
In order to determine op type, we were comparing strings. Since op type enum is introduced, this change replaces string comparisons with op type comparisons.

This change is part of ops migration from python to cpp code.
For details check out: https://github.com/tenstorrent/tt-forge-fe/issues/2378
