### PR TITLE
Fix: Include test-models job in check-all-green validation

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -83,6 +83,7 @@ jobs:
       - build-docs
       - build
       - test
+      - test-models
     runs-on: Ubuntu-latest
     steps:
     - name: Check if the needed jobs succeeded or failed


### PR DESCRIPTION

### Problem
The `test-models` job was not included in the `check-all-green` job's `needs` list, which allowed PRs to be merged even when the `test-models` job failed. This meant that model regression tests could fail without blocking PR merges.

### Solution
Added `test-models` to the `needs` list of the `check-all-green` job so that it is properly validated before allowing PR merges.

### Impact
- PRs will now fail the `check-all-green` check if `test-models` fails
- Prevents merging PRs with failing model regression tests
- Ensures all required jobs must pass before merge