### PR TITLE
Disable memory layout analysis on resnet.

### DIFF
--- a/forge/test/benchmark/benchmark/models/resnet_hf.py
+++ b/forge/test/benchmark/benchmark/models/resnet_hf.py
@@ -114,7 +114,7 @@ def test_resnet_hf(training, batch_size, data_format, input_size, channel_size, 
 
     # Turn on MLIR optimizations.
     compiler_cfg.mlir_config = (
-        MLIRConfig().set_enable_optimizer(True).set_enable_fusing(True).set_enable_memory_layout_analysis(True)
+        MLIRConfig().set_enable_optimizer(True).set_enable_fusing(True).set_enable_memory_layout_analysis(False)
     )
 
     # TODO: Remove this line when the issue with reinitialization is resolved.


### PR DESCRIPTION
Resnet still hangs with enabled memory layout analysis. Until we solve the problem we disable memory layout analysis on resnet.
