### PR TITLE
Update rev of unimport

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
       - id: check-added-large-files
       - id: check-yaml
   - repo: https://github.com/hakancelikdev/unimport
-    rev: 1.2.1
+    rev: 1.3.0
     hooks:
       - id: unimport
         args: ["--ignore-init", "--gitignore"]


### PR DESCRIPTION
A non-existent rev was causing pre-commit to fail.

### Problem description
See https://github.com/tenstorrent/tt-forge-fe/actions/runs/17833610925/job/50704865494)
error: pathspec '1.2.1' did not match any file(s) known to git
