### PR TITLE
Fix shape mismatch caused by broadcast-to-TMS

### DIFF
--- a/forge/csrc/passes/lower_to_mlir.cpp
+++ b/forge/csrc/passes/lower_to_mlir.cpp
@@ -170,6 +170,10 @@ class AttributeMapper
 
         add_op_mapping("upsample2d", "scale_factor", AttributeRemap(std::nullopt, TargetType::DenseI32ArrayAttr));
 
+        // Broadcast
+        add_op_mapping(
+            "broadcast", "broadcast_dimensions", AttributeRemap(std::nullopt, TargetType::DenseI64ArrayAttr));
+
         // Add more default mappings here
     }
 };
@@ -811,6 +815,7 @@ class MLIRGenerator
         lowering_handler_map["avg_pool2d"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::AvgPool2dOp>;
         lowering_handler_map["batchnorm"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::BatchNormOp>;
         lowering_handler_map["bitwise_and"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::BitwiseAndOp>;
+        lowering_handler_map["broadcast"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::BroadcastOp>;
         lowering_handler_map["cast"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::TypecastOp>;
         lowering_handler_map["clip"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ClampScalarOp>;
         lowering_handler_map["concatenate"] = &MLIRGenerator::emit_mlir_ttforge_op<mlir::tt::ttir::ConcatOp>;

--- a/forge/forge/op/tm.py
+++ b/forge/forge/op/tm.py
@@ -387,8 +387,12 @@ def Broadcast(name: str, operandA: Tensor, dim: int, shape: int) -> Tensor:
     Tensor
         Forge tensor
     """
+    broadcast_dimensions = [1] * len(operandA.shape.dims)
+    broadcast_dimensions[dim] = shape
 
-    return op(OpType.Broadcast, name, operandA, dim=dim, size=shape).get_tensor()
+    return op(
+        OpType.Broadcast, name, operandA, broadcast_dimensions=broadcast_dimensions, dim=dim, size=shape
+    ).get_tensor()
 
 
 def Repeat(name: str, operandA: Tensor, repeats: List[int]) -> Tensor:


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-forge-fe/issues/2819)

### Problem description
The convert_to_tms transformation during pre-lowering inserts a TMS operation into the cast node, which is unary. This leads to a verification issue, as the cast operation is expected to preserve the original shape after this change the following alvert and distilbert will be facing the config issue,and the post processing of those model is rectified in this https://github.com/tenstorrent/tt-forge-fe/pull/2858

### What's changed
The Broadcast Op Mapping and attr mapping is added in lower_to_mlir and modified the Broadcast op in tm.py to include the broadcast_dimension attr and modified the pre_lowering_passes convert_to_tms function to include the check wether the consumer is unary op and then adding the tms by this changes the following models that is block will now execute end to end now.
**Core Changes**
MLIR Integration: Added Broadcast operation mapping and attribute mapping in lower_to_mlir
TM Operation Enhancement: Modified Broadcast op in tm.py to include broadcast_dimension attribute
Pre-lowering Logic: Enhanced convert_broadcast_ops_to_tms function with unary consumer detection and improved TM insertion
Frontend Node Detection: Added logic to distinguish between user-defined and frontend-transformed broadcast nodes using layer tag patterns


### Model Log
[bert_onnx.log](https://github.com/user-attachments/files/21834969/bert_onnx.log)
[albert_basev1.log](https://github.com/user-attachments/files/21833445/albert_basev1.log)
[clip_onnx.log](https://github.com/user-attachments/files/21829788/clip_onnx.log)
[codegen_mono.log](https://github.com/user-attachments/files/21829789/codegen_mono.log)
[codegen_multi.log](https://github.com/user-attachments/files/21829791/codegen_multi.log)
[codegen_nl.log](https://github.com/user-attachments/files/21829793/codegen_nl.log)
[distilbert_onnx.log](https://github.com/user-attachments/files/21833615/distilbert_onnx.log)
[nanogpt_onnx.log](https://github.com/user-attachments/files/21833628/nanogpt_onnx.log)


### Checklist
- [x] New/Existing tests provide coverage for changes

### Example Transformation Comparison
**Before Fix**
<img width="1549" height="817" alt="Screenshot 2025-08-18 at 1 22 32 PM" src="https://github.com/user-attachments/assets/d89beada-3caf-4d95-a7b0-79a2eac54911" />

**After Fix**
<img width="1422" height="754" alt="Screenshot 2025-08-18 at 1 21 32 PM" src="https://github.com/user-attachments/assets/82050476-0976-4565-a9dc-800efbf20ea6" />