### PR TITLE
Update latest status of model test scripts markers

### DIFF
--- a/forge/test/models/onnx/vision/segformer/test_segformer.py
+++ b/forge/test/models/onnx/vision/segformer/test_segformer.py
@@ -16,7 +16,7 @@ from test.utils import download_model
 variants_img_classification = [
     pytest.param("nvidia/mit-b0", marks=pytest.mark.push),
     pytest.param("nvidia/mit-b2"),
-    pytest.param("nvidia/mit-b3", marks=pytest.mark.xfail),
+    pytest.param("nvidia/mit-b3"),
     pytest.param("nvidia/mit-b4", marks=pytest.mark.xfail),
     pytest.param("nvidia/mit-b5", marks=pytest.mark.xfail),
 ]
@@ -35,7 +35,7 @@ def test_segformer_image_classification_onnx(variant, forge_tmp_path):
         source=Source.HUGGINGFACE,
     )
 
-    if variant in ["nvidia/mit-b3", "nvidia/mit-b4", "nvidia/mit-b5"]:
+    if variant in ["nvidia/mit-b4", "nvidia/mit-b5"]:
         pytest.xfail(reason="Fatal Python error: Aborted")
 
     # Load the model from HuggingFace

--- a/forge/test/models/onnx/vision/swin/test_swin.py
+++ b/forge/test/models/onnx/vision/swin/test_swin.py
@@ -9,7 +9,6 @@ from transformers import (
     ViTImageProcessor,
 )
 import onnx
-import torch
 import forge
 import torch
 from forge.verify.verify import verify

--- a/forge/test/models/onnx/vision/swin/test_swin.py
+++ b/forge/test/models/onnx/vision/swin/test_swin.py
@@ -11,6 +11,8 @@ from transformers import (
 import onnx
 import torch
 import forge
+import torch
+from forge.verify.verify import verify
 
 from test.models.pytorch.vision.swin.model_utils.image_utils import load_image
 from test.models.pytorch.vision.vision_utils.utils import load_vision_model_and_input
@@ -18,7 +20,6 @@ from forge.forge_property_utils import Framework, Source, Task, ModelArch, recor
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 @pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
 def test_swin_v2_tiny_image_classification_onnx(variant, forge_tmp_path):
 
@@ -30,7 +31,6 @@ def test_swin_v2_tiny_image_classification_onnx(variant, forge_tmp_path):
         task=Task.IMAGE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
     )
-    pytest.xfail(reason="Segmentation Fault")
 
     # Load the model
     framework_model = Swinv2ForImageClassification.from_pretrained(variant)
@@ -53,6 +53,11 @@ def test_swin_v2_tiny_image_classification_onnx(variant, forge_tmp_path):
 
     # Forge compile framework model
     compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
 
 
 @pytest.mark.nightly
@@ -89,6 +94,11 @@ def test_swin_v2_tiny_masked_onnx(variant, forge_tmp_path):
 
     # Forge compile framework model
     compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
 
 
 variants_with_weights = {"swin_v2_t": "Swin_V2_T_Weights"}
@@ -125,3 +135,8 @@ def test_swin_torchvision(variant, forge_tmp_path):
 
     # Forge compile framework model
     compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/vision/vovnet/test_vovnet.py
+++ b/forge/test/models/onnx/vision/vovnet/test_vovnet.py
@@ -47,7 +47,6 @@ def test_vovnet_osmr_pytorch(variant, forge_tmp_path):
         source=Source.OSMR,
         task=Task.OBJECT_DETECTION,
     )
-    pytest.xfail(reason="Segmentation Fault")
 
     # Load model and inputs
     framework_model, inputs, _ = generate_model_vovnet_imgcls_osmr_pytorch(variant)
@@ -65,6 +64,8 @@ def test_vovnet_osmr_pytorch(variant, forge_tmp_path):
 
     # Forge compile framework model
     compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
+    # Model Verification
+    verify(inputs, framework_model, compiled_model)
 
 
 def generate_model_vovnet39_imgcls_stigma_pytorch():
@@ -85,7 +86,6 @@ def test_vovnet_v1_39_stigma_onnx(variant, forge_tmp_path):
         source=Source.TORCH_HUB,
         task=Task.OBJECT_DETECTION,
     )
-    pytest.xfail(reason="Segmentation Fault")
 
     framework_model, inputs, _ = generate_model_vovnet39_imgcls_stigma_pytorch()
 
@@ -102,6 +102,9 @@ def test_vovnet_v1_39_stigma_onnx(variant, forge_tmp_path):
 
     # Forge compile framework model
     compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
+
+    # Model Verification
+    verify(inputs, framework_model, compiled_model)
 
 
 def generate_model_vovnet57_imgcls_stigma_pytorch():
@@ -123,7 +126,6 @@ def test_vovnet_v1_57_stigma_onnx(variant, forge_tmp_path):
         source=Source.TORCH_HUB,
         task=Task.OBJECT_DETECTION,
     )
-    pytest.xfail(reason="Segmentation Fault")
 
     framework_model, inputs, _ = generate_model_vovnet57_imgcls_stigma_pytorch()
 
@@ -140,6 +142,9 @@ def test_vovnet_v1_57_stigma_onnx(variant, forge_tmp_path):
 
     # Forge compile framework model
     compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
+
+    # Model Verification
+    verify(inputs, framework_model, compiled_model)
 
 
 def generate_model_vovnet_imgcls_timm_pytorch(variant):

--- a/forge/test/models/pytorch/text/phi3/test_phi3_5.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3_5.py
@@ -39,7 +39,8 @@ def test_phi3_5_causal_lm(variant):
         priority=ModelPriority.P1,
     )
 
-    pytest.xfail(reason="Segmentation Fault")
+<<<<<<< HEAD
+    pytest.xfail(reason="https://github.com/tenstorrent/tt-forge-fe/issues/2903")
 
     # Load model and inputs via loader
     loader = Phi35Loader(variant)

--- a/forge/test/models/pytorch/text/phi3/test_phi3_5.py
+++ b/forge/test/models/pytorch/text/phi3/test_phi3_5.py
@@ -39,7 +39,6 @@ def test_phi3_5_causal_lm(variant):
         priority=ModelPriority.P1,
     )
 
-<<<<<<< HEAD
     pytest.xfail(reason="https://github.com/tenstorrent/tt-forge-fe/issues/2903")
 
     # Load model and inputs via loader


### PR DESCRIPTION
## Issue 
Fixes: https://github.com/tenstorrent/tt-forge-fe/issues/2921
### Problem description
The latest status of the model execution is not properly recorded in the test scripts 
### What's changed
The test scripts for the model such as the swin, segformer, phi3, vovnet has been updated with the latest status.

