### PR TITLE
Fix vgg19_unet ModelLoader

### DIFF
--- a/forge/test/models/pytorch/vision/unet/test_vgg19_unet.py
+++ b/forge/test/models/pytorch/vision/unet/test_vgg19_unet.py
@@ -35,8 +35,9 @@ def test_vgg19_unet():
     )
 
     # Load model and input
-    framework_model = ModelLoader.load_model(dtype_override=torch.bfloat16)
-    input_sample = ModelLoader.load_inputs(dtype_override=torch.bfloat16)
+    loader = ModelLoader()
+    framework_model = loader.load_model(dtype_override=torch.bfloat16)
+    input_sample = loader.load_inputs(dtype_override=torch.bfloat16)
 
     # Configurations
     compiler_cfg = CompilerConfig()


### PR DESCRIPTION
### Description
This PR Includes the fix for the issue `TypeError: ModelLoader.load_model() missing 1 required positional argument: 'self'`

### What's changed
The test script of the vgg19_unet has been modified

### Checklist
- [ ] New/Existing tests provide coverage for changes

### Model Log
[vgg19_unet.log](https://github.com/user-attachments/files/21583343/vgg19_unet.log)

