### PR TITLE
[nightly] use nightly marker

### DIFF
--- a/.github/workflows/on-nightly.yml
+++ b/.github/workflows/on-nightly.yml
@@ -24,6 +24,7 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
+      build: 'Release'
 
   test_forge_model:
     needs:
@@ -32,9 +33,10 @@ jobs:
     uses: ./.github/workflows/test-sub.yml
     secrets: inherit
     with:
-      test_mark: 'pr_models_regression'
-      test_group_cnt: 3
-      test_group_ids: '[1,2,3]'
+      test_mark: 'nightly'
+      test_group_cnt: 6
+      test_group_ids: '[1,2,3,4,5,6]'
       docker-image: ${{ needs.docker-build.outputs.docker-image }}
       run_id: ${{ github.run_id }}
-      runs-on: '[{"runs-on": "n150"}, {"runs-on": "n300"}]'
+      runs-on: '[{"runs-on": "n150"}]'
+      tests_to_filter: 'forge/test/models/tensorflow,forge/test/models/onnx,forge/test/models/paddlepaddle'

--- a/forge/test/models/paddlepaddle/text/bert/test_bert.py
+++ b/forge/test/models/paddlepaddle/text/bert/test_bert.py
@@ -34,7 +34,18 @@ inputs_map = {
 
 
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant, input", [(key, value["sequence"]) for key, value in inputs_map.items()])
+@pytest.mark.parametrize(
+    "variant, input",
+    [
+        ("bert-base-uncased", inputs_map["bert-base-uncased"]["sequence"]),
+        ("cl-tohoku/bert-base-japanese", inputs_map["cl-tohoku/bert-base-japanese"]["sequence"]),
+        pytest.param(
+            "uer/chinese-roberta-base",
+            inputs_map["uer/chinese-roberta-base"]["sequence"],
+            marks=pytest.mark.skip(reason="Skipped test"),
+        ),
+    ],
+)
 def test_bert_sequence_classification(variant, input):
     # Record Forge properties
     module_name = record_model_properties(


### PR DESCRIPTION
To cover all of the wanted tests in the nightly run - use the `nightly` marker.

Additionally:

- filter out all tests which are not ONNX, paddlepaddle or tensorflow.
- for nightly only build release
- run everything on n150
- skip one flaky test