### PR TITLE
Make optimizer always work in fp32

### DIFF
--- a/forge/csrc/autograd/autograd.cpp
+++ b/forge/csrc/autograd/autograd.cpp
@@ -604,25 +604,27 @@ NodeContext autograd_engine::create_optimizer_op(
 {
     // Create cast nodes for non-fp32 operands to ensure fp32 computation
     std::vector<NodeContext> casted_operands;
-    for (const NodeContext &operand : operands) {
-        if (operand.output_df == DataFormat::Float32 || !is_float_data_format(operand.output_df)) {
+    for (const NodeContext &operand : operands)
+    {
+        if (operand.output_df == DataFormat::Float32 || !is_float_data_format(operand.output_df))
+        {
             casted_operands.push_back(operand);
             continue;
         }
         // Create cast node to fp32
-        std::string cast_name = "opt_cast_to_fp32_" + current_fwd_op->name() + "_" + 
-                                std::to_string(operand_index) + "_" + std::to_string(created_op_index) + "_" + 
-                                std::to_string(casted_operands.size()) + "_" + std::to_string(operand.id);
+        std::string cast_name = "opt_cast_to_fp32_" + current_fwd_op->name() + "_" + std::to_string(operand_index) +
+                                "_" + std::to_string(created_op_index) + "_" + std::to_string(casted_operands.size()) +
+                                "_" + std::to_string(operand.id);
         auto cast_node = graph->add_node(
-            graphlib::create_node<graphlib::PyOpNode>(cast_name, 
-                graphlib::OpType("cast", {}, {{"dtype", static_cast<int>(DataFormat::Float32)}})),
+            graphlib::create_node<graphlib::PyOpNode>(
+                cast_name, graphlib::OpType("cast", {}, {{"dtype", static_cast<int>(DataFormat::Float32)}})),
             graph->get_subgraph_id_for_node(current_fwd_op->id()));
-        
+
         graph->add_edge(Edge(operand.id, operand.output_index, cast_node->id(), 0, graphlib::EdgeType::kData));
         cast_node->set_shape(graph->node_by_id(operand.id)->shape());
         cast_node->set_optimizer();
         cast_node->set_output_df(DataFormat::Float32);
-        
+
         casted_operands.push_back(NodeContext(cast_node));
     }
 
@@ -762,7 +764,6 @@ NodeContext autograd_engine::create_input(
 
     return NodeContext(node);
 }
-
 
 // From the node in the forward graph, create a recompute node for the backward graph.
 // This will also connect the newly created recompute node to its operands (based on the operands of the fwd node).

--- a/forge/csrc/autograd/autograd.cpp
+++ b/forge/csrc/autograd/autograd.cpp
@@ -704,7 +704,8 @@ NodeContext autograd_engine::create_input(
     std::string &suffix_identifier,
     const std::vector<std::uint32_t> &tensor_shape,
     bool copy_consteval_operations,
-    bool disable_consteval)
+    bool disable_consteval,
+    std::optional<DataFormat> dtype)
 {
     std::string base_string = (epoch_type == graphlib::NodeEpochType::Backward) ? "bwd" : "opt";
 
@@ -721,7 +722,7 @@ NodeContext autograd_engine::create_input(
     }
 
     node->set_shape(Shape::create(tensor_shape));
-    node->set_output_df(current_fwd_op->output_df());
+    node->set_output_df(dtype.value_or(current_fwd_op->output_df()));
 
     if (epoch_type == graphlib::NodeEpochType::Backward)
     {

--- a/forge/csrc/autograd/autograd.hpp
+++ b/forge/csrc/autograd/autograd.hpp
@@ -127,7 +127,8 @@ class autograd_engine
         std::string &suffix_identifier,
         const std::vector<std::uint32_t> &tensor_shape,
         bool copy_consteval_operations,
-        bool disable_consteval = false);
+        bool disable_consteval = false,
+        std::optional<DataFormat> dtype = std::nullopt);
 
     bool contains_bwd_nodes() const;
     const std::map<int, std::vector<Node *>> &get_bwd_nodes(Node *fwd) const;

--- a/forge/csrc/autograd/python_bindings.cpp
+++ b/forge/csrc/autograd/python_bindings.cpp
@@ -118,7 +118,8 @@ void AutogradModule(py::module &m_autograd)
                std::string input_name,
                const std::vector<std::uint32_t> &tensor_shape,
                bool copy_consteval_operations,
-               bool disable_consteval)
+               bool disable_consteval,
+               std::optional<DataFormat> dtype)
             {
                 // Note requires_grad = False
                 return self.autograd->create_input(
@@ -129,13 +130,15 @@ void AutogradModule(py::module &m_autograd)
                     input_name,
                     tensor_shape,
                     copy_consteval_operations,
-                    disable_consteval);
+                    disable_consteval,
+                    dtype);
             },
             py::arg("input_name"),
             py::arg("tensor_shape"),
             py::kw_only(),
             py::arg("copy_consteval_operations") = false,
-            py::arg("disable_consteval") = false)
+            py::arg("disable_consteval") = false,
+            py::arg("dtype") = std::nullopt)
         .def(
             "loopback",
             [](tt::autograd::autograd_context &self,

--- a/forge/csrc/lower_to_forge/common.hpp
+++ b/forge/csrc/lower_to_forge/common.hpp
@@ -160,6 +160,23 @@ inline bool is_a_data_format(DataFormat df)
     }
 }
 
+inline bool is_float_data_format(DataFormat df)
+{
+    switch (df)
+    {
+        case DataFormat::Float32:
+        case DataFormat::Float16:
+        case DataFormat::Float16_b:
+        case DataFormat::Bfp8:
+        case DataFormat::Bfp4:
+        case DataFormat::Bfp2:
+        case DataFormat::Bfp8_b:
+        case DataFormat::Bfp4_b:
+        case DataFormat::Lf8: return true;
+        default: return false;
+    }
+}
+
 inline DataFormat to_a_data_format(DataFormat df)
 {
     switch (df)

--- a/forge/forge/optimizers.py
+++ b/forge/forge/optimizers.py
@@ -325,7 +325,7 @@ class Adam(Optimizer):
     def generate_op_trace(self, ac, parameter, gradient):
         parameter_shape = parameter.shape.as_list()
         if self.weight_decay > 0.0:
-            weight_decay = ac.tensor(torch.full(parameter_shape, self.weight_decay))
+            weight_decay = ac.tensor(torch.full(parameter_shape, self.weight_decay, dtype=self.torch_dtype))
         else:
             weight_decay = None
 
@@ -352,14 +352,18 @@ class Adam(Optimizer):
         if self.bias_correction:
             # bias_correction1 = 1 - beta1 ** step
             beta1_one = ac.tensor(torch.full(parameter_shape, 1.0, dtype=self.torch_dtype))
-            beta1_pow = ac.input("beta1_pow", parameter.shape, disable_consteval=True, dtype=self.forge_dtype)  # stores beta1 ** step
+            beta1_pow = ac.input(
+                "beta1_pow", parameter.shape, disable_consteval=True, dtype=self.forge_dtype
+            )  # stores beta1 ** step
             updated_beta1_pow = ac.op("multiply", (beta1_pow, beta1))
             bias_correction1 = ac.op("subtract", (beta1_one, updated_beta1_pow))
             reciprocal_bias_correction1 = ac.op("reciprocal", (bias_correction1,))
 
             # bias_correction2 = 1 - beta2 ** step
             beta2_one = ac.tensor(torch.full(parameter_shape, 1.0, dtype=self.torch_dtype))
-            beta2_pow = ac.input("beta2_pow", parameter.shape, disable_consteval=True, dtype=self.forge_dtype)  # stores beta2 ** step
+            beta2_pow = ac.input(
+                "beta2_pow", parameter.shape, disable_consteval=True, dtype=self.forge_dtype
+            )  # stores beta2 ** step
             updated_beta2_pow = ac.op("multiply", (beta2_pow, beta2))
             bias_correction2 = ac.op("subtract", (beta2_one, updated_beta2_pow))
             sqrt_bias_correction2 = ac.op("sqrt", (bias_correction2,))

--- a/forge/forge/optimizers.py
+++ b/forge/forge/optimizers.py
@@ -24,6 +24,8 @@ class Optimizer:
 
     dynamic_params = False
     linked_modules: Optional[List[CompiledModel]] = None
+    torch_dtype = torch.float32
+    forge_dtype = forge._C.DataFormat.Float32
 
     # For each parameter that we are optimizing, we store a dictionary of optimizer parameters for that particular parameter.
     # The derived classes will populate this dictionary with the necessary optimizer parameters.
@@ -165,7 +167,7 @@ class SGD(Optimizer):
             opt_inputs["lr"] = Tensor.create_from_torch(learning_rate_tensor)
 
     def generate_op_trace(self, ac, parameter, gradient):
-        lr = ac.input("lr", (1,))
+        lr = ac.input("lr", (1,), dtype=self.forge_dtype)
 
         grad_times_lr = ac.op("multiply", (gradient, lr))
         param_minus_lr_times_grad = ac.op("subtract", (parameter, grad_times_lr))
@@ -235,40 +237,40 @@ class Adam(Optimizer):
         if parameters:
             self.set_parameters_to_optimize(parameters)
 
-    def get_cpu_param_dict(self, dtype: torch.dtype, shape: Tuple[int]) -> Dict:
+    def get_cpu_param_dict(self, shape: Tuple[int]) -> Dict:
         # TODO: shapes are set to the shape of the parameter because of the following issue
         # https://github.com/tenstorrent/tt-metal/issues/16352
         if self.bias_correction:
             return {
-                "torch_mean": torch.full(shape, 0.0, dtype=dtype),
-                "torch_variance": torch.full(shape, 0.0, dtype=dtype),
-                "torch_beta1_pow": torch.full(shape, 1.0, dtype=dtype),
-                "torch_beta2_pow": torch.full(shape, 1.0, dtype=dtype),
+                "torch_mean": torch.full(shape, 0.0, dtype=self.torch_dtype),
+                "torch_variance": torch.full(shape, 0.0, dtype=self.torch_dtype),
+                "torch_beta1_pow": torch.full(shape, 1.0, dtype=self.torch_dtype),
+                "torch_beta2_pow": torch.full(shape, 1.0, dtype=self.torch_dtype),
             }
         else:
             return {
-                "torch_mean": torch.full(shape, 0.0, dtype=dtype),
-                "torch_variance": torch.full(shape, 0.0, dtype=dtype),
+                "torch_mean": torch.full(shape, 0.0, dtype=self.torch_dtype),
+                "torch_variance": torch.full(shape, 0.0, dtype=self.torch_dtype),
             }
 
-    def get_param_dict(self, dtype: torch.dtype, shape: Tuple[int]) -> Dict:
+    def get_param_dict(self, shape: Tuple[int]) -> Dict:
         """
         Return a dict of optimizer parameter names to tensor
         """
-        torch_lr = torch.full((1,), self.learning_rate, dtype=dtype)
+        torch_lr = torch.full((1,), self.learning_rate, dtype=self.torch_dtype)
         if self.bias_correction:
             return {
-                "lr": Tensor.create_from_torch(torch.full(shape, self.learning_rate, dtype=dtype)),
-                "mean": Tensor.create_from_torch(torch.full(shape, 0.0, dtype=dtype)),
-                "variance": Tensor.create_from_torch(torch.full(shape, 0.0, dtype=dtype)),
-                "beta1_pow": Tensor.create_from_torch(torch.full(shape, 1.0, dtype=dtype)),
-                "beta2_pow": Tensor.create_from_torch(torch.full(shape, 1.0, dtype=dtype)),
+                "lr": Tensor.create_from_torch(torch.full(shape, self.learning_rate, dtype=self.torch_dtype)),
+                "mean": Tensor.create_from_torch(torch.full(shape, 0.0, dtype=self.torch_dtype)),
+                "variance": Tensor.create_from_torch(torch.full(shape, 0.0, dtype=self.torch_dtype)),
+                "beta1_pow": Tensor.create_from_torch(torch.full(shape, 1.0, dtype=self.torch_dtype)),
+                "beta2_pow": Tensor.create_from_torch(torch.full(shape, 1.0, dtype=self.torch_dtype)),
             }
         else:
             return {
-                "lr": Tensor.create_from_torch(torch.full(shape, self.learning_rate, dtype=dtype)),
-                "mean": Tensor.create_from_torch(torch.full(shape, 0.0, dtype=dtype)),
-                "variance": Tensor.create_from_torch(torch.full(shape, 0.0, dtype=dtype)),
+                "lr": Tensor.create_from_torch(torch.full(shape, self.learning_rate, dtype=self.torch_dtype)),
+                "mean": Tensor.create_from_torch(torch.full(shape, 0.0, dtype=self.torch_dtype)),
+                "variance": Tensor.create_from_torch(torch.full(shape, 0.0, dtype=self.torch_dtype)),
             }
 
     def get_optimizer_state_keys(self) -> List:
@@ -285,10 +287,10 @@ class Adam(Optimizer):
         for parameter in parameters:
             if parameter.requires_grad:
                 self.parameter_to_opt_inputs[parameter.get_name()] = self.get_param_dict(
-                    parameter.pt_data_format, parameter.shape.get_pytorch_shape()
+                    parameter.shape.get_pytorch_shape()
                 )
                 self.parameter_to_opt_torch_inputs[parameter.get_name()] = self.get_cpu_param_dict(
-                    parameter.pt_data_format, parameter.shape.get_pytorch_shape()
+                    parameter.shape.get_pytorch_shape()
                 )
 
     def set_optimizer_parameters(self, learning_rate: Optional[float] = None) -> None:
@@ -317,11 +319,10 @@ class Adam(Optimizer):
 
         # {mean, variance} get updated in the loopback
         for parameter, opt_inputs in self.parameter_to_opt_inputs.items():
-            torch_lr = torch.full(parameter.shape.as_list(), self.learning_rate, dtype=opt_inputs["lr"].pt_data_format)
+            torch_lr = torch.full(parameter.shape.as_list(), self.learning_rate, dtype=self.torch_dtype)
             opt_inputs["lr"] = Tensor.create_from_torch(torch_lr)
 
     def generate_op_trace(self, ac, parameter, gradient):
-
         parameter_shape = parameter.shape.as_list()
         if self.weight_decay > 0.0:
             weight_decay = ac.tensor(torch.full(parameter_shape, self.weight_decay))
@@ -333,32 +334,32 @@ class Adam(Optimizer):
             gradient = ac.op("add", (gradient, weight_decay_times_param))
 
         # self.mean = self.beta1 * self.mean + one_minus_beta1 * gradient
-        mean = ac.input("mean", parameter.shape, copy_consteval_operations=True)
-        beta1 = ac.tensor(torch.full(parameter_shape, self.beta1))
-        one_minus_beta1 = ac.tensor(torch.full(parameter_shape, 1 - self.beta1))
+        mean = ac.input("mean", parameter.shape, copy_consteval_operations=True, dtype=self.forge_dtype)
+        beta1 = ac.tensor(torch.full(parameter_shape, self.beta1, dtype=self.torch_dtype))
+        one_minus_beta1 = ac.tensor(torch.full(parameter_shape, 1 - self.beta1, dtype=self.torch_dtype))
         mean_times_beta1 = ac.op("multiply", (mean, beta1))
         gradient_times_one_minus_beta1 = ac.op("multiply", (gradient, one_minus_beta1))
         updated_mean = ac.op("add", (mean_times_beta1, gradient_times_one_minus_beta1))
 
         # self.variance = self.beta2 * self.variance + one_minus_beta2 * gradient**2
-        variance = ac.input("variance", parameter.shape, copy_consteval_operations=True)
-        beta2 = ac.tensor(torch.full(parameter_shape, self.beta2))
-        one_minus_beta2 = ac.tensor(torch.full(parameter_shape, 1 - self.beta2))
+        variance = ac.input("variance", parameter.shape, copy_consteval_operations=True, dtype=self.forge_dtype)
+        beta2 = ac.tensor(torch.full(parameter_shape, self.beta2, dtype=self.torch_dtype))
+        one_minus_beta2 = ac.tensor(torch.full(parameter_shape, 1 - self.beta2, dtype=self.torch_dtype))
         variance_times_beta2 = ac.op("multiply", (variance, beta2))
         gradient_squared = ac.op("multiply", (gradient, gradient))
         gradient_squared_times_one_minus_beta2 = ac.op("multiply", (gradient_squared, one_minus_beta2))
         updated_variance = ac.op("add", (variance_times_beta2, gradient_squared_times_one_minus_beta2))
         if self.bias_correction:
             # bias_correction1 = 1 - beta1 ** step
-            beta1_one = ac.tensor(torch.full(parameter_shape, 1.0))
-            beta1_pow = ac.input("beta1_pow", parameter.shape, disable_consteval=True)  # stores beta1 ** step
+            beta1_one = ac.tensor(torch.full(parameter_shape, 1.0, dtype=self.torch_dtype))
+            beta1_pow = ac.input("beta1_pow", parameter.shape, disable_consteval=True, dtype=self.forge_dtype)  # stores beta1 ** step
             updated_beta1_pow = ac.op("multiply", (beta1_pow, beta1))
             bias_correction1 = ac.op("subtract", (beta1_one, updated_beta1_pow))
             reciprocal_bias_correction1 = ac.op("reciprocal", (bias_correction1,))
 
             # bias_correction2 = 1 - beta2 ** step
-            beta2_one = ac.tensor(torch.full(parameter_shape, 1.0))
-            beta2_pow = ac.input("beta2_pow", parameter.shape, disable_consteval=True)  # stores beta2 ** step
+            beta2_one = ac.tensor(torch.full(parameter_shape, 1.0, dtype=self.torch_dtype))
+            beta2_pow = ac.input("beta2_pow", parameter.shape, disable_consteval=True, dtype=self.forge_dtype)  # stores beta2 ** step
             updated_beta2_pow = ac.op("multiply", (beta2_pow, beta2))
             bias_correction2 = ac.op("subtract", (beta2_one, updated_beta2_pow))
             sqrt_bias_correction2 = ac.op("sqrt", (bias_correction2,))
@@ -370,7 +371,7 @@ class Adam(Optimizer):
         else:
             sqrt_of_variance = ac.op("sqrt", (updated_variance,))
 
-        epsilon = ac.tensor(torch.full(parameter_shape, self.epsilon))
+        epsilon = ac.tensor(torch.full(parameter_shape, self.epsilon, dtype=self.torch_dtype))
         sqrt_of_variance_plus_epsilon = ac.op("add", (sqrt_of_variance, epsilon))
         reciprocal_of_sqrt_of_variance_plus_epsilon = ac.op("reciprocal", (sqrt_of_variance_plus_epsilon,))
 
@@ -396,7 +397,7 @@ class Adam(Optimizer):
                 mean_times_reciprocal_of_sqrt_of_variance_plus_epsilon
             )
 
-        lr = ac.input("lr", parameter.shape)
+        lr = ac.input("lr", parameter.shape, dtype=self.forge_dtype)
         parameter_delta = ac.op(
             "multiply", (mean_times_reciprocal_of_sqrt_of_variance_plus_epsilon_plus_weight_decay_times_param, lr)
         )

--- a/forge/forge/optimizers.py
+++ b/forge/forge/optimizers.py
@@ -257,7 +257,6 @@ class Adam(Optimizer):
         """
         Return a dict of optimizer parameter names to tensor
         """
-        torch_lr = torch.full((1,), self.learning_rate, dtype=self.torch_dtype)
         if self.bias_correction:
             return {
                 "lr": Tensor.create_from_torch(torch.full(shape, self.learning_rate, dtype=self.torch_dtype)),

--- a/forge/forge/optimizers.py
+++ b/forge/forge/optimizers.py
@@ -119,15 +119,15 @@ class SGD(Optimizer):
         # For each Parameter, we register its associated set of optimizer parameters
         for parameter in parameters:
             if parameter.requires_grad:
-                self.parameter_to_opt_inputs[parameter.get_name()] = self.get_param_dict(parameter.pt_data_format)
+                self.parameter_to_opt_inputs[parameter.get_name()] = self.get_param_dict()
 
-    def get_param_dict(self, dtype: torch.dtype) -> Dict:
+    def get_param_dict(self) -> Dict:
         """
         Return a dict of optimizer parameter names to tensor
         """
         # Forge needs a pytorch array for now
         # TODO(jchu): modify these two lines when we deprecate the old path
-        learning_rate_torch = torch.full((1,), self.learning_rate, dtype=dtype)
+        learning_rate_torch = torch.full((1,), self.learning_rate, dtype=self.torch_dtype)
 
         learning_rate = Tensor.create_from_torch(learning_rate_torch)
         return {"lr": learning_rate}
@@ -163,7 +163,7 @@ class SGD(Optimizer):
             self.learning_rate = learning_rate
 
         for parameter, opt_inputs in self.parameter_to_opt_inputs.items():
-            learning_rate_tensor = torch.full((1,), self.learning_rate, dtype=opt_inputs["lr"].pt_data_format)
+            learning_rate_tensor = torch.full((1,), self.learning_rate, dtype=self.torch_dtype)
             opt_inputs["lr"] = Tensor.create_from_torch(learning_rate_tensor)
 
     def generate_op_trace(self, ac, parameter, gradient):


### PR DESCRIPTION
### Ticket
Closes #2716 

### Problem description
Training jobs were diverging for llama lora training when optimizer was left on device.
Upon further inspection, it was due to having bf16 in optimizer computations.
Torch, by default, computes everything in fp32 in the optimizer, so we should as well.

### What's changed
During autograd, all inputs that aren't fp32 get a cast operation.
All optimizer outputs that do not have matching dtypes with their respective inputs get a cast node.
Autograd was extended to accept dtype as well.
Optimizers now have a default dtype of fp32.