### PR TITLE
ONNX bringup of generality models - set4

### DIFF
--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -79,6 +79,7 @@ class Task(BaseEnum):
     BRAIN_TUMOR_SEGMENTATION = ("brain_tumor_segmentation", "Brain Tumor Segmentation")
     TEXT_TO_VIDEO_GENERATION = ("text_to_video_generation", "Text-to-Video generation")
     SENETNCE_SEGMENTATION = ("sentence_segmentation", "Sentence Segmentation")
+    TIME_SERIES_FORECASTING = ("time_series_forecasting", "Time Series Forecasting")
 
 
 class Source(BaseEnum):

--- a/forge/test/models/onnx/audio/test_whisper_onnx.py
+++ b/forge/test/models/onnx/audio/test_whisper_onnx.py
@@ -1,0 +1,109 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+import onnx
+from transformers import AutoProcessor, WhisperConfig, WhisperForConditionalGeneration
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.utils import download_model
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_features, decoder_input_ids):
+        inputs = {"input_features": input_features, "decoder_input_ids": decoder_input_ids}
+        output = self.model(**inputs)
+        return output.logits
+
+
+variants = [
+    "openai/whisper-tiny",
+    "openai/whisper-base",
+    "openai/whisper-small",
+    "openai/whisper-medium",
+    pytest.param(
+        "openai/whisper-large",
+        marks=[
+            pytest.mark.xfail(reason="Fatal Python error: Aborted"),
+        ],
+    ),
+]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants)
+def test_whisper_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.WHISPER,
+        variant=variant,
+        task=Task.SPEECH_RECOGNITION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Load model (with tokenizer and feature extractor)
+    processor = download_model(AutoProcessor.from_pretrained, variant)
+    model_config = WhisperConfig.from_pretrained(variant)
+    model = download_model(
+        WhisperForConditionalGeneration.from_pretrained,
+        variant,
+        config=model_config,
+    )
+    model.config.use_cache = False
+
+    # Load and preprocess sample audio
+    sample = torch.load("forge/test/models/files/samples/audio/1272-128104-0000.pt", weights_only=False)
+    sample_audio = sample["audio"]["array"]
+
+    inputs = processor(sample_audio, return_tensors="pt")
+    input_features = inputs.input_features
+
+    # Get decoder inputs
+    decoder_start_token_tensor = torch.tensor(model.generation_config.decoder_start_token_id, dtype=torch.long)
+    decoder_input_ids = torch.ones((1, 1), dtype=torch.long) * decoder_start_token_tensor
+
+    inputs = [input_features, decoder_input_ids]
+
+    torch_model = Wrapper(model)
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    if variant in ["openai/whisper-medium", "openai/whisper-large"]:
+        onnx.checker.check_model(onnx_path)
+        framework_model = forge.OnnxModule(module_name, onnx_model, onnx_path)
+        model = framework_model
+    else:
+        onnx.checker.check_model(onnx_model)
+        framework_model = forge.OnnxModule(module_name, onnx_model)
+        model = onnx_model
+
+    # Compile model
+    compiled_model = forge.compile(model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/multimodal/clip/test_clip_onnx.py
+++ b/forge/test/models/onnx/multimodal/clip/test_clip_onnx.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.models.pytorch.multimodal.clip.model_utils.clip_model import CLIPTextWrapper
+import onnx
+import torch
+from third_party.tt_forge_models.clip import ModelLoader
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "variant",
+    [
+        pytest.param(
+            "openai/clip-vit-base-patch32",
+        ),
+    ],
+)
+def test_clip_onnx(variant, forge_tmp_path):
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.CLIP,
+        variant=variant,
+        suffix="text",
+        source=Source.HUGGINGFACE,
+        task=Task.TEXT_GENERATION,
+    )
+
+    # Load Model and input
+    loader = ModelLoader()
+    model = loader.load_model()
+    torch_model = CLIPTextWrapper(model)
+    inputs = loader.load_inputs()
+    inputs = [inputs["input_ids"], inputs["attention_mask"]]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/multimodal/llava/test_llava_onnx.py
+++ b/forge/test/models/onnx/multimodal/llava/test_llava_onnx.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+
+import pytest
+import torch
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+import onnx
+from test.models.pytorch.multimodal.llava.model_utils.utils import load_inputs
+from test.models.pytorch.multimodal.llava.test_llava import load_model
+
+variants = ["llava-hf/llava-1.5-7b-hf"]
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail(reason="Hangs at generate initial graph stage.")
+@pytest.mark.parametrize("variant", variants, ids=variants)
+def test_llava_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.LLAVA,
+        variant=variant,
+        task=Task.CONDITIONAL_GENERATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    torch_model, processor = load_model(variant)
+    image = "https://www.ilankelman.org/stopsigns/australia.jpg"
+    text = "What’s shown in this image?"
+
+    # Input sample
+    input_ids, attn_mask, pixel_values = load_inputs(image, text, processor)
+    inputs = [input_ids, attn_mask, pixel_values]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    torch.onnx.export(torch_model, (inputs[0], inputs[1], inputs[2]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_path)
+    framework_model = forge.OnnxModule(module_name, onnx_model, onnx_path)
+
+    # Compile model
+    compiled_model = forge.compile(framework_model, inputs, module_name=module_name)
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/multimodal/vilt/test_vilt_onnx.py
+++ b/forge/test/models/onnx/multimodal/vilt/test_vilt_onnx.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+
+from test.models.pytorch.multimodal.vilt.test_vilt import generate_model_vilt_question_answering_hf_pytorch
+import forge
+import onnx
+from forge.verify.verify import verify
+
+variants = ["dandelin/vilt-b32-finetuned-vqa"]
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants, ids=variants)
+def test_vilt_question_answering_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX, model=ModelArch.VILT, variant=variant, task=Task.QA, source=Source.HUGGINGFACE
+    )
+    torch_model, inputs, model = generate_model_vilt_question_answering_hf_pytorch(variant)
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
+    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+    # Post processing
+    logits = co_out[0]
+    idx = logits.argmax(-1).item()
+    print(f"Predicted answer: {model.config.id2label[idx]}")

--- a/forge/test/models/onnx/text/nanogpt/test_nanogpt_onnx.py
+++ b/forge/test/models/onnx/text/nanogpt/test_nanogpt_onnx.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+import onnx
+from test.models.pytorch.text.nanogpt.test_nanogpt import GPTModelWrapper
+from third_party.tt_forge_models.nanogpt.pytorch import ModelLoader
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    "variant",
+    [
+        "FinancialSupport/NanoGPT",
+    ],
+)
+def test_nanogpt_text_generation_onnx(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.NANOGPT,
+        variant=variant,
+        task=Task.TEXT_GENERATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Load model and input
+    loader = ModelLoader()
+    model = loader.load_model()
+    input_tokens = loader.load_inputs()
+    torch_model = GPTModelWrapper(model)
+    input_ids = input_tokens["input_ids"]
+    attn_mask = input_tokens["attention_mask"]
+    inputs = [input_ids, attn_mask]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1] + ".onnx"
+    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/text/t5/test_t5_onnx.py
+++ b/forge/test/models/onnx/text/t5/test_t5_onnx.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+import torch
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+from third_party.tt_forge_models.t5.pytorch import ModelLoader
+import onnx
+
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids, decoder_input_ids):
+        inputs = {"input_ids": input_ids, "decoder_input_ids": decoder_input_ids}
+        output = self.model(**inputs)
+        return output
+
+
+variants = ["t5-small"]
+
+
+@pytest.mark.xfail
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", variants)
+def test_t5_generation(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.T5,
+        variant=variant,
+        task=Task.TEXT_GENERATION,
+        source=Source.HUGGINGFACE,
+    )
+
+    # Load model and input
+    loader = ModelLoader()
+    model = loader.load_model()
+    input_tokens = loader.load_inputs()
+    torch_model = Wrapper(model)
+    input_ids = input_tokens["input_ids"]
+    decoder_start_token_tensor = torch.tensor(model.generation_config.decoder_start_token_id, dtype=torch.long)
+    decoder_input_ids = torch.ones((1, 1), dtype=torch.long) * decoder_start_token_tensor
+    inputs = [input_ids, decoder_input_ids]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1] + ".onnx"
+    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/timeseries/test_nbeats_onnx.py
+++ b/forge/test/models/onnx/timeseries/test_nbeats_onnx.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import pytest
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+from test.models.pytorch.timeseries.nbeats.model_utils.dataset import (
+    get_electricity_dataset_input,
+)
+from test.models.pytorch.timeseries.nbeats.model_utils.model import (
+    NBeatsWithGenericBasis,
+    NBeatsWithSeasonalityBasis,
+    NBeatsWithTrendBasis,
+)
+import onnx
+import torch
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", ["seasionality_basis"])
+def test_nbeats_with_seasonality_basis_onnx(variant, forge_tmp_path):
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.NBEATS,
+        variant=variant,
+        task=Task.TIME_SERIES_FORECASTING,
+        source=Source.GITHUB,
+    )
+
+    # Prepare model and input
+    x, x_mask = get_electricity_dataset_input()
+
+    torch_model = NBeatsWithSeasonalityBasis(
+        input_size=72,
+        output_size=24,
+        num_of_harmonics=1,
+        stacks=30,
+        layers=4,
+        layer_size=2048,
+    )
+    torch_model.eval()
+
+    inputs = [x, x_mask]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/{variant}.onnx"
+    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", ["generic_basis"])
+def test_nbeats_with_generic_basis(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.NBEATS,
+        variant=variant,
+        task=Task.TIME_SERIES_FORECASTING,
+        source=Source.GITHUB,
+    )
+
+    # Prepare model and input
+    x, x_mask = get_electricity_dataset_input()
+
+    torch_model = NBeatsWithGenericBasis(input_size=72, output_size=24, stacks=30, layers=4, layer_size=512)
+    torch_model.eval()
+
+    inputs = [x, x_mask]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/{variant}.onnx"
+    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", ["trend_basis"])
+def test_nbeats_with_trend_basis(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.NBEATS,
+        variant=variant,
+        task=Task.TIME_SERIES_FORECASTING,
+        source=Source.GITHUB,
+    )
+
+    x, x_mask = get_electricity_dataset_input()
+
+    torch_model = NBeatsWithTrendBasis(
+        input_size=72,
+        output_size=24,
+        degree_of_polynomial=3,
+        stacks=30,
+        layers=4,
+        layer_size=256,
+    )
+    torch_model.eval()
+
+    inputs = [x, x_mask]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/{variant}.onnx"
+    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
+++ b/forge/test/models/pytorch/timeseries/nbeats/test_nbeats.py
@@ -32,8 +32,8 @@ def test_nbeats_with_seasonality_basis(variant):
         framework=Framework.PYTORCH,
         model=ModelArch.NBEATS,
         variant=variant,
-        task=Task.CAUSAL_LM,
-        source=Source.HUGGINGFACE,
+        task=Task.TIME_SERIES_FORECASTING,
+        source=Source.GITHUB,
     )
 
     x, x_mask = get_electricity_dataset_input()
@@ -66,8 +66,8 @@ def test_nbeats_with_generic_basis(variant):
         framework=Framework.PYTORCH,
         model=ModelArch.NBEATS,
         variant=variant,
-        task=Task.CAUSAL_LM,
-        source=Source.HUGGINGFACE,
+        task=Task.TIME_SERIES_FORECASTING,
+        source=Source.GITHUB,
     )
 
     x, x_mask = get_electricity_dataset_input()
@@ -93,8 +93,8 @@ def test_nbeats_with_trend_basis(variant):
         framework=Framework.PYTORCH,
         model=ModelArch.NBEATS,
         variant=variant,
-        task=Task.CAUSAL_LM,
-        source=Source.HUGGINGFACE,
+        task=Task.TIME_SERIES_FORECASTING,
+        source=Source.GITHUB,
     )
 
     x, x_mask = get_electricity_dataset_input()


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2633

### Problem description

- Add ONNX tests for generality models 

### What's changed

This PR adds ONNX  tests for below generality models 

- Whisper
- Clip
- Llava
- Vilt
- Nano-GPT
- T5
- Nbeats

### Checklist
- [x] New/Existing tests provide coverage for changes

### Logs

- [jul23_clip_onnx.log](https://github.com/user-attachments/files/21384890/jul23_clip_onnx.log)
- [jul23_llava_onnx.log](https://github.com/user-attachments/files/21384891/jul23_llava_onnx.log)
- [jul23_nanogpt_onnx_new.log](https://github.com/user-attachments/files/21385058/jul23_nanogpt_onnx_new.log)
- [jul23_nbeats_onnx.log](https://github.com/user-attachments/files/21384893/jul23_nbeats_onnx.log)
- [jul23_t5_onnx.log](https://github.com/user-attachments/files/21384894/jul23_t5_onnx.log)
- [jul23_vilt_onnx.log](https://github.com/user-attachments/files/21384895/jul23_vilt_onnx.log)
- [jul23_whisper_onnx.log](https://github.com/user-attachments/files/21384897/jul23_whisper_onnx.log)
