### PR TITLE
Binary & unary bitwise int inputs

### DIFF
--- a/forge/test/operators/pytorch/eltwise_binary/test_binary.py
+++ b/forge/test/operators/pytorch/eltwise_binary/test_binary.py
@@ -141,6 +141,11 @@ class TestVerification:
         value_range = ValueRanges.LARGE
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 
+        dev_data_format = test_vector.dev_data_format
+        if dev_data_format is None and test_vector.operator in TestCollectionData.bitwise.operators:
+            # For bitwise operators, use int data format
+            dev_data_format = TestCollectionData.single_int.dev_data_formats[0]
+
         model_type = cls.MODEL_TYPES[test_vector.input_source]
         pytorch_model = (
             model_type(
@@ -148,7 +153,7 @@ class TestVerification:
                 opname=test_vector.operator,
                 shape=test_vector.input_shape,
                 kwargs=kwargs,
-                dtype=test_vector.dev_data_format,
+                dtype=dev_data_format,
                 value_range=value_range,
             )
             if test_vector.input_source in (InputSource.CONST_EVAL_PASS,)
@@ -164,7 +169,7 @@ class TestVerification:
         # Using AllCloseValueChecker in all cases except for integer data formats
         # and logical operators ge, ne, gt, lt:
         verify_config: VerifyConfig
-        if test_vector.dev_data_format in TestCollectionTorch.int.dev_data_formats:
+        if dev_data_format in TestCollectionTorch.int.dev_data_formats:
             verify_config = VerifyConfig(value_checker=AutomaticValueChecker())
         else:
             verify_config = VerifyConfig(value_checker=AllCloseValueChecker(rtol=1e-2, atol=1e-2))
@@ -174,7 +179,7 @@ class TestVerification:
             test_device=test_device,
             input_shapes=input_shapes,
             input_params=input_params,
-            dev_data_format=test_vector.dev_data_format,
+            dev_data_format=dev_data_format,
             math_fidelity=test_vector.math_fidelity,
             value_range=value_range,
             warm_reset=warm_reset,
@@ -329,6 +334,14 @@ class TestCollectionData:
         math_fidelities=TestCollectionCommon.single.math_fidelities,
     )
 
+    all_int = TestCollection(
+        dev_data_formats=TestCollectionTorch.int.dev_data_formats,
+    )
+
+    single_int = TestCollection(
+        dev_data_formats=TestCollectionTorch.int.dev_data_formats[0:1],
+    )
+
 
 class BinaryTestPlanBuilder:
     """Helper class for building test plans for binary operators"""
@@ -340,6 +353,12 @@ class BinaryTestPlanBuilder:
         """Build test plan collections for binary operator"""
 
         operators = [operator]
+
+        all_dev_data_formats = TestCollectionData.all.dev_data_formats
+        single_dev_data_formats = TestCollectionData.single.dev_data_formats
+        if operator in TestCollectionData.bitwise.operators:
+            all_dev_data_formats = TestCollectionData.all_int.dev_data_formats
+            single_dev_data_formats = TestCollectionData.single_int.dev_data_formats
 
         collections = [
             # Test plan:
@@ -359,11 +378,7 @@ class BinaryTestPlanBuilder:
                 input_sources=TestCollectionData.single.input_sources,
                 input_shapes=TestCollectionData.single.input_shapes,
                 kwargs=generate_kwargs,
-                dev_data_formats=[
-                    item
-                    for item in TestCollectionData.all.dev_data_formats
-                    if item not in TestCollectionData.single.dev_data_formats
-                ],
+                dev_data_formats=[item for item in all_dev_data_formats if item not in single_dev_data_formats],
                 math_fidelities=TestCollectionData.single.math_fidelities,
             ),
             # Test plan:
@@ -373,7 +388,7 @@ class BinaryTestPlanBuilder:
                 input_sources=TestCollectionData.single.input_sources,
                 input_shapes=TestCollectionData.single.input_shapes,
                 kwargs=generate_kwargs,
-                dev_data_formats=TestCollectionData.single.dev_data_formats,
+                dev_data_formats=single_dev_data_formats,
                 math_fidelities=TestCollectionData.all.math_fidelities,
             ),
         ]
@@ -487,10 +502,6 @@ class TestPlansData:
             TestCollection(
                 operators=TestCollectionData.not_implemented.operators,
                 failing_reason=FailingReasons.NOT_IMPLEMENTED,
-            ),
-            TestCollection(
-                operators=TestCollectionData.bitwise.operators,
-                failing_reason=FailingReasons.UNSUPPORTED_DATA_FORMAT,
             ),
             TestCollection(
                 operators=[

--- a/forge/test/operators/pytorch/eltwise_unary/test_unary.py
+++ b/forge/test/operators/pytorch/eltwise_unary/test_unary.py
@@ -95,11 +95,14 @@ class TestVerification:
         value_range = ValueRanges.SMALL
         kwargs = test_vector.kwargs if test_vector.kwargs else {}
 
+        dev_data_format = test_vector.dev_data_format
+        if dev_data_format is None and test_vector.operator in TestCollectionData.bitwise.operators:
+            # For bitwise operators, use int data format
+            dev_data_format = TestCollectionData.single_int.dev_data_formats[0]
+
         model_type = cls.MODEL_TYPES[test_vector.input_source]
         pytorch_model = (
-            model_type(
-                operator, test_vector.input_shape, kwargs, dtype=test_vector.dev_data_format, value_range=value_range
-            )
+            model_type(operator, test_vector.input_shape, kwargs, dtype=dev_data_format, value_range=value_range)
             if test_vector.input_source in (InputSource.CONST_EVAL_PASS,)
             else model_type(operator, kwargs)
         )
@@ -110,7 +113,7 @@ class TestVerification:
 
         # Using AllCloseValueChecker in all cases except for integer data formats
         verify_config: VerifyConfig
-        if test_vector.dev_data_format in TestCollectionTorch.int.dev_data_formats:
+        if dev_data_format in TestCollectionTorch.int.dev_data_formats:
             verify_config = VerifyConfig(value_checker=AutomaticValueChecker())
         else:
             verify_config = VerifyConfig(value_checker=AllCloseValueChecker(rtol=1e-2, atol=1e-2))
@@ -120,7 +123,7 @@ class TestVerification:
             test_device=test_device,
             input_shapes=input_shapes,
             input_params=input_params,
-            dev_data_format=test_vector.dev_data_format,
+            dev_data_format=dev_data_format,
             math_fidelity=test_vector.math_fidelity,
             value_range=value_range,
             warm_reset=warm_reset,
@@ -258,6 +261,13 @@ class TestCollectionData:
         ],
     )
 
+    all_int = TestCollection(
+        dev_data_formats=TestCollectionTorch.int.dev_data_formats,
+    )
+
+    single_int = TestCollection(
+        dev_data_formats=TestCollectionTorch.int.dev_data_formats[0:1],
+    )
     # torch.float16 is not supported well - python crashes
     common_to_skip = TestCollection(
         dev_data_formats=[torch.float16],
@@ -397,12 +407,6 @@ TestParamsData.test_plan_not_implemented = TestPlan(
             input_sources=TestCollectionCommon.single.input_sources,
             input_shapes=TestCollectionCommon.single.input_shapes,
             failing_reason=FailingReasons.NOT_IMPLEMENTED,
-        ),
-        TestCollection(
-            operators=TestCollectionData.bitwise.operators,
-            input_sources=TestCollectionCommon.single.input_sources,
-            input_shapes=TestCollectionCommon.single.input_shapes,
-            failing_reason=FailingReasons.UNSUPPORTED_DATA_FORMAT,
         ),
         TestCollectionData.common_to_skip,
     ],


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Broken bitwise operators tests. Bitwise operators doesn't support float inputs so should be tested with int
Tests raise RuntimeError: "bitwise_and_cpu" not implemented for 'Float'

### What's changed
Test bitwise operators with int inputs.
Now raising The following operators are not implemented: ['aten::bitwise_and']

### Checklist
- [ ] New/Existing tests provide coverage for changes
