### PR TITLE
Remove Optimization Passes for YOLO Performance Models

### DIFF
--- a/.github/workflows/perf-benchmark-sub.yml
+++ b/.github/workflows/perf-benchmark-sub.yml
@@ -18,15 +18,15 @@ jobs:
       fail-fast: false
       matrix:
         build: [
-          { runs-on: "n150", name: "mnist_linear",             dir: "MNISTLinear",                  ts: 'na',             bs: 32,  lp: 32, df: 'float32'   },
-          { runs-on: "n150", name: "resnet50_hf",              dir: "ResNetForImageClassification", ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16'  },
-          # { runs-on: "n150", name: "resnet50_hf_config",              dir: "ResNetForImageClassificationConfig", ts: 'classification', bs: 8,  lp: 32, df: 'bfloat16' }, It will be added to CI later.
-          { runs-on: "n150", name: "llama",                    dir: "LlamaModel",                   ts: 'na',             bs: 1,   lp: 32, df: 'float32',  },
-          { runs-on: "n150", name: "mobilenetv2_basic",        dir: "MobileNetv2Basic",             ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16', },
-          { runs-on: "n150", name: "efficientnet_timm",        dir: "EfficientNetTimmB0",           ts: 'classification', bs: 6,   lp: 32, df: 'bfloat16', },
-          { runs-on: "n150", name: "segformer",                dir: "Segformer",                    ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16',  },
-          { runs-on: "n150", name: "vit_base",                 dir: "ViTBase",                      ts: 'classification', bs: 8,   lp: 32, df: 'float32',  },
-          { runs-on: "n150", name: "vovnet_timm",              dir: "VovnetTimm",                   ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16', },
+          # { runs-on: "n150", name: "mnist_linear",             dir: "MNISTLinear",                  ts: 'na',             bs: 32,  lp: 32, df: 'float32'   },
+          # { runs-on: "n150", name: "resnet50_hf",              dir: "ResNetForImageClassification", ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16'  },
+          # # { runs-on: "n150", name: "resnet50_hf_config",              dir: "ResNetForImageClassificationConfig", ts: 'classification', bs: 8,  lp: 32, df: 'bfloat16' }, It will be added to CI later.
+          # { runs-on: "n150", name: "llama",                    dir: "LlamaModel",                   ts: 'na',             bs: 1,   lp: 32, df: 'float32',  },
+          # { runs-on: "n150", name: "mobilenetv2_basic",        dir: "MobileNetv2Basic",             ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16', },
+          # { runs-on: "n150", name: "efficientnet_timm",        dir: "EfficientNetTimmB0",           ts: 'classification', bs: 6,   lp: 32, df: 'bfloat16', },
+          # { runs-on: "n150", name: "segformer",                dir: "Segformer",                    ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16',  },
+          # { runs-on: "n150", name: "vit_base",                 dir: "ViTBase",                      ts: 'classification', bs: 8,   lp: 32, df: 'float32',  },
+          # { runs-on: "n150", name: "vovnet_timm",              dir: "VovnetTimm",                   ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16', },
           { runs-on: "n150", name: "yolo_v4",                  dir: "YOLOv4",                       ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16', },
           { runs-on: "n150", name: "yolo_v8",                  dir: "YOLOv8",                       ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16', },
           { runs-on: "n150", name: "yolo_v9",                  dir: "YOLOv9",                       ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16', },

--- a/.github/workflows/perf-benchmark-sub.yml
+++ b/.github/workflows/perf-benchmark-sub.yml
@@ -18,15 +18,15 @@ jobs:
       fail-fast: false
       matrix:
         build: [
-          # { runs-on: "n150", name: "mnist_linear",             dir: "MNISTLinear",                  ts: 'na',             bs: 32,  lp: 32, df: 'float32'   },
-          # { runs-on: "n150", name: "resnet50_hf",              dir: "ResNetForImageClassification", ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16'  },
-          # # { runs-on: "n150", name: "resnet50_hf_config",              dir: "ResNetForImageClassificationConfig", ts: 'classification', bs: 8,  lp: 32, df: 'bfloat16' }, It will be added to CI later.
-          # { runs-on: "n150", name: "llama",                    dir: "LlamaModel",                   ts: 'na',             bs: 1,   lp: 32, df: 'float32',  },
-          # { runs-on: "n150", name: "mobilenetv2_basic",        dir: "MobileNetv2Basic",             ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16', },
-          # { runs-on: "n150", name: "efficientnet_timm",        dir: "EfficientNetTimmB0",           ts: 'classification', bs: 6,   lp: 32, df: 'bfloat16', },
-          # { runs-on: "n150", name: "segformer",                dir: "Segformer",                    ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16',  },
-          # { runs-on: "n150", name: "vit_base",                 dir: "ViTBase",                      ts: 'classification', bs: 8,   lp: 32, df: 'float32',  },
-          # { runs-on: "n150", name: "vovnet_timm",              dir: "VovnetTimm",                   ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16', },
+          { runs-on: "n150", name: "mnist_linear",             dir: "MNISTLinear",                  ts: 'na',             bs: 32,  lp: 32, df: 'float32'   },
+          { runs-on: "n150", name: "resnet50_hf",              dir: "ResNetForImageClassification", ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16'  },
+          # { runs-on: "n150", name: "resnet50_hf_config",              dir: "ResNetForImageClassificationConfig", ts: 'classification', bs: 8,  lp: 32, df: 'bfloat16' }, It will be added to CI later.
+          { runs-on: "n150", name: "llama",                    dir: "LlamaModel",                   ts: 'na',             bs: 1,   lp: 32, df: 'float32',  },
+          { runs-on: "n150", name: "mobilenetv2_basic",        dir: "MobileNetv2Basic",             ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16', },
+          { runs-on: "n150", name: "efficientnet_timm",        dir: "EfficientNetTimmB0",           ts: 'classification', bs: 6,   lp: 32, df: 'bfloat16', },
+          { runs-on: "n150", name: "segformer",                dir: "Segformer",                    ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16',  },
+          { runs-on: "n150", name: "vit_base",                 dir: "ViTBase",                      ts: 'classification', bs: 8,   lp: 32, df: 'float32',  },
+          { runs-on: "n150", name: "vovnet_timm",              dir: "VovnetTimm",                   ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16', },
           { runs-on: "n150", name: "yolo_v4",                  dir: "YOLOv4",                       ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16', },
           { runs-on: "n150", name: "yolo_v8",                  dir: "YOLOv8",                       ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16', },
           { runs-on: "n150", name: "yolo_v9",                  dir: "YOLOv9",                       ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16', },

--- a/forge/test/benchmark/benchmark/models/yolo_v10.py
+++ b/forge/test/benchmark/benchmark/models/yolo_v10.py
@@ -95,7 +95,7 @@ def test_yolo_v10(
         framework_model = framework_model.to(torch.bfloat16)
 
     # Compiler configuration
-    compiler_config = CompilerConfig(enable_optimization_passes=True)
+    compiler_config = CompilerConfig()
     # @TODO - For now, we are skipping enabling MLIR optimizations, because it is not working with the current version of the model.
     # Turn on MLIR optimizations.
     # compiler_config.mlir_config = MLIRConfig().set_enable_consteval(True).set_enable_optimizer(True)

--- a/forge/test/benchmark/benchmark/models/yolo_v4.py
+++ b/forge/test/benchmark/benchmark/models/yolo_v4.py
@@ -96,7 +96,7 @@ def test_yolo_v4(
         framework_model = framework_model.to(torch.bfloat16)
 
     # Compiler configuration
-    compiler_config = CompilerConfig(enable_optimization_passes=True)
+    compiler_config = CompilerConfig()
     # Turn on MLIR optimizations.
     compiler_config.mlir_config = (
         MLIRConfig().set_enable_optimizer(True).set_enable_memory_layout_analysis(False).set_enable_fusing(True)

--- a/forge/test/benchmark/benchmark/models/yolo_v8.py
+++ b/forge/test/benchmark/benchmark/models/yolo_v8.py
@@ -93,7 +93,7 @@ def test_yolo_v8(
         framework_model = framework_model.to(torch.bfloat16)
 
     # Compiler configuration
-    compiler_config = CompilerConfig(enable_optimization_passes=True)
+    compiler_config = CompilerConfig()
     # Turn on MLIR optimizations.
     compiler_config.mlir_config = (
         MLIRConfig().set_enable_optimizer(True).set_enable_memory_layout_analysis(False).set_enable_fusing(True)

--- a/forge/test/benchmark/benchmark/models/yolo_v9.py
+++ b/forge/test/benchmark/benchmark/models/yolo_v9.py
@@ -94,7 +94,7 @@ def test_yolo_v9(
         framework_model = framework_model.to(torch.bfloat16)
 
     # Compiler configuration
-    compiler_config = CompilerConfig(enable_optimization_passes=True)
+    compiler_config = CompilerConfig()
     # Turn on MLIR optimizations.
     compiler_config.mlir_config = (
         MLIRConfig().set_enable_optimizer(True).set_enable_memory_layout_analysis(False).set_enable_fusing(True)


### PR DESCRIPTION
Enabling optimization passes in the frontend introduces some errors in all YOLO performance benchmark models, so we disable it. This pass should be deprecated in the future, but for now it's there because some models still need it.

There is, also, slightly changes in performance for these models:
YOLOv4, decreased, 11.21 --> 8.1938
YOLOv8, decreased, 10.52 --> 9.0943
YOLOv9, decreased, 0.197 --> 0.1907
YOLOv10, decreased, 0.237 --> 0.2366

There is [the job](https://github.com/tenstorrent/tt-forge-fe/actions/runs/16314405947/job/46077753862).