### PR TITLE
Fix failure inspector runs-on machine parameter

### DIFF
--- a/.github/workflows/fail-inspector.yml
+++ b/.github/workflows/fail-inspector.yml
@@ -59,7 +59,6 @@ jobs:
     runs-on:
       - ${{ matrix.build.runs-on }}
       - in-service
-      - runner
 
     steps:
         - name: Checkout


### PR DESCRIPTION
### Ticket
/

### Problem description
The nightly failure inspector has been failing.
The `test` job was being executed on runners that satisfy 3 labels: `${{ matrix.build.runs-on }}`, `in-service` and `runner`.
The problem is that the label `runner` was removed from all of the runners when they got moved to the Forge shared runner group.
That caused the `test` job to look for the runner with all 3 labels, which doesn't exist so the job just failed after the timeout (24 hours)

### What's changed
The `runner` label requirement has been removed from the `test` job.

### Checklist
- [ ] New/Existing tests provide coverage for changes
