### PR TITLE
Add enable_fusing_conv2d_with_multiply_pattern flag

### DIFF
--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -196,6 +196,11 @@ PYBIND11_MODULE(_C, m)
             [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_fusing(enable); },
             py::arg("enable"))
         .def(
+            "set_enable_fusing_conv2d_with_multiply_pattern",
+            [](tt::passes::MLIRConfig &self, bool enable)
+            { return self.set_fusing_conv2d_with_multiply_pattern(enable); },
+            py::arg("enable"))
+        .def(
             "set_custom_config",
             [](tt::passes::MLIRConfig &self, const std::string &config) { return self.set_custom_config(config); },
             py::arg("config"))

--- a/forge/csrc/passes/mlir_compiler.cpp
+++ b/forge/csrc/passes/mlir_compiler.cpp
@@ -207,6 +207,7 @@ void to_json(::nlohmann::json& j, const MLIRConfig& p)
         {"enable_optimizer", p.enable_optimizer},
         {"enable_memory_layout_analysis", p.enable_memory_layout_analysis},
         {"enable_fusing", p.enable_fusing},
+        {"enable_fusing_conv2d_with_multiply_pattern", p.enable_fusing_conv2d_with_multiply_pattern},
         {"custom_config", p.custom_config}};
 }
 
@@ -216,6 +217,7 @@ void from_json(const ::nlohmann::json& j, MLIRConfig& p)
     j.at("enable_optimizer").get_to(p.enable_optimizer);
     j.at("enable_memory_layout_analysis").get_to(p.enable_memory_layout_analysis);
     j.at("enable_fusing").get_to(p.enable_fusing);
+    j.at("enable_fusing_conv2d_with_multiply_pattern").get_to(p.enable_fusing_conv2d_with_multiply_pattern);
     j.at("custom_config").get_to(p.custom_config);
 }
 

--- a/forge/csrc/passes/mlir_compiler.hpp
+++ b/forge/csrc/passes/mlir_compiler.hpp
@@ -30,6 +30,7 @@ struct MLIRConfig
     std::optional<bool> enable_optimizer = std::nullopt;
     std::optional<bool> enable_memory_layout_analysis = std::nullopt;
     std::optional<bool> enable_fusing = std::nullopt;
+    std::optional<bool> enable_fusing_conv2d_with_multiply_pattern = std::nullopt;
 
     // Custom configuration string for the MLIR compiler.
     std::string custom_config = "";
@@ -55,6 +56,12 @@ struct MLIRConfig
     MLIRConfig& set_enable_fusing(bool enable)
     {
         enable_fusing = enable;
+        return *this;
+    }
+
+    MLIRConfig& set_fusing_conv2d_with_multiply_pattern(bool enable)
+    {
+        enable_fusing_conv2d_with_multiply_pattern = enable;
         return *this;
     }
 

--- a/forge/csrc/passes/mlir_passes.cpp
+++ b/forge/csrc/passes/mlir_passes.cpp
@@ -65,6 +65,11 @@ std::string config_to_pipeline_options(const std::optional<MLIRConfig> &mlir_con
         {
             options << " enable-fusing-pass=" << *mlir_config->enable_fusing;
         }
+        if (mlir_config->enable_fusing_conv2d_with_multiply_pattern.has_value())
+        {
+            options << " enable-fusing-conv2d-with-multiply-pattern="
+                    << *mlir_config->enable_fusing_conv2d_with_multiply_pattern;
+        }
 
         // Add custom configuration options.
         options << " " << mlir_config->custom_config;

--- a/forge/test/benchmark/benchmark/models/resnet_hf.py
+++ b/forge/test/benchmark/benchmark/models/resnet_hf.py
@@ -114,7 +114,11 @@ def test_resnet_hf(training, batch_size, data_format, input_size, channel_size, 
 
     # Turn on MLIR optimizations.
     compiler_cfg.mlir_config = (
-        MLIRConfig().set_enable_optimizer(True).set_enable_fusing(True).set_enable_memory_layout_analysis(True)
+        MLIRConfig()
+        .set_enable_optimizer(True)
+        .set_enable_fusing(True)
+        .set_enable_fusing_conv2d_with_multiply_pattern(True)
+        .set_enable_memory_layout_analysis(False)
     )
 
     # TODO: Remove this line when the issue with reinitialization is resolved.


### PR DESCRIPTION
### Problem description
To enable fusing by default in `tt-mlir`, we need to disable the `Conv2dWithMultiply` pattern by default. In this PR, I’m enabling it specifically for ResNet due to the performance regression when it’s disabled.

### Checklist
- [x] New/Existing tests provide coverage for changes
