### PR TITLE
Fix opt pytorch model

### DIFF
--- a/forge/test/mlir/operators/nn/test_nn.py
+++ b/forge/test/mlir/operators/nn/test_nn.py
@@ -871,3 +871,31 @@ def test_resize1d(data, output_size, align_corners, forge_tmp_path):
     compiled_model = forge.compile(framework_model, sample_inputs=[x])
 
     verify([x], framework_model, compiled_model)
+
+
+@pytest.mark.push
+def test_scaled_dot_product_attention():
+    class ScaledDotProductAttentionModel(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, query_states, key_states, value_states):
+            return torch.nn.functional.scaled_dot_product_attention(
+                query=query_states, key=key_states, value=value_states, scale=2.0, enable_gqa=True
+            )
+
+    framework_model = ScaledDotProductAttentionModel()
+    framework_model.eval()
+
+    query_states = torch.rand([1, 12, 256, 64])
+    key_states = torch.rand([1, 12, 256, 64])
+    value_states = torch.rand([1, 12, 256, 64])
+
+    inputs = [query_states, key_states, value_states]
+
+    compiled_model = forge.compile(
+        framework_model,
+        inputs,
+    )
+
+    verify(inputs, framework_model, compiled_model)


### PR DESCRIPTION

The PR will fix pcc drop in OPTSequenceClassification, OPTForQuestionAnswering and OPTForCausalLM Model tests expect  OPT 1.3B model variant(i.e facebook/opt-1.3b) in CausalLM task.

The PCC drops occurs due to below reason,
   1. [JIT Trace issues ](https://github.com/huggingface/transformers/blob/51f94ea06d19a6308c61bbb4dc97c40aabd12bad/src/transformers/models/opt/modeling_opt.py#L510)in the casual mask calculation by [_update_causal_mask](https://github.com/huggingface/transformers/blob/51f94ea06d19a6308c61bbb4dc97c40aabd12bad/src/transformers/models/opt/modeling_opt.py#L632) function present in OPTDecoder nn module. Resolved the tracing issue by calculating casual mask  from attention mask using [_prepare_4d_causal_attention_mask](https://github.com/huggingface/transformers/blob/51f94ea06d19a6308c61bbb4dc97c40aabd12bad/src/transformers/modeling_attn_mask_utils.py#L302) function which was used by previous transformers version text generation models and then will pass the casual mask as input to the original model forward function since we have already calculated casual mask, it won't calculate casual mask again which helps to resolve the tracing issues and position_ids will be also calculated inside the ModelWrapper because it was calculated based upon the attention mask(i.e not causal mask).
   2. SPDA attention implementation in TVM pytorch frontend conversion produces accuracy drop due to improper fetching of scale factor. Updated the implementation to fetch optional parameter from correct indices based upon the latest [torch sdpa implementation](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html), if not provided, it will assign default value and also supported enable_gpa parameter(i.e grouped query attention). Created a sanity to verify it.  
   
   
The OPT 1.3B model variant(i.e facebook/opt-1.3b) in CausalLM task was failing with pcc drop of 0.71 in the OPTPositionalEmedding layer. Created issues in [tt-mlir](https://github.com/tenstorrent/tt-mlir/issues/4174) and [tt-metal ](https://github.com/tenstorrent/tt-metal/issues/25656)to replicate with add and embedding ops.


Logs:
[test_opt.log](https://github.com/user-attachments/files/21393604/test_opt.log)