### PR TITLE
Store failing reason

### DIFF
--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -492,6 +492,23 @@ class ModelInfo:
 
 @dataclass_json
 @dataclass
+class SweepsTags:
+    operator: str = ""
+    input_source: str = ""
+    input_shape: str = ""
+    dev_data_format: str = ""
+    math_fidelity: str = ""
+    kwargs: str = ""
+    expected_failing_reason: str = ""
+    expected_failing_reason_desc: str = ""
+    expected_component: str = ""
+    detected_failing_reason: str = ""
+    detected_failing_reason_desc: str = ""
+    detected_component: str = ""
+
+
+@dataclass_json
+@dataclass
 class Tags:
     model_name: Optional[str] = None
     bringup_status: str = ""
@@ -503,6 +520,7 @@ class Tags:
     inputs: Optional[List[TensorDesc]] = None
     outputs: Optional[List[TensorDesc]] = None
     model_info: Optional[ModelInfo] = None
+    sweeps: Optional[SweepsTags] = None
     failure_category: str = ""
     refined_error_message: str = ""
     group: Optional[str] = None
@@ -964,6 +982,93 @@ def record_consistency_limits(
         fph.add("tags.atol", atol)
     if rtol is not None:
         fph.add("tags.rtol", rtol)
+
+
+def record_sweeps_test_tags(
+    operator: str,
+    input_source: str = None,
+    input_shape: str = None,
+    dev_data_format: str = None,
+    math_fidelity: str = None,
+    kwargs: str = None,
+):
+    """
+    Records the operator and additional tags in the sweeps tags.
+    Args:
+        operator (str): The operator name.
+        input_source (str): The source of the input data.
+        dev_data_format (str): The data format used in the device.
+        math_fidelity (str): The math fidelity level.
+        input_shape (str): The shape of the input data.
+        kwargs (str): Additional keyword arguments to be recorded.
+    """
+    fph = forge_property_handler_var.get()
+    if fph is None:
+        return
+
+    if operator is not None:
+        fph.add("tags.sweeps.operator", operator)
+    if input_source is not None:
+        fph.add("tags.sweeps.input_source", input_source)
+    if input_shape is not None:
+        fph.add("tags.sweeps.input_shape", input_shape)
+    if dev_data_format is not None:
+        fph.add("tags.sweeps.dev_data_format", dev_data_format)
+    if math_fidelity is not None:
+        fph.add("tags.sweeps.math_fidelity", math_fidelity)
+    if kwargs is not None:
+        fph.add("tags.sweeps.kwargs", kwargs)
+
+
+def record_sweeps_expected_failing_reason(
+    expected_failing_reason: str = "",
+    expected_failing_reason_desc: str = "",
+    expected_component: str = "",
+):
+    """
+    Records the operator and failing reason in the sweeps tags.
+
+    Args:
+        operator (str): The operator name.
+        expected_failing_reason (str): The expected failing reason.
+        expected_failing_reason_desc (str): The description of the expected failing reason.
+        expected_component (str): The expected component.
+    """
+    fph = forge_property_handler_var.get()
+    if fph is None:
+        return
+
+    if expected_failing_reason is not None:
+        fph.add("tags.sweeps.expected_failing_reason", expected_failing_reason)
+    if expected_failing_reason_desc is not None:
+        fph.add("tags.sweeps.expected_failing_reason_desc", expected_failing_reason_desc)
+    if expected_component is not None:
+        fph.add("tags.sweeps.expected_component", expected_component)
+
+
+def record_sweeps_detected_failing_reason(
+    detected_failing_reason: str = "",
+    detected_failing_reason_desc: str = "",
+    detected_component: str = "",
+):
+    """
+    Records detected failing reason and its description in the sweeps tags.
+
+    Args:
+        detected_failing_reason (str): The detected failing reason.
+        detected_failing_reason_desc (str): The description of the detected failing reason.
+        detected_component (str): The detected component.
+    """
+    fph = forge_property_handler_var.get()
+    if fph is None:
+        return
+
+    if detected_failing_reason is not None:
+        fph.add("tags.sweeps.detected_failing_reason", detected_failing_reason)
+    if detected_failing_reason_desc is not None:
+        fph.add("tags.sweeps.detected_failing_reason_desc", detected_failing_reason_desc)
+    if detected_component is not None:
+        fph.add("tags.sweeps.detected_component", detected_component)
 
 
 def record_forge_op_name(forge_op_name: str):

--- a/forge/test/operators/utils/__init__.py
+++ b/forge/test/operators/utils/__init__.py
@@ -30,8 +30,10 @@ from .plan import FailingRulesConverter
 from .plan import TestPlanScanner
 from .test_data import TestCollectionCommon
 from .test_data import TestCollectionTorch
+from .logger_utils import SweepsTagsLogger
 from .failing_reasons import FailingReason
 from .failing_reasons import FailingReasons
+from .failing_reasons import FailingReasonsFinder
 from .failing_reasons_validation import FailingReasonsValidation
 from .pytest import PyTestUtils
 from .pytest import PytestParamsUtils
@@ -66,8 +68,10 @@ __all__ = [
     "TestPlanScanner",
     "TestCollectionCommon",
     "TestCollectionTorch",
+    "SweepsTagsLogger",
     "FailingReason",
     "FailingReasons",
+    "FailingReasonsFinder",
     "FailingReasonsValidation",
     "PyTestUtils",
     "PytestParamsUtils",

--- a/forge/test/operators/utils/failing_reasons_validation.py
+++ b/forge/test/operators/utils/failing_reasons_validation.py
@@ -9,7 +9,7 @@ from loguru import logger
 
 from .failing_reasons import ExceptionData
 from .failing_reasons import FailingReasons
-from .pytest import PyTestUtils
+from .failing_reasons import FailingReasonsFinder
 
 
 class FailingReasonsValidation:
@@ -32,15 +32,7 @@ class FailingReasonsValidation:
             return False
 
         if len(failing_reason.value.checks) > 0:
-            ex_class_name = f"{type(exception_value).__module__}.{type(exception_value).__name__}"
-            ex_class_name = ex_class_name.replace("builtins.", "")
-            ex_message = f"{exception_value}"
-            exception_traceback = PyTestUtils.remove_colors(exception_traceback)
-            ex_data = ExceptionData(
-                class_name=ex_class_name,
-                message=ex_message,
-                error_log=exception_traceback,
-            )
+            ex_data = FailingReasonsFinder.build_ex_data(exception_value, exception_traceback)
 
             # Checking if exception data matches the failing reason
             if ex_data in failing_reason.value:

--- a/forge/test/operators/utils/logger_utils.py
+++ b/forge/test/operators/utils/logger_utils.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+# Logger utils for sweeps tags properties
+
+
+from forge.forge_property_utils import record_sweeps_test_tags, record_sweeps_expected_failing_reason
+from forge.forge_property_utils import record_sweeps_detected_failing_reason
+
+from .plan import TestPlanUtils
+
+from .failing_reasons import FailingReasons
+from .failing_reasons import ExceptionData
+from .failing_reasons import FailingReasonsFinder
+
+
+class SweepsTagsLogger:
+    @classmethod
+    def log_test_properties(cls, test_vector):
+        record_sweeps_test_tags(
+            operator=test_vector.operator,
+            input_source=test_vector.input_source.name if test_vector.input_source is not None else None,
+            input_shape=f"{test_vector.input_shape}" if test_vector.input_shape is not None else None,
+            dev_data_format=TestPlanUtils.dev_data_format_to_str(test_vector.dev_data_format),
+            math_fidelity=test_vector.math_fidelity.name if test_vector.math_fidelity is not None else None,
+            kwargs=f"{test_vector.kwargs}" if test_vector.kwargs is not None else None,
+        )
+
+    @classmethod
+    def log_expected_failing_reason(cls, xfail_reason: str):
+        failing_reason = FailingReasons.find_by_description(xfail_reason)
+        if not failing_reason:
+            failing_reason = FailingReasons.UNCLASSIFIED
+        failing_reason_name = failing_reason.name
+        failing_reason_desc = failing_reason.value.description
+        component = failing_reason.value.component_checker_description
+        record_sweeps_expected_failing_reason(
+            expected_failing_reason=failing_reason_name,
+            expected_failing_reason_desc=failing_reason_desc,
+            expected_component=component,
+        )
+
+    @classmethod
+    def log_detected_failing_reason(cls, ex_data: ExceptionData):
+        failing_reason = FailingReasonsFinder.find_reason_by_ex_data(ex_data)
+        if not failing_reason:
+            failing_reason = FailingReasons.UNCLASSIFIED
+        failing_reason_name = failing_reason.name
+        failing_reason_desc = failing_reason.value.description
+        component = failing_reason.value.component_checker_description
+        record_sweeps_detected_failing_reason(
+            detected_failing_reason=failing_reason_name,
+            detected_failing_reason_desc=failing_reason_desc,
+            detected_component=component,
+        )


### PR DESCRIPTION
### Ticket
#2675

### Problem description
Present failing reasons (expected and detected) in superset dashboard.

### What's changed
Calculating actual failing reason and store as detected via test case tags.
Storing failing component (expected and detected).
Storing sweeps test properties: input_source, input_shape, dev_data_format, math_fidelity, kwargs.

### Checklist
- [ ] New/Existing tests provide coverage for changes
