### PR TITLE
Fix yolox package installation ci issue

### DIFF
--- a/forge/test/models/onnx/vision/yolo/test_yolox_onnx.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolox_onnx.py
@@ -2,16 +2,10 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-"""
-Reason to install yolox=0.3.0 through subprocess :
-requirements of yolox=0.3.0 can be found here https://github.com/Megvii-BaseDetection/YOLOX/blob/0.3.0/requirements.txt
-onnx==1.8.1 and onnxruntime==1.8.0 are required by yolox which are incompatible with our package versions
-Dependencies required by yolox for pytorch implemetation are already present in pybuda and packages related to onnx is not needed
-pip install yolox==0.3.0 --no-deps can be used to install a package without installing its dependencies through terminal
-But in pybuda packages were installed through requirements.txt file not though terminal.
-unfortunately there is no way to include --no-deps in  requirements.txt file.
-for this reason , yolox==0.3.0 is intalled through subprocess.
-"""
+from test.utils import install_yolox_if_missing
+
+# Install yolox==0.3.0 without installing its dependencies
+assert install_yolox_if_missing()
 
 import os
 
@@ -21,6 +15,8 @@ import requests
 import torch
 import onnx
 from third_party.tt_forge_models.tools.utils import get_file
+from yolox.data.data_augment import preproc as preprocess
+from yolox.exp import get_exp
 
 import forge
 from forge.forge_property_utils import (
@@ -32,6 +28,10 @@ from forge.forge_property_utils import (
 )
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import VerifyConfig, verify
+
+from test.models.pytorch.vision.yolo.model_utils.yolox_utils import (
+    print_detection_results,
+)
 
 variants = [
     pytest.param(
@@ -46,21 +46,9 @@ variants = [
 ]
 
 
-# @pytest.mark.nightly
+@pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_yolox_pytorch(variant, forge_tmp_path):
-
-    import subprocess
-
-    subprocess.run(
-        ["pip", "install", "yolox==0.3.0", "--no-deps"]
-    )  # Install yolox==0.3.0 without installing its dependencies
-
-    from yolox.data.data_augment import preproc as preprocess
-    from yolox.exp import get_exp
-    from test.models.pytorch.vision.yolo.model_utils.yolox_utils import (
-        print_detection_results,
-    )
 
     pcc = 0.99
     if variant == "yolox_nano":

--- a/forge/test/models/pytorch/vision/yolo/test_yolox.py
+++ b/forge/test/models/pytorch/vision/yolo/test_yolox.py
@@ -2,6 +2,11 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
+from test.utils import install_yolox_if_missing
+
+# Install yolox==0.3.0 without installing its dependencies
+assert install_yolox_if_missing()
+
 import pytest
 import torch
 from third_party.tt_forge_models.yolox.pytorch import ModelLoader, ModelVariant


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-forge-fe/issues/3007

#### **Issue Summary**
In the [nightly pipeline](https://github.com/tenstorrent/tt-forge-fe/actions/runs/18854341154/job/53831605920#step:14:86), the **test collection step failed** while installing `yolox==0.3.0` using `subprocess`.
##### Test Collection Failure:
```
AssertionError: torch is required for pre-compiling ops, please install it first.
```
This occurred even though `torch` was already installed. The issue appeared **only when installing YOLOX through `subprocess`**, because the `pip` installation inside the subprocess used an **isolated build environment** by default.  
In this isolated environment, preinstalled dependencies like `torch` were not accessible — causing YOLOX’s setup script to fail when trying to import `torch` for pre-compiling ops.

#### **Root Cause**
- `pip` uses *build isolation* by default), creating a temporary environment without access to already installed site-packages.  
- YOLOX’s `setup.py` attempts to import `torch` during build time. Since the isolated environment doesn’t have `torch`, the build failed which leads to test collection failures.

#### **Fix Implemented**
Disabled build isolation and improved subprocess reliability.

**Changes made:**
1. Added `--no-build-isolation` to ensure YOLOX can access the existing `torch` installation from the main environment.  
2. Replaced `"pip"` call with `[sys.executable, "-m", "pip"]` to ensure the correct Python interpreter is used.
3. Added `check=True` to raise an exception if the subprocess command fails, improving error visibility.


#### Note:

Verified the fix in nightly pipeline - https://github.com/tenstorrent/tt-forge-fe/actions/runs/18902879090/job/53956216370
