### PR TITLE
Add onnx bring-up tests for detr, mobilenetv2, and efficientnet variants

### DIFF
--- a/forge/test/models/onnx/vision/detr/test_detr.py
+++ b/forge/test/models/onnx/vision/detr/test_detr.py
@@ -14,6 +14,10 @@ from forge.verify.verify import verify
 from test.utils import download_model
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
 from test.models.models_utils import preprocess_input_data
+from third_party.tt_forge_models.tools.utils import get_file
+from PIL import Image
+import numpy as np
+from torchvision import transforms
 
 
 @pytest.mark.nightly
@@ -88,3 +92,52 @@ def test_detr_segmentation_onnx(variant, forge_tmp_path):
 
     # Model Verification
     _, co_out = verify(inputs, framework_model, compiled_model)
+
+
+@pytest.mark.nightly
+@pytest.mark.xfail
+@pytest.mark.parametrize("variant", ["facebook/detr-resnet-50"])
+def test_detr_onnx_torchhub(variant, forge_tmp_path):
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.DETR,
+        variant=variant,
+        task=Task.OBJECT_DETECTION,
+        source=Source.TORCH_HUB,
+    )
+
+    # Load the model
+    torch_model = torch.hub.load("facebookresearch/detr:main", "detr_resnet50", pretrained=True)
+    torch_model.eval()
+
+    # Prepare input
+    image_file = get_file(
+        "https://huggingface.co/spaces/nakamura196/yolov5-char/resolve/8a166e0aa4c9f62a364dafa7df63f2a33cbb3069/ultralytics/yolov5/data/images/zidane.jpg"
+    )
+    input_image = Image.open(str(image_file))
+    m, s = np.mean(input_image, axis=(0, 1)), np.std(input_image, axis=(0, 1))
+    preprocess = transforms.Compose(
+        [
+            transforms.ToTensor(),
+            transforms.Normalize(mean=m, std=s),
+        ]
+    )
+    input_tensor = preprocess(input_image)
+    input_batch = input_tensor.unsqueeze(0)
+    inputs = [input_batch]
+
+    # Export model to ONNX
+    onnx_path = f"{forge_tmp_path}/detr_obj_det_torch_hub.onnx"
+    torch.onnx.export(torch_model, (inputs[0],), onnx_path, opset_version=17)
+
+    # Load ONNX model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Forge compile framework model
+    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
+
+    # Model Verification
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/models/onnx/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/onnx/vision/efficientnet/test_efficientnet.py
@@ -12,6 +12,10 @@ from forge.verify.config import VerifyConfig, AutomaticValueChecker
 from test.models.onnx.vision.vision_utils import load_inputs
 from test.models.models_utils import print_cls_results
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
+from efficientnet_pytorch import EfficientNet
+from third_party.tt_forge_models.tools.utils import get_file
+from PIL import Image
+from torchvision import transforms
 
 params = [
     pytest.param("efficientnet_b0", marks=[pytest.mark.push]),
@@ -71,6 +75,73 @@ def test_efficientnet_onnx(variant, forge_tmp_path):
         verify_cfg=VerifyConfig(
             value_checker=AutomaticValueChecker(pcc=pcc),
         ),
+    )
+
+    # Run model on sample data and print results
+    print_cls_results(fw_out[0], co_out[0])
+
+
+variants = [
+    "efficientnet-b0",
+    "efficientnet-b1",
+    "efficientnet-b2",
+    "efficientnet-b3",
+    "efficientnet-b4",
+    "efficientnet-b5",
+    "efficientnet-b6",
+    "efficientnet-b7",
+]
+
+
+@pytest.mark.parametrize("variant", variants)
+@pytest.mark.nightly
+def test_efficientnet_onnx_export_from_package(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.EFFICIENTNET,
+        variant=variant,
+        source=Source.GITHUB,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load model
+    torch_model = EfficientNet.from_pretrained(variant)
+    torch_model.set_swish(memory_efficient=False)
+    torch_model.eval()
+
+    # Prepare Input
+    image_file = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
+    img = Image.open(str(image_file))
+    tfms = transforms.Compose(
+        [
+            transforms.Resize(224),
+            transforms.ToTensor(),
+            transforms.Normalize([0.485, 0.456, 0.406], [0.229, 0.224, 0.225]),
+        ]
+    )
+    input_tensor = tfms(img).unsqueeze(0)
+    inputs = [input_tensor]
+
+    # Export to ONNX
+    onnx_variant = variant.replace("-", "_")
+    onnx_path = f"{forge_tmp_path}/{onnx_variant}.onnx"
+    torch.onnx.export(torch_model, (inputs[0],), onnx_path)
+
+    # Load onnx model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model verification and inference
+    fw_out, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
     )
 
     # Run model on sample data and print results

--- a/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
+++ b/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
@@ -14,6 +14,7 @@ from forge.verify.config import VerifyConfig, AutomaticValueChecker
 from test.models.onnx.vision.mobilenetv2.model_utils.utils import load_inputs
 from test.models.models_utils import print_cls_results
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
+from third_party.tt_forge_models.mobilenetv2.pytorch import ModelLoader, ModelVariant
 
 params = [
     pytest.param("mobilenetv2_050"),
@@ -67,3 +68,41 @@ def test_mobilenetv2_onnx(variant, forge_tmp_path):
 
     # # Run model on sample data and print results
     print_cls_results(fw_out[0], co_out[0])
+
+
+@pytest.mark.nightly
+@pytest.mark.parametrize("variant", [ModelVariant.MOBILENET_V2_TORCHVISION])
+def test_mobilenetv2_onnx_torchvision(variant, forge_tmp_path):
+
+    # Record Forge Property
+    module_name = record_model_properties(
+        framework=Framework.ONNX,
+        model=ModelArch.MOBILENETV2,
+        variant=variant,
+        source=Source.TORCHVISION,
+        task=Task.IMAGE_CLASSIFICATION,
+    )
+
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    torch_model = loader.load_model()
+    input_tensor = loader.load_inputs()
+    inputs = [input_tensor]
+
+    # Export to ONNX
+    onnx_path = f"{forge_tmp_path}/mobilenetv2_torchvision.onnx"
+    torch.onnx.export(torch_model, (inputs[0],), onnx_path)
+
+    # Load onnx model
+    onnx_model = onnx.load(onnx_path)
+    onnx.checker.check_model(onnx_model)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
+
+    # Model Verification and Inference
+    _, co_out = verify(inputs, framework_model, compiled_model)
+
+    # Post processing
+    loader.print_cls_results(co_out)


### PR DESCRIPTION
### Ticket

- Fixes https://github.com/tenstorrent/tt-forge-fe/issues/2915

### Problem description

- Bring up new variants of DETR, MobileNetV2, and EfficientNet models in ONNX. 

### What's changed

- This PR addresses the issue by adding ONNX bring-up tests for the following variants:  

| Variants              | Source                              |
|---------------------|-------------------------------------|
| detr-resnet-50 | torchhub                         |
| efficientnet-b0     | python package `efficientnet_pytorch` |
| efficientnet-b1     | python package `efficientnet_pytorch` |
| efficientnet-b2     | python package `efficientnet_pytorch` |
| efficientnet-b3     | python package `efficientnet_pytorch` |
| efficientnet-b4     | python package `efficientnet_pytorch` |
| efficientnet-b5     | python package `efficientnet_pytorch` |
| efficientnet-b6     | python package `efficientnet_pytorch` |
| efficientnet-b7     | python package `efficientnet_pytorch` |
| mobilenet_v2        | torchvision                        |

### Checklist
- [x] Verified the tests with local testing

### Logs

- [aug25_mob_onnx.log](https://github.com/user-attachments/files/22056612/aug25_mob_onnx.log)
- [aug29_detr_onnx.log](https://github.com/user-attachments/files/22056616/aug29_detr_onnx_1.log)
- [aug30_efficientnet_onnx.log](https://github.com/user-attachments/files/22056617/aug30_efficientnet_onnx.log)
