### PR TITLE
Fix dual conv2d op and resnet failure caused by jax upgrade

### DIFF
--- a/forge/forge/module.py
+++ b/forge/forge/module.py
@@ -349,7 +349,7 @@ class TFModule(Module):
     def get_parameters(self) -> List[Parameter]:
         params = []
         vars_as_pt = to_pt_tensors(self.module.trainable_variables)
-        names = [var.name for var in self.module.trainable_variables]
+        names = [var.path for var in self.module.trainable_variables]
         for param, name in zip(vars_as_pt, names):
             forge_param = Parameter(param, requires_grad=True, name=name)
             params.append(forge_param)

--- a/forge/forge/python_codegen.py
+++ b/forge/forge/python_codegen.py
@@ -426,7 +426,7 @@ class ForgeWriter(PythonWriter):
 
             self.wl("for weight in weights:")
             self.indent += 1
-            self.wl("name = weight.name")
+            self.wl("name = weight.path")
             if self.contains_incompatible_np_floats:
                 self.wl(
                     "# Some floating-point weights in the model havea a dtype that is incompatible with the .numpy() call."

--- a/forge/forge/tvm_calls/forge_compile.py
+++ b/forge/forge/tvm_calls/forge_compile.py
@@ -1285,13 +1285,13 @@ def format_tvm_graph_weights(inputs, module, compiler_cfg, framework=None):
         }
 
     elif framework == "tensorflow":
-        trainable_weight_names = [t_weight.name for t_weight in module.trainable_weights]
+        trainable_weight_names = [t_weight.path for t_weight in module.trainable_weights]
         weights = {
-            weight.name: (
+            weight.path: (
                 torch.Tensor(
                     tf.cast(weight, tf.float32).numpy() if tf.as_dtype(weight.dtype).is_floating else weight.numpy()
                 ),
-                weight.name in trainable_weight_names,
+                weight.path in trainable_weight_names,
             )
             for weight in module.weights
         }

--- a/forge/forge/tvm_calls/forge_utils.py
+++ b/forge/forge/tvm_calls/forge_utils.py
@@ -231,10 +231,10 @@ def construct_tvm_ir(framework: str, model, tvm_mod, params, compiler_cfg: Compi
         for (bad_name, value) in params.items():
             weight_found = False
             for tf_weight in model.weights:
-                if np.array_equal(tf_weight.numpy(), value.numpy()) and tf_weight.name not in found_weights:
-                    param_name_lookup[bad_name] = tf_weight.name
+                if np.array_equal(tf_weight.numpy(), value.numpy()) and tf_weight.path not in found_weights:
+                    param_name_lookup[bad_name] = tf_weight.path
                     weight_found = True
-                    found_weights.append(tf_weight.name)
+                    found_weights.append(tf_weight.path)
                     break
             if not weight_found:
                 param_name_lookup[bad_name] = bad_name

--- a/forge/test/mlir/test_ops_tf.py
+++ b/forge/test/mlir/test_ops_tf.py
@@ -95,7 +95,7 @@ def test_conv2d(
     verify(inputs, framework_model, compiled_model)
 
 
-@pytest.mark.xfail
+@pytest.mark.push
 def test_dual_conv2d():
 
     tf.random.set_seed(0)

--- a/forge/test/models/tensorflow/vision/resnet/test_resnet.py
+++ b/forge/test/models/tensorflow/vision/resnet/test_resnet.py
@@ -14,7 +14,7 @@ from forge.verify.verify import verify
 from test.models.tensorflow.vision.resnet.model_utils.image_utils import get_sample_inputs
 
 
-@pytest.mark.xfail
+@pytest.mark.push
 @pytest.mark.nightly
 def test_resnet_tensorflow():
 


### PR DESCRIPTION
### Ticket
Fixes #2563 

### Problem description
Jax and tensorflow version upgrade caused failures in dual conv2d and resnet tf tests.

### What's changed
This PR updates the way we retrieve the name of a TensorFlow model weight from tf_weight.name to tf_weight.path.
In earlier versions of TensorFlow, tf_weight.name reliably returned the full name of the variable, which was used to map weights correctly. However, in more recent TensorFlow versions, the .name attribute no longer returns the expected full path in all cases, leading to incorrect or failed mappings.

Logs of test cases which are passing now:
[dual_conv2d_tf.log](https://github.com/user-attachments/files/21310289/dual_conv2d_tf.log)
[resnet_tf.log](https://github.com/user-attachments/files/21310292/resnet_tf.log)
