### PR TITLE
Support test-expression input in test workflow

### DIFF
--- a/.github/workflows/test-sub.yml
+++ b/.github/workflows/test-sub.yml
@@ -35,6 +35,10 @@ on:
         description: 'Filters for tests (comma separated)'
         required: false
         type: string
+      test-expression:
+        description: 'Run tests which match the given substring expression'
+        required: false
+        type: string
       run_id:
         description: 'Run id the workflow where to find installation (or else it will search)'
         required: false
@@ -181,19 +185,23 @@ jobs:
           source env/activate
           echo "Collecting tests for group ${{ matrix.test_group_id }} with mark '${{ inputs.test_mark }}'..."
           set +e
-          pytest --splits ${{ inputs.test_group_cnt }} \
-               --group ${{ matrix.test_group_id }} \
-               --splitting-algorithm least_duration \
-               -m "${{ inputs.test_mark }}" --collect-only -q \
+          pytest_args=(
+            "--splits" "${{ inputs.test_group_cnt }}"
+            "--group" "${{ matrix.test_group_id }}"
+            "--splitting-algorithm" "least_duration"
+            "-m" "${{ inputs.test_mark }}"
+            "--collect-only"
+          )
+          if [ -n "${{ inputs.test-expression }}" ]; then
+            pytest_args+=("-k" "${{ inputs.test-expression }}")
+          fi
+          pytest "${pytest_args[@]}" -q \
                 | sed -n '/^Collected tests /,/^collected /p' | sed '/^[Cc]ollected /d' >.pytest_tests_to_run
 
           if [ $? -ne 0 ]; then
             echo "Failed to collect tests. Doing dry run..."
             set -e
-            pytest --splits ${{ inputs.test_group_cnt }} \
-                --group ${{ matrix.test_group_id }} \
-                --splitting-algorithm least_duration \
-                -m "${{ inputs.test_mark }}" --collect-only -svv
+            pytest "${pytest_args[@]}" -svv
             exit 1
           fi
           echo "Collected tests."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,12 +64,16 @@ on:
         description: 'Filters for tests (comma separated)'
         required: false
         type: string
+      test-expression:
+        description: 'Run tests which match the given substring expression'
+        required: false
+        type: string
 
 permissions:
   packages: write
   checks: write
 
-run-name: "Test (Rebuild: ${{ inputs.rebuild }} - Preset: ${{ inputs.preset }} - Mark: ${{ inputs.test_mark }} - ${{ inputs.sh-runner && format('{0}-shared', inputs.runs-on) || (inputs.runs-on) }} - ${{ inputs.test_group_cnt }} - Ops: ${{ inputs.operators }} - Filters: ${{ inputs.filters }})"
+run-name: "Test (Rebuild: ${{ inputs.rebuild }} - Preset: ${{ inputs.preset }} - Mark: ${{ inputs.test_mark }} - ${{ inputs.sh-runner && format('{0}-shared', inputs.runs-on) || (inputs.runs-on) }} - ${{ inputs.test_group_cnt }} - Ops: ${{ inputs.operators }} - Filters: ${{ inputs.filters }} - Test Expression: ${{ inputs.test-expression }})"
 
 jobs:
 
@@ -89,9 +93,10 @@ jobs:
           echo "- On Crash: ${{ inputs.on-crash }}" >> $GITHUB_STEP_SUMMARY
           echo "- Operators: ${{ inputs.operators }}" >> $GITHUB_STEP_SUMMARY
           echo "- Filters: ${{ inputs.filters }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Test Expression: ${{ inputs.test-expression }}" >> $GITHUB_STEP_SUMMARY
       - name: Save inputs to file
         run: |
-          echo '{ "branch_name": "${{ github.ref_name }}", "rebuild": "${{ inputs.rebuild }}", "preset": "${{ inputs.preset }}", "test_mark": "${{ inputs.test_mark }}", "runs-on": "${{ inputs.runs-on }}", "sh-runner": "$${{ inputs.sh-runner }}", "test_group_cnt": "${{ inputs.test_group_cnt }}", "on-crash": "${{ inputs.on-crash }}", "operators": "${{ inputs.operators }}", "filters": "${{ inputs.filters }}" }' > inputs.json
+          echo '{ "branch_name": "${{ github.ref_name }}", "rebuild": "${{ inputs.rebuild }}", "preset": "${{ inputs.preset }}", "test_mark": "${{ inputs.test_mark }}", "runs-on": "${{ inputs.runs-on }}", "sh-runner": "$${{ inputs.sh-runner }}", "test_group_cnt": "${{ inputs.test_group_cnt }}", "on-crash": "${{ inputs.on-crash }}", "operators": "${{ inputs.operators }}", "filters": "${{ inputs.filters }}", "test-expression": "${{ inputs.test-expression }}" }' > inputs.json
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -113,6 +118,7 @@ jobs:
       runs-on: ${{ steps.set-inputs.outputs.runs-on }}
       operators: ${{ steps.set-inputs.outputs.operators }}
       filters: ${{ steps.set-inputs.outputs.filters }}
+      test-expression: ${{ steps.set-inputs.outputs.test-expression }}
       run_id: ${{ steps.set-inputs.outputs.runid }}
       continue_on_crash: ${{ inputs.on-crash == 'Continue' }}
     steps:
@@ -130,6 +136,7 @@ jobs:
           echo "runs-on=[{\"runs-on\": \"${{ inputs.runs-on }}\"}]" >> $GITHUB_OUTPUT
           echo "operators=${{ inputs.operators }}" >> $GITHUB_OUTPUT
           echo "filters=${{ inputs.filters }}" >> $GITHUB_OUTPUT
+          echo "test-expression=${{ inputs.test-expression }}" >> $GITHUB_OUTPUT
           case "${{ inputs.preset }}" in
             "Full Model Passing")
               echo "test_mark=nightly and not xfail" >> $GITHUB_OUTPUT
@@ -180,4 +187,5 @@ jobs:
       sh-runner: ${{ inputs.sh-runner }}
       operators: ${{ needs.set-inputs.outputs.operators }}
       filters: ${{ needs.set-inputs.outputs.filters }}
+      test-expression: ${{ needs.set-inputs.outputs.test-expression }}
       run_id: ${{ needs.set-inputs.outputs.run_id }}


### PR DESCRIPTION
### Summary
Add a new workflow input `test-expression` that lets developers run a subset of pytest tests using a substring expression. This exposes pytest’s -k matching as an easy-to-use workflow parameter to quickly target tests by name.

### Motivation
We're enabling training support in the model-analysis pipeline, and in those scenarios we sometimes need to run either inference or training test subsets. test-expression makes it possible to select the appropriate subset