### PR TITLE
Fix group and priority property recording

### DIFF
--- a/forge/test/models/pytorch/text/falcon/test_falcon.py
+++ b/forge/test/models/pytorch/text/falcon/test_falcon.py
@@ -10,6 +10,7 @@ from forge.forge_property_utils import (
     Framework,
     ModelArch,
     ModelGroup,
+    ModelPriority,
     Source,
     Task,
     record_model_properties,
@@ -93,8 +94,10 @@ def test_falcon_3(variant):
         ModelVariant.FALCON_10B,
     ]:
         group = ModelGroup.RED
+        priority = ModelPriority.P1
     else:
         group = ModelGroup.GENERALITY
+        priority = ModelPriority.P2
 
     # Record Forge Property
     module_name = record_model_properties(
@@ -104,6 +107,7 @@ def test_falcon_3(variant):
         task=Task.CAUSAL_LM,
         source=Source.HUGGINGFACE,
         group=group,
+        priority=priority,
     )
 
     if variant != ModelVariant.FALCON_1B:

--- a/forge/test/models/pytorch/text/qwen/test_qwen_v3.py
+++ b/forge/test/models/pytorch/text/qwen/test_qwen_v3.py
@@ -106,6 +106,8 @@ def test_qwen3_embedding(variant):
         variant=variant,
         task=Task.SENTENCE_EMBEDDING_GENERATION,
         source=Source.HUGGINGFACE,
+        group=ModelGroup.GENERALITY if variant == EmbeddingVariant.QWEN_3_EMBEDDING_0_6B else ModelGroup.RED,
+        priority=ModelPriority.P2 if variant == EmbeddingVariant.QWEN_3_EMBEDDING_0_6B else ModelPriority.P1,
     )
 
     if variant in [EmbeddingVariant.QWEN_3_EMBEDDING_4B, EmbeddingVariant.QWEN_3_EMBEDDING_8B]:

--- a/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
+++ b/forge/test/models/pytorch/vision/mobilenet/test_mobilenet_v2.py
@@ -13,6 +13,7 @@ from forge.forge_property_utils import (
     Framework,
     ModelArch,
     ModelGroup,
+    ModelPriority,
     Source,
     Task,
     record_model_properties,
@@ -35,6 +36,7 @@ def test_mobilenetv2_basic(variant):
         source=Source.TORCH_HUB,
         task=Task.IMAGE_CLASSIFICATION,
         group=ModelGroup.RED,
+        priority=ModelPriority.P1,
     )
 
     # Load the model and inputs

--- a/forge/test/models/pytorch/vision/swin/test_swin.py
+++ b/forge/test/models/pytorch/vision/swin/test_swin.py
@@ -21,6 +21,8 @@ from forge.config import CompilerConfig
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
+    ModelGroup,
+    ModelPriority,
     Source,
     Task,
     record_model_properties,
@@ -127,6 +129,13 @@ variants = [
 @pytest.mark.parametrize("variant", variants)
 def test_swin_torchvision(variant):
 
+    if variant == ModelVariant.SWIN_V2_S:
+        group = ModelGroup.RED
+        priority = ModelPriority.P1
+    else:
+        group = ModelGroup.GENERALITY
+        priority = ModelPriority.P2
+
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.PYTORCH,
@@ -134,6 +143,8 @@ def test_swin_torchvision(variant):
         variant=variant.value,
         task=Task.IMAGE_CLASSIFICATION,
         source=Source.TORCHVISION,
+        group=group,
+        priority=priority,
     )
 
     # Load model and input using ModelLoader

--- a/forge/test/models/pytorch/vision/unet/test_unet.py
+++ b/forge/test/models/pytorch/vision/unet/test_unet.py
@@ -83,7 +83,12 @@ def test_unet_qubvel_pytorch():
 @pytest.mark.xfail
 def test_unet_torchhub_pytorch():
     module_name = record_model_properties(
-        framework=Framework.PYTORCH, model=ModelArch.UNET, source=Source.TORCH_HUB, task=Task.IMAGE_SEGMENTATION
+        framework=Framework.PYTORCH,
+        model=ModelArch.UNET,
+        source=Source.TORCH_HUB,
+        task=Task.IMAGE_SEGMENTATION,
+        group=ModelGroup.RED,
+        priority=ModelPriority.P1,
     )
 
     loader = ModelLoader(variant=ModelVariant.TORCHHUB_BRAIN_UNET)


### PR DESCRIPTION
## Summary  
This PR fixes incorrect or missing **model group** and **priority** assignments by updating the `ModelGroup` and `ModelPriority` properties for Qwen v3, MobileNet v2, Swin, and Falcon models.  

## Changes  

### ModelGroup & Priority Updates  
- **From `GENERALITY → RED`**  
- **From `P2 → P1`**  
  - `Qwen/Qwen3-Embedding-8B`  
  - `Qwen/Qwen3-Embedding-4B`  
  - `swin_v2_s`  

### Record Missing `ModelPriority` (set to `P1` for RED models):  
- `Falcon_1B`  
- `Falcon_3B`  
- `Falcon_7B`  
- `Falcon_10B`  
- `mobilnet_v2` 