### PR TITLE
Use tt-metal's install_dependencies.sh to install libstdc++-12-dev after metal uplift 

### DIFF
--- a/.github/Dockerfile.base
+++ b/.github/Dockerfile.base
@@ -50,7 +50,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
     python3.11 \
     python3.11-dev \
     python3.11-venv \
-    python3.11-distutils
+    python3-pip
 
 # Setup / install metal dependencies
 RUN wget https://raw.githubusercontent.com/tenstorrent/tt-metal/${TT_METAL_DEPENDENCIES_COMMIT}/{install_dependencies.sh,tt_metal/sfpi-info.sh,tt_metal/sfpi-version} && \


### PR DESCRIPTION
### Ticket
None

### Problem description
After metal uplift https://github.com/tenstorrent/tt-mlir/pull/6063, Builds fail when compiling `tt-metal`'s `levelized_graph.cpp` (introduced in tt-metal commit `dac6d279d509b819e24baee51e0152cd09ca40d`) with C++20 ranges errors:
```
error: invalid operands to binary expression ('std::vector<int>' and 'Partial<_Filter, ...>')
return get_connections(node) | std::views::filter(& {
~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The error occurs because `clang-17` uses GCC 11's `libstdc++` headers (`/usr/bin/../lib/gcc/x86_64-linux-gnu/11/../../../../include/c++/11/`), which have incomplete C++20 ranges support (The pipe operator (`|`) for ranges views)

Build does not fail in tt-mlir because
- `tt-mlir`'s Dockerfile runs `tt-metal`'s `install_dependencies.sh --docker`, which installs `g++-12` (pulling in `libstdc++-12-dev` as a dependency)
- `tt-forge-fe`'s Dockerfile was missing this step, so it only had GCC 11's libstdc++ headers available

### What's changed
- Integrated `tt-metal`'s `install_dependencies.sh --docker` into the Dockerfile to automatically install `g++-12` and `libstdc++-12-dev`
- Removed duplicate MPI-ULFM installation (now handled by `install_dependencies.sh`)

### Alternatives
- Simply adding in the missing lib works too
  - [[see change here]](https://github.com/tenstorrent/tt-forge-fe/compare/main...refs/heads/brata/libstdcpp12)
  - [[see CI with build passing here]](https://github.com/tenstorrent/tt-forge-fe/actions/runs/19773082262)
- Predrag pointed out we could also base tt-forge-fe docker on tt-mlir's docker [[like tt-xla does]](https://github.com/tenstorrent/tt-xla/blob/main/.github/Dockerfile.base#L3)

### Checklist
- [x] New/Existing tests provide coverage for changes
- Installing `libstdc++-12-dev` locally resolved the build error
- CI run with uplifted metal and this fix: https://github.com/tenstorrent/tt-forge-fe/actions/runs/19768146406
  - Build passes, but tests fail due to unrelated tt-mlir changes
