### PR TITLE
Added precompiled headers and unity build for ops.

### DIFF
--- a/forge/csrc/ops/CMakeLists.txt
+++ b/forge/csrc/ops/CMakeLists.txt
@@ -122,5 +122,8 @@ add_library(ops
     python_bindings.cpp)
 
 target_link_libraries(ops PUBLIC coverage_config)
-
 target_compile_options(ops PRIVATE ${STATIC_LIB_FLAGS} ${TTFORGE_CSRC_CFLAGS})
+
+# Enable precompiled headers and unity build for faster compilation.
+target_precompile_headers(ops PRIVATE ops_pch.hpp)
+set_target_properties(ops PROPERTIES UNITY_BUILD ON)

--- a/forge/csrc/ops/ops_pch.hpp
+++ b/forge/csrc/ops/ops_pch.hpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Precompiled header for ops library.
+ */
+#pragma once
+
+// Standard library headers.
+#include <map>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+// Torch headers.
+#include <torch/extension.h>
+#include <torch/torch.h>
+
+// Project headers.
+#include "autograd/autograd.hpp"
+#include "graph_lib/node_types.hpp"
+#include "graph_lib/shape.hpp"
+#include "op.hpp"
+#include "op_interface.hpp"
+#include "passes/decomposing_context.hpp"
+#include "utils/assert.hpp"


### PR DESCRIPTION
With this change, we have ~8x build time improvement for ops library.