### PR TITLE
Link FFE Scripts for Deepseek math and Beit to tt_forge_models

### DIFF
--- a/forge/test/models/pytorch/multimodal/deepseek_math/test_deepseek_math.py
+++ b/forge/test/models/pytorch/multimodal/deepseek_math/test_deepseek_math.py
@@ -2,6 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+from third_party.tt_forge_models.deepseek.deepseek_math.pytorch import (
+    ModelLoader as MathLoader,
+)
+from third_party.tt_forge_models.deepseek.deepseek_math.pytorch import (
+    ModelVariant as MathVariant,
+)
 
 import forge
 from forge.forge_property_utils import (
@@ -11,48 +17,59 @@ from forge.forge_property_utils import (
     Task,
     record_model_properties,
 )
+from forge.verify.verify import verify
 
+from test.models.models_utils import generate_no_cache, pad_inputs
 from test.models.pytorch.multimodal.deepseek_math.model_utils.model_utils import (
     DeepSeekWrapper,
-    download_model_and_tokenizer,
-    generation,
 )
 
-
-@pytest.mark.parametrize("variant", ["deepseek-math-7b-instruct"])
-def test_deepseek_inference_no_cache_cpu(variant):
-    model_name = f"deepseek-ai/{variant}"
-    model, tokenizer, input_ids = download_model_and_tokenizer(model_name)
-
-    framework_model = DeepSeekWrapper(model)
-    framework_model.eval()
-
-    generated_text = generation(
-        max_new_tokens=200, compiled_model=framework_model, input_ids=input_ids, tokenizer=tokenizer
-    )
-    print(generated_text)
+DEEPSEEK_MATH_VARIANTS = [
+    MathVariant.DEEPSEEK_7B_INSTRUCT,
+]
 
 
-@pytest.mark.out_of_memory
-@pytest.mark.parametrize("variant", ["deepseek-math-7b-instruct"])
-def test_deepseek_inference(variant):
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", DEEPSEEK_MATH_VARIANTS)
+def test_deepseek_math_inference_no_cache(variant):
     # Record Forge Property
     module_name = record_model_properties(
-        framework=Framework.PYTORCH, model=ModelArch.DEEPSEEK, variant=variant, task=Task.QA, source=Source.HUGGINGFACE
+        framework=Framework.PYTORCH,
+        model=ModelArch.DEEPSEEK,
+        variant=variant,
+        task=Task.QA,
+        source=Source.HUGGINGFACE,
     )
     pytest.xfail(reason="Requires multi-chip support")
 
-    model_name = f"deepseek-ai/{variant}"
-    model, tokenizer, input_ids = download_model_and_tokenizer(model_name)
+    # Load Model and Tokenizer
+    loader = MathLoader(variant=variant)
+    model = loader.load_model()
+    tokenizer = loader._load_tokenizer()
     framework_model = DeepSeekWrapper(model)
     framework_model.eval()
 
+    # Prepare inputs
+    inputs = loader.load_inputs()
+    padded_inputs, seq_len = pad_inputs(inputs)
+
+    # Compile model
     compiled_model = forge.compile(
         framework_model,
-        sample_inputs=[input_ids],
+        sample_inputs=[padded_inputs],
         module_name=module_name,
     )
-    generated_text = generation(
-        max_new_tokens=1, compiled_model=compiled_model, input_ids=input_ids, tokenizer=tokenizer
+
+    # Verify correctness
+    verify([padded_inputs], framework_model, compiled_model)
+
+    # Generate output
+    generated_text = generate_no_cache(
+        max_new_tokens=512,
+        model=compiled_model,
+        inputs=padded_inputs,
+        seq_len=seq_len,
+        tokenizer=tokenizer,
     )
     print(generated_text)

--- a/forge/test/models/pytorch/vision/beit/test_beit.py
+++ b/forge/test/models/pytorch/vision/beit/test_beit.py
@@ -1,63 +1,55 @@
-# SPDX-FileCopyrightText: (c) 2024 Tenstorrent AI ULC
-
+# SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
+#
 # SPDX-License-Identifier: Apache-2.0
+
 import pytest
 import torch
+from third_party.tt_forge_models.beit.pytorch import ModelLoader as BeitLoader
+from third_party.tt_forge_models.beit.pytorch import ModelVariant as BeitVariant
 
 import forge
-from forge._C import DataFormat
-from forge.config import CompilerConfig
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
+    ModelGroup,
+    ModelPriority,
     Source,
     Task,
     record_model_properties,
 )
 from forge.verify.verify import verify
 
-from test.models.pytorch.vision.beit.model_utils.utils import load_input, load_model
-
-variants = [
-    pytest.param(
-        "microsoft/beit-base-patch16-224",
-        marks=[pytest.mark.xfail],
-    ),
-    pytest.param(
-        "microsoft/beit-large-patch16-224",
-        marks=[pytest.mark.xfail],
-    ),
+BEIT_VARIANTS = [
+    pytest.param(BeitVariant.BASE, marks=[pytest.mark.xfail]),
+    pytest.param(BeitVariant.LARGE, marks=[pytest.mark.xfail]),
 ]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants)
-def test_beit_image_classification(variant):
-
+@pytest.mark.parametrize("variant", BEIT_VARIANTS)
+def test_beit_image_classification_pytorch(variant):
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.PYTORCH,
         model=ModelArch.BEIT,
         variant=variant,
-        source=Source.HUGGINGFACE,
         task=Task.IMAGE_CLASSIFICATION,
+        source=Source.HUGGINGFACE,
+        group=ModelGroup.GENERALITY,
+        priority=ModelPriority.P2,
     )
 
     # Load model and input
-    framework_model = load_model(variant).to(torch.bfloat16)
-    inputs = load_input(variant)
-    inputs = [inputs[0].to(torch.bfloat16)]
+    loader = BeitLoader(variant)
+    model = loader.load_model(dtype_override=torch.bfloat16)
+    input_dict = loader.load_inputs(dtype_override=torch.bfloat16)
 
-    data_format_override = DataFormat.Float16_b
-    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+    # prepare inputs
+    inputs = [input_dict["pixel_values"]]
+    model.eval()
 
     # Forge compile framework model
-    compiled_model = forge.compile(
-        framework_model,
-        sample_inputs=inputs,
-        module_name=module_name,
-        compiler_cfg=compiler_cfg,
-    )
+    compiled_model = forge.compile(model, inputs, module_name)
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    verify(inputs, model, compiled_model)


### PR DESCRIPTION
### Problem description
This PR Includes the Linkage of the deepseek math modal and Beit modal to FFE Scripts.

### What's changed
Test script of the deepsee_math and Beit has been modified

### Checklist
- [x] New/Existing tests provide coverage for changes

### Model Log
[deepseek_math.log](https://github.com/user-attachments/files/21583271/deepseek_math.log)
[beit.log](https://github.com/user-attachments/files/21583277/beit.log)

