### PR TITLE
[test] fix failing unit test in release mode

### DIFF
--- a/forge/csrc/passes/commute_utils.cpp
+++ b/forge/csrc/passes/commute_utils.cpp
@@ -928,13 +928,19 @@ void update_select_attr(
     select_op->set_op_attr("select_dim", select_dim);
 
     if (begin.has_value())
+    {
         select_op->set_op_attr("begin", begin.value());
+    }
 
     if (length.has_value())
-        select_op->set_op_attr("lenght", length.value());
+    {
+        select_op->set_op_attr("length", length.value());
+    }
 
     if (stride.has_value())
+    {
         select_op->set_op_attr("stride", stride.value());
+    }
 
     log_trace(
         LogGraphCompiler,
@@ -942,7 +948,7 @@ void update_select_attr(
         select_op->name(),
         select_dim,
         begin.value_or(std::get<int>(select_op->op_attr("begin"))),
-        length.value_or(std::get<int>(select_op->op_attr("lenght"))),
+        length.value_or(std::get<int>(select_op->op_attr("length"))),
         stride.value_or(std::get<int>(select_op->op_attr("stride"))));
 }
 

--- a/forge/csrc/test/passes/test_erase_inverse_ops.cpp
+++ b/forge/csrc/test/passes/test_erase_inverse_ops.cpp
@@ -336,9 +336,13 @@ struct UpdateSelectNamedAttrsTest : testing::Test
         graph = new graphlib::Graph(graphlib::IRLevel::IR_TT_FORGE, "UpdateSelectNamedAttrs");
 
         graphlib::Shape initial_shape = graphlib::Shape::create({1, 512, 160});
-        tt::graphlib::InputNode *input_node = create_input(*graph, "input", initial_shape);
+        graphlib::InputNode *input_node = create_input(*graph, "input", initial_shape);
         auto select_node =
             add_node<graphlib::PyOpNode>(*graph, "select", "select", {dim, begin, length, stride}, {input_node});
+        select_node->set_op_attr("select_dim", dim);
+        select_node->set_op_attr("begin", begin);
+        select_node->set_op_attr("length", length);
+        select_node->set_op_attr("stride", stride);
 
         create_output(*graph, "out", select_node);
     }


### PR DESCRIPTION
The `UpdateSelectNamedAttrsTest` test is failing due to the `select` op's named attributes not being set in the test.

The failure occurs when the function `update_select_attr` calls `log_trace` function and its arguments are evaluated, i.e. `select_op->op_attr("begin")`. Since the test doesn't set this attribute, this fails.

This only happens on `Release` builds, not sure why...