### PR TITLE
Sanitize json floats for pcc, atol and rtol

### DIFF
--- a/forge/forge/forge_property_utils.py
+++ b/forge/forge/forge_property_utils.py
@@ -5,6 +5,7 @@
 from enum import Enum, auto
 from pytest import FixtureRequest
 import json
+import numpy as np
 import re
 import contextvars
 from dataclasses import dataclass, is_dataclass, field
@@ -941,6 +942,21 @@ def record_model_properties(
     return module_name
 
 
+def sanitize_json_float(value: Optional[float]) -> Optional[float]:
+    """
+    Sanitize float values for JSON serialization.
+
+    Parameters:
+        value: The float value to sanitize.
+
+    Returns:
+        The sanitized float value, or None if the value is NaN or Inf.
+    """
+    if value is None or np.isnan(value) or np.isinf(value):
+        return None
+    return value
+
+
 def record_consistency_limits(
     framework_outputs: Union[Tuple[TorchTensor, ...], List[TorchTensor]], compiled_outputs: List[TorchTensor]
 ):
@@ -958,6 +974,9 @@ def record_consistency_limits(
     pcc, atol, rtol = determine_consistency_limits(
         framework_outputs=framework_outputs, compiled_outputs=compiled_outputs
     )
+    pcc = sanitize_json_float(pcc)
+    atol = sanitize_json_float(atol)
+    rtol = sanitize_json_float(rtol)
     if pcc is not None:
         fph.add("tags.pcc", pcc)
     if atol is not None:


### PR DESCRIPTION
### Ticket
#2812 

### Problem description
JSON format doesn't support nan, inf, and -inf values.

### What's changed
Use None if the value is NaN or Inf to comply with standard JSON serialization.

### Checklist
- [ ] New/Existing tests provide coverage for changes
