### PR TITLE
Add env var for IRD_LF_CACHE

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -33,7 +33,7 @@ on:
 # Set cache root to avoid IRD_LF_CACHE error when loading CenterNet ONNX model in CI
 env:
   DOCKER_CACHE_ROOT: /mnt/dockercache
-  IRD_LF_CACHE: varsity.IRD_LF_CACHE
+  IRD_LF_CACHE: ${{ vars.IRD_LF_CACHE }}
 
 permissions:
   packages: write

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -33,6 +33,7 @@ on:
 # Set cache root to avoid IRD_LF_CACHE error when loading CenterNet ONNX model in CI
 env:
   DOCKER_CACHE_ROOT: /mnt/dockercache
+  IRD_LF_CACHE: varsity.IRD_LF_CACHE
 
 permissions:
   packages: write

--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v3.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v3.py
@@ -22,7 +22,6 @@ from third_party.tt_forge_models.yolov3 import ModelLoader  # isort:skip
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-forge-fe/issues/2660")
 def test_yolo_v3():
     # Record Forge Property
     module_name = record_model_properties(


### PR DESCRIPTION
### Ticket
Fixes: [Link to Github Issue](https://github.com/tenstorrent/tt-forge-fe/issues/2660)

### Problem description
We are facing "IRD_LF_CACHE" variable is not set properly for the following models in Nightly [Pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/16508778987/job/46687269962).

forge/test/models/pytorch/vision/yolo/test_yolo_v3.py::test_yolo_v3

FAILURE REASON:
ERROR ValueError: IRD_LF_CACHE environment variable is not set. Please set it to the address of the IRD LF cache.

TEST REF:
pytest forge/test/models/pytorch/vision/yolo/test_yolo_v3.py::test_yolo_v3 -vss

### What's changed

- Added env variable for IRD_LF_CACHE

### Checklist
- [x] New/Existing tests provide coverage for changes
