### PR TITLE
Track changes of tt-forge-fe model Bringup & link FFE tests - set11

### DIFF
--- a/forge/test/models/pytorch/vision/dla/test_dla.py
+++ b/forge/test/models/pytorch/vision/dla/test_dla.py
@@ -19,9 +19,6 @@ from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
-from test.models.models_utils import print_cls_results
-from test.models.pytorch.vision.vision_utils.utils import load_timm_model_and_input
-
 variants = [
     ModelVariant.DLA34,
     ModelVariant.DLA46_C,
@@ -70,26 +67,29 @@ def test_dla_pytorch(variant):
     loader.print_cls_results(co_out)
 
 
-variants = ["dla34.in1k"]
+timm_variants = [
+    ModelVariant.DLA34_IN1K,
+]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants)
+@pytest.mark.parametrize("variant", timm_variants)
 def test_dla_timm(variant):
 
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.PYTORCH,
         model=ModelArch.DLA,
-        variant=variant,
+        variant=variant.value,
         source=Source.TIMM,
         task=Task.IMAGE_CLASSIFICATION,
     )
 
-    # Load the model and inputs
-    framework_model, inputs = load_timm_model_and_input(variant)
-    framework_model.to(torch.bfloat16)
-    inputs = [inp.to(torch.bfloat16) for inp in inputs]
+    # Load model and inputs using ModelLoader
+    loader = ModelLoader(variant=variant)
+    framework_model = loader.load_model(dtype_override=torch.bfloat16)
+    input_tensor = loader.load_inputs(dtype_override=torch.bfloat16)
+    inputs = [input_tensor]
 
     data_format_override = DataFormat.Float16_b
     compiler_cfg = CompilerConfig(default_df_override=data_format_override)
@@ -99,11 +99,11 @@ def test_dla_timm(variant):
         framework_model, sample_inputs=inputs, module_name=module_name, compiler_cfg=compiler_cfg
     )
     verify_cfg = VerifyConfig()
-    if variant == "dla34.in1k":
+    if variant == ModelVariant.DLA34_IN1K:
         verify_cfg = VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.98))
 
     # Model Verification and Inference
-    fw_out, co_out = verify(inputs, framework_model, compiled_model, verify_cfg=verify_cfg)
+    _, co_out = verify(inputs, framework_model, compiled_model, verify_cfg=verify_cfg)
 
     # Post processing
-    print_cls_results(fw_out[0], co_out[0])
+    loader.print_cls_results(co_out)

--- a/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/pytorch/vision/efficientnet/test_efficientnet.py
@@ -3,14 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import timm
 import torch
-from loguru import logger
-from PIL import Image
 from third_party.tt_forge_models.efficientnet.pytorch import ModelLoader, ModelVariant
-from third_party.tt_forge_models.tools.utils import get_file
-from timm.data import resolve_data_config
-from timm.data.transforms_factory import create_transform
 
 import forge
 from forge._C import DataFormat
@@ -24,36 +18,28 @@ from forge.forge_property_utils import (
     Task,
     record_model_properties,
 )
-from forge.verify.verify import verify
-
-from test.models.models_utils import print_cls_results
-from test.utils import download_model
+from forge.verify.value_checkers import AutomaticValueChecker
+from forge.verify.verify import VerifyConfig, verify
 
 ## https://huggingface.co/docs/timm/models/efficientnet
 
+# TIMM variants using loader enums
 variants = [
-    pytest.param(
-        "efficientnet_b0",
-        id="efficientnet_b0",
-        marks=[pytest.mark.push],
-    ),
-    pytest.param(
-        "efficientnet_b4",
-        id="efficientnet_b4",
-    ),
-    pytest.param("hf_hub:timm/efficientnet_b0.ra_in1k", id="hf_hub_timm_efficientnet_b0_ra_in1k"),
-    pytest.param("hf_hub:timm/efficientnet_b4.ra2_in1k", id="hf_hub_timm_efficientnet_b4_ra2_in1k"),
-    pytest.param("hf_hub:timm/efficientnet_b5.in12k_ft_in1k", id="hf_hub_timm_efficientnet_b5_in12k_ft_in1k"),
-    pytest.param("hf_hub:timm/tf_efficientnet_b0.aa_in1k", id="hf_hub_timm_tf_efficientnet_b0_aa_in1k"),
-    pytest.param("hf_hub:timm/efficientnetv2_rw_s.ra2_in1k", id="hf_hub_timm_efficientnetv2_rw_s_ra2_in1k"),
-    pytest.param("hf_hub:timm/tf_efficientnetv2_s.in21k", id="hf_hub_timm_tf_efficientnetv2_s_in21k"),
+    pytest.param(ModelVariant.TIMM_EFFICIENTNET_B0, id="efficientnet_b0", marks=[pytest.mark.push]),
+    pytest.param(ModelVariant.TIMM_EFFICIENTNET_B4, id="efficientnet_b4"),
+    pytest.param(ModelVariant.HF_TIMM_EFFICIENTNET_B0_RA_IN1K, id="hf_hub_timm_efficientnet_b0_ra_in1k"),
+    pytest.param(ModelVariant.HF_TIMM_EFFICIENTNET_B4_RA2_IN1K, id="hf_hub_timm_efficientnet_b4_ra2_in1k"),
+    pytest.param(ModelVariant.HF_TIMM_EFFICIENTNET_B5_IN12K_FT_IN1K, id="hf_hub_timm_efficientnet_b5_in12k_ft_in1k"),
+    pytest.param(ModelVariant.HF_TIMM_TF_EFFICIENTNET_B0_AA_IN1K, id="hf_hub_timm_tf_efficientnet_b0_aa_in1k"),
+    pytest.param(ModelVariant.HF_TIMM_EFFICIENTNETV2_RW_S_RA2_IN1K, id="hf_hub_timm_efficientnetv2_rw_s_ra2_in1k"),
+    pytest.param(ModelVariant.HF_TIMM_TF_EFFICIENTNETV2_S_IN21K, id="hf_hub_timm_tf_efficientnetv2_s_in21k"),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_efficientnet_timm(variant):
-    if variant in ["efficientnet_b0"]:
+    if variant == ModelVariant.TIMM_EFFICIENTNET_B0:
         group = ModelGroup.RED
         priority = ModelPriority.P1
     else:
@@ -64,39 +50,18 @@ def test_efficientnet_timm(variant):
     module_name = record_model_properties(
         framework=Framework.PYTORCH,
         model=ModelArch.EFFICIENTNET,
-        variant=variant,
+        variant=variant.value,
         source=Source.TIMM,
         task=Task.IMAGE_CLASSIFICATION,
         group=group,
         priority=priority,
     )
 
-    # Load model
-    framework_model = download_model(timm.create_model, variant, pretrained=True).to(torch.bfloat16)
-    framework_model.eval()
-
-    # Load and pre-process image
-    try:
-        if variant == "hf_hub:timm/tf_efficientnetv2_s.in21k":
-            file_path = get_file(
-                "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png"
-            )
-            img = Image.open(file_path).convert("RGB")
-            use_1k_labels = False
-        else:
-            file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
-            img = Image.open(file_path).convert("RGB")
-            use_1k_labels = True
-        config = resolve_data_config({}, model=framework_model)
-        transform = create_transform(**config)
-        img_tensor = transform(img).unsqueeze(0)
-    except:
-        logger.warning(
-            "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
-        )
-        img_tensor = torch.rand(1, 3, 224, 224)
-
-    inputs = [img_tensor.to(torch.bfloat16)]
+    # Load model and inputs using ModelLoader
+    loader = ModelLoader(variant=variant)
+    framework_model = loader.load_model(dtype_override=torch.bfloat16)
+    input_tensor = loader.load_inputs(dtype_override=torch.bfloat16)
+    inputs = [input_tensor]
 
     data_format_override = DataFormat.Float16_b
     compiler_cfg = CompilerConfig(default_df_override=data_format_override)
@@ -108,12 +73,17 @@ def test_efficientnet_timm(variant):
         module_name=module_name,
         compiler_cfg=compiler_cfg,
     )
+    pcc = 0.99
+    if variant in [ModelVariant.HF_TIMM_EFFICIENTNET_B0_RA_IN1K, ModelVariant.TIMM_EFFICIENTNET_B0]:
+        pcc = 0.98
 
     # Model Verification
-    fw_out, co_out = verify(inputs, framework_model, compiled_model)
+    _, co_out = verify(
+        inputs, framework_model, compiled_model, verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc))
+    )
 
     # Run model on sample data and print results
-    print_cls_results(fw_out[0], co_out[0], use_1k_labels=use_1k_labels)
+    loader.print_cls_results(co_out)
 
 
 variants = [

--- a/forge/test/models/pytorch/vision/vgg/test_vgg.py
+++ b/forge/test/models/pytorch/vision/vgg/test_vgg.py
@@ -3,17 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import timm
 import torch
-from loguru import logger
-from PIL import Image
-from pytorchcv.model_provider import get_model as ptcv_get_model
-from third_party.tt_forge_models.tools.utils import get_file
 from third_party.tt_forge_models.vgg.pytorch import ModelLoader, ModelVariant
-from timm.data import resolve_data_config
-from timm.data.transforms_factory import create_transform
-from torchvision import transforms
-from vgg_pytorch import VGG
 
 import forge
 from forge._C import DataFormat
@@ -25,21 +16,17 @@ from forge.forge_property_utils import (
     Task,
     record_model_properties,
 )
-from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
-from forge.verify.verify import verify
+from forge.verify.verify import VerifyConfig, verify
 
-from test.models.models_utils import print_cls_results
-from test.models.pytorch.vision.vision_utils.utils import load_vision_model_and_input
-from test.utils import download_model
-
+# OSMR (pytorchcv) variants
 variants = [
-    pytest.param("vgg11"),
-    pytest.param("vgg13"),
-    pytest.param("vgg16"),
-    pytest.param("vgg19"),
-    pytest.param("bn_vgg19"),
-    pytest.param("bn_vgg19b"),
+    pytest.param(ModelVariant.VGG11),
+    pytest.param(ModelVariant.VGG13),
+    pytest.param(ModelVariant.VGG16),
+    pytest.param(ModelVariant.VGG19),
+    pytest.param(ModelVariant.VGG19_BN_OSMR),
+    pytest.param(ModelVariant.VGG19_BNB_OSMR),
 ]
 
 
@@ -51,46 +38,26 @@ def test_vgg_osmr_pytorch(variant):
     module_name = record_model_properties(
         framework=Framework.PYTORCH,
         model=ModelArch.VGG,
-        variant=variant,
+        variant=variant.value,
         source=Source.OSMR,
         task=Task.OBJECT_DETECTION,
     )
 
-    framework_model = download_model(ptcv_get_model, variant, pretrained=True).to(torch.bfloat16)
-    framework_model.eval()
-
-    # Image preprocessing
-    try:
-        file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
-        input_image = Image.open(file_path).convert("RGB")
-        preprocess = transforms.Compose(
-            [
-                transforms.Resize(256),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-            ]
-        )
-        input_tensor = preprocess(input_image)
-        input_batch = input_tensor.unsqueeze(0)  # create a mini-batch as expected by the model
-    except:
-        logger.warning(
-            "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
-        )
-        input_batch = torch.rand(1, 3, 224, 224)
-
-    inputs = [input_batch.to(torch.bfloat16)]
+    # Load model and inputs via loader
+    loader = ModelLoader(variant=variant)
+    framework_model = loader.load_model(dtype_override=torch.bfloat16)
+    input_tensor = loader.load_inputs(dtype_override=torch.bfloat16)
+    inputs = [input_tensor]
 
     data_format_override = DataFormat.Float16_b
     compiler_cfg = CompilerConfig(default_df_override=data_format_override)
 
     pcc = 0.99
-
-    if variant in ["vgg16", "bn_vgg19"]:
+    if variant in [ModelVariant.VGG16, ModelVariant.VGG19_BN_OSMR]:
         pcc = 0.98
-    elif variant == "vgg19":
+    elif variant == ModelVariant.VGG19:
         pcc = 0.97
-    elif variant == "bn_vgg19b":
+    elif variant == ModelVariant.VGG19_BNB_OSMR:
         pcc = 0.96
 
     # Forge compile framework model
@@ -102,7 +69,7 @@ def test_vgg_osmr_pytorch(variant):
     )
 
     # Model Verification
-    fw_out, co_out = verify(
+    _, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
@@ -110,11 +77,13 @@ def test_vgg_osmr_pytorch(variant):
     )
 
     # Run model on sample data and print results
-    print_cls_results(fw_out[0], co_out[0])
+    loader.print_cls_results(co_out)
 
 
 @pytest.mark.nightly
 def test_vgg_19_hf_pytorch():
+
+    variant = ModelVariant.HF_VGG19
 
     # Record Forge Property
     module_name = record_model_properties(
@@ -125,38 +94,10 @@ def test_vgg_19_hf_pytorch():
         task=Task.OBJECT_DETECTION,
     )
 
-    """
-    # https://pypi.org/project/vgg-pytorch/
-    # Variants:
-    vgg11, vgg11_bn
-    vgg13, vgg13_bn
-    vgg16, vgg16_bn
-    vgg19, vgg19_bn
-    """
-    framework_model = download_model(VGG.from_pretrained, "vgg19").to(torch.bfloat16)
-    framework_model.eval()
-
-    # Image preprocessing
-    try:
-        file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
-        input_image = Image.open(file_path).convert("RGB")
-        preprocess = transforms.Compose(
-            [
-                transforms.Resize(256),
-                transforms.CenterCrop(224),
-                transforms.ToTensor(),
-                transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
-            ]
-        )
-        input_tensor = preprocess(input_image)
-        input_batch = input_tensor.unsqueeze(0)  # create a mini-batch as expected by the model
-    except:
-        logger.warning(
-            "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
-        )
-        input_batch = torch.rand(1, 3, 224, 224)
-
-    inputs = [input_batch.to(torch.bfloat16)]
+    loader = ModelLoader(variant=variant)
+    framework_model = loader.load_model(dtype_override=torch.bfloat16)
+    input_tensor = loader.load_inputs(dtype_override=torch.bfloat16)
+    inputs = [input_tensor]
 
     data_format_override = DataFormat.Float16_b
     compiler_cfg = CompilerConfig(default_df_override=data_format_override)
@@ -170,34 +111,16 @@ def test_vgg_19_hf_pytorch():
     )
 
     # Model Verification
-    fw_out, co_out = verify(inputs, framework_model, compiled_model)
+    _, co_out = verify(inputs, framework_model, compiled_model)
 
     # Run model on sample data and print results
-    print_cls_results(fw_out[0], co_out[0])
-
-
-def preprocess_timm_model(model_name):
-    model = timm.create_model(model_name, pretrained=True)
-    model.eval()
-    try:
-        config = resolve_data_config({}, model=model)
-        transform = create_transform(**config)
-        file_path = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
-        img = Image.open(file_path).convert("RGB")
-        img_tensor = transform(img).unsqueeze(0)  # transform and add batch dimension
-    except:
-        logger.warning(
-            "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
-        )
-        img_tensor = torch.rand(1, 3, 224, 224)
-
-    return model, img_tensor
+    loader.print_cls_results(co_out)
 
 
 @pytest.mark.nightly
 def test_vgg_bn19_timm_pytorch():
 
-    variant = "vgg19_bn"
+    variant = ModelVariant.TIMM_VGG19_BN
 
     # Record Forge Property
     module_name = record_model_properties(
@@ -208,11 +131,10 @@ def test_vgg_bn19_timm_pytorch():
         task=Task.OBJECT_DETECTION,
     )
 
-    torch.multiprocessing.set_sharing_strategy("file_system")
-    framework_model, image_tensor = download_model(preprocess_timm_model, variant)
-
-    inputs = [image_tensor.to(torch.bfloat16)]
-    framework_model.to(torch.bfloat16)
+    loader = ModelLoader(variant=variant)
+    framework_model = loader.load_model(dtype_override=torch.bfloat16)
+    input_tensor = loader.load_inputs(dtype_override=torch.bfloat16)
+    inputs = [input_tensor]
 
     data_format_override = DataFormat.Float16_b
     compiler_cfg = CompilerConfig(default_df_override=data_format_override)
@@ -226,18 +148,17 @@ def test_vgg_bn19_timm_pytorch():
     )
 
     # Model Verification
-    fw_out, co_out = verify(inputs, framework_model, compiled_model)
+    _, co_out = verify(inputs, framework_model, compiled_model)
 
     # Run model on sample data and print results
-    print_cls_results(fw_out[0], co_out[0])
-
-
-variants = [ModelVariant.VGG19_BN]
+    loader.print_cls_results(co_out)
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants)
-def test_vgg_bn19_torchhub_pytorch(variant):
+def test_vgg_bn19_torchhub_pytorch():
+
+    variant = ModelVariant.VGG19_BN
+
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.PYTORCH,
@@ -246,7 +167,8 @@ def test_vgg_bn19_torchhub_pytorch(variant):
         source=Source.TORCH_HUB,
         task=Task.OBJECT_DETECTION,
     )
-    # Load model and inputs
+
+    # Load model and inputs via loader
     loader = ModelLoader(variant=variant)
     framework_model = loader.load_model(dtype_override=torch.bfloat16)
     input_tensor = loader.load_inputs(dtype_override=torch.bfloat16)
@@ -259,34 +181,27 @@ def test_vgg_bn19_torchhub_pytorch(variant):
     compiled_model = forge.compile(
         framework_model, sample_inputs=inputs, module_name=module_name, compiler_cfg=compiler_cfg
     )
+
     # Model Verification and Inference
     _, co_out = verify(
         inputs,
         framework_model,
         compiled_model,
     )
+
     # Post processing
     loader.print_cls_results(co_out)
 
 
-variants_with_weights = {
-    "vgg11": "VGG11_Weights",
-    "vgg11_bn": "VGG11_BN_Weights",
-    "vgg13": "VGG13_Weights",
-    "vgg13_bn": "VGG13_BN_Weights",
-    "vgg16": "VGG16_Weights",
-    "vgg16_bn": "VGG16_BN_Weights",
-    "vgg19": "VGG19_Weights",
-}
-
 variants = [
-    "vgg11",
-    "vgg11_bn",
-    "vgg13",
-    "vgg13_bn",
-    "vgg16",
-    "vgg16_bn",
-    "vgg19",
+    ModelVariant.TV_VGG11,
+    ModelVariant.TV_VGG11_BN,
+    ModelVariant.TV_VGG13,
+    ModelVariant.TV_VGG13_BN,
+    ModelVariant.TV_VGG16,
+    ModelVariant.TV_VGG16_BN,
+    ModelVariant.TV_VGG19,
+    ModelVariant.TV_VGG19_BN,
 ]
 
 
@@ -304,10 +219,10 @@ def test_vgg_torchvision(variant):
     )
 
     # Load model and input
-    weight_name = variants_with_weights[variant]
-    framework_model, inputs = load_vision_model_and_input(variant, "classification", weight_name)
-    framework_model.to(torch.bfloat16)
-    inputs = [inputs[0].to(torch.bfloat16)]
+    loader = ModelLoader(variant=variant)
+    framework_model = loader.load_model(dtype_override=torch.bfloat16)
+    input_tensor = loader.load_inputs(dtype_override=torch.bfloat16)
+    inputs = [input_tensor]
 
     data_format_override = DataFormat.Float16_b
     compiler_cfg = CompilerConfig(default_df_override=data_format_override)
@@ -321,13 +236,13 @@ def test_vgg_torchvision(variant):
     )
 
     pcc = 0.99
-    if variant in ["vgg16_bn", "vgg13_bn"]:
+    if variant in [ModelVariant.TV_VGG16_BN, ModelVariant.TV_VGG13_BN]:
         pcc = 0.98
 
-    # Model Verificatiogn and inference
-    fw_out, co_out = verify(
+    # Model Verification and inference
+    _, co_out = verify(
         inputs, framework_model, compiled_model, verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc))
     )
 
     # Run model on sample data and print results
-    print_cls_results(fw_out[0], co_out[0])
+    loader.print_cls_results(co_out)

--- a/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
+++ b/forge/test/models/pytorch/vision/wideresnet/test_wideresnet.py
@@ -3,13 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import timm
 import torch
-from PIL import Image
-from third_party.tt_forge_models.tools.utils import get_file
 from third_party.tt_forge_models.wide_resnet.pytorch import ModelLoader, ModelVariant
-from timm.data import resolve_data_config
-from timm.data.transforms_factory import create_transform
 
 import forge
 from forge._C import DataFormat
@@ -26,7 +21,6 @@ from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
 from test.models.pytorch.vision.wideresnet.model_utils.utils import post_processing
-from test.utils import download_model
 
 variants = [
     ModelVariant.WIDE_RESNET50_2,
@@ -75,27 +69,12 @@ def test_wideresnet_pytorch(variant):
     loader.post_processing(co_out)
 
 
-def generate_model_wideresnet_imgcls_timm(variant):
-    # STEP 2: Create Forge module from PyTorch model
-    framework_model = download_model(timm.create_model, variant, pretrained=True)
-    framework_model.eval()
-
-    # STEP 3: Prepare input
-    config = resolve_data_config({}, model=framework_model)
-    transform = create_transform(**config)
-
-    input_image = get_file("https://github.com/pytorch/hub/raw/master/images/dog.jpg")
-    img = Image.open(str(input_image)).convert("RGB")
-    img_tensor = transform(img).unsqueeze(0)
-
-    return framework_model.to(torch.bfloat16), [img_tensor.to(torch.bfloat16)]
-
-
-variants = ["wide_resnet50_2", "wide_resnet101_2"]
+# TIMM variants to test via loader
+variants = [ModelVariant.TIMM_WIDE_RESNET50_2, ModelVariant.TIMM_WIDE_RESNET101_2]
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
+@pytest.mark.parametrize("variant", variants, ids=[v.value for v in variants])
 def test_wideresnet_timm(variant):
 
     # Record Forge Property
@@ -107,7 +86,11 @@ def test_wideresnet_timm(variant):
         task=Task.IMAGE_CLASSIFICATION,
     )
 
-    (framework_model, inputs) = generate_model_wideresnet_imgcls_timm(variant)
+    # Load model and inputs via loader (TIMM source)
+    loader = ModelLoader(variant=variant)
+    framework_model = loader.load_model(dtype_override=torch.bfloat16)
+    input_tensor = loader.load_inputs(dtype_override=torch.bfloat16)
+    inputs = [input_tensor]
 
     data_format_override = DataFormat.Float16_b
     compiler_cfg = CompilerConfig(default_df_override=data_format_override)
@@ -121,7 +104,7 @@ def test_wideresnet_timm(variant):
     )
 
     verify_cfg = VerifyConfig()
-    if variant == "wide_resnet50_2":
+    if variant == ModelVariant.TIMM_WIDE_RESNET50_2:
         verify_cfg = VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95))
 
     # Model Verification


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2822

### Problem description

- Add variant support for existing models and bring up tt-forge-fe models in tt-forge-models & link FFE tests.

### What's changed
- This PR tracks [these](https://github.com/tenstorrent/tt-forge-models/pull/87) changes & by linking FFE tests for the models supported in this [PR](https://github.com/tenstorrent/tt-forge-models/pull/87/files).

### Logs
[alexnet_modified.log](https://github.com/user-attachments/files/21773550/alexnet_modified.log)
[dla_modified.log](https://github.com/user-attachments/files/21773552/dla_modified.log)
[vgg_modified.log](https://github.com/user-attachments/files/21773562/vgg_modified.log)
[vovnet_modified.log](https://github.com/user-attachments/files/21773558/vovnet_modified.log)
[wideresnet_modified.log](https://github.com/user-attachments/files/21773568/wideresnet_modified.log)
