### PR TITLE
Use docker cache for build on shared runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       - ${{ matrix.build.runs-on }}
 
     container:
-      image: ${{ inputs.docker-image }}
+      image: ${{ format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image) }}
 
     steps:
 
@@ -148,7 +148,7 @@ jobs:
       - ${{ matrix.build.runs-on }}
 
     container:
-      image: ${{ inputs.docker-image }}
+      image: ${{ format('harbor.ci.tenstorrent.net/{0}', inputs.docker-image) }}
 
     steps:
 


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Builds are executed on shared runners but docker cache is not used.

### What's changed
Use docker cache for build on shared runners.

### Checklist
- [ ] New/Existing tests provide coverage for changes
