### PR TITLE
Remove hardcoded stack and reshape logic from DecomposeStack DFPatternCallback

### DIFF
--- a/forge/test/models/onnx/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3_onnx.py
+++ b/forge/test/models/onnx/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3_onnx.py
@@ -35,6 +35,7 @@ def test_ssdlite320_mobilenetv3(variant, forge_tmp_path):
         task=Task.IMAGE_CLASSIFICATION,
         source=Source.TORCHVISION,
     )
+    pytest.xfail(reason="Hang at RemoveRedundantTake TVM callback")
 
     # Load model and input
     weight_name = variants_with_weights[variant]


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2773

### Problem description


- The ssdlite320_mobilenet_v3_large ONNX model failed with the error: 
```
InternalError: Check failed: boxes_shape.size() == 3 (5 vs. 3) : Input boxes should be 3-D.
```
- The dimensionality mismatch originated from a [stack and reshape operation](https://github.com/pytorch/vision/blob/f515c45fc80e8e7e1b06b93ef6b07de609149e1f/torchvision/ops/boxes.py#L181C5-L182C46) inside the [clip_boxes_to_image](https://github.com/pytorch/vision/blob/9eb57cd5c96be7fe31923eb65399c3819d064587/torchvision/models/detection/ssd.py#L427) function, which is part of the [postprocess_detections](https://github.com/pytorch/vision/blob/9eb57cd5c96be7fe31923eb65399c3819d064587/torchvision/models/detection/ssd.py#L414C9-L414C31)

- Sanity tests failed with the error:  
```
Error: tensor type `Tensor[(3234, 2, 2, 1), float32]` has 4 dimensions, while `Tensor[(3234, 4), float32]` has 2 dimensions
```

### Root Cause

- The ONNX export followed by Relay transformation converted the PyTorch `stack + reshape` operation into the following structure:

```
def @main(%onnx::Unsqueeze_0: Tensor[(3234, 2), float32] /* ty=Tensor[(3234, 2), float32] span=/Unsqueeze.onnx::Unsqueeze_0:0:0 */, %onnx::Unsqueeze_1: Tensor[(3234, 2), float32] /* ty=Tensor[(3234, 2), float32] span=/Unsqueeze_1.onnx::Unsqueeze_1:0:0 */) -> Tensor[(3234, 4), float32] {
  %0 = expand_dims(%onnx::Unsqueeze_0, axis=2) /* ty=Tensor[(3234, 2, 1), float32] span=/Unsqueeze:0:0 */;
  %1 = expand_dims(%onnx::Unsqueeze_1, axis=2) /* ty=Tensor[(3234, 2, 1), float32] span=/Unsqueeze_1:0:0 */;
  %2 = (%0, %1) /* /Concat:0:0 */ /* ty=(Tensor[(3234, 2, 1), float32], Tensor[(3234, 2, 1), float32]) span=/Concat:0:0 */;
  %3 = concatenate(%2, axis=2) /* ty=Tensor[(3234, 2, 2), float32] span=/Concat:0:0 */;
  reshape(%3, newshape=[3234, 4]) /* ty=Tensor[(3234, 4), float32] span=/Reshape:0:0 */
}
```

- This pattern was matched by the [DecomposeStack DFPatternCallback](https://github.com/tenstorrent/tt-forge-fe/blob/1ac963656cc621a2016185133a3f5ac6ab1be965/forge/forge/tvm_calls/relay/op/forge_passes.py#L385), which replaces the above pattern with a `stack + reshape + squeeze`.

- However, the initial implementation introduced several hardcoded assumptions:
  -  A fixed axis=-1 for the stack op, ignoring the original concatenate axis.
  -  A hardcoded reshape pattern newshape=[0, 0, 0, -1, 1] that produced 5D tensors.
  -  A squeeze(axis=[4]) operation that failed to restore the correct output shape.

- These assumptions led to incorrect output dimensions, breaking semantic equivalence and causing downstream failures.

### What's changed

- Updated the DecomposeStack  to correctly:
    - Extract the axis used in the original concatenate op.
    - Retrieve the target shape from the original reshape op.
    - Use these extracted values in the new stack and reshape operations.
- Removed hardcoded reshape values, stack axis and squeeze logic that were producing incorrect shapes.
- After this fix, the model started hanging at the RemoveRedundantTake TVM callback, so xfail was added to that test to to prevent breaking nightly runs


### Checklist
- [x] Verified the fix with op-level, block-level sanity tests along with model test.

### Logs

- [aug8_ssd_mobilenet_before_fix.log](https://github.com/user-attachments/files/21688538/aug8_ssd_mobilenet_bf.log)
- [aug8_block_sanity_before_fix.log](https://github.com/user-attachments/files/21688533/aug8_block_sanity_bf.log)
- [aug8_sanity_before_fix.log](https://github.com/user-attachments/files/21688535/aug8_sanity_bf.log)
- [aug8_ssd_mobilenet_after_fix.log](https://github.com/user-attachments/files/21688537/aug8_ssd_mobilenet_af.log) (after  keyboard interrupt)
- [aug8_ssd_mobilenet_af_1.log](https://github.com/user-attachments/files/21688536/aug8_ssd_mobilenet_af_1.log) (Hangs) 
- [aug8_block_sanity_after_fix.log](https://github.com/user-attachments/files/21688532/aug8_block_sanity_af.log)
- [aug8_sanity_after_fix.log](https://github.com/user-attachments/files/21688534/aug8_sanity_af.log)





