### PR TITLE
[runtime] open only single device

### DIFF
--- a/forge/csrc/runtime/runtime.cpp
+++ b/forge/csrc/runtime/runtime.cpp
@@ -75,20 +75,13 @@ void verify_input_descs(
 std::vector<tt::Tensor> run_program(runtime::Binary& binary, int program_idx, std::vector<tt::Tensor>& inputs)
 {
     auto& system = TTSystem::get_system();
-    for (auto& device : system.devices)
-    {
-        if (!device->is_open())
-        {
-            device->open_device();
-        }
-    }
 
     // For now, we only support a single device.
     constexpr size_t device_id = 0;
     auto& tt_device = system.devices[device_id];
     if (!tt_device->is_open())
     {
-        log_fatal(LogTTDevice, "Failed to open device");
+        tt_device->open_device();
     }
 
     auto& device = *tt_device->rt_device;


### PR DESCRIPTION
Previously, we were trying to open each available device - that logic is broken. This was not caught since we don't have any multi-board systems on CI.

Since `tt-forge-fe` doesn't support multi-chip yet, just open one device for the execution of the program.

Issue #3078