### PR TITLE
Fix tt-forge-fe model Migration related regressions

### DIFF
--- a/forge/test/models/pytorch/vision/deit/test_deit.py
+++ b/forge/test/models/pytorch/vision/deit/test_deit.py
@@ -38,6 +38,7 @@ def test_deit_imgcls_hf_pytorch(variant):
     # Load model and inputs
     loader = ModelLoader(variant=variant)
     framework_model = loader.load_model(dtype_override=torch.bfloat16)
+    framework_model.config.return_dict = False
     inputs_dict = loader.load_inputs(dtype_override=torch.bfloat16)
 
     # Extract pixel_values from inputs dict

--- a/forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py
+++ b/forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py
@@ -21,7 +21,10 @@ from forge.verify.verify import verify
 variants = [
     ModelVariant.GHOSTNET_100,
     ModelVariant.GHOSTNET_100_IN1K,
-    ModelVariant.GHOSTNETV2_100_IN1K,
+    pytest.param(
+        ModelVariant.GHOSTNETV2_100_IN1K,
+        marks=[pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-forge-fe/issues/1656")],
+    ),
 ]
 
 

--- a/forge/test/models/pytorch/vision/googlenet/test_googlenet.py
+++ b/forge/test/models/pytorch/vision/googlenet/test_googlenet.py
@@ -24,6 +24,7 @@ variants = [
 
 
 @pytest.mark.nightly
+@pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-forge-fe/issues/2700")
 @pytest.mark.parametrize("variant", variants)
 def test_googlenet_pytorch(variant):
     # Record Forge Property

--- a/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
+++ b/forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py
@@ -19,17 +19,35 @@ from forge.forge_property_utils import (
 from forge.verify.verify import verify
 
 variants = [
-    ModelVariant.MIXER_B16_224,
-    ModelVariant.MIXER_B16_224_IN21K,
-    ModelVariant.MIXER_B16_224_MIIL,
-    ModelVariant.MIXER_B16_224_MIIL_IN21K,
-    ModelVariant.MIXER_B32_224,
-    ModelVariant.MIXER_L16_224,
-    ModelVariant.MIXER_L16_224_IN21K,
-    ModelVariant.MIXER_L32_224,
-    ModelVariant.MIXER_S16_224,
-    ModelVariant.MIXER_S32_224,
-    ModelVariant.MIXER_B16_224_GOOG_IN21K,
+    pytest.param(
+        ModelVariant.MIXER_B16_224,
+        marks=[pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-forge-fe/issues/2599")],
+    ),
+    pytest.param(
+        ModelVariant.MIXER_B16_224_IN21K,
+        marks=[pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-forge-fe/issues/2599")],
+    ),
+    pytest.param(ModelVariant.MIXER_B16_224_MIIL),
+    pytest.param(
+        ModelVariant.MIXER_B16_224_MIIL_IN21K,
+        marks=[pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-forge-fe/issues/2599")],
+    ),
+    pytest.param(ModelVariant.MIXER_B32_224),
+    pytest.param(
+        ModelVariant.MIXER_L16_224,
+        marks=[pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-forge-fe/issues/2599")],
+    ),
+    pytest.param(
+        ModelVariant.MIXER_L16_224_IN21K,
+        marks=[pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-forge-fe/issues/2599")],
+    ),
+    pytest.param(ModelVariant.MIXER_L32_224),
+    pytest.param(ModelVariant.MIXER_S16_224),
+    pytest.param(ModelVariant.MIXER_S32_224),
+    pytest.param(
+        ModelVariant.MIXER_B16_224_GOOG_IN21K,
+        marks=[pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-forge-fe/issues/2599")],
+    ),
 ]
 
 


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2697
- Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2695

### Problem description

- Xfail markers from below test cases were mistakenly removed in this [PR](https://github.com/tenstorrent/tt-forge-fe/pull/2657) 

```
forge/test/models/pytorch/vision/googlenet/test_googlenet.py::test_googlenet_pytorch[googlenet]
forge/test/models/pytorch/vision/ghostnet/test_ghostnet.py::test_ghostnet_timm[ghostnetv2_100.in1k]
forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py::test_mlp_mixer_timm_pytorch[mixer_l16_224_in21k]
forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py::test_mlp_mixer_timm_pytorch[mixer_b16_224_in21k]
forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py::test_mlp_mixer_timm_pytorch[mixer_b16_224]
forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py::test_mlp_mixer_timm_pytorch[mixer_b16_224_miil_in21k]
forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py::test_mlp_mixer_timm_pytorch[mixer_b16_224.goog_in21k]
forge/test/models/pytorch/vision/mlp_mixer/test_mlp_mixer.py::test_mlp_mixer_timm_pytorch[mixer_l16_224]
```

- This [PR](https://github.com/tenstorrent/tt-forge-models/pull/52) missed to add optional dtype conversion for input in deit leads to below regression 

```
RuntimeError: TT_ASSERT @ /proj_sw/user_dev/kkannan/jul29_bgd25/tt-forge-fe/forge/csrc/passes/dataformat.cpp:98: node->output_df() == default_df_override || node_is_int
E       info:
E       Non integer Input activations should have output_df same as dataformat override which is: Float16_b, but node output_df is: Float32
```

### What's changed
Addressed the issue by tracking [these](https://github.com/tenstorrent/tt-forge-models/pull/64) changes and adding xfail markers along with issue links.

### Checklist
- [x ] New/Existing tests provide coverage for changes

### Logs

- [jul31_deit_before_fix.log](https://github.com/user-attachments/files/21524974/jul31_deit_bf.log)
- [jul31_deit_after_fix.log](https://github.com/user-attachments/files/21524973/jul31_deit_af.log)

