### PR TITLE
Add scheduled trigger to on-nightly workflow

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -39,6 +39,8 @@ on:
           - n150
           - n300
           - p150
+  schedule:
+    - cron: '0 0 * * *' # Runs at 00:00 UTC every day
 
 # Set cache root to avoid IRD_LF_CACHE error when loading CenterNet ONNX model in CI
 env:


### PR DESCRIPTION
## Summary

Add a scheduled trigger to automatically run the nightly workflow daily at 00:00 UTC. The workflow will run automatically on a daily schedule to check onnx and paddlepaddle model failures.