### PR TITLE
Fix conv2d and resize2d models ops

### DIFF
--- a/forge/test/models_ops/test_conv2d.py
+++ b/forge/test/models_ops/test_conv2d.py
@@ -89849,20 +89849,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1235,
-        [((1, 512, 30, 30), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[2, 2]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "False",
+    pytest.param(
+        (
+            Conv2D1235,
+            [((1, 512, 30, 30), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[2, 2]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "False",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1236,
@@ -90020,20 +90023,23 @@ forge_modules_and_shapes_dtypes_list = [
             },
         },
     ),
-    (
-        Conv2D1244,
-        [((1, 512, 30, 30), torch.float32)],
-        {
-            "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_480x480"],
-            "pcc": 0.99,
-            "args": {
-                "stride": "[2, 2]",
-                "padding": "[1, 1, 1, 1]",
-                "dilation": "1",
-                "groups": "1",
-                "channel_last": "False",
+    pytest.param(
+        (
+            Conv2D1244,
+            [((1, 512, 30, 30), torch.float32)],
+            {
+                "model_names": ["pt_yolo_v5_yolov5l_img_cls_torchhub_480x480"],
+                "pcc": 0.99,
+                "args": {
+                    "stride": "[2, 2]",
+                    "padding": "[1, 1, 1, 1]",
+                    "dilation": "1",
+                    "groups": "1",
+                    "channel_last": "False",
+                },
             },
-        },
+        ),
+        marks=[pytest.mark.xfail(reason="Data mismatch between framework output and compiled model output")],
     ),
     (
         Conv2D1245,

--- a/forge/test/models_ops/test_resize2d.py
+++ b/forge/test/models_ops/test_resize2d.py
@@ -1611,31 +1611,24 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"sizes": "[128, 128]", "mode": '"bilinear"', "align_corners": "False", "channel_last": "False"},
         },
     ),
-    pytest.param(
-        (
-            Resize2D20,
-            [((1, 768, 128, 128), torch.bfloat16)],
-            {
-                "model_names": [
-                    "pt_segformer_nvidia_segformer_b3_finetuned_ade_512_512_sem_seg_hf",
-                    "pt_segformer_nvidia_segformer_b4_finetuned_ade_512_512_sem_seg_hf",
-                    "pt_segformer_nvidia_segformer_b2_finetuned_ade_512_512_sem_seg_hf",
-                ],
-                "pcc": 0.99,
-                "default_df_override": "Float16_b",
-                "args": {
-                    "sizes": "[128, 128]",
-                    "mode": '"bilinear"',
-                    "align_corners": "False",
-                    "channel_last": "False",
-                },
+    (
+        Resize2D20,
+        [((1, 768, 128, 128), torch.bfloat16)],
+        {
+            "model_names": [
+                "pt_segformer_nvidia_segformer_b3_finetuned_ade_512_512_sem_seg_hf",
+                "pt_segformer_nvidia_segformer_b4_finetuned_ade_512_512_sem_seg_hf",
+                "pt_segformer_nvidia_segformer_b2_finetuned_ade_512_512_sem_seg_hf",
+            ],
+            "pcc": 0.99,
+            "default_df_override": "Float16_b",
+            "args": {
+                "sizes": "[128, 128]",
+                "mode": '"bilinear"',
+                "align_corners": "False",
+                "channel_last": "False",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:141: tt::exception"
-            )
-        ],
+        },
     ),
     pytest.param(
         (
@@ -2304,30 +2297,23 @@ forge_modules_and_shapes_dtypes_list = [
             "args": {"sizes": "[128, 128]", "mode": '"bilinear"', "align_corners": "False", "channel_last": "False"},
         },
     ),
-    pytest.param(
-        (
-            Resize2D20,
-            [((1, 768, 128, 128), torch.float32)],
-            {
-                "model_names": [
-                    "onnx_segformer_nvidia_segformer_b3_finetuned_ade_512_512_sem_seg_hf",
-                    "onnx_segformer_nvidia_segformer_b2_finetuned_ade_512_512_sem_seg_hf",
-                    "onnx_segformer_nvidia_segformer_b4_finetuned_ade_512_512_sem_seg_hf",
-                ],
-                "pcc": 0.99,
-                "args": {
-                    "sizes": "[128, 128]",
-                    "mode": '"bilinear"',
-                    "align_corners": "False",
-                    "channel_last": "False",
-                },
+    (
+        Resize2D20,
+        [((1, 768, 128, 128), torch.float32)],
+        {
+            "model_names": [
+                "onnx_segformer_nvidia_segformer_b3_finetuned_ade_512_512_sem_seg_hf",
+                "onnx_segformer_nvidia_segformer_b2_finetuned_ade_512_512_sem_seg_hf",
+                "onnx_segformer_nvidia_segformer_b4_finetuned_ade_512_512_sem_seg_hf",
+            ],
+            "pcc": 0.99,
+            "args": {
+                "sizes": "[128, 128]",
+                "mode": '"bilinear"',
+                "align_corners": "False",
+                "channel_last": "False",
             },
-        ),
-        marks=[
-            pytest.mark.xfail(
-                reason="RuntimeError: TT_THROW @ /__w/tt-forge-fe/tt-forge-fe/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/tt_metal/impl/allocator/bank_manager.cpp:141: tt::exception"
-            )
-        ],
+        },
     ),
     (
         Resize2D36,


### PR DESCRIPTION
### Summary:

In the [latest nightly models ops pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/17361763674/job/49283384631), **conv2d** models ops tests was failing with **data mismatch between framework and compiled models outputs** with `lesser pcc drop of 0.989 `so added xfail markers for respective conv2d tests and two resize2d ops tests was xpassed after [this fix](https://github.com/tenstorrent/tt-forge-fe/pull/2800) so removed xfail markers for those resize2d ops tests.

### Test cases:

```
forge/test/models_ops/test_conv2d.py::test_module[Conv2D1235-[((1, 512, 30, 30), torch.float32)]]
forge/test/models_ops/test_conv2d.py::test_module[Conv2D1244-[((1, 512, 30, 30), torch.float32)]]
forge/test/models_ops/test_resize2d.py::test_module[Resize2D20-[((1, 768, 128, 128), torch.bfloat16)]]
forge/test/models_ops/test_resize2d.py::test_module[Resize2D20-[((1, 768, 128, 128), torch.float32)]]
```