### PR TITLE
Reschedule the nigthly tests for 3 hours earlier

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -28,7 +28,7 @@ on:
           - 'Yes'
           - 'No'
   schedule:
-    - cron: '0 19 * * *'  # Runs at 22:00 UTC every day
+    - cron: '0 20 * * *'  # Runs at 20:00 UTC every day
 
 # Set cache root to avoid IRD_LF_CACHE error when loading CenterNet ONNX model in CI
 env:

--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -28,7 +28,7 @@ on:
           - 'Yes'
           - 'No'
   schedule:
-    - cron: '0 22 * * *'  # Runs at 22:00 UTC every day
+    - cron: '0 19 * * *'  # Runs at 22:00 UTC every day
 
 # Set cache root to avoid IRD_LF_CACHE error when loading CenterNet ONNX model in CI
 env:


### PR DESCRIPTION
### Ticket
[Issue](https://github.com/tenstorrent/tt-forge/issues/371)

### Problem description
TT-Forge nightly performance benchmark results need to be available earlier, so nightly tests on frontends need to be 2 hours earlier.

### What's changed
The nightly tests have been rescheduled to run 2 hours earlier.

### Checklist
- [ ] New/Existing tests provide coverage for changes
