### PR TITLE
Fix beit, mobilenetv2 and segformer models

### DIFF
--- a/forge/test/models/pytorch/vision/beit/test_beit.py
+++ b/forge/test/models/pytorch/vision/beit/test_beit.py
@@ -8,6 +8,8 @@ from third_party.tt_forge_models.beit.pytorch import ModelLoader as BeitLoader
 from third_party.tt_forge_models.beit.pytorch import ModelVariant as BeitVariant
 
 import forge
+from forge._C import DataFormat
+from forge.config import CompilerConfig
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -42,14 +44,18 @@ def test_beit_image_classification_pytorch(variant):
     # Load model and input
     loader = BeitLoader(variant)
     model = loader.load_model(dtype_override=torch.bfloat16)
+    model.config.return_dict = False
     input_dict = loader.load_inputs(dtype_override=torch.bfloat16)
 
     # prepare inputs
     inputs = [input_dict["pixel_values"]]
     model.eval()
 
+    data_format_override = DataFormat.Float16_b
+    compiler_cfg = CompilerConfig(default_df_override=data_format_override)
+
     # Forge compile framework model
-    compiled_model = forge.compile(model, inputs, module_name)
+    compiled_model = forge.compile(model, inputs, module_name, compiler_cfg=compiler_cfg)
 
     # Model Verification
     verify(inputs, model, compiled_model)

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -166,6 +166,7 @@ def test_mobilenetv2_deeplabv3(variant):
     # Load the model and inputs
     loader = ModelLoader(variant=variant)
     framework_model = loader.load_model(dtype_override=torch.bfloat16)
+    framework_model.config.return_dict = False
     input_tensor = loader.load_inputs(dtype_override=torch.bfloat16)
     inputs = [input_tensor]
 

--- a/forge/test/models/pytorch/vision/segformer/test_segformer.py
+++ b/forge/test/models/pytorch/vision/segformer/test_segformer.py
@@ -81,9 +81,9 @@ def test_segformer_image_classification_pytorch(variant):
 
 
 variants_semseg = [
-    pytest.param("nvidia/segformer-b0-finetuned-ade-512-512", marks=pytest.mark.xfail),
-    pytest.param("nvidia/segformer-b1-finetuned-ade-512-512", marks=pytest.mark.xfail),
-    pytest.param("nvidia/segformer-b2-finetuned-ade-512-512", marks=[pytest.mark.out_of_memory, pytest.mark.xfail]),
+    pytest.param("nvidia/segformer-b0-finetuned-ade-512-512"),
+    pytest.param("nvidia/segformer-b1-finetuned-ade-512-512"),
+    pytest.param("nvidia/segformer-b2-finetuned-ade-512-512", marks=pytest.mark.xfail),
     pytest.param("nvidia/segformer-b3-finetuned-ade-512-512", marks=pytest.mark.xfail),
     pytest.param("nvidia/segformer-b4-finetuned-ade-512-512", marks=pytest.mark.xfail),
 ]
@@ -103,7 +103,7 @@ def test_segformer_semantic_segmentation_pytorch(variant):
     )
 
     # Load the model from HuggingFace
-    framework_model = SegformerForSemanticSegmentation.from_pretrained(variant).to(torch.bfloat16)
+    framework_model = SegformerForSemanticSegmentation.from_pretrained(variant, return_dict=False).to(torch.bfloat16)
     framework_model.eval()
 
     # Load the sample image


### PR DESCRIPTION
The PR will fix `RuntimeError: Unknown type of tensor` error in segformer semantic segmentaion, mobilnetv2 and beit models 

1) Segformer Failure:

`RuntimeError: Unknown type of tensor: <class 'transformers.modeling_outputs.SemanticSegmenterOutput'>`

##### Failed tests:

```
forge/test/models/pytorch/vision/segformer/test_segformer.py::test_segformer_semantic_segmentation_pytorch[nvidia/segformer-b0-finetuned-ade-512-512]
forge/test/models/pytorch/vision/segformer/test_segformer.py::test_segformer_semantic_segmentation_pytorch[nvidia/segformer-b1-finetuned-ade-512-512]
forge/test/models/pytorch/vision/segformer/test_segformer.py::test_segformer_semantic_segmentation_pytorch[nvidia/segformer-b2-finetuned-ade-512-512]
forge/test/models/pytorch/vision/segformer/test_segformer.py::test_segformer_semantic_segmentation_pytorch[nvidia/segformer-b3-finetuned-ade-512-512]
forge/test/models/pytorch/vision/segformer/test_segformer.py::test_segformer_semantic_segmentation_pytorch[nvidia/segformer-b4-finetuned-ade-512-512]
```


2) Mobilnetv2 Failure:

`RuntimeError: Unknown type of tensor: <class 'transformers.modeling_outputs.SemanticSegmenterOutput'>`

##### Failed tests:

```

forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py::test_mobilenetv2_deeplabv3[google/deeplabv3_mobilenet_v2_1.0_513]
```



3) Beit Failure:

`RuntimeError: Unknown type of tensor: <class 'transformers.modeling_outputs.ImageClassifierOutput'>` 

##### Failed tests:

```
forge/test/models/pytorch/vision/beit/test_beit.py::test_beit_image_classification[microsoft/beit-base-patch16-224]
forge/test/models/pytorch/vision/beit/test_beit.py::test_beit_image_classification[microsoft/beit-large-patch16-224]
```
