### PR TITLE
Update framework property recording for onnx models

### DIFF
--- a/forge/test/models/onnx/text/codegen/test_codegen_onnx.py
+++ b/forge/test/models/onnx/text/codegen/test_codegen_onnx.py
@@ -42,7 +42,7 @@ def test_codegen(variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = record_model_properties(
-        framework=Framework.PYTORCH,
+        framework=Framework.ONNX,
         model=ModelArch.CODEGEN,
         variant=variant,
         task=Task.CAUSAL_LM,

--- a/forge/test/models/onnx/timeseries/test_nbeats_onnx.py
+++ b/forge/test/models/onnx/timeseries/test_nbeats_onnx.py
@@ -80,7 +80,7 @@ def test_nbeats_with_generic_basis(variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = record_model_properties(
-        framework=Framework.PYTORCH,
+        framework=Framework.ONNX,
         model=ModelArch.NBEATS,
         variant=variant,
         task=Task.TIME_SERIES_FORECASTING,
@@ -122,7 +122,7 @@ def test_nbeats_with_trend_basis(variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = record_model_properties(
-        framework=Framework.PYTORCH,
+        framework=Framework.ONNX,
         model=ModelArch.NBEATS,
         variant=variant,
         task=Task.TIME_SERIES_FORECASTING,

--- a/forge/test/models/onnx/vision/retinanet/test_retinanet_onnx.py
+++ b/forge/test/models/onnx/vision/retinanet/test_retinanet_onnx.py
@@ -38,7 +38,7 @@ def test_retinanet(variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = record_model_properties(
-        framework=Framework.PYTORCH,
+        framework=Framework.ONNX,
         model=ModelArch.RETINANET,
         variant=variant,
         source=Source.HUGGINGFACE,

--- a/forge/test/models/onnx/vision/ssd300_vgg16/test_ssd300_vgg16_onnx.py
+++ b/forge/test/models/onnx/vision/ssd300_vgg16/test_ssd300_vgg16_onnx.py
@@ -31,7 +31,7 @@ def test_ssd300_vgg16(variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = record_model_properties(
-        framework=Framework.PYTORCH,
+        framework=Framework.ONNX,
         model=ModelArch.SSD300VGG16,
         variant=variant,
         task=Task.IMAGE_CLASSIFICATION,

--- a/forge/test/models/onnx/vision/vgg/test_vgg_onnx.py
+++ b/forge/test/models/onnx/vision/vgg/test_vgg_onnx.py
@@ -47,7 +47,7 @@ def test_vgg_osmr_pytorch(variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = record_model_properties(
-        framework=Framework.PYTORCH,
+        framework=Framework.ONNX,
         model=ModelArch.VGG,
         variant=variant,
         source=Source.OSMR,

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v6_onnx.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v6_onnx.py
@@ -48,7 +48,7 @@ def test_yolo_v6_pytorch(variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = record_model_properties(
-        framework=Framework.PYTORCH,
+        framework=Framework.ONNX,
         model=ModelArch.YOLOV6,
         variant=variant,
         source=Source.TORCH_HUB,

--- a/forge/test/models/onnx/vision/yolo/test_yolox_onnx.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolox_onnx.py
@@ -56,7 +56,7 @@ def test_yolox_pytorch(variant, forge_tmp_path):
 
     # Record Forge Property
     module_name = record_model_properties(
-        framework=Framework.PYTORCH,
+        framework=Framework.ONNX,
         model=ModelArch.YOLOX,
         variant=variant,
         source=Source.TORCH_HUB,


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-forge-fe/issues/3029

### Summary

The Full Online Model Analysis pipeline was updated to run only ONNX and PaddlePaddle models. However, in the Superset dashboard, PyTorch framework data were still appearing in [this superset dashboard.](https://superset.tenstorrent.com/superset/dashboard/105/?native_filters_key=C_mTwfxdyfY)
This issue occurred because certain ONNX models were incorrectly recorded as PyTorch in the record_model_properties function.
The PR fixes this by ensuring the framework is correctly identified and recorded for all ONNX models.