### PR TITLE
Add model analysis workflow for collecting workflow data

### DIFF
--- a/.github/workflows/produce_data.yml
+++ b/.github/workflows/produce_data.yml
@@ -10,6 +10,7 @@ on:
       - "On nightly Blackhole"
       - "Test"
       - "Performance benchmark"
+      - "Model Analysis"
     types:
       - completed
 


### PR DESCRIPTION
### Summary
The Full Online Model Analysis CI pipeline data was not uploaded to Superset because the `[internal] Collect workflow data` workflow did not trigger after the pipeline completed.

### Root Cause
The issue occurred because the **Model Analysis** workflow was **not included** in the `workflow_run` trigger list of the `[internal] Collect workflow data` workflow.

### Fix
Added **"Model Analysis"** to the list of workflows monitored by `workflow_run` in the `[internal] Collect workflow data` workflow.
After this change, when the **Model Analysis CI pipeline** completes, the `[internal] Collect workflow data` workflow will automatically trigger and upload the collected data to **Superset**.
