### PR TITLE
Modify Export of MLP Mixer onnx

### DIFF
--- a/forge/test/models/onnx/vision/mlp_mixer/test_mlp_mixer_onnx.py
+++ b/forge/test/models/onnx/vision/mlp_mixer/test_mlp_mixer_onnx.py
@@ -56,7 +56,6 @@ varaints = [
     ),
     pytest.param(
         "mixer_s16_224",
-        marks=[pytest.mark.xfail],
     ),
     pytest.param(
         "mixer_s32_224",
@@ -125,6 +124,7 @@ def test_mlp_mixer_timm_onnx(variant, forge_tmp_path):
         opset_version=17,
         input_names=["input"],
         output_names=["output"],
+        keep_initializers_as_inputs=True,
     )
 
     # Load and verify ONNX model


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2736

### Problem description

- MLP mixer onnx model variants mixer_b32_224, mixer_l32_224, mixer_s16_224, mixer_s32_224 fail with `AttributeError: <class 'tvm.relay.expr.Call'> has no attribute name_hint` during frontend conversion of LayerNorm op to tvm relay. This issue was arising because one of the inputs to layernorm op was a call node while expected is a relay variable. blocks.0.norm1.weight which is one of the inputs to layernorm remains as a Var object 
`inputs[1] = Var(blocks.0.norm1.weight, ty=TensorType([768], float32))`

While the other input  blocks.0.norm1.bias gets created as an identity during export. TVM converts the identity to a copy operation and the copy operation wraps the original Var in a CallNode 
`inputs[2] = CallNode(Op(copy), [Var(stem.proj.bias, ty=TensorType([768], float32))], (nullptr), [])`

And when LayerNorm requests its bias input, it gets the CallNode instead of a direct Var and when name_hint is tried to be retrieved from a callnode , it fails since callnode doesn't have that attribute.

### What's changed
- This PR sets keep_initializers_as_inputs as True while onnx export so that onnx doesn't try to merge or share parameters and all parameters become explicit graph inputs preventing formation of identity op, hence now TVM gets clean Var objects for all inputs. Now the mixer_s16_224 variant test passes e2e while the remaining variants with this issue are progressing upto runtime. 

### Logs
[mlp_mixer_onnx.log](https://github.com/user-attachments/files/21726315/mlp_mixer_onnx.log)