### PR TITLE
Fixes for benchmark tests

### DIFF
--- a/.github/workflows/perf-benchmark-sub.yml
+++ b/.github/workflows/perf-benchmark-sub.yml
@@ -25,7 +25,7 @@ jobs:
           { runs-on: "n150", name: "mobilenetv2_basic",        dir: "MobileNetv2Basic",             ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16', },
           { runs-on: "n150", name: "efficientnet_timm",        dir: "EfficientNetTimmB0",           ts: 'classification', bs: 6,   lp: 32, df: 'bfloat16', },
           { runs-on: "n150", name: "segformer",                dir: "Segformer",                    ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16',  },
-          { runs-on: "n150", name: "vit_base",                 dir: "ViTBase",                      ts: 'classification', bs: 8,   lp: 32, df: 'float32',  },
+          { runs-on: "n150", name: "vit_base",                 dir: "ViTBase",                      ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16',  },
           { runs-on: "n150", name: "vovnet_timm",              dir: "VovnetTimm",                   ts: 'classification', bs: 8,   lp: 32, df: 'bfloat16', },
           { runs-on: "n150", name: "yolo_v4",                  dir: "YOLOv4",                       ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16', },
           { runs-on: "n150", name: "yolo_v8",                  dir: "YOLOv8",                       ts: 'na',             bs: 1,   lp: 32, df: 'bfloat16', },

--- a/forge/test/benchmark/benchmark/models/vit.py
+++ b/forge/test/benchmark/benchmark/models/vit.py
@@ -96,7 +96,7 @@ def test_vit_base(training, batch_size, input_size, channel_size, loop_count, va
 
     if data_format == "bfloat16":
         # Convert input to bfloat16
-        input_sample = [input.to(torch.bfloat16) for input in input_sample]
+        inputs = [input.to(torch.bfloat16) for input in inputs]
 
     # Load the model from Hugging Face
     framework_model = download_model(ViTForImageClassification.from_pretrained, variant, return_dict=False)

--- a/forge/test/benchmark/benchmark/models/yolo_v10.py
+++ b/forge/test/benchmark/benchmark/models/yolo_v10.py
@@ -95,10 +95,13 @@ def test_yolo_v10(
         framework_model = framework_model.to(torch.bfloat16)
 
     # Compiler configuration
-    compiler_config = CompilerConfig(enable_optimization_passes=True)
-    # @TODO - For now, we are skipping enabling MLIR optimizations, because it is not working with the current version of the model.
+    compiler_config = CompilerConfig()
+
     # Turn on MLIR optimizations.
-    # compiler_config.mlir_config = MLIRConfig().set_enable_consteval(True).set_enable_optimizer(True)
+    compiler_config.mlir_config = (
+        MLIRConfig().set_enable_fusing(True).set_enable_optimizer(True).set_enable_memory_layout_analysis(False)
+    )
+
     if data_format == "bfloat16":
         # Convert model to bfloat16
         compiler_config.default_df_override = DataFormat.Float16_b

--- a/forge/test/benchmark/benchmark/models/yolo_v10.py
+++ b/forge/test/benchmark/benchmark/models/yolo_v10.py
@@ -122,7 +122,7 @@ def test_yolo_v10(
     start = time.time()
     for _ in range(loop_count):
         co_out = compiled_model(*input_sample)
-  end = time.time()
+    end = time.time()
 
     fw_out = framework_model(*input_sample)
     co_out = [co.to("cpu") for co in co_out]

--- a/forge/test/benchmark/benchmark/models/yolo_v9.py
+++ b/forge/test/benchmark/benchmark/models/yolo_v9.py
@@ -108,6 +108,11 @@ def test_yolo_v9(
         framework_model, sample_inputs=input_sample, module_name=module_name, compiler_cfg=compiler_config
     )
 
+    # Enable program cache on all devices
+    settings = DeviceSettings()
+    settings.enable_program_cache = True
+    configure_devices(device_settings=settings)
+
     # Run for the first time to warm up the model, it will be done by verify function.
     # This is required to get accurate performance numbers.
     verify(input_sample, framework_model, compiled_model)


### PR DESCRIPTION
1. ViT - run with bfloat16 dtype
2. Yolo_v9 - enable program cache
3. Yolo_v10 - enable optimizer

