### PR TITLE
Link deepseek_coder,gpt2_seqcls, gpt2_casuallm,Hippyn,llava  in FFE Script test from tt_forge_models

### DIFF
--- a/forge/test/models/onnx/multimodal/llava/test_llava_onnx.py
+++ b/forge/test/models/onnx/multimodal/llava/test_llava_onnx.py
@@ -1,30 +1,52 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
-
 # SPDX-License-Identifier: Apache-2.0
-
 
 import pytest
 import torch
+import onnx
 
 import forge
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
+    ModelGroup,
+    ModelPriority,
     Source,
     Task,
     record_model_properties,
 )
 from forge.verify.verify import verify
-import onnx
-from test.models.pytorch.multimodal.llava.model_utils.utils import load_inputs
-from test.models.pytorch.multimodal.llava.test_llava import load_model
+from third_party.tt_forge_models.llava.pytorch import (
+    ModelLoader as ConditionalGenModelLoader,
+)
+from third_party.tt_forge_models.llava.pytorch import (
+    ModelVariant as ConditionalGenModelVariant,
+)
 
-variants = ["llava-hf/llava-1.5-7b-hf"]
+
+class Wrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+
+    def forward(self, input_ids, attention_mask, pixel_values):
+        inputs = {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "pixel_values": pixel_values,
+        }
+        output = self.model(**inputs)
+        return output.logits
+
+
+LLAVA_VARIANTS = [
+    ConditionalGenModelVariant.LLAVA_1_5_7B,
+]
 
 
 @pytest.mark.xfail
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", LLAVA_VARIANTS)
 def test_llava_onnx(variant, forge_tmp_path):
 
     # Record Forge Property
@@ -34,33 +56,40 @@ def test_llava_onnx(variant, forge_tmp_path):
         variant=variant,
         task=Task.CONDITIONAL_GENERATION,
         source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
     )
 
-    pytest.xfail(reason="Hangs at generate initial graph stage.")
+    # Load model and inputs
+    loader = ConditionalGenModelLoader()
+    torch_model = loader.load_model()
+    wrapped_model = Wrapper(torch_model)
 
-    torch_model, processor = load_model(variant)
-    image = "https://www.ilankelman.org/stopsigns/australia.jpg"
-    text = "What’s shown in this image?"
+    inputs_dict = loader.load_inputs()
+    input_ids = inputs_dict["input_ids"]
+    attention_mask = inputs_dict["attention_mask"]
+    pixel_values = inputs_dict["pixel_values"]
 
-    # Input sample
-    input_ids, attn_mask, pixel_values = load_inputs(image, text, processor)
-    inputs = [input_ids, attn_mask, pixel_values]
+    inputs = [input_ids, attention_mask, pixel_values]
 
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
-    torch.onnx.export(torch_model, (inputs[0], inputs[1], inputs[2]), onnx_path, opset_version=17)
+    # ONNX export path
+    onnx_path = f"{forge_tmp_path}/{str(variant).lower().replace('-', '_')}.onnx"
 
-    # Load framework model
+    # Export to ONNX
+    torch.onnx.export(
+        wrapped_model,
+        (input_ids, attention_mask, pixel_values),
+        onnx_path,
+        input_names=["input_ids", "attention_mask", "pixel_values"],
+    )
+
+    # Load and validate ONNX model
     onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_path)
+
     framework_model = forge.OnnxModule(module_name, onnx_model, onnx_path)
 
-    # Compile model
+    # Compile ONNX model
     compiled_model = forge.compile(framework_model, inputs, module_name=module_name)
 
     # Model Verification
-    verify(
-        inputs,
-        framework_model,
-        compiled_model,
-    )
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/models/pytorch/atomic/hippynn/test_hippynn.py
+++ b/forge/test/models/pytorch/atomic/hippynn/test_hippynn.py
@@ -1,16 +1,14 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
-#
+
 # SPDX-License-Identifier: Apache-2.0
 
-import os
 
-os.environ["HIPPYNN_USE_CUSTOM_KERNELS"] = "False"
-
-import ase.build
-import ase.units
 import pytest
 import torch
-from hippynn.graphs import inputs
+from third_party.tt_forge_models.hippynn.pytorch import ModelLoader as AtomicModelLoader
+from third_party.tt_forge_models.hippynn.pytorch import (
+    ModelVariant as AtomicModelVariant,
+)
 
 import forge
 from forge.forge_property_utils import (
@@ -21,8 +19,6 @@ from forge.forge_property_utils import (
     record_model_properties,
 )
 from forge.verify.verify import verify
-
-from test.models.pytorch.atomic.hippynn.model_utils.model import load_model
 
 
 class HippynWrapper(torch.nn.Module):
@@ -38,33 +34,37 @@ class HippynWrapper(torch.nn.Module):
         return output_dict
 
 
-@pytest.mark.xfail
+HIPPYNN_VARIANTS = [
+    AtomicModelVariant.BASE,
+]
+
+
 @pytest.mark.nightly
-def test_hippynn():
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", HIPPYNN_VARIANTS)
+def test_hippynn(variant):
 
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.PYTORCH,
         model=ModelArch.HIPPYNN,
-        variant="default",
+        variant=variant,
         task=Task.ATOMIC_ML,
         source=Source.GITHUB,
     )
 
     # Load model
-    framework_model, output_key = load_model()
-    framework_model.eval()
+    loader = AtomicModelLoader()
+    framework_model, output_key = loader.load_model()
     framework_model = HippynWrapper(framework_model, output_key=output_key)
 
     # Load inputs
-    atoms = ase.build.molecule("H2O")
-    pos = torch.as_tensor(atoms.positions / ase.units.Bohr).unsqueeze(0).to(torch.get_default_dtype())
-    sp = torch.as_tensor(atoms.get_atomic_numbers()).unsqueeze(0)
+    inputs = loader.load_inputs()
 
     # Forge compile framework model
     compiled_model = forge.compile(
         framework_model,
-        sample_inputs=(sp, pos),
+        sample_inputs=inputs,
         module_name=module_name,
     )
     # Model Verification

--- a/forge/test/models/pytorch/multimodal/deepseek_coder/model_utils/model_utils.py
+++ b/forge/test/models/pytorch/multimodal/deepseek_coder/model_utils/model_utils.py
@@ -2,19 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import torch
-from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers.modeling_attn_mask_utils import _prepare_4d_causal_attention_mask
-
-
-def download_model_and_tokenizer(model_name, **kwargs):
-    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
-    model = AutoModelForCausalLM.from_pretrained(model_name, trust_remote_code=True)
-
-    # Prepare input sentence
-    messages = [{"role": "user", "content": "write a bubble sort algorithm in python."}]
-    inputs = tokenizer.apply_chat_template(messages, add_generation_prompt=True, return_tensors="pt").to(model.device)
-
-    return model, tokenizer, inputs
 
 
 class DeepSeekWrapper(torch.nn.Module):

--- a/forge/test/models/pytorch/multimodal/deepseek_coder/test_deepseek_coder.py
+++ b/forge/test/models/pytorch/multimodal/deepseek_coder/test_deepseek_coder.py
@@ -1,7 +1,13 @@
 # SPDX-FileCopyrightText: (c) 2025 Tenstorrent AI ULC
-#
+
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+from third_party.tt_forge_models.deepseek.deepseek_coder.pytorch import (
+    ModelLoader as CausalLMLoader,
+)
+from third_party.tt_forge_models.deepseek.deepseek_coder.pytorch import (
+    ModelVariant as CausalLMVariant,
+)
 
 import forge
 from forge.forge_property_utils import (
@@ -13,16 +19,18 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
-from test.models.models_utils import generate_no_cache, pad_inputs
 from test.models.pytorch.multimodal.deepseek_coder.model_utils.model_utils import (
     DeepSeekWrapper,
-    download_model_and_tokenizer,
 )
+
+DEEPSEEK_VARIANTS = [
+    CausalLMVariant.DEEPSEEK_1_3B_INSTRUCT,
+]
 
 
 @pytest.mark.nightly
 @pytest.mark.xfail
-@pytest.mark.parametrize("variant", ["deepseek-coder-1.3b-instruct"])
+@pytest.mark.parametrize("variant", DEEPSEEK_VARIANTS)
 def test_deepseek_inference_no_cache(variant):
 
     # Record Forge Property
@@ -33,11 +41,13 @@ def test_deepseek_inference_no_cache(variant):
 
     # Load Model and Tokenizer
     model_name = f"deepseek-ai/{variant}"
-    model, tokenizer, inputs = download_model_and_tokenizer(model_name)
+    loader = CausalLMLoader()
+    model = loader.load_model()
     framework_model = DeepSeekWrapper(model)
     framework_model.eval()
+    tokenizer = loader._load_tokenizer()
 
-    padded_inputs, seq_len = pad_inputs(inputs)
+    padded_inputs, seq_len = loader.load_inputs()
 
     # Forge compile framework model
     compiled_model = forge.compile(
@@ -49,24 +59,7 @@ def test_deepseek_inference_no_cache(variant):
     # Model Verification
     verify([padded_inputs], framework_model, compiled_model)
 
-    generated_text = generate_no_cache(
+    generated_text = loader.decode_output(
         max_new_tokens=512, model=compiled_model, inputs=padded_inputs, seq_len=seq_len, tokenizer=tokenizer
-    )
-    print(generated_text)
-
-
-@pytest.mark.skip_model_analysis
-@pytest.mark.parametrize("variant", ["deepseek-coder-1.3b-instruct"])
-def test_deepseek_inference_no_cache_cpu(variant):
-    model_name = f"deepseek-ai/{variant}"
-    model, tokenizer, inputs = download_model_and_tokenizer(model_name)
-
-    framework_model = DeepSeekWrapper(model)
-    framework_model.eval()
-
-    padded_inputs, seq_len = pad_inputs(inputs)
-
-    generated_text = generate_no_cache(
-        max_new_tokens=512, model=framework_model, inputs=padded_inputs, seq_len=seq_len, tokenizer=tokenizer
     )
     print(generated_text)

--- a/forge/test/models/pytorch/multimodal/llava/test_llava.py
+++ b/forge/test/models/pytorch/multimodal/llava/test_llava.py
@@ -1,11 +1,14 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-
-
 import pytest
 import torch
-from transformers import AutoProcessor, LlavaForConditionalGeneration
+from third_party.tt_forge_models.llava.pytorch import (
+    ModelLoader as ConditionalGenModelLoader,
+)
+from third_party.tt_forge_models.llava.pytorch import (
+    ModelVariant as ConditionalGenModelVariant,
+)
 
 import forge
 from forge.forge_property_utils import (
@@ -19,8 +22,6 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
-from test.models.pytorch.multimodal.llava.model_utils.utils import load_inputs
-
 
 class Wrapper(torch.nn.Module):
     def __init__(self, model):
@@ -33,19 +34,15 @@ class Wrapper(torch.nn.Module):
         return output.logits
 
 
-def load_model(variant):
-    processor = AutoProcessor.from_pretrained(variant)
-    model = LlavaForConditionalGeneration.from_pretrained(variant)
-    model = Wrapper(model)
-    return model, processor
-
-
-variants = ["llava-hf/llava-1.5-7b-hf"]
+LLAVA_VARIANTS = [
+    ConditionalGenModelVariant.LLAVA_1_5_7B,
+]
 
 
 @pytest.mark.out_of_memory
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", LLAVA_VARIANTS)
 def test_llava(variant):
 
     # Record Forge Property
@@ -59,15 +56,13 @@ def test_llava(variant):
         priority=ModelPriority.P1,
     )
 
-    pytest.xfail(reason="Requires multi-chip support")
-
-    framework_model, processor = load_model(variant)
-    image = "https://www.ilankelman.org/stopsigns/australia.jpg"
-    text = "What’s shown in this image?"
+    loader = ConditionalGenModelLoader()
+    framework_model = loader.load_model()
+    framework_model = Wrapper(framework_model)
 
     # Input sample
-    input_ids, attn_mask, pixel_values = load_inputs(image, text, processor)
-    inputs = [input_ids, attn_mask, pixel_values]
+    inputs = loader.load_inputs()
+    inputs = [inputs["input_ids"], inputs["attention_mask"], inputs["pixel_values"]]
 
     # Forge compile framework model
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)

--- a/forge/test/models/pytorch/text/gpt2/test_gpt2.py
+++ b/forge/test/models/pytorch/text/gpt2/test_gpt2.py
@@ -1,101 +1,63 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
+
 import pytest
-import torch
-from transformers import (
-    AutoModelForSequenceClassification,
-    AutoTokenizer,
-    GPT2Config,
-    GPT2LMHeadModel,
-)
+from third_party.tt_forge_models.gpt2.pytorch import ModelLoader, ModelVariant
 
 import forge
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
+    ModelGroup,
+    ModelPriority,
     Source,
     Task,
     record_model_properties,
 )
 from forge.verify.verify import verify
 
-from test.utils import download_model
+VARIANT_TO_TASK = {
+    ModelVariant.GPT2_BASE: Task.TEXT_GENERATION,
+    ModelVariant.GPT2_SEQUENCE_CLASSIFICATION: Task.SEQUENCE_CLASSIFICATION,
+}
+
+VARIANTS = [
+    ModelVariant.GPT2_BASE,
+    ModelVariant.GPT2_SEQUENCE_CLASSIFICATION,
+]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize(
-    "variant",
-    [
-        "gpt2",
-    ],
-)
-def test_gpt2_text_gen(variant):
-    # Record Forge Property
-    module_name = record_model_properties(
-        framework=Framework.PYTORCH,
-        model=ModelArch.GPT,
-        variant=variant,
-        task=Task.TEXT_GENERATION,
-        source=Source.HUGGINGFACE,
-    )
-
-    # Load tokenizer and model from HuggingFace
-    config = GPT2Config.from_pretrained(variant)
-    config_dict = config.to_dict()
-    config_dict["return_dict"] = False
-    config_dict["use_cache"] = False
-    config = GPT2Config(**config_dict)
-    model = download_model(GPT2LMHeadModel.from_pretrained, variant, config=config)
-
-    input_ids = torch.cat(
-        [torch.randint(1, model.config.vocab_size, (1, 255)), torch.zeros(1, 1, dtype=torch.int64)], dim=-1
-    ).to(torch.int64)
-    inputs = [input_ids]
-
-    # Forge compile framework model
-    compiled_model = forge.compile(model, sample_inputs=inputs, module_name=module_name)
-
-    # Model Verification
-    verify(inputs, model, compiled_model)
-
-
-@pytest.mark.nightly
-@pytest.mark.parametrize(
-    "variant",
-    [
-        "mnoukhov/gpt2-imdb-sentiment-classifier",
-    ],
-)
-def test_gpt2_sequence_classification(variant):
+@pytest.mark.parametrize("variant", VARIANTS)
+def test_gpt2_variants(variant):
+    # Determine task
+    task = VARIANT_TO_TASK[variant]
 
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.PYTORCH,
         model=ModelArch.GPT,
         variant=variant,
-        task=Task.SEQUENCE_CLASSIFICATION,
+        task=task,
         source=Source.HUGGINGFACE,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
     )
 
-    # Load tokenizer and model from HuggingFace
-    tokenizer = download_model(AutoTokenizer.from_pretrained, variant, padding_side="left")
-    model = download_model(
-        AutoModelForSequenceClassification.from_pretrained, variant, return_dict=False, use_cache=False
-    )
-    model.eval()
+    # Load model and inputs via ModelLoader
+    loader = ModelLoader(variant=variant)
+    model = loader.load_model()
+    inputs_dict = loader.load_inputs()
+    inputs = [inputs_dict["input_ids"]]
 
-    # Prepare input
-    test_input = "This is a sample text from "
-    input_tokens = tokenizer(test_input, return_tensors="pt")
-    inputs = [input_tokens["input_ids"]]
-
-    # Forge compile framework model
+    # Compile with Forge
     compiled_model = forge.compile(model, sample_inputs=inputs, module_name=module_name)
 
-    # Model Verification and Inference
+    # Run verification
     _, co_out = verify(inputs, model, compiled_model)
 
-    # post processing
-    predicted_value = co_out[0].argmax(-1).item()
-    print(f"Predicted Sentiment: {model.config.id2label[predicted_value]}")
+    # For classification variant, decode and print sentiment
+    if variant == ModelVariant.GPT2_SEQUENCE_CLASSIFICATION:
+        predicted_value = loader.decode_output(co_out)
+        print(f"Predicted Sentiment: {predicted_value}")

--- a/forge/test/models/pytorch/text/llama/test_llama3.py
+++ b/forge/test/models/pytorch/text/llama/test_llama3.py
@@ -105,7 +105,7 @@ def test_llama3_causal_lm_pytorch(variant):
     model = loader.load_model()
     framework_model = TextModelWrapper(model=model, text_embedding=model.model.embed_tokens)
     framework_model.eval()
-    input_dict = loader.load_inputs()
+    input_dict, seq_len = loader.load_inputs()
     inputs = [input_dict["input_ids"], input_dict["attention_mask"]]
 
     # Forge compile framework model


### PR DESCRIPTION
### Description
This PR Includes the linking of the tt_forge_models to the FFE test scripts 

### What's changed
The test script for the deepseek_code,llava,gpt2,hippyn are changed

### Checklist
- [x] New/Existing tests provide coverage for changes

### ModelLogs
[deepseek_coder_.log](https://github.com/user-attachments/files/21567742/deepseek_coder_.log)
[gpt2_log_seq_cls_decode.log](https://github.com/user-attachments/files/21567744/gpt2_log_seq_cls_decode.log)
[gpt2_log.log](https://github.com/user-attachments/files/21567745/gpt2_log.log)
[hippyn_model.log](https://github.com/user-attachments/files/21567749/hippyn_model.log)
[llava_model.log](https://github.com/user-attachments/files/21567750/llava_model.log)

