### PR TITLE
Fix stride mismatch error in ssd300resnet50 by making input tensor contiguous

### DIFF
--- a/forge/test/models/onnx/vision/ssd300_resnet50/test_ssd300_resnet50_onnx.py
+++ b/forge/test/models/onnx/vision/ssd300_resnet50/test_ssd300_resnet50_onnx.py
@@ -24,7 +24,6 @@ from test.models.pytorch.vision.ssd300_resnet50.model_utils.image_utils import (
 
 
 @pytest.mark.nightly
-@pytest.mark.xfail
 def test_pytorch_ssd300_resnet50(forge_tmp_path):
     # Record Forge Property
     module_name = record_model_properties(
@@ -52,7 +51,7 @@ def test_pytorch_ssd300_resnet50(forge_tmp_path):
     HWC = prepare_input(input_image)
     CHW = np.swapaxes(np.swapaxes(HWC, 0, 2), 1, 2)
     batch = np.expand_dims(CHW, axis=0)
-    input_batch = torch.from_numpy(batch).float()
+    input_batch = torch.from_numpy(batch).float().contiguous()
     inputs = [input_batch]
 
     # STEP 4: Export to ONNX


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2904

### Problem description

- When running SSD300 ResNet50 model with preprocessed input images, the model fails with stride mismatch error:

```
RuntimeError: Tensor 0 - stride mismatch: expected [270000, 90000, 300, 1], got [3, 1, 900, 3]
```

**Note:** The model passes with random inputs, indicating the issue is in the preprocessing pipeline.[aug28_ssd_rand_ip.log](https://github.com/user-attachments/files/22021437/aug28_ssd_rand_ip.log)


### Root cause 

- The preprocessing pipeline includes multiple axis swapping operations:

```
HWC = prepare_input(input_image)  
CHW = np.swapaxes(np.swapaxes(HWC, 0, 2), 1, 2) 
batch = np.expand_dims(CHW, axis=0)  
```

- Analysis of memory layout changes: [aug28_ssd_input_info.log](https://github.com/user-attachments/files/22021500/aug28_ssd_need_info.log)
  - Initial HWC array:
    - C_CONTIGUOUS: True, proper memory layout
    - Strides: (7200, 24, 8)
  - After axis swaps (CHW):
    - C_CONTIGUOUS: False, becomes non-contiguous
    - Strides: (8, 7200, 24)
    - Creates a view instead of new array
  - Final tensor has incorrect strides [3, 1, 900, 3] instead of expected [270000, 90000, 300, 1]

### What's changed 

- Added .contiguous() call after tensor creation to ensure proper memory layout.
- Model passed E2E after this fix so xfail marker removed.

### Checklist
- [x] Verified the change by local testing

### Logs

- [aug28_ssd300resnet50_before_fix.log](https://github.com/user-attachments/files/22021514/aug28_ssd_bf.log)
- [aug28_ssd300resnet50_after_fix.log](https://github.com/user-attachments/files/22021513/aug28_ssd_af.log)

