### PR TITLE
Fix http rate limit execeed in ssd300resnet50 and yolov5 onnx model

### DIFF
--- a/forge/test/models/onnx/vision/ssd300_resnet50/test_ssd300_resnet50_onnx.py
+++ b/forge/test/models/onnx/vision/ssd300_resnet50/test_ssd300_resnet50_onnx.py
@@ -21,6 +21,7 @@ from forge.verify.verify import verify
 from test.models.pytorch.vision.ssd300_resnet50.model_utils.image_utils import (
     prepare_input,
 )
+from test.utils import download_model
 
 
 @pytest.mark.pr_models_regression
@@ -35,7 +36,9 @@ def test_pytorch_ssd300_resnet50(forge_tmp_path):
     )
 
     # STEP 2 : prepare model
-    framework_model = torch.hub.load("NVIDIA/DeepLearningExamples:torchhub", "nvidia_ssd", pretrained=False)
+    framework_model = download_model(
+        torch.hub.load, "NVIDIA/DeepLearningExamples:torchhub", "nvidia_ssd", pretrained=False
+    )
     url = "https://api.ngc.nvidia.com/v2/models/nvidia/ssd_pyt_ckpt_amp/versions/19.09.0/files/nvidia_ssdpyt_fp16_190826.pt"
     checkpoint_path = "nvidia_ssdpyt_fp16_190826.pt"
 

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v5_onnx.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v5_onnx.py
@@ -31,7 +31,7 @@ def generate_model_yoloV5I320_imgcls_torchhub_pytorch(variant, size):
 
 
 size = [
-    pytest.param("n", id="yolov5n"),
+    pytest.param("n", id="yolov5n", marks=pytest.mark.pr_models_regression),
     pytest.param("s", id="yolov5s"),
     pytest.param("m", id="yolov5m"),
     pytest.param("l", id="yolov5l"),

--- a/forge/test/utils.py
+++ b/forge/test/utils.py
@@ -64,7 +64,7 @@ def default_loader(path: str):
 
 def yolov5_loader(path: str, variant: str = "ultralytics/yolov5"):
     try:
-        model = torch.hub.load(variant, "custom", path=path)
+        model = download_model(torch.hub.load, variant, "custom", path=path)
         return model
     except Exception as e:
         print(f"YOLOv5 loading error: {e}")


### PR DESCRIPTION

## Problem

The test `test_pytorch_ssd300_resnet50` in `forge/test/models/onnx/vision/ssd300_resnet50/test_ssd300_resnet50_onnx.py` is a flaky test case that fails with the following error:

```
urllib.error.HTTPError: HTTP Error 403: rate limit exceeded
```

The failure occurs when `torch.hub.load()` attempts to validate the repository. When we retry the job, it passes successfully. To address this flakiness, we are adding a retry mechanism for loading the model.

## Fix

Wrapped the `torch.hub.load()` call with the `download_model` utility function, which provides retry logic to handle transient failures. The `download_model` wrapper automatically retries up to 3 times with exponential backoff when encountering HTTP errors, ensuring the test passes even when transient failures occur.

