### PR TITLE
[Feature] Create constant tensor from decomposing context

### DIFF
--- a/forge/csrc/passes/decomposing_context.hpp
+++ b/forge/csrc/passes/decomposing_context.hpp
@@ -7,6 +7,11 @@
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/utils.hpp"
 
+namespace at
+{
+class Tensor;
+}
+
 namespace tt
 {
 
@@ -55,7 +60,8 @@ class DecomposingContext
         bool optimize_hoist = false,
         DataFormat output_df = DataFormat::Invalid);
     void fuse(NodeContext operand, graphlib::PortId out_port = 0);
-    NodeContext tensor(std::shared_ptr<void> tensor_handle, graphlib::Shape tensor_shape);
+
+    NodeContext tensor(const at::Tensor& tensor);
 
     Graph* get_graph() { return graph; }
 

--- a/forge/csrc/passes/python_bindings.cpp
+++ b/forge/csrc/passes/python_bindings.cpp
@@ -8,6 +8,8 @@
 #include "passes/decomposing_context.hpp"
 #include "python_bindings_common.hpp"
 #include "shared_utils/sparse_matmul_utils.hpp"
+#include "torch/extension.h"  // Needed for c++ to/from python type conversion.
+#include "torch/torch.h"
 
 namespace tt
 {
@@ -106,12 +108,7 @@ void PassesModule(py::module &m_passes)
         .def("fuse", &tt::DecomposingContext::fuse, py::arg("operand"), py::arg("producer_output_port_id") = 0)
         .def(
             "tensor",
-            [](tt::DecomposingContext &self, py::object tensor)
-            {
-                return self.tensor(
-                    make_shared_py_object(tensor),
-                    graphlib::Shape::create(tensor.attr("shape").cast<std::vector<std::uint32_t>>()));
-            },
+            [](tt::DecomposingContext &self, py::object tensor) { return self.tensor(py::cast<at::Tensor>(tensor)); },
             py::arg("tensor"))
         .def(
             "get_pytorch_tensor",


### PR DESCRIPTION
### What's changed
Added support for creating tensors in decomposing context from C++, enabling the ongoing migration of operations to C++.

## Example of usage
```cpp
  NodeContext create_tensor_example(DecomposingContext &dc, const at::Tensor &input)
  {
      return dc.tensor(input);
  }
```