### PR TITLE
Fix variant forge property recording

### DIFF
--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -907,6 +907,9 @@ def record_model_properties(
     if fph is None:
         return
 
+    if not isinstance(variant, str):
+        variant = str(variant)
+
     # Record individual properties
     fph.add("tags.model_info.framework", framework.full)
     fph.add("tags.model_info.model_arch", model.full)


### PR DESCRIPTION
Fixes #2711 

The record_model_properties function will be used by the model tests to record models info such as model arch, variant name, task, source, etc. In the  record_model_properties we are expecting the variant argument as str but the enum is passed which result in ` Error parsing tags: malformed node or string on line 1: <ast.Name object at 0x7ff819fd0910>` error in data collection transformation from XML to JSON. The base class of the enum is StrEnum so will convert the enum to str by calling` __str__ `method of StrEnum class  for resolving the issue.

Example:
In [phi1 pytorch](https://github.com/tenstorrent/tt-forge-fe/blob/7ad31f996ab937c0ae7ff1db623fa5b4c042a9ba/forge/test/models/pytorch/text/phi1/test_phi1_5.py#L48) model, we are passing the enum(i.e ModelVariant.PHI1_5). The [ModelVariant](https://github.com/tenstorrent/tt-forge-models/blob/2d5636e8f14d6efd779eefe6c8ea460a1b6ecfaf/phi1_5/token_classification/pytorch/loader.py#L23) enum is inherited from [StrEnum](https://github.com/tenstorrent/tt-forge-models/blob/2d5636e8f14d6efd779eefe6c8ea460a1b6ecfaf/config.py#L12) class, will call [str](https://github.com/tenstorrent/tt-forge-models/blob/2d5636e8f14d6efd779eefe6c8ea460a1b6ecfaf/config.py#L15) method for extracting the value of the ModelVariant enum(i.e microsoft/phi-1_5).

