### PR TITLE
Fix ConvertEmulatedDtypes and remove sanity run before forge compilation in yolov5

### DIFF
--- a/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolo_v5.py
@@ -43,7 +43,6 @@ size = [
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size)
-@pytest.mark.xfail(reason="Issue Link: https://github.com/tenstorrent/tt-forge-fe/issues/2631")
 def test_yolov5_320x320(restore_package_versions, size):
 
     pcc = 0.99
@@ -66,12 +65,6 @@ def test_yolov5_320x320(restore_package_versions, size):
     )
     framework_model = framework_model.to(torch.bfloat16)
     inputs = [inputs[0].to(torch.bfloat16)]
-
-    # Perform a sanity run before Forge compilation which does constant folding and preserve the
-    # expected Relay IR. Skipping the sanity run prevents constant folding, resulting in a
-    # different TVM Relay IR and producing float32 outputs instead of the expected bfloat16
-    # during Forge verification.
-    framework_model(*inputs)
 
     # Configurations
     compiler_cfg = CompilerConfig()
@@ -111,7 +104,6 @@ size = [
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size)
-@pytest.mark.xfail(reason="Issue Link: https://github.com/tenstorrent/tt-forge-fe/issues/2631")
 def test_yolov5_640x640(restore_package_versions, size):
 
     # Record Forge Property
@@ -130,12 +122,6 @@ def test_yolov5_640x640(restore_package_versions, size):
     )
     framework_model = framework_model.to(torch.bfloat16)
     inputs = [inputs[0].to(torch.bfloat16)]
-
-    # Perform a sanity run before Forge compilation which does constant folding and preserve the
-    # expected Relay IR. Skipping the sanity run prevents constant folding, resulting in a
-    # different TVM Relay IR and producing float32 outputs instead of the expected bfloat16
-    # during Forge verification.
-    framework_model(*inputs)
 
     # Configurations
     compiler_cfg = CompilerConfig()
@@ -169,7 +155,6 @@ size = [
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("size", size)
-@pytest.mark.xfail(reason="Issue Link: https://github.com/tenstorrent/tt-forge-fe/issues/2631")
 def test_yolov5_480x480(restore_package_versions, size):
 
     # Record Forge Property
@@ -189,12 +174,6 @@ def test_yolov5_480x480(restore_package_versions, size):
 
     framework_model = framework_model.to(torch.bfloat16)
     inputs = [inputs[0].to(torch.bfloat16)]
-
-    # Perform a sanity run before Forge compilation which does constant folding and preserve the
-    # expected Relay IR. Skipping the sanity run prevents constant folding, resulting in a
-    # different TVM Relay IR and producing float32 outputs instead of the expected bfloat16
-    # during Forge verification.
-    framework_model(*inputs)
 
     # Configurations
     compiler_cfg = CompilerConfig()
@@ -234,12 +213,6 @@ def test_yolov5_1280x1280(restore_package_versions, variant):
     input_shape = (1, 3, 1280, 1280)
     input_tensor = torch.rand(input_shape)
     inputs = [input_tensor.to(torch.bfloat16)]
-
-    # Perform a sanity run before Forge compilation which does constant folding and preserve the
-    # expected Relay IR. Skipping the sanity run prevents constant folding, resulting in a
-    # different TVM Relay IR and producing float32 outputs instead of the expected bfloat16
-    # during Forge verification.
-    framework_model(*inputs)
 
     # Configurations
     compiler_cfg = CompilerConfig()


### PR DESCRIPTION
The yolov5 model was regressed with `AssertionError: only single axis transpose supported at this time, decompose in tvm` and fixed it in this [PR](https://github.com/tenstorrent/tt-forge-fe/pull/2639) by performing sanity before forge compilation  and also noticed generated relay IR difference between with and without sanity run and found out constant folding is happening when we do compilation with sanity and also if the sanity run is skipped, framework model output remains in float32 rather than  bfloat16. After further analysis found out, the yolov5 model has Detect nn module which has grid and anchor_grid tensor initialised in the init function and at first sanity, grid and anchor_grid tensor are computed using make_grid when the grid and input height and width are not same(i.e [if self.dynamic or self.grid[i].shape[2:4] != x[i].shape[2:4]:](https://github.com/ultralytics/yolov5/blob/2540fd4c1c2d9186126a71b3eb681d3a0a11861e/models/yolo.py#L101))  and at the second inference it will not compute grid and anchor_grid tensor since the grid is already computed and matches with input height and width which leads to different graph IR generation so it is not exactly constant folding. The framework model output remains in float32 instaed of bfloat16 this problem was also raised in grid and anchor_grid present in the Detect module. If don't perform sanity run, the model is in bfloat16 and in the ConvertEmulatedDtypes class converts params, buffers, inputs and tensor peresent in the init function from bfloat16 to float32 for TVM Relay IR generation but the grid and anchor_grid are list of tensor in bfloat16 dtype present in the init function which is not converted from bfloat16 to float16 and and at the same time we did run sanity so at the jit trace, the grid and anchor are computed using make_grid since the grid and input height and width are not same which converts the grid and anchor_grid from bfloat16 to float32 because the grid and anchor_grid dtypes are determined by anchors buffer which is in float32 and after TVM graph generation all the params, buffers, inputs and tensors present in the init function are converted back to bfloat16 from float32 but the grid and anchors are not converted and it will be in float32 which leads model output remains in float32 instaed of bfloat16 in forge verification. To resolve this issues, added support for converting the list/tuple of tensor present in the init function from bfloat16 to float32 before TVM graph generated and vice versa in the ConvertEmulatedDtypes class. Now all the yolov5 model tests runs wihout sanity run before compilation
