### PR TITLE
Replace skip statements with xfail statements

### DIFF
--- a/forge/test/models/onnx/audio/test_whisper_large.py
+++ b/forge/test/models/onnx/audio/test_whisper_large.py
@@ -30,7 +30,7 @@ variants = ["openai/whisper-large-v3"]
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB)")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants, ids=variants)
 def test_whisper_large_v3_onnx(variant, tmp_path):
 
@@ -42,6 +42,8 @@ def test_whisper_large_v3_onnx(variant, tmp_path):
         task=Task.CAUSAL_LM,
         source=Source.HUGGINGFACE,
     )
+
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load Model and feature extractor
     model = download_model(WhisperModel.from_pretrained, variant, return_dict=False)

--- a/forge/test/models/onnx/multimodal/oft/test_oft_onnx.py
+++ b/forge/test/models/onnx/multimodal/oft/test_oft_onnx.py
@@ -10,8 +10,7 @@ from test.models.onnx.multimodal.oft.model_utils.oft_utils import get_inputs, ge
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 
 
-@pytest.mark.skip_model_analysis
-@pytest.mark.skip(reason="Segmentation Fault")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["runwayml/stable-diffusion-v1-5"])
 @pytest.mark.nightly
 def test_oft(forge_tmp_path, variant):
@@ -23,6 +22,8 @@ def test_oft(forge_tmp_path, variant):
         task=Task.CONDITIONAL_GENERATION,
         source=Source.HUGGINGFACE,
     )
+
+    pytest.xfail(reason="Segmentation Fault")
 
     # Load model and inputs
     pipe, inputs = get_inputs(model=variant)

--- a/forge/test/models/onnx/multimodal/stable_diffusion/test_stable_diffusion_xl.py
+++ b/forge/test/models/onnx/multimodal/stable_diffusion/test_stable_diffusion_xl.py
@@ -36,9 +36,7 @@ class StableDiffusionXLWrapper(torch.nn.Module):
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip(
-    reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB during compile time)"
-)
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["stable-diffusion-xl-base-1.0"])
 def test_stable_diffusion_generation(variant, forge_tmp_path):
     # Build Module Name
@@ -49,6 +47,8 @@ def test_stable_diffusion_generation(variant, forge_tmp_path):
         task=Task.CONDITIONAL_GENERATION,
         source=Source.HUGGINGFACE,
     )
+
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load the pipeline
     pipe = load_pipe(variant, variant_type="xl")

--- a/forge/test/models/onnx/text/deepcogito/test_cogito_v1_onnx.py
+++ b/forge/test/models/onnx/text/deepcogito/test_cogito_v1_onnx.py
@@ -15,7 +15,7 @@ from test.models.pytorch.text.deepcogito.model_utils.model import get_input_mode
 
 
 @pytest.mark.out_of_memory
-@pytest.mark.skip(reason="Skipping due to CI/CD Limitations")
+@pytest.mark.xfail
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["deepcogito/cogito-v1-preview-llama-3B"])
 def test_cogito_generation_onnx(forge_tmp_path, variant):
@@ -27,6 +27,7 @@ def test_cogito_generation_onnx(forge_tmp_path, variant):
         task=Task.TEXT_GENERATION,
         source=Source.HUGGINGFACE,
     )
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and tokenizer
     sample_inputs, framework_model = get_input_model(variant)

--- a/forge/test/models/onnx/text/gemma/test_gemma_v1.py
+++ b/forge/test/models/onnx/text/gemma/test_gemma_v1.py
@@ -15,18 +15,15 @@ import torch
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize(
     "variant",
     [
         pytest.param(
             "google/gemma-1.1-2b-it",
-            marks=pytest.mark.skip(
-                reason="Insufficient host DRAM to run this model; Flakey test, not hitting host OOM on every run"
-            ),
         ),
         pytest.param(
             "google/gemma-1.1-7b-it",
-            marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model"),
         ),
     ],
 )
@@ -36,6 +33,8 @@ def test_gemma_v1_onnx(variant, forge_tmp_path):
     module_name = record_model_properties(
         framework=Framework.ONNX, model=ModelArch.GEMMA, variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
+
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and tokenizer from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/onnx/text/gemma/test_gemma_v2.py
+++ b/forge/test/models/onnx/text/gemma/test_gemma_v2.py
@@ -21,16 +21,15 @@ Gemma2DecoderLayer.forward = Gemma2DecoderLayer_patched_forward
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize(
     "variant",
     [
         pytest.param(
             "google/gemma-2-2b-it",
-            marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model"),
         ),
         pytest.param(
             "google/gemma-2-9b-it",
-            marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model"),
         ),
     ],
 )
@@ -40,6 +39,8 @@ def test_gemma_v2_onnx(variant, forge_tmp_path):
     module_name = record_model_properties(
         framework=Framework.ONNX, model=ModelArch.GEMMA, variant=variant, task=Task.CAUSAL_LM, source=Source.HUGGINGFACE
     )
+
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load tokenizer and model
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/onnx/text/gliner/test_gliner_onnx.py
+++ b/forge/test/models/onnx/text/gliner/test_gliner_onnx.py
@@ -15,9 +15,8 @@ from forge.forge_property_utils import Framework, ModelArch, Source, Task, recor
 variants = ["urchade/gliner_multi-v2.1"]
 
 
-@pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Segmentation Fault")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_gliner_onnx(variant, forge_tmp_path):
 
@@ -29,6 +28,8 @@ def test_gliner_onnx(variant, forge_tmp_path):
         task=Task.TOKEN_CLASSIFICATION,
         source=Source.GITHUB,
     )
+
+    pytest.xfail(reason="Segmentation Fault")
 
     # Load model
     framework_model = GLiNER.from_pretrained(variant)

--- a/forge/test/models/onnx/text/llama/test_llama3.py
+++ b/forge/test/models/onnx/text/llama/test_llama3.py
@@ -17,32 +17,27 @@ import onnx
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize(
     "variant",
     [
         pytest.param(
             "meta-llama/Llama-3.1-8B",
-            marks=pytest.mark.skip(reason="Segmentation fault"),
         ),
         pytest.param(
             "meta-llama/Llama-3.2-1B",
-            marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 26 GB"),
         ),
         pytest.param(
             "meta-llama/Llama-3.2-3B",
-            marks=pytest.mark.skip(reason="Segmentation fault"),
         ),
         pytest.param(
             "meta-llama/Llama-3.1-8B-Instruct",
-            marks=pytest.mark.skip(reason="Segmentation fault"),
         ),
         pytest.param(
             "meta-llama/Llama-3.2-1B-Instruct",
-            marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 30 GB"),
         ),
         pytest.param(
             "meta-llama/Llama-3.2-3B-Instruct",
-            marks=pytest.mark.skip(reason="Segmentation fault"),
         ),
     ],
 )
@@ -56,6 +51,15 @@ def test_llama3_causal_lm_onnx(variant, forge_tmp_path):
         task=Task.CAUSAL_LM,
         source=Source.HUGGINGFACE,
     )
+    if variant in [
+        "meta-llama/Llama-3.1-8B",
+        "meta-llama/Llama-3.2-3B",
+        "meta-llama/Llama-3.1-8B-Instruct",
+        "meta-llama/Llama-3.2-3B-Instruct",
+    ]:
+        pytest.xfail(reason="Segmentation Fault")
+    else:
+        pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and tokenizer
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/onnx/text/ministral/test_ministral.py
+++ b/forge/test/models/onnx/text/ministral/test_ministral.py
@@ -17,7 +17,7 @@ variants = ["ministral/Ministral-3b-instruct"]
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Transient test - Out of memory due to other tests in CI pipeline")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_ministral(variant, forge_tmp_path):
 
@@ -29,6 +29,8 @@ def test_ministral(variant, forge_tmp_path):
         task=Task.CAUSAL_LM,
         source=Source.HUGGINGFACE,
     )
+
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load tokenizer and model
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant, return_tensors="pt")

--- a/forge/test/models/onnx/text/mistral/test_mistral.py
+++ b/forge/test/models/onnx/text/mistral/test_mistral.py
@@ -20,7 +20,7 @@ variants = ["mistralai/Mistral-7B-Instruct-v0.3"]
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
-@pytest.mark.skip(reason="Segmentation Fault")
+@pytest.mark.xfail
 def test_mistral_v0_3_onnx(variant, forge_tmp_path):
 
     # Record Forge Property
@@ -31,6 +31,7 @@ def test_mistral_v0_3_onnx(variant, forge_tmp_path):
         task=Task.CAUSAL_LM,
         source=Source.HUGGINGFACE,
     )
+    pytest.xfail(reason="Segmentation Fault")
 
     # Load tokenizer and model
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/onnx/text/phi1/test_phi1_5_onnx.py
+++ b/forge/test/models/onnx/text/phi1/test_phi1_5_onnx.py
@@ -18,7 +18,7 @@ variants = ["microsoft/phi-1_5"]
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Transient test - Out of memory due to other tests in CI pipeline")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_phi1_5_clm_onnx(variant, forge_tmp_path):
 
@@ -30,6 +30,7 @@ def test_phi1_5_clm_onnx(variant, forge_tmp_path):
         source=Source.HUGGINGFACE,
         task=Task.CAUSAL_LM,
     )
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load tokenizer and model
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant, return_tensors="pt")

--- a/forge/test/models/onnx/text/phi1/test_phi1_onnx.py
+++ b/forge/test/models/onnx/text/phi1/test_phi1_onnx.py
@@ -18,7 +18,7 @@ variants = ["microsoft/phi-1"]
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip("Insufficient host DRAM to run this model (requires a bit more than 22 GB during compile time)")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_phi_causal_lm_onnx(variant, forge_tmp_path):
 
@@ -30,6 +30,7 @@ def test_phi_causal_lm_onnx(variant, forge_tmp_path):
         source=Source.HUGGINGFACE,
         task=Task.CAUSAL_LM,
     )
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load tokenizer
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/onnx/text/phi2/test_phi2.py
+++ b/forge/test/models/onnx/text/phi2/test_phi2.py
@@ -18,7 +18,7 @@ variants = ["microsoft/phi-2"]
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Transient test - Out of memory due to other tests in CI pipeline")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_phi2_clm_onnx(variant, forge_tmp_path):
 
@@ -30,6 +30,7 @@ def test_phi2_clm_onnx(variant, forge_tmp_path):
         source=Source.HUGGINGFACE,
         task=Task.CAUSAL_LM,
     )
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load tokenizer
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant, return_tensors="pt", trust_remote_code=True)

--- a/forge/test/models/onnx/text/phi3/test_phi3.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3.py
@@ -18,7 +18,7 @@ variants = ["microsoft/phi-3-mini-4k-instruct", "microsoft/Phi-3-mini-128k-instr
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
-@pytest.mark.skip(reason="Transient test - Out of memory due to other tests in CI pipeline")
+@pytest.mark.xfail
 def test_phi3_causal_lm_onnx(variant, forge_tmp_path):
 
     # Record Forge Property
@@ -29,6 +29,7 @@ def test_phi3_causal_lm_onnx(variant, forge_tmp_path):
         task=Task.CAUSAL_LM,
         source=Source.HUGGINGFACE,
     )
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant, return_tensors="pt", trust_remote_code=True)

--- a/forge/test/models/onnx/text/phi3/test_phi3_5.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3_5.py
@@ -18,7 +18,7 @@ variants = ["microsoft/Phi-3.5-mini-instruct"]
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip("Transient test - Out of memory due to other tests in CI pipeline")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_5_causal_lm_onnx(variant, forge_tmp_path):
 
@@ -30,6 +30,7 @@ def test_phi3_5_causal_lm_onnx(variant, forge_tmp_path):
         task=Task.CAUSAL_LM,
         source=Source.HUGGINGFACE,
     )
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and tokenizer
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/onnx/text/phi3/test_phi3_5_vision.py
+++ b/forge/test/models/onnx/text/phi3/test_phi3_5_vision.py
@@ -29,7 +29,7 @@ variants = ["microsoft/Phi-3.5-vision-instruct"]
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip("Segmentation Fault")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_5_vision(variant, forge_tmp_path):
 
@@ -41,6 +41,7 @@ def test_phi3_5_vision(variant, forge_tmp_path):
         task=Task.MULTIMODAL_TEXT_GENERATION,
         source=Source.HUGGINGFACE,
     )
+    pytest.xfail(reason="Segmentation Fault")
 
     # Load model and processor
     model = download_model(

--- a/forge/test/models/onnx/text/qwen/test_qwen_v2.py
+++ b/forge/test/models/onnx/text/qwen/test_qwen_v2.py
@@ -16,32 +16,27 @@ import torch
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize(
     "variant",
     [
         pytest.param(
             "Qwen/Qwen2.5-0.5B",
-            marks=pytest.mark.skip("Transient test - Out of memory due to other tests in CI pipeline"),
         ),
         pytest.param(
             "Qwen/Qwen2.5-1.5B",
-            marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB"),
         ),
         pytest.param(
             "Qwen/Qwen2.5-3B",
-            marks=pytest.mark.skip(reason="Segmentation Fault"),
         ),
         pytest.param(
             "Qwen/Qwen2.5-0.5B-Instruct",
-            marks=pytest.mark.skip("Transient test - Out of memory due to other tests in CI pipeline"),
         ),
         pytest.param(
             "Qwen/Qwen2.5-1.5B-Instruct",
-            marks=pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB"),
         ),
         pytest.param(
             "Qwen/Qwen2.5-3B-Instruct",
-            marks=pytest.mark.skip(reason="Segmentation Fault"),
         ),
     ],
 )
@@ -55,6 +50,11 @@ def test_qwen_clm_onnx(variant, forge_tmp_path):
         task=Task.CAUSAL_LM,
         source=Source.HUGGINGFACE,
     )
+
+    if variant in ["Qwen/Qwen2.5-3B", "Qwen/Qwen2.5-3B-Instruct"]:
+        pytest.xfail(reason="Segmentation Fault")
+    else:
+        pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and tokenizer
     framework_model = AutoModelForCausalLM.from_pretrained(variant, device_map="cpu", return_dict=False)

--- a/forge/test/models/onnx/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/onnx/vision/efficientnet/test_efficientnet.py
@@ -14,54 +14,14 @@ from test.models.models_utils import print_cls_results
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 
 params = [
-    pytest.param("efficientnet_b0", marks=[pytest.mark.push]),
-    pytest.param(
-        "efficientnet_b1",
-    ),
-    pytest.param(
-        "efficientnet_b2",
-        marks=[
-            pytest.mark.xfail(
-                reason="[RuntimeError][Conv2d] bias_ntiles == weight_matrix_width_ntile Issue Link: https://github.com/tenstorrent/tt-mlir/issues/3949"
-            )
-        ],
-    ),
-    pytest.param(
-        "efficientnet_b2a",
-        marks=[
-            pytest.mark.xfail(
-                reason="[RuntimeError][Conv2d] bias_ntiles == weight_matrix_width_ntile Issue Link: https://github.com/tenstorrent/tt-mlir/issues/3949"
-            )
-        ],
-    ),
-    pytest.param(
-        "efficientnet_b3",
-        marks=[
-            pytest.mark.xfail(
-                reason="[RuntimeError][Conv2d] bias_ntiles == weight_matrix_width_ntile Issue Link: https://github.com/tenstorrent/tt-mlir/issues/3949"
-            )
-        ],
-    ),
-    pytest.param(
-        "efficientnet_b3a",
-        marks=[
-            pytest.mark.xfail(
-                reason="[RuntimeError][Conv2d] bias_ntiles == weight_matrix_width_ntile Issue Link: https://github.com/tenstorrent/tt-mlir/issues/3949"
-            )
-        ],
-    ),
-    pytest.param(
-        "efficientnet_b4",
-        marks=[
-            pytest.mark.xfail(
-                reason="[RuntimeError][Conv2d] bias_ntiles == weight_matrix_width_ntile Issue Link: https://github.com/tenstorrent/tt-mlir/issues/3949"
-            )
-        ],
-    ),
-    pytest.param(
-        "efficientnet_b5",
-        marks=[pytest.mark.skip(reason="Out of memory due - not enough space to allocate L1 buffer across banks")],
-    ),
+    pytest.param("efficientnet_b0", marks=pytest.mark.push),
+    pytest.param("efficientnet_b1", marks=pytest.mark.xfail()),
+    pytest.param("efficientnet_b2", marks=pytest.mark.xfail()),
+    pytest.param("efficientnet_b2a", marks=pytest.mark.xfail()),
+    pytest.param("efficientnet_b3", marks=pytest.mark.xfail()),
+    pytest.param("efficientnet_b3a", marks=pytest.mark.xfail()),
+    pytest.param("efficientnet_b4", marks=pytest.mark.xfail()),
+    pytest.param("efficientnet_b5", marks=pytest.mark.xfail()),
     pytest.param("efficientnet_lite0"),
 ]
 
@@ -78,6 +38,12 @@ def test_efficientnet_onnx(variant, forge_tmp_path):
         source=Source.TIMM,
         task=Task.IMAGE_CLASSIFICATION,
     )
+    if variant == "efficientnet_b5":
+        pytest.xfail(reason="Requires multi-chip support")
+    elif variant in ["efficientnet_b1", "efficientnet_b2", "efficientnet_b3", "efficientnet_b3a", "efficientnet_b4"]:
+        pytest.xfail(
+            reason="[RuntimeError][Conv2d] bias_ntiles == weight_matrix_width_ntile Issue Link: https://github.com/tenstorrent/tt-mlir/issues/3949"
+        )
 
     # Load efficientnet model
     model = timm.create_model(variant, pretrained=True)

--- a/forge/test/models/onnx/vision/swin/test_swin.py
+++ b/forge/test/models/onnx/vision/swin/test_swin.py
@@ -17,8 +17,8 @@ from test.models.pytorch.vision.vision_utils.utils import load_vision_model_and_
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 
 
-@pytest.mark.skip(reason="Segmentation Fault at run_mlir_compiler compilation stage")
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
 def test_swin_v2_tiny_image_classification_onnx(variant, forge_tmp_path):
 
@@ -30,6 +30,7 @@ def test_swin_v2_tiny_image_classification_onnx(variant, forge_tmp_path):
         task=Task.IMAGE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
     )
+    pytest.xfail(reason="Segmentation Fault")
 
     # Load the model
     framework_model = Swinv2ForImageClassification.from_pretrained(variant)

--- a/forge/test/models/onnx/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/onnx/vision/vovnet/test_vovnet.py
@@ -36,7 +36,7 @@ def generate_model_vovnet_imgcls_osmr_pytorch(variant):
 
 
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Segmentation Fault")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["vovnet27s"])
 def test_vovnet_osmr_pytorch(variant, forge_tmp_path):
 
@@ -48,6 +48,7 @@ def test_vovnet_osmr_pytorch(variant, forge_tmp_path):
         source=Source.OSMR,
         task=Task.OBJECT_DETECTION,
     )
+    pytest.xfail(reason="Segmentation Fault")
 
     # Load model and inputs
     framework_model, inputs, _ = generate_model_vovnet_imgcls_osmr_pytorch(variant)
@@ -74,7 +75,7 @@ def generate_model_vovnet39_imgcls_stigma_pytorch():
 
 
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Segmentation Fault")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["vovnet39"])
 def test_vovnet_v1_39_stigma_onnx(variant, forge_tmp_path):
 
@@ -86,6 +87,7 @@ def test_vovnet_v1_39_stigma_onnx(variant, forge_tmp_path):
         source=Source.TORCH_HUB,
         task=Task.OBJECT_DETECTION,
     )
+    pytest.xfail(reason="Segmentation Fault")
 
     framework_model, inputs, _ = generate_model_vovnet39_imgcls_stigma_pytorch()
 
@@ -112,7 +114,7 @@ def generate_model_vovnet57_imgcls_stigma_pytorch():
 
 
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Segmentation Fault")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["vovnet_v1_57"])
 def test_vovnet_v1_57_stigma_onnx(variant, forge_tmp_path):
 
@@ -124,6 +126,7 @@ def test_vovnet_v1_57_stigma_onnx(variant, forge_tmp_path):
         source=Source.TORCH_HUB,
         task=Task.OBJECT_DETECTION,
     )
+    pytest.xfail(reason="Segmentation Fault")
 
     framework_model, inputs, _ = generate_model_vovnet57_imgcls_stigma_pytorch()
 

--- a/forge/test/models/paddlepaddle/text/llama/test_llama.py
+++ b/forge/test/models/paddlepaddle/text/llama/test_llama.py
@@ -16,7 +16,7 @@ variants = ["facebook/llama-7b"]
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip()
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_llama(variant):
     # Record Forge properties
@@ -27,6 +27,7 @@ def test_llama(variant):
         source=Source.PADDLENLP,
         task=Task.CAUSAL_LM,
     )
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load Model and Tokenizer
     model = LlamaForCausalLM.from_pretrained(variant)

--- a/forge/test/models/pytorch/multimodal/deepseek_coder/test_deepseek_coder.py
+++ b/forge/test/models/pytorch/multimodal/deepseek_coder/test_deepseek_coder.py
@@ -21,14 +21,15 @@ from test.models.pytorch.multimodal.deepseek_coder.model_utils.model_utils impor
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["deepseek-coder-1.3b-instruct"])
 def test_deepseek_inference_no_cache(variant):
-    pytest.skip("Insufficient host DRAM to run this model (requires a bit more than 32 GB during compile time)")
 
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.PYTORCH, model=ModelArch.DEEPSEEK, variant=variant, task=Task.QA, source=Source.HUGGINGFACE
     )
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load Model and Tokenizer
     model_name = f"deepseek-ai/{variant}"

--- a/forge/test/models/pytorch/multimodal/deepseek_math/test_deepseek_math.py
+++ b/forge/test/models/pytorch/multimodal/deepseek_math/test_deepseek_math.py
@@ -19,7 +19,6 @@ from test.models.pytorch.multimodal.deepseek_math.model_utils.model_utils import
 )
 
 
-@pytest.mark.skip_model_analysis
 @pytest.mark.parametrize("variant", ["deepseek-math-7b-instruct"])
 def test_deepseek_inference_no_cache_cpu(variant):
     model_name = f"deepseek-ai/{variant}"
@@ -35,12 +34,14 @@ def test_deepseek_inference_no_cache_cpu(variant):
 
 
 @pytest.mark.out_of_memory
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["deepseek-math-7b-instruct"])
 def test_deepseek_inference(variant):
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.PYTORCH, model=ModelArch.DEEPSEEK, variant=variant, task=Task.QA, source=Source.HUGGINGFACE
     )
+    pytest.xfail(reason="Requires multi-chip support")
 
     model_name = f"deepseek-ai/{variant}"
     model, tokenizer, input_ids = download_model_and_tokenizer(model_name)

--- a/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_xl.py
+++ b/forge/test/models/pytorch/multimodal/stable_diffusion/test_stable_diffusion_xl.py
@@ -45,7 +45,6 @@ class StableDiffusionXLWrapper(torch.nn.Module):
 
 
 @pytest.mark.nightly
-@pytest.mark.skip_model_analysis
 @pytest.mark.parametrize(
     "variant",
     [

--- a/forge/test/models/pytorch/text/deepcogito/test_cogito_v1.py
+++ b/forge/test/models/pytorch/text/deepcogito/test_cogito_v1.py
@@ -17,7 +17,7 @@ from test.models.pytorch.text.deepcogito.model_utils.model import get_input_mode
 
 
 @pytest.mark.out_of_memory
-@pytest.mark.skip("Skipping due to Out of Memory issue")
+@pytest.mark.xfail
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", ["deepcogito/cogito-v1-preview-llama-3B"])
 def test_cogito_generation(variant):
@@ -30,6 +30,7 @@ def test_cogito_generation(variant):
         task=Task.TEXT_GENERATION,
         source=Source.HUGGINGFACE,
     )
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and tokenizer
     input_tensor_list, framework_model = get_input_model(variant)

--- a/forge/test/models/pytorch/text/phi3/test_phi3.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3.py
@@ -118,7 +118,7 @@ def test_phi3_token_classification(variant):
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Insufficient host DRAM to run this model (requires a bit more than 31 GB")
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
 def test_phi3_sequence_classification(variant):
 
@@ -130,6 +130,7 @@ def test_phi3_sequence_classification(variant):
         task=Task.SEQUENCE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
     )
+    pytest.xfail(reason="Requires multi-chip support")
 
     # Phi3Config from pretrained variant, disable return_dict and caching.
     config = Phi3Config.from_pretrained(variant)

--- a/forge/test/models/pytorch/text/phi4/test_phi4.py
+++ b/forge/test/models/pytorch/text/phi4/test_phi4.py
@@ -72,10 +72,9 @@ def test_phi_4_causal_lm_pytorch(variant):
     verify(sample_inputs, framework_model, compiled_model)
 
 
-@pytest.mark.out_of_memory
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
-@pytest.mark.skip(reason="Skipped due to kill at consteval compilation stage")
+@pytest.mark.xfail
 def test_phi_4_token_classification_pytorch(variant):
 
     # Record Forge Property
@@ -86,6 +85,7 @@ def test_phi_4_token_classification_pytorch(variant):
         task=Task.TOKEN_CLASSIFICATION,
         source=Source.HUGGINGFACE,
     )
+    pytest.xfail(reason="Test is killed at consteval compilation stage")
 
     # Load tokenizer and model from HuggingFace
     model = download_model(AutoModelForTokenClassification.from_pretrained, variant, use_cache=False)
@@ -105,10 +105,9 @@ def test_phi_4_token_classification_pytorch(variant):
     verify(inputs, framework_model, compiled_model)
 
 
-@pytest.mark.out_of_memory
 @pytest.mark.nightly
+@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants)
-@pytest.mark.skip(reason="Skipped due to kill at consteval compilation stage")
 def test_phi_4_sequence_classification_pytorch(variant):
 
     # Record Forge Property
@@ -119,6 +118,7 @@ def test_phi_4_sequence_classification_pytorch(variant):
         task=Task.SEQUENCE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
     )
+    pytest.xfail(reason="Test is killed at consteval compilation stage")
 
     # Load tokenizer and model from HuggingFace
     tokenizer = download_model(AutoTokenizer.from_pretrained, variant)

--- a/forge/test/models/pytorch/vision/monodle/test_monodle.py
+++ b/forge/test/models/pytorch/vision/monodle/test_monodle.py
@@ -22,12 +22,13 @@ from test.models.pytorch.vision.monodle.model_utils.model import CenterNet3D
 
 
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Floating point exception(core dumped)")
+@pytest.mark.xfail
 def test_monodle_pytorch():
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.PYTORCH, model=ModelArch.MONODLE, source=Source.TORCHVISION, task=Task.OBJECT_DETECTION
     )
+    pytest.xfail(reason="Floating point exception(core dumped)")
 
     # Load data sample
     dataset = load_dataset("imagenet-1k", split="validation", streaming=True)

--- a/forge/test/models/pytorch/vision/oft/test_oft.py
+++ b/forge/test/models/pytorch/vision/oft/test_oft.py
@@ -20,9 +20,8 @@ from forge.verify.verify import verify
 from third_party.tt_forge_models.oft import ModelLoader  # isort:skip
 
 
-@pytest.mark.skip_model_analysis
 @pytest.mark.nightly
-@pytest.mark.skip(reason="Getting hang at generate_initial_graph pass")
+@pytest.mark.xfail
 def test_oft():
     # Record Forge Property
     module_name = record_model_properties(
@@ -32,6 +31,7 @@ def test_oft():
         task=Task.OBJECT_DETECTION,
         source=Source.GITHUB,
     )
+    pytest.xfail(reason="Getting hang at generate_initial_graph pass")
 
     # Load model and input
     framework_model = ModelLoader.load_model()

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -78,7 +78,6 @@ def test_swin_v1_tiny_4_224_hf_pytorch(variant):
 
 
 @pytest.mark.nightly
-@pytest.mark.skip_model_analysis
 @pytest.mark.parametrize(
     "variant",
     [
@@ -100,7 +99,7 @@ def test_swin_v2_tiny_4_256_hf_pytorch(variant):
         priority=ModelPriority.P1,
     )
 
-    pytest.xfail(reason="Transient failure - Segmentation fault")
+    pytest.xfail(reason="Segmentation fault")
 
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
     framework_model = Swinv2Model.from_pretrained(variant)
@@ -115,13 +114,12 @@ def test_swin_v2_tiny_4_256_hf_pytorch(variant):
 
 
 @pytest.mark.nightly
-@pytest.mark.skip_model_analysis
+@pytest.mark.xfail
 @pytest.mark.parametrize(
     "variant",
     [
         pytest.param(
             "microsoft/swinv2-tiny-patch4-window8-256",
-            marks=[pytest.mark.skip(reason="Transient failure - Segmentation fault")],
         ),
     ],
 )
@@ -135,6 +133,7 @@ def test_swin_v2_tiny_image_classification(variant):
         task=Task.IMAGE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
     )
+    pytest.xfail(reason="Segmentation Fault")
 
     feature_extractor = ViTImageProcessor.from_pretrained(variant)
     framework_model = Swinv2ForImageClassification.from_pretrained(variant)


### PR DESCRIPTION
This PR replaces all pytest.mark.skip markers with pytest.mark.xfail statements.
