### PR TITLE
Refactor ConvertEmulatedDtypes to convert the entire model to fallback dtype instead of individually converting parameters and buffers

### DIFF
--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -5,6 +5,8 @@ import pytest
 import torch
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -69,9 +71,17 @@ def test_yolov5_320x320(restore_package_versions, size):
         "ultralytics/yolov5",
         size=size,
     )
+    framework_model.to(torch.bfloat16)
+    inputs = [inputs[0].to(torch.bfloat16)]
+
+    # Configurations
+    compiler_cfg = CompilerConfig()
+    compiler_cfg.default_df_override = DataFormat.Float16_b
 
     # Forge compile framework model
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, module_name=module_name, compiler_cfg=compiler_cfg
+    )
 
     # Model Verification
     verify(
@@ -118,9 +128,17 @@ def test_yolov5_640x640(restore_package_versions, size):
         "ultralytics/yolov5",
         size=size,
     )
+    framework_model.to(torch.bfloat16)
+    inputs = [inputs[0].to(torch.bfloat16)]
+
+    # Configurations
+    compiler_cfg = CompilerConfig()
+    compiler_cfg.default_df_override = DataFormat.Float16_b
 
     # Forge compile framework model
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, module_name=module_name, compiler_cfg=compiler_cfg
+    )
 
     # Model Verification
     verify(inputs, framework_model, compiled_model)
@@ -162,8 +180,17 @@ def test_yolov5_480x480(restore_package_versions, size):
         size=size,
     )
 
+    framework_model.to(torch.bfloat16)
+    inputs = [inputs[0].to(torch.bfloat16)]
+
+    # Configurations
+    compiler_cfg = CompilerConfig()
+    compiler_cfg.default_df_override = DataFormat.Float16_b
+
     # Forge compile framework model
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, module_name=module_name, compiler_cfg=compiler_cfg
+    )
 
     # Model Verification
     verify(inputs, framework_model, compiled_model)
@@ -191,12 +218,19 @@ def test_yolov5_1280x1280(restore_package_versions, variant):
         variant="ultralytics/yolov5",
     )
 
+    framework_model.to(torch.bfloat16)
     input_shape = (1, 3, 1280, 1280)
     input_tensor = torch.rand(input_shape)
-    inputs = [input_tensor]
+    inputs = [input_tensor.to(torch.bfloat16)]
+
+    # Configurations
+    compiler_cfg = CompilerConfig()
+    compiler_cfg.default_df_override = DataFormat.Float16_b
 
     # Forge compile framework model
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
+    compiled_model = forge.compile(
+        framework_model, sample_inputs=inputs, module_name=module_name, compiler_cfg=compiler_cfg
+    )
 
     # Model Verification
     verify(inputs, framework_model, compiled_model)


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-forge-fe/issues/2488

### Problem description

- Some models, such as YOLOv5, define tensors like [stride](https://github.com/ultralytics/yolov5/blob/2540fd4c1c2d9186126a71b3eb681d3a0a11861e/models/yolo.py#L111) as [tensor attribute](https://github.com/ultralytics/yolov5/blob/2540fd4c1c2d9186126a71b3eb681d3a0a11861e/models/yolo.py#L255)  rather than as parameters or buffers.
- The existing ConvertEmulatedDtypes context manager only handled parameters, buffers, and inputs for dtype conversion (e.g., from bfloat16 to float32), and missed such tensor attributes. 
- This led to `TypeError: Got unsupported ScalarType BFloat16 in yolov5 on bfp16 conversion` in frontend conversion.

### What's changed

Determine the model's original dtype based on parameters.
Use `model.to(fallback)` and `model.to(original_dtype)` for conversion instead of manually handling parameters and buffers. 

### Logs
[jul11_yolov5_bfp16_before_fix.log](https://github.com/user-attachments/files/21179619/jul11_yolov5_bfp16_bf.log)

