### PR TITLE
Fix reshape removal logic in RemoveRedundantReshape DFPatternCallback

### DIFF
--- a/forge/forge/tvm_calls/relay/op/forge_passes.py
+++ b/forge/forge/tvm_calls/relay/op/forge_passes.py
@@ -1045,8 +1045,10 @@ class RemoveRedundantReshape(DFPatternCallback):
     def callback(self, pre, post, node_map):
         act = node_map[self.input_tensor][0]
         reshape_op = node_map[self.reshape][0]
+        input_shape = list(act.checked_type.shape)
         new_shape = list(reshape_op.attrs.newshape)
-        if len(new_shape) == 0:
+        # Remove the reshape if the input and target shapes are identical
+        if input_shape == new_shape:
             return act
         else:
             return post

--- a/forge/test/models/onnx/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3_onnx.py
+++ b/forge/test/models/onnx/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3_onnx.py
@@ -23,7 +23,6 @@ variants_with_weights = {
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", variants_with_weights.keys())
 def test_ssdlite320_mobilenetv3(variant, forge_tmp_path):
 
@@ -35,7 +34,8 @@ def test_ssdlite320_mobilenetv3(variant, forge_tmp_path):
         task=Task.IMAGE_CLASSIFICATION,
         source=Source.TORCHVISION,
     )
-    pytest.xfail(reason="Hang at RemoveRedundantTake TVM callback")
+
+    pytest.xfail(reason="Fatal Python error: Segmentation fault")
 
     # Load model and input
     weight_name = variants_with_weights[variant]


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2798

### Problem description

- The ssdlite320_mobilenet_v3_large ONNX model failed with the error:

```
TVMError: relay.concatenate requires all tensors have the same ndim
```

- Issue is arising from [this block](https://github.com/pytorch/vision/blob/9eb57cd5c96be7fe31923eb65399c3819d064587/torchvision/models/detection/ssd.py#L435C17-L440C79) where [incorrect reshape removal logic](https://github.com/tenstorrent/tt-forge-fe/blob/1012bb456cc97557c83197971fae61800b7c6052/forge/forge/tvm_calls/relay/op/forge_passes.py#L1042C9-L1042C32) in the RemoveRedundantReshape DFPatternCallback causes dimension mismatches in downstream concatenate operations.

### Root cause

- The RemoveRedundantReshape callback incorrectly removes legitimate scalar conversion operations.

- Input graph to RemoveRedundantReshape: 


```
%5 = shape_of(%4, dtype="int64") /* ty=Tensor[(1), int64] span=/Shape:0:0 */;
reshape(%5, newshape=[]) /* ty=int64 span=/Gather:0:0 */
```

**Analysis:**

- %5 is a 1D tensor: Tensor[(1), int64]
- reshape(%5, newshape=[]) should convert it to a scalar: int64 (0D tensor)
- This is a legitimate 1D → 0D conversion, not a redundant operation

**Flawed logic:**

```
if len(new_shape) == 0:  # newshape=[] → len([]) == 0 is True
    return act  # INCORRECT: Returns input tensor directly
```

- The callback assumes newshape=[] indicates redundancy, but newshape=[] means "convert to scalar".

**Result:** 

- The callback returns %5 directly, preserving it as Tensor[(1), int64] instead of converting to scalar int64.

- Output graph after incorrect reshape removal: 

```
%5 = shape_of(%4, dtype="int64") /* ty=Tensor[(1), int64] span=/Shape:0:0 */
```

- For complete input and output graph - [aug12_os_bf_info.log](https://github.com/user-attachments/files/21734221/aug12_os_bf_info.log)

**Downstream impact:**

- Later concatenate operations expect scalars but receive 1D tensors, causing the dimension mismatch error -> `TVMError: relay.concatenate requires all tensors have the same ndim`


### What's changed

- Modified the RemoveRedundantReshape callback to only remove truly redundant reshape operations where the input and output shapes are identical


### Checklist
- [x] Verified the fix with op-level, block-level sanity tests along with model test.

### Logs

Before fix 

- [aug12_op_sanity_bf.log](https://github.com/user-attachments/files/21734089/aug12_os_bf.log)
- [aug12_block_sanity_bf.log](https://github.com/user-attachments/files/21734087/aug12_bs_bf.log)
- [aug12_model_bf.log](https://github.com/user-attachments/files/21734091/aug12_ssd_mob_bf.log)

After fix

- [aug12_op_sanity_af.log](https://github.com/user-attachments/files/21734088/aug12_os_af.log)
- [aug12_block_sanity_af.log](https://github.com/user-attachments/files/21734086/aug12_bs_af.log)
- [aug12_model_af.log](https://github.com/user-attachments/files/21734090/aug12_ssd_mob_af.log)

**Note :** 

Below PRs should be merged before current one 

- [Remove hardcoded stack and reshape logic from DecomposeStack DFPatternCallback](https://github.com/tenstorrent/tt-forge-fe/pull/2782) 
- Fix Hang in ssdlite320 mobilenetv3 onnx model by handling type error in RemoveRedundantTake - [tt-tvm](https://github.com/tenstorrent/tt-tvm/pull/101) , [tt-forge-fe](https://github.com/tenstorrent/tt-forge-fe/pull/2792) 
