### PR TITLE
Run perf benchmark optionally on PR

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -66,7 +66,7 @@ jobs:
       runs-on: '[{"runs-on": "n150"}, {"runs-on": "n300"}]'
 
   perf-benchmark:
-    if: inputs.run_perf_benchmark == 'true'
+    if: inputs.run_perf_benchmark
     needs:
       - docker-build
       - build

--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -7,6 +7,10 @@ on:
         description: 'Git SHA of commit in tenstorrent/tt-mlir'
         required: false
         type: string
+      run_perf_benchmark:
+        description: 'Run performance benchmark'
+        required: false
+        type: boolean
   pull_request:
     branches: [ "main" ]
 
@@ -61,6 +65,17 @@ jobs:
       run_id: ${{ github.run_id }}
       runs-on: '[{"runs-on": "n150"}, {"runs-on": "n300"}]'
 
+  perf-benchmark:
+    if: inputs.run_perf_benchmark == 'true'
+    needs:
+      - docker-build
+      - build
+    uses: ./.github/workflows/perf-benchmark-sub.yml
+    secrets: inherit
+    with:
+      docker-image: ${{ needs.docker-build.outputs.docker-image }}
+      run_id: ${{ needs.build.outputs.run_id }}
+
   check-all-green:
     if: always()
     needs:
@@ -70,9 +85,11 @@ jobs:
       - build-docs
       - build
       - test
+      - perf-benchmark
     runs-on: Ubuntu-latest
     steps:
     - name: Check if the needed jobs succeeded or failed
       uses: re-actors/alls-green@release/v1
       with:
         jobs: ${{ toJSON(needs) }}
+        allowed-skips: perf-benchmark

--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -8,6 +8,10 @@ on:
         required: false
         default: false
         type: boolean
+      mlir_override:
+        description: 'Git SHA of commit in tenstorrent/tt-mlir'
+        required: false
+        type: string
 
 permissions:
   packages: write
@@ -17,6 +21,8 @@ jobs:
   docker-build:
     uses: ./.github/workflows/build-image.yml
     secrets: inherit
+    with:
+      mlir_override: ${{ inputs.mlir_override }}
 
   set-inputs:
     runs-on: ubuntu-latest
@@ -42,6 +48,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
+      mlir_override: ${{ inputs.mlir_override }}
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
       build: ${{ needs.set-inputs.outputs.buildtype}}
 


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge-fe/pull/2433#issuecomment-3036834994

### Problem description
Need possibility to optionally trigger perf benchmark tests using the same build with same tt_mlir override passed to the onPR.
Could tt_mlir override be added to perf benchmark tests workflow?

### What's changed
mlir_override added to perf benchmark test workflow.
Added optional trigger for perf benchmarks for onPR.

### Checklist
OnPR run with perf benchmark enabled:
https://github.com/tenstorrent/tt-forge-fe/actions/runs/16116190846

This PR with perf benchmark not enabled (skipped)

- [ ] New/Existing tests provide coverage for changes
