### PR TITLE
[BW] ReduceAvg fix

### DIFF
--- a/forge/csrc/ops/op_repeat.cpp
+++ b/forge/csrc/ops/op_repeat.cpp
@@ -70,7 +70,8 @@ NodeContext backward(
     const NodeContext &gradient)
 {
     TT_DBG_ASSERT(op.type() == OpType::Repeat, "Wrong op type.");
-    return op.base_backward(old_op_type, ac, operand, inputs, output, gradient);
+    TT_THROW("Repeat backward is not implemented");
+    unreachable();
 }
 
 void decompose_initial(


### PR DESCRIPTION
### Ticket
fixes: #2785

### Problem description
When `broadcast` is being propagated to MLIR, it just folds into `input_tm`, but in this case it should be materialized. Looking under the hood, when `broadcast` is not folded, it is implemented as `repeat`.  

### What's changed
- Changed `broadcast` op with `repeat`
- fixed backward of `repeat` to now properly handle not implemented `backward` instead of calling non existent python code
