### PR TITLE
Restructure Surya OCR test

### DIFF
--- a/forge/test/models/pytorch/vision/suryaocr/requirements.txt
+++ b/forge/test/models/pytorch/vision/suryaocr/requirements.txt
@@ -1,1 +1,1 @@
-surya-ocr==0.13.0
+surya-ocr==0.15.4

--- a/forge/test/models/pytorch/vision/suryaocr/test_surya_ocr_detect.py
+++ b/forge/test/models/pytorch/vision/suryaocr/test_surya_ocr_detect.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+import shutil
+
+import pytest
+from third_party.tt_forge_models.suryaocr.pytorch.loader import (
+    ModelLoader,
+    ModelVariant,
+)
+
+import forge
+from forge.forge_property_utils import (
+    Framework,
+    ModelArch,
+    ModelGroup,
+    ModelPriority,
+    Source,
+    Task,
+    record_model_properties,
+)
+from forge.verify.verify import verify
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+def test_surya_ocr():
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.PYTORCH,
+        model=ModelArch.SURYAOCR,
+        variant="ocr_detection",
+        task=Task.OPTICAL_CHARACTER_RECOGNITION,
+        source=Source.GITHUB,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
+    )
+
+    # Load model and inputs via loader
+    loader = ModelLoader(variant=ModelVariant.OCR_DETECTION)
+    inputs = loader.load_inputs()
+    framework_model = loader.load_model()
+
+    # Forge compile framework model
+    compiled_model = forge.compile(
+        framework_model,
+        sample_inputs=inputs,
+        module_name=module_name,
+    )
+
+    # Model Verification
+    _, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post process outputs
+    output_dir = "test/models/pytorch/vision/suryaocr/surya_detect"
+    try:
+        loader.post_process(co_out, output_dir)
+    finally:
+        shutil.rmtree(output_dir, ignore_errors=True)


### PR DESCRIPTION
### Ticket
Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2799

### Problem description
The existing Surya OCR test fails with a `KeyError: 'encoder'` when attempting to load the model. This was observed using surya-ocr==0.13.0 and torch==2.1.0, which was the setup initially used when the test was introduced.

### What's changed
The current setup on main was initially tested with surya-ocr version 0.13.0 and torch version 2.1.0 when this test was brought up.Tried running cpu inference of surya-ocr version 0.13.0 which was returning the same above error, hence upgraded the surya-ocr version to latest which was 0.15.4 and ran cpu inference for ocr text task which was successful. Hence this PR restructures the existing test to be compatible with the package update. Text Detection and Text Recognition(OCR) Tasks are added as two separate tests and it tracks the changes from [this](https://github.com/tenstorrent/tt-forge-models/pull/116) PR.

Summary of changes made are as follows:

- The Text Recognition OCR task related test faces `AttributeError: 'Tensor' object has no attribute 'is_integer'` during jit trace which was fixed by monkey-patching the surya ocr processor to convert num tokens to int.
- Surya OCR pipeline expects PIL images, not tensors, hence it is converted to tensors before sending to wrapper and revived back to images before forward function call.

- In the created wrappers, outputs are tied to input tensors (e.g., + zero_f) to prevent outputs being traced as constants.

- Model returns outputs in format of OCRResult hence helper functions are used to convert outputs to tensors and restoring back to original format before they are post-processed.

- pack_prediction function converts a list of OCR results (with text, bounding boxes, and confidence scores) into tensors. It initializes large zero-filled tensors for all required fields like lines_bbox, lines_conf, text_codes etc. and iterates through the OCR predictions and fills in the tensors.

- The tensors from pack_prediction are passed as inputs to unpack_predictions function which iterates through each image in the batch and for each predicted text line , it reads its bounding box, confidence and decodes the character codes to reconstruct the original text string.

- dicts_to_objects function converts the unpacked dictionaries into OCRResultLite and TextLineLite formats so that they are in expected format for post-processing.

- Current status of model is it fails in run_mlir_compiler stage with following error:
`loc("reshape_4.dc.squeeze.3"("third_party.tt_forge_models.suryaocr.pytorch.src.utils.SuryaOCRWrapper::")): error: 'ttir.squeeze' op Output tensor must have at least one dimension.
loc("pt_surya_ocr_default_optical_character_recognition_github":0:0): error: module verification failed.`

### Logs
[surya_ocr_pytorch.log](https://github.com/user-attachments/files/21990644/surya_ocr_pytorch.log)
[surya_ocr_detect.log](https://github.com/user-attachments/files/21990658/surya_ocr_detect.log)

