### PR TITLE
Added missing named attributes for all operations.

### DIFF
--- a/forge/csrc/graph_lib/node_types.hpp
+++ b/forge/csrc/graph_lib/node_types.hpp
@@ -672,7 +672,10 @@ class EdgeAttributes
     void clear_broadcast_dims();
     void set_broadcast_dim(int dim, int size_or_factor, bool explicit_bcast = false)
     {
-        tms.push_back(OpType("broadcast", {dim, size_or_factor, explicit_bcast}));
+        tms.push_back(OpType(
+            "broadcast",
+            {dim, size_or_factor, explicit_bcast},
+            {{"dim", dim}, {"size", size_or_factor}, {"explicit_bcast", explicit_bcast}}));
     }
     void remove_broadcast_dim(int dim);
     inline UBlockOrder get_ublock_order() const { return ublock_order; }

--- a/forge/csrc/graph_lib/utils.cpp
+++ b/forge/csrc/graph_lib/utils.cpp
@@ -1213,7 +1213,10 @@ bool swap_broadcast_dims(graphlib::Graph *graph, graphlib::Edge edge, int old_di
             bool explicit_bcast = std::get<bool>(op_type.legacy_attrs_[2]);
             if (dim == old_dim)
             {
-                graphlib::OpType updated_bcast("broadcast", {new_dim, size, explicit_bcast});
+                graphlib::OpType updated_bcast(
+                    "broadcast",
+                    {new_dim, size, explicit_bcast},
+                    {{"dim", new_dim}, {"size", size}, {"explicit_bcast", explicit_bcast}});
                 new_tms.push_back(updated_bcast);
                 swapped = true;
             }
@@ -1718,7 +1721,8 @@ void ConstEvalGraph::pad_output_to_forge_dims(std::string const &name_prefix)
     {
         if (shape[dim] % graphlib::Shape::FORGE_TILE_DIM != 0)
         {
-            graphlib::OpType pad_tile("pad_tile", {dim, (int)shape[dim]});
+            graphlib::OpType pad_tile(
+                "pad_tile", {dim, (int)shape[dim]}, {{"dim", dim}, {"original_length", (int)shape[dim]}});
             auto consteval_pad_tile = graphlib::create_node<graphlib::PyOpNode>(
                 name_prefix + "_pad_tile_" + ((dim == -1) ? "c_" : "r_") + output->name(), pad_tile);
             shape[dim] = align_up_tile(shape[dim]);

--- a/forge/csrc/ops/op_reshape.cpp
+++ b/forge/csrc/ops/op_reshape.cpp
@@ -83,7 +83,7 @@ void decompose_reshape(const Op &op, DecomposingContext &dc, const std::vector<N
 
     NodeContext result = inputs[0];  // clang-format off
     for (; rank < 0; ++rank) result = dc.op(graphlib::OpType("squeeze",   {0},                           {{"dim", 0}}), {std::move(result)});
-    for (; rank > 0; --rank) result = dc.op(graphlib::OpType("unsqueeze", {0, int(result.shape.size())}, {{"dim", 0}}), {result});  // clang-format on
+    for (; rank > 0; --rank) result = dc.op(graphlib::OpType("unsqueeze", {0, int(result.shape.size())}, {{"dim", 0}, {"orig_shape_len", int(result.shape.size())}}), {result});  // clang-format on
 
     dc.fuse(result);
 }

--- a/forge/csrc/passes/constant_folding.cpp
+++ b/forge/csrc/passes/constant_folding.cpp
@@ -91,7 +91,7 @@ static void insert_pad_within_tile(graphlib::Graph *graph, graphlib::Edge edge, 
     bool implicit_broadcast = producer_dim_size == 1;
     if (implicit_broadcast)
     {
-        tms.push_back(graphlib::OpType("broadcast", {dim, size}, {}));
+        tms.push_back(graphlib::OpType("broadcast", {dim, size}, {{"dim", dim}, {"size", size}}));
         return;
     }
 
@@ -104,7 +104,10 @@ static void insert_pad_within_tile(graphlib::Graph *graph, graphlib::Edge edge, 
                 consumer->clone("pad_tile_" + producer->name() + "_" + std::to_string(edge.edge_creation_id)),
                 graph->get_subgraph_id_for_node(producer->id()))
             ->as<graphlib::OpNode>();
-    pad_tile->change_op_type(graphlib::OpType("pad_tile", {dim, (int)producer->shape()[dim]}));
+    pad_tile->change_op_type(graphlib::OpType(
+        "pad_tile",
+        {dim, (int)producer->shape()[dim]},
+        {{"dim", dim}, {"original_length", (int)producer->shape()[dim]}}));
     auto [incoming_edge, outgoing_edge] = graphlib::insert_node_on_edge(graph, edge, pad_tile);
     if (only_bcast)
     {

--- a/forge/csrc/passes/erase_unnecessary_4d_tm_sequence.cpp
+++ b/forge/csrc/passes/erase_unnecessary_4d_tm_sequence.cpp
@@ -141,7 +141,10 @@ static void commute_4d_tm_ops(graphlib::Graph *graph, std::vector<graphlib::Node
     std::vector<graphlib::PyOpNode *> new_select_nodes;
     for (int i = 0; i < fourth_dim; i++)
     {
-        graphlib::OpType op_type("select", {-3, i * third_dim, third_dim, orig_third_dim});
+        graphlib::OpType op_type(
+            "select",
+            {-3, i * third_dim, third_dim, orig_third_dim},
+            {{"dim", -3}, {"begin", i * third_dim}, {"length", third_dim}, {"stride", orig_third_dim}});
         std::string op_name = first->name() + "_replaced_select.";
         op_name += std::to_string(i);
         graphlib::PyOpNode *new_node = graph->add_node(
@@ -153,7 +156,7 @@ static void commute_4d_tm_ops(graphlib::Graph *graph, std::vector<graphlib::Node
     }
 
     // create interleave op
-    graphlib::OpType op_type("interleave", {-3, 1});
+    graphlib::OpType op_type("interleave", {-3, 1}, {{"dim", -3}, {"stride", 1}});
     std::string op_name = first->name() + "_replaced_interleave.0";
     graphlib::PyOpNode *new_interleave_node = graph->add_node(
         graphlib::create_node<graphlib::PyOpNode>(op_name, op_type), graph->get_subgraph_id_for_node(first->id()));

--- a/forge/csrc/passes/fracture.cpp
+++ b/forge/csrc/passes/fracture.cpp
@@ -196,7 +196,10 @@ static std::unique_ptr<graphlib::PyOpNode> create_slice(
 
     int start = i * (int)shape[dim];
     int length = (int)shape[dim];
-    graphlib::OpType select("select", {dim, start, length, stride});
+    graphlib::OpType select(
+        "select",
+        {dim, start, length, stride},
+        {{"dim", dim}, {"begin", start}, {"length", length}, {"stride", stride}});
     auto new_op = graphlib::create_node<graphlib::PyOpNode>(new_op_name, select);
     new_op->set_shape(shape);
     new_op->set_epoch_type(op->get_epoch_type());

--- a/forge/csrc/passes/fuse_per_channel_ops.cpp
+++ b/forge/csrc/passes/fuse_per_channel_ops.cpp
@@ -328,7 +328,8 @@ static bool fuse_per_channel_concat(graphlib::Graph *graph, graphlib::OpNode *co
                     while (input_ndim < concat->shape().size())
                     {
                         // insert unsqueeze tms
-                        graphlib::OpType op_type("unsqueeze", {0, (int)input_ndim});
+                        graphlib::OpType op_type(
+                            "unsqueeze", {0, (int)input_ndim}, {{"dim", 0}, {"orig_shape_len", (int)input_ndim}});
                         graph->get_edge_attributes(current_edge)->append_tm(op_type);
                         input_ndim++;
                     }

--- a/forge/csrc/passes/link_past_cache_ios.cpp
+++ b/forge/csrc/passes/link_past_cache_ios.cpp
@@ -73,7 +73,8 @@ void rotate_params(graphlib::Graph *graph, std::vector<graphlib::Node *> params_
     {
         graphlib::Shape shape = param->shape();
         int end = shape[-2];
-        graphlib::OpType index_op_right("index", {-2, 32, end, 1});
+        graphlib::OpType index_op_right(
+            "index", {-2, 32, end, 1}, {{"dim", -2}, {"begin", 32}, {"length", end}, {"stride", 1}});
         auto index_node_right = graph->add_node(
             graphlib::create_node<graphlib::PyOpNode>(param->name() + "_index_right", index_op_right), subgraph_index);
         graphlib::Edge read_edge_right(
@@ -81,7 +82,8 @@ void rotate_params(graphlib::Graph *graph, std::vector<graphlib::Node *> params_
         graph->add_edge(read_edge_right);
         calculate_and_set_node_shape(graph, index_node_right);
 
-        graphlib::OpType index_op_left("index", {-2, 0, 32, 1});
+        graphlib::OpType index_op_left(
+            "index", {-2, 0, 32, 1}, {{"dim", -2}, {"begin", 0}, {"length", 32}, {"stride", 1}});
         auto index_node_left = graph->add_node(
             graphlib::create_node<graphlib::PyOpNode>(param->name() + "_index_left", index_op_left), subgraph_index);
         graphlib::Edge read_edge_left(
@@ -272,7 +274,8 @@ std::map<std::string, std::size_t> convert_inputs_to_params(
             {
                 graphlib::Shape concat_shape = producers[0]->shape();
                 int end = concat_shape[-2];
-                graphlib::OpType index_op("index", {-2, -32, end, 1});
+                graphlib::OpType index_op(
+                    "index", {-2, -32, end, 1}, {{"dim", -2}, {"begin", -32}, {"length", end}, {"stride", 1}});
                 auto index_node = graph->add_node(
                     graphlib::create_node<graphlib::PyOpNode>(producers[0]->name() + "_index", index_op),
                     graph->get_subgraph_id_for_node(producers[0]->id()));
@@ -287,7 +290,7 @@ std::map<std::string, std::size_t> convert_inputs_to_params(
             // Add control-edge and hstack op if needed
             if (slice_factor > 1)
             {
-                graphlib::OpType stack_op("hstack", {slice_factor});
+                graphlib::OpType stack_op("hstack", {slice_factor}, {{"slice_factor", slice_factor}});
                 auto stack_node = graph->add_node(
                     graphlib::create_node<graphlib::PyOpNode>(output_node->name() + "_stack", stack_op),
                     graph->get_subgraph_id_for_node(output_node->id()));
@@ -438,7 +441,7 @@ std::map<std::string, std::size_t> convert_inputs_to_params(
 
         if (is_concat and slice_factor > 1)
         {
-            graphlib::OpType slice_op("hslice", {slice_factor});
+            graphlib::OpType slice_op("hslice", {slice_factor}, {{"slice_factor", slice_factor}});
             auto slice_node = graph->add_node(
                 graphlib::create_node<graphlib::PyOpNode>(input_node->name() + "_slice", slice_op),
                 graph->get_subgraph_id_for_node(input_node->id()));
@@ -477,7 +480,7 @@ std::map<std::string, std::size_t> convert_inputs_to_params(
         int stack_factor = output_node->shape().canonical()[-3] / input_param->shape().canonical()[-3];
         if (stack_factor > 1)
         {
-            graphlib::OpType stack_op("hstack", {stack_factor});
+            graphlib::OpType stack_op("hstack", {stack_factor}, {{"slice_factor", stack_factor}});
             auto stack_node = graph->add_node(
                 graphlib::create_node<graphlib::PyOpNode>(output_node->name() + "_stack", stack_op),
                 graph->get_subgraph_id_for_node(output_node->id()));

--- a/forge/csrc/passes/pad_output_buffer.cpp
+++ b/forge/csrc/passes/pad_output_buffer.cpp
@@ -23,7 +23,10 @@ void insert_forge_pad(
     graphlib::Node *node = graph->node_by_id(edge.consumer_node_id);
 
     // Construct forge_pad node and insert in graph
-    graphlib::OpType forge_pad_op_type("forge_pad", {rt_pad_amount, ct_pad_amount, 0});
+    graphlib::OpType forge_pad_op_type(
+        "forge_pad",
+        {rt_pad_amount, ct_pad_amount, 0},
+        {{"rt_pad_amount", rt_pad_amount}, {"ct_pad_amount", ct_pad_amount}, {"pad_value", 0}});
     auto forge_pad_ref_node = graph->add_node(
         graphlib::create_node<graphlib::PyOpNode>(node->name() + "_pad", forge_pad_op_type),
         graph->get_subgraph_id_for_node(node->id()));

--- a/forge/csrc/test/passes/test_decompose_nd_reshape_split.cpp
+++ b/forge/csrc/test/passes/test_decompose_nd_reshape_split.cpp
@@ -37,10 +37,18 @@ TEST_F(DecomposeNdReshapeSplitTest, basic_dimension_split_optimization)
     reshape_node->set_shape(graphlib::Shape::create({2, 2, 6}));
 
     // Create index operations
-    auto index1_node = add_node<graphlib::PyOpNode>(*graph, "index1", "index", {1, 0, 1, 1}, {reshape_node});
+    auto index1_node = add_node<graphlib::PyOpNode>(
+        *graph,
+        "index1",
+        graphlib::OpType("index", {1, 0, 1, 1}, {{"dim", 1}, {"begin", 0}, {"length", 1}, {"stride", 1}}),
+        {reshape_node});
     index1_node->set_shape(graphlib::Shape::create({2, 1, 6}));
 
-    auto index2_node = add_node<graphlib::PyOpNode>(*graph, "index2", "index", {1, 1, 2, 1}, {reshape_node});
+    auto index2_node = add_node<graphlib::PyOpNode>(
+        *graph,
+        "index2",
+        graphlib::OpType("index", {1, 1, 2, 1}, {{"dim", 1}, {"begin", 1}, {"length", 2}, {"stride", 1}}),
+        {reshape_node});
     index2_node->set_shape(graphlib::Shape::create({2, 1, 6}));
 
     // Create squeeze operations

--- a/forge/csrc/test/passes/test_link_past_cache_ios.cpp
+++ b/forge/csrc/test/passes/test_link_past_cache_ios.cpp
@@ -38,7 +38,8 @@ struct WhisperPastCacheBase : testing::Test
         auto transpose_1 = add_node<graphlib::PyOpNode>(
             *graph, "transpose_1", graphlib::OpType("transpose", {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto matmul_1 = add_node<graphlib::PyOpNode>(*graph, "matmul_1", "matmul", {}, {in_1, transpose_1});
-        auto hslice_1 = add_node<graphlib::PyOpNode>(*graph, "hslice_1", "hslice", {12}, {matmul_1});
+        auto hslice_1 = add_node<graphlib::PyOpNode>(
+            *graph, "hslice_1", graphlib::OpType("hslice", {12}, {{"slice_factor", 12}}), {matmul_1});
         auto concat_1 = add_node<graphlib::PyOpNode>(
             *graph, "concat_1", graphlib::OpType("concatenate", {}, {{"dim", -2}}), {pkv_input_1, hslice_1});
         auto output_1 = create_output(*graph, "output_1", concat_1);
@@ -46,7 +47,8 @@ struct WhisperPastCacheBase : testing::Test
         auto transpose_2 = add_node<graphlib::PyOpNode>(
             *graph, "transpose_2", graphlib::OpType("transpose", {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto matmul_2 = add_node<graphlib::PyOpNode>(*graph, "matmul_2", "matmul", {}, {in_2, transpose_2});
-        auto hslice_2 = add_node<graphlib::PyOpNode>(*graph, "hslice_2", "hslice", {12}, {matmul_2});
+        auto hslice_2 = add_node<graphlib::PyOpNode>(
+            *graph, "hslice_2", graphlib::OpType("hslice", {12}, {{"slice_factor", 12}}), {matmul_2});
         auto concat_2 = add_node<graphlib::PyOpNode>(
             *graph, "concat_2", graphlib::OpType("concatenate", {}, {{"dim", -2}}), {pkv_input_2, hslice_2});
         auto output_2 = create_output(*graph, "output_2", concat_2);
@@ -136,7 +138,8 @@ struct WhisperPastCacheSubGraph : testing::Test
             *graph, "transpose_1", graphlib::OpType("transpose", {}, {{"dim0", -2}, {"dim1", -1}}), {weight}, {}, 0);
         auto matmul_1 =
             add_node<graphlib::PyOpNode>(*graph, "matmul_1", "matmul", {}, {reshape_1, transpose_1}, {}, {}, {}, 0);
-        auto hslice_1 = add_node<graphlib::PyOpNode>(*graph, "hslice_1", "hslice", {6}, {matmul_1}, {}, {}, {}, 0);
+        auto hslice_1 = add_node<graphlib::PyOpNode>(
+            *graph, "hslice_1", graphlib::OpType("hslice", {6}, {{"slice_factor", 6}}), {matmul_1}, {}, 0);
         auto output_1_1 = create_output(*graph, "output_1_1", hslice_1, 0);
         auto reshape_1_ = add_node<graphlib::PyOpNode>(
             *graph,
@@ -235,7 +238,8 @@ struct T5PastCacheRotate : testing::Test
         auto transpose_1 = add_node<graphlib::PyOpNode>(
             *graph, "transpose_1", graphlib::OpType("transpose", {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto matmul_1 = add_node<graphlib::PyOpNode>(*graph, "matmul_1", "matmul", {}, {in_1, transpose_1});
-        auto hslice_1 = add_node<graphlib::PyOpNode>(*graph, "hslice_1", "hslice", {8}, {matmul_1});
+        auto hslice_1 = add_node<graphlib::PyOpNode>(
+            *graph, "hslice_1", graphlib::OpType("hslice", {8}, {{"slice_factor", 8}}), {matmul_1});
         auto concat_1 = add_node<graphlib::PyOpNode>(
             *graph, "concat_1", graphlib::OpType("concatenate", {}, {{"dim", -2}}), {pkv_input_1, hslice_1});
         auto output_1 = create_output(*graph, "output_1", concat_1);
@@ -244,7 +248,8 @@ struct T5PastCacheRotate : testing::Test
         auto transpose_2 = add_node<graphlib::PyOpNode>(
             *graph, "transpose_2", graphlib::OpType("transpose", {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto matmul_2 = add_node<graphlib::PyOpNode>(*graph, "matmul_2", "matmul", {}, {in_2, transpose_2});
-        auto hslice_2 = add_node<graphlib::PyOpNode>(*graph, "hslice_2", "hslice", {8}, {matmul_2});
+        auto hslice_2 = add_node<graphlib::PyOpNode>(
+            *graph, "hslice_2", graphlib::OpType("hslice", {8}, {{"slice_factor", 8}}), {matmul_2});
         auto concat_2 = add_node<graphlib::PyOpNode>(
             *graph, "concat_2", graphlib::OpType("concatenate", {}, {{"dim", -2}}), {pkv_input_2, hslice_2});
         auto output_2 = create_output(*graph, "output_2", concat_2);
@@ -364,10 +369,15 @@ struct Falcon40bPastCache : testing::Test
         auto transpose_1 = add_node<graphlib::PyOpNode>(
             *graph, "transpose_1", graphlib::OpType("transpose", {}, {{"dim0", -2}, {"dim1", -1}}), {weight});
         auto matmul_1 = add_node<graphlib::PyOpNode>(*graph, "matmul_1", "matmul", {}, {in_1_1, transpose_1});
-        auto hslice_1 = add_node<graphlib::PyOpNode>(*graph, "hslice_1", "hslice", {1}, {matmul_1});
+        auto hslice_1 = add_node<graphlib::PyOpNode>(
+            *graph, "hslice_1", graphlib::OpType("hslice", {1}, {{"slice_factor", 1}}), {matmul_1});
         auto multiply_1 = add_node<graphlib::PyOpNode>(*graph, "multiply_1", "multiply", {}, {hslice_1, cos_0});
         auto add_1 = add_node<graphlib::PyOpNode>(*graph, "add_1", "add", {}, {multiply_1, in_1_2});
-        auto broadcast_1 = add_node<graphlib::PyOpNode>(*graph, "broadcast_1", "broadcast", {-3, 32, 1}, {add_1});
+        auto broadcast_1 = add_node<graphlib::PyOpNode>(
+            *graph,
+            "broadcast_1",
+            graphlib::OpType("broadcast", {-3, 32, 1}, {{"dim", -3}, {"size", 32}, {"explicit_bcast", true}}),
+            {add_1});
         auto output_1 = create_output(*graph, "output_1", broadcast_1);
 
         // path 2
@@ -485,8 +495,16 @@ struct Fuyu8bPastCache : testing::Test
             *graph, "reshape_2", graphlib::OpType("reshape", {}, {{"shape", std::vector{1, 416, 64, 64}}}), {matmul_2});
         auto transpose_2 = add_node<graphlib::PyOpNode>(
             *graph, "transpose_2", graphlib::OpType("transpose", {}, {{"dim0", -3}, {"dim1", -2}}), {reshape_2});
-        auto index_2_1 = add_node<graphlib::PyOpNode>(*graph, "index_2_1", "index", {-1, 0, 32, 64}, {transpose_2});
-        auto index_2_2 = add_node<graphlib::PyOpNode>(*graph, "index_2_2", "index", {-1, 32, 64, 64}, {transpose_2});
+        auto index_2_1 = add_node<graphlib::PyOpNode>(
+            *graph,
+            "index_2_1",
+            graphlib::OpType("index", {-1, 0, 32, 64}, {{"dim", -1}, {"begin", 0}, {"length", 32}, {"stride", 64}}),
+            {transpose_2});
+        auto index_2_2 = add_node<graphlib::PyOpNode>(
+            *graph,
+            "index_2_2",
+            graphlib::OpType("index", {-1, 32, 64, 64}, {{"dim", -1}, {"begin", 32}, {"length", 64}, {"stride", 64}}),
+            {transpose_2});
         auto add_2 = add_node<graphlib::PyOpNode>(*graph, "add_2", "add", {}, {in_add, index_2_2});
         auto concat_2 = add_node<graphlib::PyOpNode>(
             *graph, "concat_2", graphlib::OpType("concatenate", {}, {{"dim", -1}}), {index_2_1, add_2});

--- a/forge/forge/op/dram_queue.py
+++ b/forge/forge/op/dram_queue.py
@@ -29,4 +29,4 @@ def DRAMQueue(name: str, operandA: Tensor, *, num_entries: int) -> Tensor:
         Forge tensor
     """
 
-    return op("dram_queue", name, operandA, attrs=(num_entries,)).get_tensor()
+    return op("dram_queue", name, operandA, attrs=(num_entries,), num_entries=num_entries).get_tensor()

--- a/forge/forge/op/eltwise_nary.py
+++ b/forge/forge/op/eltwise_nary.py
@@ -91,7 +91,7 @@ def IndexCopy(name: str, operandA: Tensor, index: Tensor, value: Tensor, dim: in
     """
     if dim < 0:
         dim += len(operandA.shape)
-    return op("index_copy", name, operandA, index, value, attrs=(dim,)).get_tensor()
+    return op("index_copy", name, operandA, index, value, attrs=(dim,), dim=dim).get_tensor()
 
 
 def Stack(name: str, *operands: Tensor, axis: int) -> Tensor:

--- a/forge/forge/op/eltwise_unary.py
+++ b/forge/forge/op/eltwise_unary.py
@@ -119,7 +119,7 @@ def Pow(name: str, operandA: Tensor, exponent: Union[int, float]) -> Tensor:
         Forge tensor
     """
 
-    return op("pow", name, operandA, attrs=(exponent,)).get_tensor()
+    return op("pow", name, operandA, attrs=(exponent,), exponent=exponent).get_tensor()
 
 
 def Identity(name: str, operandA: Tensor, unsqueeze: str = None, unsqueeze_dim: int = None) -> Tensor:
@@ -242,7 +242,7 @@ def Relu(name: str, operandA: Tensor, threshold=0.0, mode="min") -> Tensor:
     if threshold == 0.0 and mode == "min":
         return op("relu", name, operandA).get_tensor()  # avoid threshold < 0.0 error due to FP arithmetics
     else:
-        return op("relu", name, operandA, attrs=(threshold, mode)).get_tensor()
+        return op("relu", name, operandA, attrs=(threshold, mode), threshold=threshold, mode=mode).get_tensor()
 
 
 def LeakyRelu(name: str, operandA: Tensor, alpha: int) -> Tensor:
@@ -293,7 +293,7 @@ def Gelu(name: str, operandA: Tensor, approximate="none") -> Tensor:
         Forge tensor
     """
 
-    return op("gelu", name, operandA, attrs=(approximate,)).get_tensor()
+    return op("gelu", name, operandA, attrs=(approximate,), approximate=approximate).get_tensor()
 
 
 def Sigmoid(name: str, operandA: Tensor) -> Tensor:
@@ -548,7 +548,7 @@ def Dropout(name: str, operandA: Tensor, p: float = 0.5, training: bool = True, 
         Forge tensor
     """
 
-    return op("dropout", name, operandA, attrs=(p, training, seed)).get_tensor()
+    return op("dropout", name, operandA, attrs=(p, training, seed), p=p, training=training, seed=seed).get_tensor()
 
 
 def Tilize(name: str, operandA: Tensor) -> Tensor:

--- a/forge/forge/op/eval/forge/convolution.py
+++ b/forge/forge/op/eval/forge/convolution.py
@@ -122,7 +122,9 @@ class Conv2d(PyOp):
 
         if bias is not None and len(bias.shape) < len(activations.shape):
             while len(bias.shape) < len(activations.shape):
-                bias = dc.op_with_named_attrs("unsqueeze", [bias], {"dim": 0}, (0, len(bias.shape)))
+                bias = dc.op_with_named_attrs(
+                    "unsqueeze", [bias], {"dim": 0, "orig_shape_len": len(bias.shape)}, (0, len(bias.shape))
+                )
 
         is_bias_unchanged = bias is None or bias == inputs[2]
 

--- a/forge/forge/op/eval/forge/eltwise_binary.py
+++ b/forge/forge/op/eval/forge/eltwise_binary.py
@@ -155,13 +155,20 @@ def decompose_post_autograd(op_type, attr, dc, inputs):
 
         if slice_factor != None:
             concat_z = dc.op("interleave", [operand0, operand1], (-3, 1))
-            result = dc.op("reduce_max", [concat_z], (-3, 2))
+            result = dc.op_with_named_attrs(
+                "reduce_max", [concat_z], {"dim_arg": -3, "stride": 2, "keep_dim": True}, (-3, 2, True)
+            )
         else:
             concat_z = dc.op_with_named_attrs("concatenate", [operand0, operand1], {"dim": -3})
-            result = dc.op("reduce_max", [concat_z], (-3,))
+            result = dc.op_with_named_attrs(
+                "reduce_max",
+                [concat_z],
+                {"dim_arg": -3, "stride": concat_z.shape[-3], "keep_dim": True},
+                (-3, concat_z.shape[-3], True),
+            )
 
         while len(result.shape) > max_operand_nd:
-            result = dc.op("squeeze", [result], (0,))
+            result = dc.op_with_named_attrs("squeeze", [result], {"dim": 0}, (0,))
 
         dc.fuse(result)
         return

--- a/forge/forge/op/eval/forge/eltwise_nary.py
+++ b/forge/forge/op/eval/forge/eltwise_nary.py
@@ -160,7 +160,12 @@ def backward(op_type, attr, ac, operand, inputs, output, grad):
         x = attr[1]
         shifts = attr[2:]
 
-        return ac.op("conv_sum", [grad], [y, x, -shifts[operand * 2], -shifts[operand * 2 + 1]])
+        return ac.op_with_named_attrs(
+            "conv_sum",
+            [grad],
+            {"y": y, "x": x, "shift_y": -shifts[operand * 2], "shift_x": -shifts[operand * 2 + 1]},
+            [y, x, -shifts[operand * 2], -shifts[operand * 2 + 1]],
+        )
 
     elif op_type == "interleave":
         axis = attr[0]
@@ -170,12 +175,21 @@ def backward(op_type, attr, ac, operand, inputs, output, grad):
         num_operands = len(inputs)
         result = grad
         if grad.shape[-1] % TILE_DIM != 0:
-            result = ac.op("pad_tile", (result,), (-1, grad.shape[-1]))
+            result = ac.op_with_named_attrs(
+                "pad_tile", (result,), {"dim": -1, "original_length": grad.shape[-1]}, (-1, grad.shape[-1])
+            )
         if grad.shape[-2] % TILE_DIM != 0:
-            result = ac.op("pad_tile", (result,), (-2, grad.shape[-2]))
+            result = ac.op_with_named_attrs(
+                "pad_tile", (result,), {"dim": -2, "original_length": grad.shape[-2]}, (-2, grad.shape[-2])
+            )
         result = ac.op("hstack", (result,), (num_operands,))
         if grad.shape[-2] % TILE_DIM != 0:
-            result = ac.op("narrow", (result,), (-2, 0, grad.shape[-2], result.shape[-2]))
+            result = ac.op_with_named_attrs(
+                "narrow",
+                (result,),
+                {"dim": -2, "start": 0, "length": grad.shape[-2], "original_length": result.shape[-2]},
+                (-2, 0, grad.shape[-2], result.shape[-2]),
+            )
         result = ac.op(
             "select",
             (result,),
@@ -187,7 +201,12 @@ def backward(op_type, attr, ac, operand, inputs, output, grad):
             ),
         )
         if grad.shape[-1] % TILE_DIM != 0:
-            result = ac.op("narrow", (result,), (-1, 0, grad.shape[-1], result.shape[-1]))
+            result = ac.op_with_named_attrs(
+                "narrow",
+                (result,),
+                {"dim": -1, "start": 0, "length": grad.shape[-1], "original_length": result.shape[-1]},
+                (-1, 0, grad.shape[-1], result.shape[-1]),
+            )
         return result
 
     assert False, f"{op_type} not defined in eltwise_nary"

--- a/forge/forge/op/eval/forge/eltwise_unary.py
+++ b/forge/forge/op/eval/forge/eltwise_unary.py
@@ -253,7 +253,7 @@ def backward(type, attr, ac, operand, inputs, output, grad):
         return res
 
     if type == "gelu":
-        gelud = ac.op("gelu_derivative", (inputs[0],), attr)
+        gelud = ac.op_with_named_attrs("gelu_derivative", (inputs[0],), {"approximate": attr[0]}, attr)
         return ac.op("multiply", (gelud, grad))
 
     if type == "log":
@@ -283,7 +283,7 @@ def backward(type, attr, ac, operand, inputs, output, grad):
         return res
 
     if type == "dropout":
-        return ac.op("dropout", (grad,), attr)
+        return ac.op_with_named_attrs("dropout", (grad,), {"p": attr[0], "training": attr[1], "seed": attr[2]}, attr)
 
     if type == "clip":
         x = inputs[0]

--- a/forge/forge/op/eval/forge/pad.py
+++ b/forge/forge/op/eval/forge/pad.py
@@ -244,7 +244,7 @@ def extract_and_mirror(dc, input, dim_axis, start, stop):
     # Mirror patch
     indices = torch.arange(stop - start - 1, -1, -1)
     indices_tensor = dc.tensor(indices)
-    patch_mirrored = dc.op("adv_index", [patch, indices_tensor], (dim_axis,))
+    patch_mirrored = dc.op_with_named_attrs("adv_index", [patch, indices_tensor], {"dim": dim_axis}, (dim_axis,))
 
     return patch_mirrored
 

--- a/forge/forge/op/eval/forge/pooling.py
+++ b/forge/forge/op/eval/forge/pooling.py
@@ -686,7 +686,12 @@ def decompose(type, attr, dc, inputs):
 
             d_start = i * sD
 
-            depth_slice = dc.op("index", [activations], (2, d_start, d_start + kD, activations.shape[2]))
+            depth_slice = dc.op_with_named_attrs(
+                "index",
+                [activations],
+                {"dim": 2, "start": d_start, "stop": d_start + kD, "stride": activations.shape[2]},
+                attrs=(2, d_start, d_start + kD, activations.shape[2]),
+            )
             depth_avg = dc.op_with_named_attrs("reduce_avg", [depth_slice], {"dim": [2], "keep_dim": True}, (2, True))
 
             named_attrs = {
@@ -722,7 +727,10 @@ def decompose(type, attr, dc, inputs):
             depth_avg_pooled = dc.op_with_named_attrs("avg_pool2d", [depth_avg], named_attrs, attr)
 
             depth_avg_pooled = dc.op_with_named_attrs(
-                "unsqueeze", [depth_avg_pooled], {"dim": 2}, (0, len(depth_avg_pooled.shape))
+                "unsqueeze",
+                [depth_avg_pooled],
+                {"dim": 2, "orig_shape_len": len(depth_avg_pooled.shape)},
+                (0, len(depth_avg_pooled.shape)),
             )
             result = dc.op_with_named_attrs("concatenate", [result, depth_avg_pooled], {"dim": (2)})
 

--- a/forge/forge/op/eval/forge/quantize.py
+++ b/forge/forge/op/eval/forge/quantize.py
@@ -183,14 +183,19 @@ def decompose(type, attr, dc, inputs):
         if len(inp_scale_shape) == 1:
             # Match ndim with actiavtion
             for i in range(0, left_ndim):
-                inp_scale = dc.op(
-                    "unsqueeze", [inp_scale], attrs=(0, len(inp_scale_shape)), output_df=inp_scale.output_df
+                inp_scale = dc.op_with_named_attrs(
+                    "unsqueeze",
+                    [inp_scale],
+                    {"dim": 0, "orig_shape_len": len(inp_scale_shape)},
+                    attrs=(0, len(inp_scale_shape)),
+                    output_df=inp_scale.output_df,
                 )
                 inp_scale_shape = [1] + inp_scale_shape
             for i in range(0, right_ndim):
-                inp_scale = dc.op(
+                inp_scale = dc.op_with_named_attrs(
                     "unsqueeze",
                     [inp_scale],
+                    {"dim": len(inp_scale_shape), "orig_shape_len": len(inp_scale_shape)},
                     attrs=(len(inp_scale_shape), len(inp_scale_shape)),
                     output_df=inp_scale.output_df,
                 )
@@ -200,14 +205,19 @@ def decompose(type, attr, dc, inputs):
         if len(out_scale_shape) == 1:
             # Match ndim with actiavtion
             for i in range(0, left_ndim):
-                out_scale = dc.op(
-                    "unsqueeze", [out_scale], attrs=(0, len(out_scale_shape)), output_df=out_scale.output_df
+                out_scale = dc.op_with_named_attrs(
+                    "unsqueeze",
+                    [out_scale],
+                    {"dim": 0, "orig_shape_len": len(out_scale_shape)},
+                    attrs=(0, len(out_scale_shape)),
+                    output_df=out_scale.output_df,
                 )
                 out_scale_shape = [1] + out_scale_shape
             for i in range(0, right_ndim):
-                out_scale = dc.op(
+                out_scale = dc.op_with_named_attrs(
                     "unsqueeze",
                     [out_scale],
+                    {"dim": len(out_scale_shape), "orig_shape_len": len(out_scale_shape)},
                     attrs=(len(out_scale_shape), len(out_scale_shape)),
                     output_df=out_scale.output_df,
                 )
@@ -215,10 +225,11 @@ def decompose(type, attr, dc, inputs):
 
         if out_scale_shape[axis] != act.shape[axis]:
             assert out_scale_shape[axis] == 1
-            out_scale = dc.op(
+            out_scale = dc.op_with_named_attrs(
                 "broadcast",
                 [out_scale],
-                attrs=(axis - len(out_scale_shape), act.shape[axis]),
+                {"dim": axis - len(out_scale_shape), "size": act.shape[axis], "explicit_bcast": True},
+                (axis - len(out_scale_shape), act.shape[axis], True),
                 output_df=out_scale.output_df,
             )
             out_scale_shape[axis] = act.shape[axis]
@@ -256,7 +267,11 @@ def decompose(type, attr, dc, inputs):
             # Match ndim with actiavtion
             for i in range(0, left_ndim):
                 scale = dc.op_with_named_attrs(
-                    "unsqueeze", [scale], {"dim": 0}, attrs=(0, len(scale_shape)), output_df=scale.output_df
+                    "unsqueeze",
+                    [scale],
+                    {"dim": 0, "orig_shape_len": len(scale_shape)},
+                    (0, len(scale_shape)),
+                    output_df=scale.output_df,
                 )
 
                 scale_shape = [1] + scale_shape
@@ -264,7 +279,7 @@ def decompose(type, attr, dc, inputs):
                 scale = dc.op_with_named_attrs(
                     "unsqueeze",
                     [scale],
-                    {"dim": len(scale_shape)},
+                    {"dim": len(scale_shape), "orig_shape_len": len(scale_shape)},
                     attrs=(len(scale_shape), len(scale_shape)),
                     output_df=scale.output_df,
                 )

--- a/forge/forge/op/eval/forge/reduce.py
+++ b/forge/forge/op/eval/forge/reduce.py
@@ -93,7 +93,9 @@ def backward(type, attr, ac, operand, inputs, output, grad):
             # This version treats multiple maximal values equally (unlike pytorch)
             mask = ac.op("subtract", [in0, output])  # has 0.0 in max positions and < 0.0 everywhere else
             mask = ac.op("add", [mask, one])  # has 1.0 in max positions and < 1.0 everywhere else
-            mask = ac.op("relu", [mask], (threshold,))  # has 1.0 in max posistions, 0.0 everywhere else
+            mask = ac.op_with_named_attrs(
+                "relu", [mask], {"threshold": threshold, "mode": "min"}, (threshold, "min")
+            )  # has 1.0 in max posistions, 0.0 everywhere else
             return ac.op("multiply", [grad, mask])
         else:
             # This version takes only the first of multiple maximal values (like pytorch)
@@ -105,12 +107,18 @@ def backward(type, attr, ac, operand, inputs, output, grad):
             neg_range = ac.tensor(neg_range_torch)
             mask = ac.op("subtract", [in0, output])  # has 0.0 in max positions and < 0.0 everywhere else
             mask = ac.op("add", [mask, one])  # has 1.0 in max positions and < 1.0 everywhere else
-            mask = ac.op("relu", [mask], (threshold,))  # has 1.0 in max posistions, 0.0 everywhere else
+            mask = ac.op_with_named_attrs(
+                "relu", [mask], {"threshold": threshold, "mode": "min"}, (threshold, "min")
+            )  # has 1.0 in max posistions, 0.0 everywhere else
             mask = ac.op("multiply", [mask, neg_range])  # puts range N...1 in max positions, 0.0 everywhere else
-            redc = ac.op("reduce_max", [mask], (dim, stride))  # argmax
+            redc = ac.op_with_named_attrs(
+                "reduce_max", [mask], {"dim_arg": dim, "stride": stride, "keep_dim": True}, (dim, stride, True)
+            )  # argmax
             mask = ac.op("subtract", [mask, redc])  # Orig range - argmax, 0.0 in FIRST max position
             mask = ac.op("add", [mask, one])  # has 1.0 is first max position, and < 1.0 everywhere else
-            mask = ac.op("relu", [mask], (threshold,))  # has 1.0 is first max position, and 0.0 everywhere else
+            mask = ac.op_with_named_attrs(
+                "relu", [mask], {"threshold": threshold, "mode": "min"}, (threshold, "min")
+            )  # has 1.0 is first max position, and 0.0 everywhere else
             return ac.op("multiply", [grad, mask])
 
     if type == "reduce_sum":
@@ -119,7 +127,9 @@ def backward(type, attr, ac, operand, inputs, output, grad):
     if type == "reduce_avg":
         dim = attr[0]
         size = ac.get_shape(inputs[0])[dim]
-        broadcast = ac.op("broadcast", (grad,), (dim, size))
+        broadcast = ac.op_with_named_attrs(
+            "broadcast", (grad,), {"dim": dim, "size": size, "explicit_bcast": True}, (dim, size, True)
+        )
         # Doing explicit broadcast here as TTNN not supporting implicit broadcast in multiply
         consts = ac.tensor(torch.full(broadcast.shape.as_list(), 1 / size))
         return ac.op("multiply", (broadcast, consts))

--- a/forge/forge/op/eval/forge/tm.py
+++ b/forge/forge/op/eval/forge/tm.py
@@ -619,10 +619,10 @@ def backward(type, attr, ac, operand, inputs, output, grad):
     assert operand == 0, "Invalid operand index"
 
     if type == "conv2d_depthwise_weights":
-        return ac.op("conv2d_depthwise_weights_bw", (grad,), attributes=attr)
+        return ac.op_with_named_attrs("conv2d_depthwise_weights_bw", (grad,), {}, attr)
 
     elif type == "conv2d_grouped_weights":
-        return ac.op("conv2d_grouped_weights_bw", (grad,), attributes=attr)
+        return ac.op_with_named_attrs("conv2d_grouped_weights_bw", (grad,), {}, attr)
 
     elif type == "select":
         assert len(attr) == 4
@@ -688,9 +688,29 @@ def backward(type, attr, ac, operand, inputs, output, grad):
             dim -= len(inputs[0].shape)
         if dim in [-1, -2] and align_up_tile(length) == align_up_tile(inputs[0].shape[dim]):
             if dim == -1:
-                return ac.op("pad", (grad,), (start, original_length - length - start, 0, False))
+                return ac.op_with_named_attrs(
+                    "pad",
+                    (grad,),
+                    {
+                        "padding": [start, original_length - length - start],
+                        "mode": 0,
+                        "value": 0,
+                        "channel_last": False,
+                    },
+                    (start, original_length - length - start, 0, False),
+                )
             elif dim == -2:
-                return ac.op("pad", (grad,), (0, 0, start, original_length - length - start, 0, False))
+                return ac.op_with_named_attrs(
+                    "pad",
+                    (grad,),
+                    {
+                        "padding": [0, 0, start, original_length - length - start],
+                        "mode": 0,
+                        "value": 0,
+                        "channel_last": False,
+                    },
+                    (0, 0, start, original_length - length - start, 0, False),
+                )
             raise ArgumentError("Only dim == 2 and dim == 3 are supported.")
         else:
             raise NotImplementedError("Unimplemented narrow in forge")
@@ -703,7 +723,7 @@ def backward(type, attr, ac, operand, inputs, output, grad):
 
         dim = attr[0]
         input_ndim = attr[1]
-        return ac.op("squeeze", (grad,), (dim,), {"dim": dim})
+        return ac.op_with_named_attrs("squeeze", (grad,), {"dim": dim}, (dim,))
 
     elif type == "squeeze":
         assert len(attr) == 1
@@ -714,7 +734,9 @@ def backward(type, attr, ac, operand, inputs, output, grad):
         dim = attr[0]
         if grad.shape.len() == 4:  # Cannot unsqueeze beyond 4D
             return ac.op(Nop.create(), (grad,))
-        return ac.op("unsqueeze", (grad,), attributes=(dim, grad.shape.len()), named_attrs={"dim": dim})
+        return ac.op_with_named_attrs(
+            "unsqueeze", (grad,), {"dim": dim, "orig_shape_len": grad.shape.len()}, attrs=(dim, grad.shape.len())
+        )
 
     elif type == "broadcast":
         assert len(attr) == 3
@@ -725,7 +747,7 @@ def backward(type, attr, ac, operand, inputs, output, grad):
         assert attr[0] >= 0 and attr[0] <= 3, f"Invalid broadcast dim after lowering: {attr[0]}"
 
         if attr[0] == 2 or attr[0] == 3:
-            ret = ac.op("reduce_sum", (grad,), (attr[0],), {"keep_dim": True})
+            ret = ac.op_with_named_attrs("reduce_sum", (grad,), {"dim_arg": attr[0], "keep_dim": True}, (attr[0], True))
         else:
             ret = ac.op_with_named_attrs(
                 "transpose",
@@ -734,7 +756,7 @@ def backward(type, attr, ac, operand, inputs, output, grad):
                 ],
                 {"dim0": attr[0], "dim1": -2},
             )
-            ret = ac.op("reduce_sum", (ret,), (-2,), {"keep_dim": True})
+            ret = ac.op_with_named_attrs("reduce_sum", (ret,), {"dim_arg": -2, "keep_dim": True}, (-2, True))
             ret = ac.op_with_named_attrs(
                 "transpose",
                 [
@@ -755,8 +777,8 @@ def backward(type, attr, ac, operand, inputs, output, grad):
         shape.insert(dim, repeats)
 
         ret = ac.op_with_named_attrs("reshape", (grad,), {"shape": shape})
-        ret = ac.op("reduce_sum", (ret,), (dim, True), {"dim_arg": [dim], "keep_dim": True})
-        ret = ac.op("squeeze", (ret,), (dim,), {"dim": dim})
+        ret = ac.op_with_named_attrs("reduce_sum", (ret,), {"dim_arg": dim, "keep_dim": True}, (dim, True))
+        ret = ac.op_with_named_attrs("squeeze", (ret,), {"dim": dim}, (dim,))
         return ret
 
     elif type == "index":
@@ -784,7 +806,9 @@ def unsqueeze_input_for_reshape_decomp(dc, inp):
     current_shape = inp.shape.as_list()
     while len(current_shape) < 4:
         current_shape.insert(0, 1)
-        inp = dc.op_with_named_attrs("unsqueeze", (inp,), {"dim": 0}, (0, len(inp.shape.as_list())))
+        inp = dc.op_with_named_attrs(
+            "unsqueeze", (inp,), {"dim": 0, "orig_shape_len": len(inp.shape.as_list())}, (0, len(inp.shape.as_list()))
+        )
 
     return inp
 
@@ -1003,8 +1027,12 @@ def decompose_select(attr, dc, inputs):
     ):
         assert len(attr) == 4, "Select should have 4 attributes"
         x = result
-        x = dc.op("pad_tile", [x], (-2, orig_shape[-2]))
-        x = dc.op("pad_tile", [x], (-1, orig_shape[-1]))
+        x = dc.op_with_named_attrs(
+            "pad_tile", [x], {"dim": -2, "original_length": orig_shape[-2]}, attrs=(-2, orig_shape[-2])
+        )
+        x = dc.op_with_named_attrs(
+            "pad_tile", [x], {"dim": -1, "original_length": orig_shape[-1]}, attrs=(-1, orig_shape[-1])
+        )
 
         cols = []
         size = len(range(index, orig_shape[dim], stride)) * len(range(index, index + length))
@@ -1031,12 +1059,32 @@ def decompose_select(attr, dc, inputs):
             result = dc.op_with_named_attrs("transpose", [result], {"dim0": -2, "dim1": -1})
 
         if is_x_select:
-            result = dc.op("narrow", [result], (-1, 0, size, result.shape[-1]))
-            result = dc.op("narrow", [result], (-2, 0, orig_shape[-2], result.shape[-2]))
+            result = dc.op_with_named_attrs(
+                "narrow",
+                [result],
+                {"dim": -1, "start": 0, "length": size, "original_length": result.shape[-1]},
+                attrs=(-1, 0, size, result.shape[-1]),
+            )
+            result = dc.op_with_named_attrs(
+                "narrow",
+                [result],
+                {"dim": -2, "start": 0, "length": orig_shape[-2], "original_length": result.shape[-2]},
+                attrs=(-2, 0, orig_shape[-2], result.shape[-2]),
+            )
         else:
 
-            result = dc.op("narrow", [result], (-1, 0, orig_shape[-1], result.shape[-1]))
-            result = dc.op("narrow", [result], (-2, 0, size, result.shape[-2]))
+            result = dc.op_with_named_attrs(
+                "narrow",
+                [result],
+                {"dim": -1, "start": 0, "length": orig_shape[-1], "original_length": result.shape[-1]},
+                attrs=(-1, 0, orig_shape[-1], result.shape[-1]),
+            )
+            result = dc.op_with_named_attrs(
+                "narrow",
+                [result],
+                {"dim": -2, "start": 0, "length": size, "original_length": result.shape[-2]},
+                attrs=(-2, 0, size, result.shape[-2]),
+            )
 
         dc.fuse(result)
 
@@ -1087,11 +1135,15 @@ def decompose_xy_unflatten(inputs, dc, orig_shape, attr):
     _orig_shape = result.shape
     # Pad X dimension to TILE_DIM size
     if _orig_shape[-2] % TILE_DIM != 0:
-        result = dc.op("pad_tile", [result], (-2, _orig_shape[-2]))
+        result = dc.op_with_named_attrs(
+            "pad_tile", [result], {"dim": -2, "original_length": _orig_shape[-2]}, attrs=(-2, _orig_shape[-2])
+        )
 
     # Pad Y dimension to TILE_DIM size
     if _orig_shape[-1] % TILE_DIM != 0:
-        result = dc.op("pad_tile", [result], (-1, _orig_shape[-1]))
+        result = dc.op_with_named_attrs(
+            "pad_tile", [result], {"dim": -1, "original_length": _orig_shape[-1]}, attrs=(-1, _orig_shape[-1])
+        )
 
     # Transpose the result matrix
     result = dc.op(TransposeTM.create(-2, -1), [result])
@@ -1143,7 +1195,7 @@ def decompose_xy_unflatten(inputs, dc, orig_shape, attr):
         result = dc.op_with_named_attrs(
             "unsqueeze",
             [result],
-            {"dim": 0},
+            {"dim": 0, "orig_shape_len": 2},
             (
                 0,
                 2,
@@ -1166,9 +1218,19 @@ def decompose_xy_unflatten(inputs, dc, orig_shape, attr):
         result = dc.op("vslice", [result], (attr[-3],))
 
     if attr[-1] % TILE_DIM != 0:
-        result = dc.op("narrow", [result], (-1, 0, attr[-1], result.shape[-1]))
+        result = dc.op_with_named_attrs(
+            "narrow",
+            [result],
+            {"dim": -1, "start": 0, "length": attr[-1], "original_length": result.shape[-1]},
+            (-1, 0, attr[-1], result.shape[-1]),
+        )
     if attr[-2] % TILE_DIM != 0:
-        result = dc.op("narrow", [result], (-2, 0, attr[-2], result.shape[-2]))
+        result = dc.op_with_named_attrs(
+            "narrow",
+            [result],
+            {"dim": -2, "start": 0, "length": attr[-2], "original_length": result.shape[-2]},
+            (-2, 0, attr[-2], result.shape[-2]),
+        )
     return result
 
 
@@ -1177,8 +1239,12 @@ def decompose_non_tile_dim_aligned_vslice(inputs, dc, orig_shape, attr):
     use_sparse_mm = True
 
     slice_factor = attr[-3]
-    result = dc.op("pad_tile", [result], (-2, orig_shape[-2]))
-    result = dc.op("pad_tile", [result], (-1, orig_shape[-1]))
+    result = dc.op_with_named_attrs(
+        "pad_tile", [result], {"dim": -2, "original_length": orig_shape[-2]}, (-2, orig_shape[-2])
+    )
+    result = dc.op_with_named_attrs(
+        "pad_tile", [result], {"dim": -1, "original_length": orig_shape[-1]}, (-1, orig_shape[-1])
+    )
     if attr[-2] % TILE_DIM != 0 or orig_shape[-2] % TILE_DIM != 0:
         padded_dim = math.ceil(attr[-2] / TILE_DIM) * TILE_DIM
         num_tiles = attr[-3] if attr[-2] < TILE_DIM else (math.ceil(attr[-3] / TILE_DIM) * TILE_DIM)
@@ -1205,9 +1271,19 @@ def decompose_non_tile_dim_aligned_vslice(inputs, dc, orig_shape, attr):
 
     result = dc.op("vslice", [result], (slice_factor,))
     if attr[-1] % TILE_DIM != 0:
-        result = dc.op("narrow", [result], (-1, 0, attr[-1], result.shape[-1]))
+        result = dc.op_with_named_attrs(
+            "narrow",
+            [result],
+            {"dim": -1, "start": 0, "length": attr[-1], "original_length": result.shape[-1]},
+            (-1, 0, attr[-1], result.shape[-1]),
+        )
     if attr[-2] % TILE_DIM != 0:
-        result = dc.op("narrow", [result], (-2, 0, attr[-2], result.shape[-2]))
+        result = dc.op_with_named_attrs(
+            "narrow",
+            [result],
+            {"dim": -2, "start": 0, "length": attr[-2], "original_length": result.shape[-2]},
+            (-2, 0, attr[-2], result.shape[-2]),
+        )
 
     return result
 
@@ -1223,11 +1299,12 @@ def decompose_post_optimize(type, attr, dc, inputs):
         result = inputs[0]
         if post_dim % TILE_DIM != 0:
             if input_shape[-2] % TILE_DIM != 0:
-                result = dc.op(
+                result = dc.op_with_named_attrs(
                     "pad_tile",
                     [
                         result,
                     ],
+                    {"dim": -2, "original_length": input_shape[-2]},
                     (-2, input_shape[-2]),
                 )
             cols = []
@@ -1248,7 +1325,7 @@ def decompose_post_optimize(type, attr, dc, inputs):
                     [
                         result,
                     ],
-                    {"dim": 0},
+                    {"dim": 0, "orig_shape_len": len(result.shape.as_list())},
                     (0, len(result.shape.as_list())),
                 )
 
@@ -1269,28 +1346,31 @@ def decompose_post_optimize(type, attr, dc, inputs):
                 ],
                 attr,
             )
-            result = dc.op(
+            result = dc.op_with_named_attrs(
                 "narrow",
                 [
                     result,
                 ],
+                {"dim": -1, "start": 0, "length": post_dim, "original_length": result.shape[-1]},
                 (-1, 0, post_dim, result.shape[-1]),
             )
             if input_shape[-2] % TILE_DIM != 0:
-                result = dc.op(
+                result = dc.op_with_named_attrs(
                     "narrow",
                     [
                         result,
                     ],
+                    {"dim": -2, "start": 0, "length": input_shape[-2], "original_length": result.shape[-2]},
                     (-2, 0, input_shape[-2], result.shape[-2]),
                 )
             dc.fuse(result)
         elif input_shape[-2] % TILE_DIM != 0:
-            result = dc.op(
+            result = dc.op_with_named_attrs(
                 "pad_tile",
                 [
                     result,
                 ],
+                {"dim": -2, "original_length": input_shape[-2]},
                 (-2, input_shape[-2]),
             )
             result = dc.op(
@@ -1300,11 +1380,12 @@ def decompose_post_optimize(type, attr, dc, inputs):
                 ],
                 attr,
             )
-            result = dc.op(
+            result = dc.op_with_named_attrs(
                 "narrow",
                 [
                     result,
                 ],
+                {"dim": -2, "start": 0, "length": input_shape[-2], "original_length": result.shape[-2]},
                 (-2, 0, input_shape[-2], result.shape[-2]),
             )
             dc.fuse(result)
@@ -1314,20 +1395,22 @@ def decompose_post_optimize(type, attr, dc, inputs):
         result = inputs[0]
         if input_shape[-1] % TILE_DIM != 0:
             if input_shape[-2] % TILE_DIM != 0:
-                result = dc.op(
+                result = dc.op_with_named_attrs(
                     "pad_tile",
                     [
                         result,
                     ],
+                    {"dim": -2, "original_length": input_shape[-2]},
                     (-2, input_shape[-2]),
                 )
             output_dim = input_shape[-1] * attr[0]
             pad_output_dim = align_up_tile(input_shape[-1]) * attr[0]
-            result = dc.op(
+            result = dc.op_with_named_attrs(
                 "pad_tile",
                 [
                     result,
                 ],
+                {"dim": -1, "original_length": input_shape[-1]},
                 (-1, input_shape[-1]),
             )
             result = dc.op(
@@ -1352,20 +1435,22 @@ def decompose_post_optimize(type, attr, dc, inputs):
             result = picker_matmul(True, dc, spm, result)
             result = dc.op_with_named_attrs("transpose", [result], {"dim0": -2, "dim1": -1})
             if input_shape[-2] % TILE_DIM != 0:
-                result = dc.op(
+                result = dc.op_with_named_attrs(
                     "narrow",
                     [
                         result,
                     ],
+                    {"dim": -2, "start": 0, "length": input_shape[-2], "original_length": result.shape[-2]},
                     (-2, 0, input_shape[-2], result.shape[-2]),
                 )
             dc.fuse(result)
         elif input_shape[-2] % TILE_DIM != 0:
-            result = dc.op(
+            result = dc.op_with_named_attrs(
                 "pad_tile",
                 [
                     result,
                 ],
+                {"dim": -2, "original_length": input_shape[-2]},
                 (-2, input_shape[-2]),
             )
             result = dc.op(
@@ -1375,11 +1460,12 @@ def decompose_post_optimize(type, attr, dc, inputs):
                 ],
                 attr,
             )
-            result = dc.op(
+            result = dc.op_with_named_attrs(
                 "narrow",
                 [
                     result,
                 ],
+                {"dim": -2, "start": 0, "length": input_shape[-2], "original_length": result.shape[-2]},
                 (-2, 0, input_shape[-2], result.shape[-2]),
             )
             dc.fuse(result)
@@ -1390,11 +1476,12 @@ def decompose_post_optimize(type, attr, dc, inputs):
         result = inputs[0]
         if post_dim % TILE_DIM != 0:
             if input_shape[-1] % TILE_DIM != 0:
-                result = dc.op(
+                result = dc.op_with_named_attrs(
                     "pad_tile",
                     [
                         result,
                     ],
+                    {"dim": -1, "original_length": input_shape[-1]},
                     (-1, input_shape[-1]),
                 )
             cols = []
@@ -1421,19 +1508,21 @@ def decompose_post_optimize(type, attr, dc, inputs):
                 ],
                 attr,
             )
-            result = dc.op(
+            result = dc.op_with_named_attrs(
                 "narrow",
                 [
                     result,
                 ],
+                {"dim": -2, "start": 0, "length": post_dim, "original_length": result.shape[-2]},
                 (-2, 0, post_dim, result.shape[-2]),
             )
             if input_shape[-1] % TILE_DIM != 0:
-                result = dc.op(
+                result = dc.op_with_named_attrs(
                     "narrow",
                     [
                         result,
                     ],
+                    {"dim": -1, "start": 0, "length": input_shape[-1], "original_length": result.shape[-1]},
                     (-1, 0, input_shape[-1], result.shape[-1]),
                 )
             dc.fuse(result)

--- a/forge/forge/op/nn.py
+++ b/forge/forge/op/nn.py
@@ -46,7 +46,7 @@ def Softmax(name: str, operandA: Tensor, *, dim: int, stable: bool = True) -> Te
     Tensor
         Forge tensor
     """
-    return op("softmax", name, operandA, attrs=(dim, stable), dimension=dim).get_tensor()
+    return op("softmax", name, operandA, attrs=(dim, stable), dimension=dim, stable=stable).get_tensor()
 
 
 def LogSoftmax(name: str, operandA: Tensor, *, dim: int, stable: bool = True) -> Tensor:
@@ -73,7 +73,7 @@ def LogSoftmax(name: str, operandA: Tensor, *, dim: int, stable: bool = True) ->
     Tensor
         Forge tensor
     """
-    return op("log_softmax", name, operandA, attrs=(dim, stable), dimension=dim).get_tensor()
+    return op("log_softmax", name, operandA, attrs=(dim, stable), dimension=dim, stable=stable).get_tensor()
 
 
 def Layernorm(
@@ -101,7 +101,7 @@ def Layernorm(
         Forge tensor
     """
 
-    return op("layernorm", name, operandA, weights, bias, attrs=(dim, epsilon)).get_tensor()
+    return op("layernorm", name, operandA, weights, bias, attrs=(dim, epsilon), dim=dim, epsilon=epsilon).get_tensor()
 
 
 def Batchnorm(
@@ -136,7 +136,9 @@ def Batchnorm(
         name = f"batchnorm_{get_unique_node_id()}"
 
     if batchnorm_flag:
-        return op("batchnorm", name, operandA, weights, bias, running_mean, running_var, attrs=(epsilon,)).get_tensor()
+        return op(
+            "batchnorm", name, operandA, weights, bias, running_mean, running_var, attrs=(epsilon,), epsilon=epsilon
+        ).get_tensor()
     else:
         running_mean = Unsqueeze(name + "_mean_unsqueeze_1", running_mean, 1)
         running_mean = Unsqueeze(name + "_mean_unsqueeze_2", running_mean, 1)

--- a/forge/forge/op/reduce.py
+++ b/forge/forge/op/reduce.py
@@ -93,7 +93,15 @@ def GroupedReduceAvg(name: str, operandA: Tensor, dim: int, groups: int, keep_di
     """
 
     assert (dim >= -4) and (dim <= 3)
-    return op("grouped_reduce_avg", name, operandA, attrs=(dim, groups, keep_dims)).get_tensor()
+    return op(
+        "grouped_reduce_avg",
+        name,
+        operandA,
+        attrs=(dim, groups, keep_dims),
+        dim=dim,
+        groups=groups,
+        keep_dims=keep_dims,
+    ).get_tensor()
 
 
 def ReduceMax(name: str, operandA: Tensor, dim: int, stride: int = -1, keep_dim: bool = True) -> Tensor:
@@ -123,5 +131,5 @@ def ReduceMax(name: str, operandA: Tensor, dim: int, stride: int = -1, keep_dim:
     #     dim += 4
 
     return op(
-        "reduce_max", name, operandA, attrs=(dim, stride, keep_dim), dim_arg=[dim], keep_dim=keep_dim
+        "reduce_max", name, operandA, attrs=(dim, stride, keep_dim), dim_arg=[dim], stride=stride, keep_dim=keep_dim
     ).get_tensor()

--- a/forge/forge/op/tm.py
+++ b/forge/forge/op/tm.py
@@ -164,7 +164,7 @@ def AdvIndex(
     if dim < 0:
         dim += len(operandA.shape)
 
-    return op("adv_index", name, operandA, operandB, attrs=(dim,)).get_tensor()
+    return op("adv_index", name, operandA, operandB, attrs=(dim,), dim=dim).get_tensor()
 
 
 def Select(
@@ -335,7 +335,9 @@ def PadTile(name: str, operandA: Tensor, dim: int, original_length: int) -> Tens
         Forge tensor
     """
 
-    return op("pad_tile", name, operandA, attrs=(dim, original_length)).get_tensor()
+    return op(
+        "pad_tile", name, operandA, attrs=(dim, original_length), dim=dim, original_length=original_length
+    ).get_tensor()
 
 
 def Broadcast(name: str, operandA: Tensor, dim: int, shape: int) -> Tensor:
@@ -362,7 +364,9 @@ def Broadcast(name: str, operandA: Tensor, dim: int, shape: int) -> Tensor:
         Forge tensor
     """
 
-    return op("broadcast", name, operandA, attrs=(dim, shape, True)).get_tensor()
+    return op(
+        "broadcast", name, operandA, attrs=(dim, shape, True), dim=dim, shape=shape, explicit_bcast=True
+    ).get_tensor()
 
 
 def Repeat(name: str, operandA: Tensor, repeats: List[int]) -> Tensor:
@@ -461,7 +465,9 @@ def Unsqueeze(name: str, operandA: Tensor, dim: int) -> Tensor:
         Forge tensor
     """
 
-    return op("unsqueeze", name, operandA, attrs=(dim, len(operandA.shape)), dim=dim).get_tensor()
+    return op(
+        "unsqueeze", name, operandA, attrs=(dim, len(operandA.shape)), dim=dim, orig_shape_len=len(operandA.shape)
+    ).get_tensor()
 
 
 def Squeeze(name: str, operandA: Tensor, dim: int) -> Tensor:
@@ -518,7 +524,16 @@ def Narrow(name: str, operandA: Tensor, dim: int, start: int, length: int, origi
         Forge tensor
     """
 
-    return op("narrow", name, operandA, attrs=(dim, start, length, original_length)).get_tensor()
+    return op(
+        "narrow",
+        name,
+        operandA,
+        attrs=(dim, start, length, original_length),
+        dim=dim,
+        start=start,
+        length=length,
+        original_length=original_length,
+    ).get_tensor()
 
 
 def PixelShuffle(name: str, operandA: Tensor, upscale_factor: int) -> Tensor:
@@ -538,7 +553,7 @@ def PixelShuffle(name: str, operandA: Tensor, upscale_factor: int) -> Tensor:
     Tensor
         Forge tensor
     """
-    return op("pixel_shuffle", name, operandA, attrs=(upscale_factor,)).get_tensor()
+    return op("pixel_shuffle", name, operandA, attrs=(upscale_factor,), upscale_factor=upscale_factor).get_tensor()
 
 
 def ForgePad(name: str, operandA: Tensor, paddings: Tuple[int, int], value: float) -> Tensor:
@@ -559,7 +574,15 @@ def ForgePad(name: str, operandA: Tensor, paddings: Tuple[int, int], value: floa
     value: float
         Value to pad with
     """
-    return op("forge_pad", name, operandA, attrs=(paddings[0], paddings[1], value)).get_tensor()
+    return op(
+        "forge_pad",
+        name,
+        operandA,
+        attrs=(paddings[0], paddings[1], value),
+        pad_r=paddings[0],
+        pad_c=paddings[1],
+        value=value,
+    ).get_tensor()
 
 
 def ForgeUnpad(
@@ -590,4 +613,8 @@ def ForgeUnpad(
         name,
         operandA,
         attrs=(paddings[0], paddings[1], original_length[0], original_length[1]),
+        pad_r=paddings[0],
+        pad_c=paddings[1],
+        original_length_r=original_length[0],
+        original_length_c=original_length[1],
     ).get_tensor()


### PR DESCRIPTION
Since we are migrating operations to cpp, we need to migrate positional (legacy) attributes to named ones. To avoid manually searching all places where we have missing named attributes, this change adds all of them at once. This should save us much effort in each change separately, since we will have all named attributes that we need for migration.

When migration is over, we can remove all positional (legacy) attributes in a single change too, without wasting time on each operation separately.

This change does not change an existing behavior, it just introduces named attributes in places where they are missing.