### PR TITLE
segfault issue in yolo v3,5,8,9,10

### DIFF
--- a/forge/test/models/pytorch/vision/yolo/model_utils/yolo_utils.py
+++ b/forge/test/models/pytorch/vision/yolo/model_utils/yolo_utils.py
@@ -6,7 +6,21 @@ import torch
 from datasets import load_dataset
 from torchvision import transforms
 from ultralytics.nn.tasks import DetectionModel
+from ultralytics.nn.modules.head import Detect
+from pathlib import Path
+import requests
+import yaml
+import yolov5
+import cv2
+import numpy as np
+from PIL import Image
+from yolov5.models.common import Detections
+from yolov5.utils.dataloaders import exif_transpose, letterbox
+from yolov5.utils.general import Profile, non_max_suppression, scale_boxes
+from test.utils import fetch_model, yolov5_loader
+from third_party.tt_forge_models.tools.utils import get_file
 
+base_url = "https://github.com/ultralytics/yolov5/releases/download/v7.0"
 
 class YoloWrapper(torch.nn.Module):
     def __init__(self, model):
@@ -42,3 +56,143 @@ def load_yolo_model_and_image(url):
     image_tensor = preprocess(image).unsqueeze(0)
 
     return model, image_tensor
+
+
+def postprocess(y):
+    
+    processed = Detect.postprocess(y.permute(0, 2, 1), 50)
+    
+    # URL to COCO class names YAML (used by Ultralytics YOLO models)
+    yaml_url = "https://raw.githubusercontent.com/ultralytics/yolov5/master/data/coco.yaml"
+
+    response = requests.get(yaml_url)
+    coco_yaml = yaml.safe_load(response.text)
+    class_names = coco_yaml['names']
+    det = processed[0] 
+    
+
+    print("Detections:")
+    for d in det:
+        x, y, w, h, score, cls = d.tolist()
+        cls = int(cls)
+        label = class_names[cls] if cls < len(class_names) else f"Unknown({cls})"
+        print(f"  Box: [x={x:.1f}, y={y:.1f}, w={w:.1f}, h={h:.1f}], Score: {score:.2f}, Class: {label} ({cls})")
+
+
+
+def load_yolov5_model_and_image(variant, size , input_size):
+    
+    name = "yolov5" + size
+    model = fetch_model(name, f"{base_url}/{name}.pt", yolov5_loader, variant=variant)
+    image_path = get_file("http://images.cocodataset.org/val2017/000000397133.jpg")
+    image_sample = cv2.imread(str(image_path))
+    image_sample = Image.fromarray(np.uint8(image_sample)).convert("RGB")
+    ims, n, files, shape0, shape1, pixel_values = data_preprocessing(image_sample, size=(input_size, input_size))
+    return model, ims, n, files, shape0, shape1, pixel_values
+
+def data_preprocessing(ims: Image.Image, size: tuple) -> tuple:
+    """Data preprocessing function for YOLOv5 object detection.
+
+    Parameters
+    ----------
+    ims : Image.Image
+        Input image
+    size : tuple
+        Desired image size
+
+    Returns
+    -------
+    tuple
+        List of images, number of samples, filenames, image size, inference size, preprocessed images
+    """
+
+    if not isinstance(ims, (list, tuple)):
+        ims = [ims]
+    num_images = len(ims)
+    shape_orig, shape_infer, filenames = [], [], []
+
+    for idx, img in enumerate(ims):
+        filename = getattr(img, "filename", f"image{idx}")
+        img = np.asarray(exif_transpose(img))
+        filename = Path(filename).with_suffix(".jpg").name
+        filenames.append(filename)
+
+        if img.shape[0] < 5:
+            img = img.transpose((1, 2, 0))
+
+        if img.ndim == 3:
+            img = img[..., :3]
+        else:
+            img = cv2.cvtColor(img, cv2.COLOR_GRAY2BGR)
+
+        shape_orig.append(img.shape[:2])
+        scale = max(size) / max(img.shape[:2])
+        shape_infer.append([int(dim * scale) for dim in img.shape[:2]])
+        ims[idx] = img if img.flags["C_CONTIGUOUS"] else np.ascontiguousarray(img)
+
+    shape_infer = [size[0] for _ in np.array(shape_infer).max(0)]
+    imgs_padded = [letterbox(img, shape_infer, auto=False)[0] for img in ims]
+    imgs_padded = np.ascontiguousarray(np.array(imgs_padded).transpose((0, 3, 1, 2)))
+    tensor_imgs = torch.from_numpy(imgs_padded) / 255
+
+    return ims, num_images, filenames, shape_orig, shape_infer, tensor_imgs
+
+
+def data_postprocessing(
+    ims: list,
+    x_shape: torch.Size,
+    pred: list,
+    model: yolov5.models.common.AutoShape,
+    n: int,
+    shape0: list,
+    shape1: list,
+    files: list,
+) -> Detections:
+    """Data postprocessing function for YOLOv5 object detection.
+
+    Parameters
+    ----------
+    ims : list
+        List of input images
+    x_shape : torch.Size
+        Shape of each image
+    pred : list
+        List of model predictions
+    model : yolov5.models.common.AutoShape
+        Model
+    n : int
+        Number of input samples
+    shape0 : list
+        Image shape
+    shape1 : list
+        Inference shape
+    files : list
+        Filenames
+
+    Returns
+    -------
+    Detections
+        Detection object
+    """
+
+    # Create dummy dt tuple (not used but required for Detections)
+    dt = (Profile(), Profile(), Profile())
+
+    # Perform NMS
+    y = non_max_suppression(
+        prediction=pred,
+        conf_thres=model.conf,
+        iou_thres=model.iou,
+        classes=None,
+        agnostic=model.agnostic,
+        multi_label=model.multi_label,
+        labels=(),
+        max_det=model.max_det,
+    )
+
+    # Scale bounding boxes
+    for i in range(n):
+        scale_boxes(shape1, y[i][:, :4], shape0[i])
+
+    # Return Detections object
+    return Detections(ims, y, files, times=dt, names=model.names, shape=x_shape)

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v10_cpu_run.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v10_cpu_run.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from test.models.pytorch.vision.yolo.model_utils.yolo_utils import (
+    YoloWrapper,
+    load_yolo_model_and_image,
+    postprocess
+)
+
+variants = ["yolov10x", "yolov10n"]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants)
+def test_yolov10(variant):
+
+   
+    # Load  model and input
+    model, image_tensor = load_yolo_model_and_image(
+        f"https://github.com/ultralytics/assets/releases/download/v8.2.0/{variant}.pt"
+    )
+    framework_model = YoloWrapper(model)
+    co_out = framework_model(image_tensor)
+    
+    # Post process
+    postprocess(co_out[0])

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5_cpu_run.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5_cpu_run.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+from test.models.pytorch.vision.yolo.model_utils.yolo_utils import data_postprocessing, load_yolov5_model_and_image
+
+
+size = [
+    pytest.param("n", id="yolov5n"),
+]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("size", size)
+def test_yolov5_320x320(restore_package_versions, size):
+
+    # prepare model and input
+    framework_model, ims, n, files, shape0, shape1, pixel_values = load_yolov5_model_and_image(
+        "ultralytics/yolov5",
+        size=size,
+        input_size=320
+    )
+    
+    output = framework_model(pixel_values)
+    
+    # Data postprocessing on Host
+    results = data_postprocessing(
+        ims,
+        pixel_values.shape,
+        output,
+        framework_model,
+        n,
+        shape0,
+        shape1,
+        files,
+    )
+
+    print("Predictions:\n", results.pandas().xyxy)

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v8_cpu_run.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v8_cpu_run.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+
+from test.models.pytorch.vision.yolo.model_utils.yolo_utils import (
+    YoloWrapper,
+    load_yolo_model_and_image,
+    postprocess
+)
+
+variants = ["yolov8x", "yolov8n"]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants)
+def test_yolov8(variant):
+
+  
+    # Load  model and input
+    model, image_tensor = load_yolo_model_and_image(
+        f"https://github.com/ultralytics/assets/releases/download/v8.2.0/{variant}.pt"
+    )
+    framework_model = YoloWrapper(model)
+    
+    co_out = framework_model(image_tensor)
+    
+    # Post process
+    postprocess(co_out[0])

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v9_cpu_run.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v9_cpu_run.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+from test.models.pytorch.vision.yolo.model_utils.yolo_utils import (
+    YoloWrapper,
+    load_yolo_model_and_image,
+    postprocess
+)
+
+
+@pytest.mark.nightly
+def test_yolov9():
+   
+    # Load  model and input
+    model, image_tensor = load_yolo_model_and_image(
+        "https://github.com/ultralytics/assets/releases/download/v8.3.0/yolov9c.pt"
+    )
+    framework_model = YoloWrapper(model)
+    
+    co_out = framework_model(image_tensor)
+    
+    # Post process
+    postprocess(co_out[0])


### PR DESCRIPTION
### Description 

- yolo v3,5,8,9,10 models facing `Fatal Python error: Aborted` in runtime in local testing & crashed in nightly too. 
<img width="1728" alt="Screenshot 2025-07-08 at 10 31 22 AM" src="https://github.com/user-attachments/assets/26891b0c-0690-4cba-8476-0fbec6341619" />

- to repro this issue just run those tests after checking out to this branch
- As I noticed this after adding post processing steps to yolo v5,8,9,10 models, I am adding those scripts as backup in this branch. 
- will add it to actual tests after`Fatal Python error: Aborted` got resolved


### Logs 

[jul7_yolov3.log](https://github.com/user-attachments/files/21116394/jul7_yolov3_org_code.log)
[jul7_yolov5.log](https://github.com/user-attachments/files/21116395/jul7_yolov5_org_code.log)
[jul7_yolov8.log](https://github.com/user-attachments/files/21116396/jul7_yolov8_org_code.log)
[jul7_yolov9.log](https://github.com/user-attachments/files/21116397/jul7_yolov9_ic.log)
[jul7_yolov10.log](https://github.com/user-attachments/files/21116398/jul7_yolov10_org_code.log)

[jul8_yolov5_cpu.log](https://github.com/user-attachments/files/21116407/jul8_yolov5_cpu.log)
[jul8_yolov8_cpu.log](https://github.com/user-attachments/files/21116408/jul8_yolov8_cpu.log)
[jul8_yolov9_cpu.log](https://github.com/user-attachments/files/21116410/jul8_yolov9_cpu.log)
[jul8_yolov10_cpu.log](https://github.com/user-attachments/files/21116411/jul8_yolov10_cpu.log)
