### PR TITLE
Handle negative stride in Index op to unblock N-BEATS ONNX model

### DIFF
--- a/forge/forge/op/tm.py
+++ b/forge/forge/op/tm.py
@@ -122,6 +122,25 @@ def Index(name: str, operandA: Tensor, dim: int, start: int, stop: int = None, s
     if stop < 0:
         stop += operandA.shape[dim]
 
+    # Handle negative stride by converting it to a positive value (simple case)
+    if stride < 0:
+        # NOTE: This simplified conversion is only valid when the size of the dimension is 1.
+        # For dimensions with size larger than 1, proper flipping logic needs to be implemented.
+        assert operandA.shape[dim] == 1, (
+            f"Negative stride conversion is only supported for dimensions of size 1. "
+            f"Got size {operandA.shape[dim]} for dim {dim}"
+        )
+
+        # Convert the negative stride to its absolute value
+        stride = abs(stride)
+
+        # Handle special case for flip-like operations: (start = -1, stop = very large negative value)
+        # This pattern typically represents a full reverse slice from end to beginning.
+        # Convert it to a standard forward slice: start = 0, stop = operandA.shape[dim]
+        if start == -1 and stop >= torch.iinfo(torch.int64).min:
+            start = 0
+            stop = operandA.shape[dim]
+
     assert stride > 0
 
     assert start < operandA.shape[dim]

--- a/forge/test/models/test_model_parts.py
+++ b/forge/test/models/test_model_parts.py
@@ -176,3 +176,45 @@ def test_remove_concat_pass(dim):
 
     compiled_model = forge.compile(model, sample_inputs=inputs)
     verify(inputs, model, compiled_model)
+
+
+@pytest.mark.parametrize(
+    "input_shape, flip_dim",
+    [
+        ((1, 1, 1024, 72), 0),
+        ((1, 1, 104, 72), 1),
+        ((1, 12, 1, 92), 2),
+        ((1, 33, 11, 1), 3),
+        ((1, 1, 17, 16), 1),
+    ],
+)
+def test_flip(input_shape, flip_dim):
+    class Flip(nn.Module):
+        def __init__(self, dim):
+            super().__init__()
+            self.dim = dim
+
+        def forward(self, x):
+            return x.flip(dims=(self.dim,))
+
+    torch_model = Flip(dim=flip_dim)
+    inputs = [torch.rand(*input_shape)]
+
+    # Export model to ONNX
+    onnx_path = "flip.onnx"
+    torch.onnx.export(torch_model, (inputs[0],), onnx_path, opset_version=17)
+
+    # Load framework model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule("sanity", onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs)
+
+    # Model Verification
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2734

### Problem description

- N-BEATS model facing negative stride assertion due to [this flip](https://github.com/ServiceNow/N-BEATS/blob/c746a4f13ffc957487e0c3279b182c3030836053/models/nbeats.py#L67C9-L68C48) operation (Note: In model The flip is performed along a dimension of size 1, making it effectively a no-op.)

### What's changed

- This PR supports negative stride in Forge's Index operation for dimensions with size 1 and verifies the fix with sanity test cases.
- The logic:
  - Checks if the dimension size is 1 and raises an error otherwise (to avoid incorrect behaviour for more complex cases).
  - Converts the negative stride to its positive equivalent
  - Recognizes a common flip pattern: start = -1, stop = very large negative value. For such cases, rewrites it into a standard forward slice from start = 0 to stop = size of the dimension.

### Logs

- [aug7_flip_sanity_before_fix.log](https://github.com/user-attachments/files/21666422/aug7_flip_sanity_before_fix.log)
- [aug7_flip_sanity_after_fix.log](https://github.com/user-attachments/files/21666421/aug7_flip_sanity_after_fix.log)
- [aug7_nbeats_onnx_before_fix.log](https://github.com/user-attachments/files/21666424/aug7_nbeats_onnx_bf.log)
- [aug7_nbeats_onnx_after_fix.log](https://github.com/user-attachments/files/21666423/aug7_nbeats_onnx_af.log)

