### PR TITLE
Enable cache tensor to be input rather than constant.

### DIFF
--- a/forge/test/mlir/llama/tests/test_llama_attention.py
+++ b/forge/test/mlir/llama/tests/test_llama_attention.py
@@ -4,6 +4,7 @@
 import torch
 import pytest
 from transformers.models.llama.modeling_llama import repeat_kv
+from transformers import LlamaConfig
 
 import forge
 from test.mlir.llama.utils.utils import load_attention
@@ -28,11 +29,19 @@ class LlamaAttentionWrapper(torch.nn.Module):
         self.layer_idx = layer_idx
         self.config = config
 
-    def forward(self, hidden_states, attention_mask, cos, sin):
+    def forward(self, hidden_states, attention_mask, cos, sin, k_cache, v_cache):
         batch_size = hidden_states.size(0)
         cache = StaticCache(config=self.config, max_batch_size=batch_size, dtype=hidden_states.dtype)
         #  It is important to set dtype=hidden_states.dtype so that StaticCache dtype is always in sync with hidden_states dtype.
         #  By default, StaticCache dtype is torch.float32 so if you do update cache with torch.bfloat16 it will cast it inside the update method.
+
+        # index 0 is because we have only one attention and one k, v cache pair
+        # in general case we would have multiple pairs for each layer
+        # By setting cache.key_cache[0] and cache.value_cache[0] to inputs we are bypassing the TVM constraint that
+        # only tensors can be inputs to the forward. Effectively, StaticCache is now input to the forward.
+        cache.key_cache[0] = k_cache
+        cache.value_cache[0] = v_cache
+
         cache_position = torch.arange(hidden_states.size()[-2])
         position_embeddings = (cos, sin)
         # Prefill: Pass empty cache to attention forward.
@@ -62,13 +71,20 @@ class LlamaDecodeStaticCacheAttentionWrapper(torch.nn.Module):
         self.layer_idx = layer_idx
         self.config = config
 
-    def forward(self, hidden_states, attention_mask, cos, sin, past_key, past_value):
+    def forward(self, hidden_states, attention_mask, cos, sin, past_key, past_value, k_cache, v_cache):
         batch_size = hidden_states.size(0)
         past_seq_len = past_key.size(-2)
 
         cache = StaticCache(config=self.config, max_batch_size=batch_size, dtype=hidden_states.dtype)
         #  It is important to set dtype=hidden_states.dtype so that StaticCache dtype is always in sync with hidden_states dtype.
         #  By default, StaticCache dtype is torch.float32 so if you do update cache with torch.bfloat16 it will cast it inside the update method.
+
+        # index 0 is because we have only one attention and one k, v cache pair
+        # in general case we would have multiple pairs for each layer
+        # By setting cache.key_cache[0] and cache.value_cache[0] to inputs we are bypassing the TVM constraint that
+        # only tensors can be inputs to the forward. Effectively, StaticCache is now input to the forward.
+        cache.key_cache[0] = k_cache
+        cache.value_cache[0] = v_cache
         cache_kwargs = {"cache_position": torch.tensor(torch.arange(past_seq_len))}
         cache.update(past_key, past_value, self.layer_idx, cache_kwargs=cache_kwargs)
         # Fill static cache with past key and value tensors like it would be in prefill. Then run one decode step.
@@ -163,18 +179,28 @@ def test_llama_attention_prefill_mode(model_path):
     # Generate dummy position embeddings
     num_attention_heads = config.num_attention_heads
     head_dim = hidden_size // num_attention_heads
+    num_key_value_heads = (
+        config.num_attention_heads
+        if getattr(config, "num_key_value_heads", None) is None
+        else config.num_key_value_heads
+    )
 
     # Generate cos and sin for RoPE
     cos = torch.randn(batch_size, seq_len, head_dim, dtype=dtype)
     sin = torch.randn(batch_size, seq_len, head_dim, dtype=dtype)
 
+    # K,V cache tensors zeros:
+    for i in range(config.num_hidden_layers):
+        key_cache = torch.zeros(batch_size, num_key_value_heads, config.max_position_embeddings, head_dim, dtype=dtype)
+        value_cache = torch.zeros(
+            batch_size, num_key_value_heads, config.max_position_embeddings, head_dim, dtype=dtype
+        )
+
     # Prepare inputs
-    inputs = [hidden_states, padded_attention_mask, cos, sin]
+    inputs = [hidden_states, padded_attention_mask, cos, sin, key_cache, value_cache]
 
     data_format_override = DataFormat.Float16_b
     compiler_cfg = CompilerConfig(default_df_override=data_format_override)
-    # Disabling MLIR consteval pass until this issue is resolved: https://github.com/tenstorrent/tt-mlir/issues/4107
-    compiler_cfg.mlir_config = MLIRConfig().set_enable_consteval(False)
     compiled_model = forge.compile(framework_model, inputs, module_name=module_name, compiler_cfg=compiler_cfg)
 
     verify(inputs, framework_model, compiled_model)
@@ -267,24 +293,30 @@ def test_llama_attention_decode_mode(model_path):
     cos = torch.randn(batch_size, seq_len, head_dim, dtype=dtype)
     sin = torch.randn(batch_size, seq_len, head_dim, dtype=dtype)
 
+    # K,V cache tensors zeros:
+    for i in range(config.num_hidden_layers):
+        key_cache = torch.zeros(batch_size, num_key_value_heads, config.max_position_embeddings, head_dim, dtype=dtype)
+        value_cache = torch.zeros(
+            batch_size, num_key_value_heads, config.max_position_embeddings, head_dim, dtype=dtype
+        )
+
     # Prepare inputs
-    inputs = [hidden_states, padded_attention_mask, cos, sin, past_key, past_value]
+    inputs = [hidden_states, padded_attention_mask, cos, sin, past_key, past_value, key_cache, value_cache]
 
     data_format_override = DataFormat.Float16_b
     compiler_cfg = CompilerConfig(default_df_override=data_format_override)
-    # Disabling MLIR consteval pass until this issue is resolved: https://github.com/tenstorrent/tt-mlir/issues/4107
-    compiler_cfg.mlir_config = MLIRConfig().set_enable_consteval(False)
     compiled_model = forge.compile(framework_model, inputs, module_name=module_name, compiler_cfg=compiler_cfg)
 
     verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
-    "n_rep, index, update_cache",
+    "n_rep, cache, index, update_cache",
     [
         # Fill and repeat cache (B=1, kv_heads=2, L=8, D=16) with 2x replication
         pytest.param(
             2,
+            torch.zeros(1, 2, 8, 16),
             torch.tensor([0, 1, 2, 3]),
             torch.ones(1, 2, 4, 16),
             id="fill_and_repeat",
@@ -292,22 +324,60 @@ def test_llama_attention_decode_mode(model_path):
     ],
 )
 @pytest.mark.push
-def test_index_copy_then_repeat_kv(n_rep, index, update_cache):
+def test_index_copy_then_repeat_kv(n_rep, cache, index, update_cache):
     class IndexCopyThenRepeatKV(torch.nn.Module):
         def __init__(self, n_rep, index):
             super().__init__()
-            self.cache = torch.zeros(1, 2, 8, 16)  # B=1, kv_heads=2, max_len=8, D=16
             self.index = index
             self.n_rep = n_rep
 
-        def forward(self, update_cache):
-            updated = torch.index_copy(self.cache, dim=2, index=self.index, source=update_cache)
+        def forward(self, cache, update_cache):
+            updated = torch.index_copy(cache, dim=2, index=self.index, source=update_cache)
             return repeat_kv(updated, self.n_rep)
 
-    inputs = [update_cache]
+    inputs = [cache, update_cache]
     model = IndexCopyThenRepeatKV(n_rep, index)
-    compiler_cfg = CompilerConfig()
-    # Disabling MLIR consteval pass until this issue is resolved: https://github.com/tenstorrent/tt-mlir/issues/4107
-    compiler_cfg.mlir_config = MLIRConfig().set_enable_consteval(False)
-    compiled = forge.compile(model, inputs, compiler_cfg=compiler_cfg)
+    compiled = forge.compile(model, inputs)
+    verify(inputs, model, compiled)
+
+
+@pytest.mark.parametrize(
+    "k_cache, v_cache, k_cache_update, v_cache_update",
+    [
+        # Fill and repeat cache (B=1, kv_heads=2, L=8, D=16) with 2x replication
+        pytest.param(
+            torch.zeros(1, 2, 8, 16),
+            torch.zeros(1, 2, 8, 16),
+            torch.ones(1, 2, 4, 16),
+            torch.ones(1, 2, 4, 16),
+            id="fill_and_repeat",
+        ),
+    ],
+)
+@pytest.mark.push
+def test_update_cache(k_cache, v_cache, k_cache_update, v_cache_update):
+    class UpdateCache(torch.nn.Module):
+        def __init__(self, config, layer_idx=0):
+            super().__init__()
+            self.config = config
+            self.layer_idx = layer_idx
+
+        def forward(self, k_cache, v_cache, k_cache_update, v_cache_update):
+            cache = StaticCache(config=self.config, max_batch_size=1, dtype=torch.float32)
+            # index 0 is because we have only one k, v cache pair
+            cache.key_cache[0] = k_cache
+            cache.value_cache[0] = v_cache
+
+            cache_kwargs = {"cache_position": torch.tensor(torch.arange(k_cache_update.size()[-2]))}
+            cache.update(k_cache_update, v_cache_update, self.layer_idx, cache_kwargs=cache_kwargs)
+            return cache.key_cache[0], cache.value_cache[0]
+
+    model_path = "meta-llama/Llama-3.2-1B"
+    config = LlamaConfig.from_pretrained(model_path)
+    # Set config for one layer attention
+    config.num_hidden_layers = 1
+    config.max_position_embeddings = 8
+    inputs = [k_cache, v_cache, k_cache_update, v_cache_update]
+    model = UpdateCache(config)
+    compiled = forge.compile(model, inputs)
     verify(inputs, model, compiled)


### PR DESCRIPTION
### Ticket
Closes #2671

### Problem description
We need to use StaticCache object to manage Llama kv cache. On the other hand, TVM requires us to have only tensors as inputs to modules (so having StaticCache object as input won't work). Solution is to create StaticCache within the module, but overwrite k and v tensors with ones provided on input. Therefore, we end up with StaticCache created within model, but compiler sees its k,v tensors as inputs.

### What's changed
- Make cache input by overwriting constant K,V tensors with input cache tensors in forward of module. This trick enables us to still have only tensors as inputs (required by TVM and torch.jit.trace) while using StaticCache abstraction to handle K,V cache update. Previously, we only created StaticCache object within function forward, which resulted in K,V cache tensors being seen as constants from compiler.
- Add small test which tests only StaticCache update on device without all other attention parts.

Caught a bug while doing this - input tensors were changed due to model having in-place operations.
Solution:
- Clone input tensors in verify before running framework model.

