### PR TITLE
Fix export tests

### DIFF
--- a/forge/test/operators/pytorch/test_commands.sh
+++ b/forge/test/operators/pytorch/test_commands.sh
@@ -57,7 +57,7 @@ function print_query_docs {
     max_width=$(tput cols)
     max_width=$((max_width * 80 / 100))
 
-    pushd ${SWEEPS_SCRIPT_DIR}/../../../
+    pushd ${SWEEPS_SCRIPT_DIR}/../../../../
     python3 -c "from test.operators.pytorch.test_all import InfoUtils; InfoUtils.print_query_params(max_width=${max_width})"
     popd
 }
@@ -78,7 +78,7 @@ function export_tests {
         file_name="${logs_dir}/${file_name}"
     fi
 
-    pushd ${SWEEPS_SCRIPT_DIR}/../../../
+    pushd ${SWEEPS_SCRIPT_DIR}/../../../../
     python3 -c "from test.operators.pytorch.test_all import InfoUtils; InfoUtils.export(file_name=\"${file_name}\")"
     popd
 }


### PR DESCRIPTION
### Ticket
Link to Github Issue

### Problem description
Export tests and print query docs commands are failing due to an incorrect calling path.

### What's changed
Call export tests and print query docs from project root.

### Checklist
- [ ] New/Existing tests provide coverage for changes
