### PR TITLE
Fix For IRD_LF_CACHE Argument Issue

### DIFF
--- a/.github/workflows/test-sub.yml
+++ b/.github/workflows/test-sub.yml
@@ -155,6 +155,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           HF_HOME: /mnt/dockercache/huggingface
+          IRD_LF_CACHE: ${{ vars.IRD_LF_CACHE }}
           FORGE_MODELS_CACHE: /mnt/dockercache/forge_models_cache
           HF_HUB_DISABLE_PROGRESS_BARS: 1
           FORGE_DISABLE_REPORTIFY_DUMP: 1


### PR DESCRIPTION

### Problem description
Facing IRD_LF_CACHE Argument Issue in Nightly Pipeline
`ValueError: IRD_LF_CACHE environment variable is not set. Please set it to the address of the IRD LF cache.`

### What's changed
Added IRD_LF_CACHE value as a variable

### Checklist
Tested In separate [pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/16598795035)

cc: @nvukobratTT @nsumrakTT 
