### PR TITLE
Added missing named attributes for all operations.

### DIFF
--- a/forge/csrc/graph_lib/utils.cpp
+++ b/forge/csrc/graph_lib/utils.cpp
@@ -1749,7 +1749,8 @@ void ConstEvalGraph::pad_output_to_forge_dims(std::string const &name_prefix)
     {
         if (shape[dim] % graphlib::Shape::FORGE_TILE_DIM != 0)
         {
-            graphlib::OpType pad_tile("pad_tile", {dim, (int)shape[dim]});
+            graphlib::OpType pad_tile(
+                "pad_tile", {dim, (int)shape[dim]}, {{"dim", dim}, {"original_length", (int)shape[dim]}});
             auto consteval_pad_tile = graphlib::create_node<graphlib::PyOpNode>(
                 name_prefix + "_pad_tile_" + ((dim == -1) ? "c_" : "r_") + output->name(), pad_tile);
             shape[dim] = align_up_tile(shape[dim]);

--- a/forge/csrc/passes/constant_folding.cpp
+++ b/forge/csrc/passes/constant_folding.cpp
@@ -104,7 +104,10 @@ static void insert_pad_within_tile(graphlib::Graph *graph, graphlib::Edge edge, 
                 consumer->clone("pad_tile_" + producer->name() + "_" + std::to_string(edge.edge_creation_id)),
                 graph->get_subgraph_id_for_node(producer->id()))
             ->as<graphlib::OpNode>();
-    pad_tile->change_op_type(graphlib::OpType("pad_tile", {dim, (int)producer->shape()[dim]}));
+    pad_tile->change_op_type(graphlib::OpType(
+        "pad_tile",
+        {dim, (int)producer->shape()[dim]},
+        {{"dim", dim}, {"original_length", (int)producer->shape()[dim]}}));
     auto [incoming_edge, outgoing_edge] = graphlib::insert_node_on_edge(graph, edge, pad_tile);
     if (only_bcast)
     {

--- a/forge/csrc/passes/erase_unnecessary_4d_tm_sequence.cpp
+++ b/forge/csrc/passes/erase_unnecessary_4d_tm_sequence.cpp
@@ -141,7 +141,10 @@ static void commute_4d_tm_ops(graphlib::Graph *graph, std::vector<graphlib::Node
     std::vector<graphlib::PyOpNode *> new_select_nodes;
     for (int i = 0; i < fourth_dim; i++)
     {
-        graphlib::OpType op_type("select", {-3, i * third_dim, third_dim, orig_third_dim});
+        graphlib::OpType op_type(
+            "select",
+            {-3, i * third_dim, third_dim, orig_third_dim},
+            {{"dim", -3}, {"begin", i * third_dim}, {"length", third_dim}, {"stride", orig_third_dim}});
         std::string op_name = first->name() + "_replaced_select.";
         op_name += std::to_string(i);
         graphlib::PyOpNode *new_node = graph->add_node(
@@ -153,7 +156,7 @@ static void commute_4d_tm_ops(graphlib::Graph *graph, std::vector<graphlib::Node
     }
 
     // create interleave op
-    graphlib::OpType op_type("interleave", {-3, 1});
+    graphlib::OpType op_type("interleave", {-3, 1}, {{"dim", -3}, {"stride", 1}});
     std::string op_name = first->name() + "_replaced_interleave.0";
     graphlib::PyOpNode *new_interleave_node = graph->add_node(
         graphlib::create_node<graphlib::PyOpNode>(op_name, op_type), graph->get_subgraph_id_for_node(first->id()));

--- a/forge/csrc/passes/fracture.cpp
+++ b/forge/csrc/passes/fracture.cpp
@@ -196,7 +196,10 @@ static std::unique_ptr<graphlib::PyOpNode> create_slice(
 
     int start = i * (int)shape[dim];
     int length = (int)shape[dim];
-    graphlib::OpType select("select", {dim, start, length, stride});
+    graphlib::OpType select(
+        "select",
+        {dim, start, length, stride},
+        {{"dim", dim}, {"begin", start}, {"length", length}, {"stride", stride}});
     auto new_op = graphlib::create_node<graphlib::PyOpNode>(new_op_name, select);
     new_op->set_shape(shape);
     new_op->set_epoch_type(op->get_epoch_type());

--- a/forge/csrc/passes/fuse_per_channel_ops.cpp
+++ b/forge/csrc/passes/fuse_per_channel_ops.cpp
@@ -328,7 +328,8 @@ static bool fuse_per_channel_concat(graphlib::Graph *graph, graphlib::OpNode *co
                     while (input_ndim < concat->shape().size())
                     {
                         // insert unsqueeze tms
-                        graphlib::OpType op_type("unsqueeze", {0, (int)input_ndim});
+                        graphlib::OpType op_type(
+                            "unsqueeze", {0, (int)input_ndim}, {{"dim", 0}, {"orig_shape_len", (int)input_ndim}});
                         graph->get_edge_attributes(current_edge)->append_tm(op_type);
                         input_ndim++;
                     }

--- a/forge/csrc/passes/pad_output_buffer.cpp
+++ b/forge/csrc/passes/pad_output_buffer.cpp
@@ -23,7 +23,10 @@ void insert_forge_pad(
     graphlib::Node *node = graph->node_by_id(edge.consumer_node_id);
 
     // Construct forge_pad node and insert in graph
-    graphlib::OpType forge_pad_op_type("forge_pad", {rt_pad_amount, ct_pad_amount, 0});
+    graphlib::OpType forge_pad_op_type(
+        "forge_pad",
+        {rt_pad_amount, ct_pad_amount, 0},
+        {{"rt_pad_amount", rt_pad_amount}, {"ct_pad_amount", ct_pad_amount}, {"pad_value", 0}});
     auto forge_pad_ref_node = graph->add_node(
         graphlib::create_node<graphlib::PyOpNode>(node->name() + "_pad", forge_pad_op_type),
         graph->get_subgraph_id_for_node(node->id()));

--- a/forge/csrc/test/passes/test_decompose_nd_reshape_split.cpp
+++ b/forge/csrc/test/passes/test_decompose_nd_reshape_split.cpp
@@ -37,10 +37,18 @@ TEST_F(DecomposeNdReshapeSplitTest, basic_dimension_split_optimization)
     reshape_node->set_shape(graphlib::Shape::create({2, 2, 6}));
 
     // Create index operations
-    auto index1_node = add_node<graphlib::PyOpNode>(*graph, "index1", "index", {1, 0, 1, 1}, {reshape_node});
+    auto index1_node = add_node<graphlib::PyOpNode>(
+        *graph,
+        "index1",
+        graphlib::OpType("index", {1, 0, 1, 1}, {{"dim", 1}, {"begin", 0}, {"length", 1}, {"stride", 1}}),
+        {reshape_node});
     index1_node->set_shape(graphlib::Shape::create({2, 1, 6}));
 
-    auto index2_node = add_node<graphlib::PyOpNode>(*graph, "index2", "index", {1, 1, 2, 1}, {reshape_node});
+    auto index2_node = add_node<graphlib::PyOpNode>(
+        *graph,
+        "index2",
+        graphlib::OpType("index", {1, 1, 2, 1}, {{"dim", 1}, {"begin", 1}, {"length", 2}, {"stride", 1}}),
+        {reshape_node});
     index2_node->set_shape(graphlib::Shape::create({2, 1, 6}));
 
     // Create squeeze operations

--- a/forge/csrc/test/passes/test_erase_inverse_ops.cpp
+++ b/forge/csrc/test/passes/test_erase_inverse_ops.cpp
@@ -359,8 +359,14 @@ struct UpdateSelectNamedAttrsTest : testing::Test
 
         graphlib::Shape initial_shape = graphlib::Shape::create({1, 512, 160});
         graphlib::InputNode *input_node = create_input(*graph, "input", initial_shape);
-        auto select_node =
-            add_node<graphlib::PyOpNode>(*graph, "select", "select", {dim, begin, length, stride}, {input_node});
+        auto select_node = add_node<graphlib::PyOpNode>(
+            *graph,
+            "select",
+            graphlib::OpType(
+                "select",
+                {dim, begin, length, stride},
+                {{"dim", dim}, {"begin", begin}, {"length", length}, {"stride", stride}}),
+            {input_node});
         select_node->set_op_attr("select_dim", dim);
         select_node->set_op_attr("begin", begin);
         select_node->set_op_attr("length", length);
@@ -460,7 +466,8 @@ struct UpdateVStackAttrsTest : testing::Test
 
         auto input_node_0 = create_input(*graph, "input_0", shape_0);
 
-        vstack_node = add_node<graphlib::PyOpNode>(*graph, "vstack", "vstack", {16}, {input_node_0});
+        vstack_node = add_node<graphlib::PyOpNode>(
+            *graph, "vstack", graphlib::OpType("vstack", {16}, {{"num_stacks", 16}}), {input_node_0});
 
         create_output(*graph, "out", vstack_node);
     }
@@ -688,7 +695,8 @@ struct EraseInverseOpsSqueezeAndUnsqueeze : testing::Test
         auto mask_node = create_input(*graph, "attention_mask", mask_shape);
         auto weights_node = create_input(*graph, "attention_weights", weights_shape);
 
-        auto cast_1_node = add_node<graphlib::PyOpNode>(*graph, "cast", "cast", {"Float32"}, {mask_node});
+        auto cast_1_node = add_node<graphlib::PyOpNode>(
+            *graph, "cast", graphlib::OpType("cast", {"Float32"}, {{"dtype", "Float32"}}), {mask_node});
         auto unsqueeze_node = add_node<graphlib::PyOpNode>(
             *graph, "unsqueeze", graphlib::OpType("unsqueeze", {0}, {{"dim", 0}}), {weights_node});
 

--- a/forge/forge/op/dram_queue.py
+++ b/forge/forge/op/dram_queue.py
@@ -29,4 +29,4 @@ def DRAMQueue(name: str, operandA: Tensor, *, num_entries: int) -> Tensor:
         Forge tensor
     """
 
-    return op("dram_queue", name, operandA, attrs=(num_entries,)).get_tensor()
+    return op("dram_queue", name, operandA, attrs=(num_entries,), num_entries=num_entries).get_tensor()

--- a/forge/forge/op/eltwise_nary.py
+++ b/forge/forge/op/eltwise_nary.py
@@ -91,7 +91,7 @@ def IndexCopy(name: str, operandA: Tensor, index: Tensor, value: Tensor, dim: in
     """
     if dim < 0:
         dim += len(operandA.shape)
-    return op("index_copy", name, operandA, index, value, attrs=(dim,)).get_tensor()
+    return op("index_copy", name, operandA, index, value, attrs=(dim,), dim=dim).get_tensor()
 
 
 def Stack(name: str, *operands: Tensor, axis: int) -> Tensor:

--- a/forge/forge/op/eltwise_unary.py
+++ b/forge/forge/op/eltwise_unary.py
@@ -119,7 +119,7 @@ def Pow(name: str, operandA: Tensor, exponent: Union[int, float]) -> Tensor:
         Forge tensor
     """
 
-    return op("pow", name, operandA, attrs=(exponent,)).get_tensor()
+    return op("pow", name, operandA, attrs=(exponent,), exponent=exponent).get_tensor()
 
 
 def Identity(name: str, operandA: Tensor, unsqueeze: str = None, unsqueeze_dim: int = None) -> Tensor:
@@ -242,7 +242,7 @@ def Relu(name: str, operandA: Tensor, threshold=0.0, mode="min") -> Tensor:
     if threshold == 0.0 and mode == "min":
         return op("relu", name, operandA).get_tensor()  # avoid threshold < 0.0 error due to FP arithmetics
     else:
-        return op("relu", name, operandA, attrs=(threshold, mode)).get_tensor()
+        return op("relu", name, operandA, attrs=(threshold, mode), threshold=threshold, mode=mode).get_tensor()
 
 
 def LeakyRelu(name: str, operandA: Tensor, alpha: float) -> Tensor:
@@ -548,7 +548,7 @@ def Dropout(name: str, operandA: Tensor, p: float = 0.5, training: bool = True, 
         Forge tensor
     """
 
-    return op("dropout", name, operandA, attrs=(p, training, seed)).get_tensor()
+    return op("dropout", name, operandA, attrs=(p, training, seed), p=p, training=training, seed=seed).get_tensor()
 
 
 def Tilize(name: str, operandA: Tensor) -> Tensor:

--- a/forge/forge/op/eval/forge/eltwise_unary.py
+++ b/forge/forge/op/eval/forge/eltwise_unary.py
@@ -171,7 +171,7 @@ def backward(type, attr, ac, operand, inputs, output, grad):
         return res
 
     if type == "dropout":
-        return ac.op("dropout", (grad,), attr)
+        return ac.op_with_named_attrs("dropout", (grad,), {"p": attr[0], "training": attr[1], "seed": attr[2]}, attr)
 
     if type == "clip":
         x = inputs[0]

--- a/forge/forge/op/eval/forge/nn.py
+++ b/forge/forge/op/eval/forge/nn.py
@@ -263,7 +263,7 @@ def backward(op_type, attr, ac, operand, inputs, output, grad):
         inputs += [grad, output]
         inputs = tuple(inputs)
 
-        return ac.op("layernorm_bw", inputs, attr)
+        return ac.op_with_named_attrs("layernorm_bw", inputs, {"dim": attr[0], "epsilon": attr[1]}, attr)
 
     if op_type == "batchnorm":
         raise NotImplementedError("Back propagation for Batchnorm op is not implemented yet")

--- a/forge/forge/op/eval/forge/pad.py
+++ b/forge/forge/op/eval/forge/pad.py
@@ -244,7 +244,7 @@ def extract_and_mirror(dc, input, dim_axis, start, stop):
     # Mirror patch
     indices = torch.arange(stop - start - 1, -1, -1)
     indices_tensor = dc.tensor(indices)
-    patch_mirrored = dc.op("adv_index", [patch, indices_tensor], (dim_axis,))
+    patch_mirrored = dc.op_with_named_attrs("adv_index", [patch, indices_tensor], {"dim": dim_axis}, (dim_axis,))
 
     return patch_mirrored
 

--- a/forge/forge/op/eval/forge/pooling.py
+++ b/forge/forge/op/eval/forge/pooling.py
@@ -686,7 +686,12 @@ def decompose(type, attr, dc, inputs):
 
             d_start = i * sD
 
-            depth_slice = dc.op("index", [activations], (2, d_start, d_start + kD, activations.shape[2]))
+            depth_slice = dc.op_with_named_attrs(
+                "index",
+                [activations],
+                {"dim": 2, "start": d_start, "stop": d_start + kD, "stride": activations.shape[2]},
+                attrs=(2, d_start, d_start + kD, activations.shape[2]),
+            )
             depth_avg = dc.op_with_named_attrs("reduce_avg", [depth_slice], {"dim_arg": [2], "keep_dim": True})
 
             named_attrs = {

--- a/forge/forge/op/nn.py
+++ b/forge/forge/op/nn.py
@@ -73,7 +73,7 @@ def LogSoftmax(name: str, operandA: Tensor, *, dim: int, stable: bool = True) ->
     Tensor
         Forge tensor
     """
-    return op("log_softmax", name, operandA, attrs=(dim, stable), dimension=dim).get_tensor()
+    return op("log_softmax", name, operandA, attrs=(dim, stable), dimension=dim, stable=stable).get_tensor()
 
 
 def Layernorm(
@@ -101,7 +101,7 @@ def Layernorm(
         Forge tensor
     """
 
-    return op("layernorm", name, operandA, weights, bias, attrs=(dim, epsilon)).get_tensor()
+    return op("layernorm", name, operandA, weights, bias, attrs=(dim, epsilon), dim=dim, epsilon=epsilon).get_tensor()
 
 
 def Batchnorm(
@@ -136,7 +136,9 @@ def Batchnorm(
         name = f"batchnorm_{get_unique_node_id()}"
 
     if batchnorm_flag:
-        return op("batchnorm", name, operandA, weights, bias, running_mean, running_var, attrs=(epsilon,)).get_tensor()
+        return op(
+            "batchnorm", name, operandA, weights, bias, running_mean, running_var, attrs=(epsilon,), epsilon=epsilon
+        ).get_tensor()
     else:
         running_mean = Unsqueeze(name + "_mean_unsqueeze_1", running_mean, 1)
         running_mean = Unsqueeze(name + "_mean_unsqueeze_2", running_mean, 1)

--- a/forge/forge/op/reduce.py
+++ b/forge/forge/op/reduce.py
@@ -93,7 +93,15 @@ def GroupedReduceAvg(name: str, operandA: Tensor, dim: int, groups: int, keep_di
     """
 
     assert (dim >= -4) and (dim <= 3)
-    return op("grouped_reduce_avg", name, operandA, attrs=(dim, groups, keep_dims)).get_tensor()
+    return op(
+        "grouped_reduce_avg",
+        name,
+        operandA,
+        attrs=(dim, groups, keep_dims),
+        dim=dim,
+        groups=groups,
+        keep_dims=keep_dims,
+    ).get_tensor()
 
 
 def ReduceMax(name: str, operandA: Tensor, dim: int, keep_dim: bool = True) -> Tensor:

--- a/forge/forge/op/tm.py
+++ b/forge/forge/op/tm.py
@@ -164,7 +164,7 @@ def AdvIndex(
     if dim < 0:
         dim += len(operandA.shape)
 
-    return op("adv_index", name, operandA, operandB, attrs=(dim,)).get_tensor()
+    return op("adv_index", name, operandA, operandB, attrs=(dim,), dim=dim).get_tensor()
 
 
 def Select(
@@ -335,7 +335,9 @@ def PadTile(name: str, operandA: Tensor, dim: int, original_length: int) -> Tens
         Forge tensor
     """
 
-    return op("pad_tile", name, operandA, attrs=(dim, original_length)).get_tensor()
+    return op(
+        "pad_tile", name, operandA, attrs=(dim, original_length), dim=dim, original_length=original_length
+    ).get_tensor()
 
 
 def Broadcast(name: str, operandA: Tensor, dim: int, shape: int) -> Tensor:
@@ -518,7 +520,16 @@ def Narrow(name: str, operandA: Tensor, dim: int, start: int, length: int, origi
         Forge tensor
     """
 
-    return op("narrow", name, operandA, attrs=(dim, start, length, original_length)).get_tensor()
+    return op(
+        "narrow",
+        name,
+        operandA,
+        attrs=(dim, start, length, original_length),
+        dim=dim,
+        start=start,
+        length=length,
+        original_length=original_length,
+    ).get_tensor()
 
 
 def PixelShuffle(name: str, operandA: Tensor, upscale_factor: int) -> Tensor:
@@ -538,7 +549,7 @@ def PixelShuffle(name: str, operandA: Tensor, upscale_factor: int) -> Tensor:
     Tensor
         Forge tensor
     """
-    return op("pixel_shuffle", name, operandA, attrs=(upscale_factor,)).get_tensor()
+    return op("pixel_shuffle", name, operandA, attrs=(upscale_factor,), upscale_factor=upscale_factor).get_tensor()
 
 
 def ForgePad(name: str, operandA: Tensor, paddings: Tuple[int, int], value: float) -> Tensor:
@@ -559,7 +570,15 @@ def ForgePad(name: str, operandA: Tensor, paddings: Tuple[int, int], value: floa
     value: float
         Value to pad with
     """
-    return op("forge_pad", name, operandA, attrs=(paddings[0], paddings[1], value)).get_tensor()
+    return op(
+        "forge_pad",
+        name,
+        operandA,
+        attrs=(paddings[0], paddings[1], value),
+        pad_r=paddings[0],
+        pad_c=paddings[1],
+        value=value,
+    ).get_tensor()
 
 
 def ForgeUnpad(
@@ -590,4 +609,8 @@ def ForgeUnpad(
         name,
         operandA,
         attrs=(paddings[0], paddings[1], original_length[0], original_length[1]),
+        pad_r=paddings[0],
+        pad_c=paddings[1],
+        original_length_r=original_length[0],
+        original_length_c=original_length[1],
     ).get_tensor()


### PR DESCRIPTION
Since we are migrating operations to cpp, we need to migrate positional attributes to named ones. To avoid manually searching all places where we have missing named attributes, this change adds all of them at once. This should save us much effort in each change separately, since we will have all named attributes that we need to migration.

When migration is over, we can remove all positional attributes in a single change too, without wasting time on each operation separately.
