### PR TITLE
Add support for external tt-mlir builds via TTMLIR_SOURCE_DIR

### DIFF
--- a/docs/src/getting_started_build_from_source.md
+++ b/docs/src/getting_started_build_from_source.md
@@ -195,6 +195,12 @@ cmake --build env/build
 >
 > **NOTE:** Special care should be taken to ensure that the already built TT-MLIR environment (toolchain) version is compatible with the one TT-Forge-FE is using.
 
+> **Using a Pre-built TT-MLIR:** If you are developing on TT-MLIR and want to use your own build instead of the submodule, you can specify the path using the `TTMLIR_SOURCE_DIR` option when configuring the main build (step 8):
+> ```bash
+> cmake -G Ninja -B build -DTTMLIR_SOURCE_DIR=/path/to/tt-mlir -DCMAKE_CXX_COMPILER=clang++-17 -DCMAKE_C_COMPILER=clang-17
+> ```
+> The build system will automatically install the required library components from your TT-MLIR build. Ensure your TT-MLIR is built with `TTMLIR_ENABLE_RUNTIME=ON`.
+
 7. Activate the virtual environment for TT-Forge-FE. (This time when you run the command, you should see a running virtual environment):
 
 ```bash

--- a/forge/csrc/CMakeLists.txt
+++ b/forge/csrc/CMakeLists.txt
@@ -7,7 +7,12 @@ set(CMAKE_PREFIX_PATH
 find_package(Python3 COMPONENTS Development REQUIRED)
 find_package(Torch REQUIRED)
 
-set(TT_MLIR_ROOT_DIR ${CMAKE_SOURCE_DIR}/third_party/tt-mlir)
+# TT_MLIR_ROOT_DIR can be overridden via -DTTMLIR_SOURCE_DIR for external builds
+if(DEFINED TTMLIR_SOURCE_DIR)
+    set(TT_MLIR_ROOT_DIR ${TTMLIR_SOURCE_DIR})
+else()
+    set(TT_MLIR_ROOT_DIR ${CMAKE_SOURCE_DIR}/third_party/tt-mlir)
+endif()
 set(TTMLIR_INCLUDE_DIRS
     ${TT_MLIR_ROOT_DIR}/include
     ${TT_MLIR_ROOT_DIR}/build/include
@@ -22,11 +27,11 @@ set(TTFORGE_CSRC_INCLUDES
     ${CMAKE_SOURCE_DIR}/third_party/pybind11/include
     ${CMAKE_SOURCE_DIR}/third_party/json/single_include
     ${CMAKE_SOURCE_DIR}/third_party/pybind11_json/include
-    ${CMAKE_SOURCE_DIR}/third_party/tt-mlir/build/include
-    ${CMAKE_SOURCE_DIR}/third_party/tt-mlir/build/runtime/include
-    ${CMAKE_SOURCE_DIR}/third_party/tt-mlir/build/install/include
-    ${CMAKE_SOURCE_DIR}/third_party/tt-mlir/runtime/include
-    ${CMAKE_SOURCE_DIR}/third_party/tt-mlir/include
+    ${TT_MLIR_ROOT_DIR}/build/include
+    ${TT_MLIR_ROOT_DIR}/build/runtime/include
+    ${TT_MLIR_ROOT_DIR}/build/install/include
+    ${TT_MLIR_ROOT_DIR}/runtime/include
+    ${TT_MLIR_ROOT_DIR}/include
     ${TTMLIR_TOOLCHAIN_DIR}/include
     ${Python3_INCLUDE_DIRS}
     ${TTMLIR_INCLUDE_DIRS}
@@ -66,11 +71,11 @@ add_dependencies(ttforge_csrc_objs tt-mlir)
 
 ######## ttforge_csrc ########
 
-set(TTMLIR_LIB_DIR "${CMAKE_SOURCE_DIR}/third_party/tt-mlir/build/install/lib")
+set(TTMLIR_LIB_DIR "${TT_MLIR_ROOT_DIR}/build/install/lib")
 
 add_library(ttforge_csrc SHARED)
 
-set(METAL_LIB_DIR "${CMAKE_SOURCE_DIR}/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/build/lib")
+set(METAL_LIB_DIR "${TT_MLIR_ROOT_DIR}/third_party/tt-metal/src/tt-metal/build/lib")
 
 # Because _ttnn library doesn't have lib prefix, this is workaround to make linking work
 add_library(ttnn SHARED IMPORTED)

--- a/forge/csrc/passes/mlir_compiler.cpp
+++ b/forge/csrc/passes/mlir_compiler.cpp
@@ -172,8 +172,17 @@ auto run_mlir_compiler_generic(tt::ForgeGraphModule& module, const std::optional
         {
             metal_src_dir = fs::path(std::string(TT_METAL_RUNTIME_ROOT));
             metal_lib_dir = fs::path(std::string(TT_METAL_RUNTIME_ROOT)).parent_path() / "tt-metal/build/lib";
-            standalone_dir =
-                fs::path(std::string(FORGE_HOME)).parent_path() / "third_party/tt-mlir/tools/ttnn-standalone";
+            // Use TTMLIR_SOURCE_DIR if set (external tt-mlir), otherwise fall back to submodule path.
+            const char* ttmlir_source_dir = std::getenv("TTMLIR_SOURCE_DIR");
+            if (ttmlir_source_dir)
+            {
+                standalone_dir = fs::path(ttmlir_source_dir) / "tools/ttnn-standalone";
+            }
+            else
+            {
+                standalone_dir =
+                    fs::path(std::string(FORGE_HOME)).parent_path() / "third_party/tt-mlir/tools/ttnn-standalone";
+            }
         }
         else
         {

--- a/forge/forge/__init__.py
+++ b/forge/forge/__init__.py
@@ -45,6 +45,7 @@ def set_home_paths():
 
     if external_ttmlir:
         external_source_path = (pathlib.Path(external_ttmlir) / "third_party/tt-metal/src/tt-metal").resolve()
+        os.environ["TTMLIR_SOURCE_DIR"] = external_ttmlir
 
     if "TT_METAL_RUNTIME_ROOT" not in os.environ:
         if in_wheel_path.exists():

--- a/forge/forge/__init__.py
+++ b/forge/forge/__init__.py
@@ -29,7 +29,7 @@ def set_home_paths():
     # TT_METAL_RUNTIME_ROOT should be one of the following:
     in_wheel_path = forge_path / "forge/tt-metal"
     in_source_path = (forge_path.parent.resolve() / "third_party/tt-mlir/third_party/tt-metal/src/tt-metal").resolve()
-    
+
     external_source_path = None
     external_ttmlir = os.environ.get("TTMLIR_SOURCE_DIR")
     if not external_ttmlir:
@@ -42,7 +42,7 @@ def set_home_paths():
                         if cached_path:
                             external_ttmlir = cached_path
                             break
-    
+
     if external_ttmlir:
         external_source_path = (pathlib.Path(external_ttmlir) / "third_party/tt-metal/src/tt-metal").resolve()
 
@@ -66,7 +66,7 @@ def set_home_paths():
     valid_source_paths = [in_source_path]
     if external_source_path:
         valid_source_paths.append(external_source_path)
-    
+
     if in_wheel_path.exists():
         os.environ["FORGE_IN_WHEEL"] = "1"
     elif any(p.exists() for p in valid_source_paths):

--- a/setup.py
+++ b/setup.py
@@ -264,7 +264,7 @@ def get_tt_mlir_commit_hash() -> str:
                     if cached_path and cached_path != "third_party/tt-mlir":
                         mlir_path = cached_path
                         break
-    
+
     if not os.path.exists(mlir_path):
         raise ValueError(f"tt-mlir not found at {mlir_path}")
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -14,9 +14,9 @@ set(TTMLIR_BUILD_DIR "${TTMLIR_SOURCE_DIR}/build")
 set(TTMLIR_INSTALL_PREFIX "${TTMLIR_BUILD_DIR}/install")
 set(METAL_LIB_DIR "${TTMLIR_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build/lib")
 
-if(TTMLIR_USE_EXTERNAL)    
+if(TTMLIR_USE_EXTERNAL)
     if(NOT EXISTS "${TTMLIR_BUILD_DIR}")
-        message(FATAL_ERROR 
+        message(FATAL_ERROR
             "External tt-mlir build directory not found: ${TTMLIR_BUILD_DIR}\n"
             "Please ensure tt-mlir is built:\n"
             "  cd ${TTMLIR_SOURCE_DIR}\n"
@@ -35,7 +35,7 @@ if(TTMLIR_USE_EXTERNAL)
             message(FATAL_ERROR "Failed to install tt-mlir SharedLib component")
         endif()
     endif()
-    
+
     # Auto-install TTNNStandalone component if needed
     if(NOT EXISTS "${TTMLIR_INSTALL_PREFIX}/lib/libTTNNCompileSo.so")
         message(STATUS "Installing tt-mlir TTNNStandalone component...")
@@ -48,7 +48,7 @@ if(TTMLIR_USE_EXTERNAL)
             message(FATAL_ERROR "Failed to install tt-mlir TTNNStandalone component")
         endif()
     endif()
-    
+
     # Copy TTMLIRRuntime if not in install dir (it's not part of standard install components)
     if(NOT EXISTS "${TTMLIR_INSTALL_PREFIX}/lib/libTTMLIRRuntime.so")
         if(EXISTS "${TTMLIR_BUILD_DIR}/runtime/lib/libTTMLIRRuntime.so")
@@ -56,12 +56,12 @@ if(TTMLIR_USE_EXTERNAL)
             file(COPY "${TTMLIR_BUILD_DIR}/runtime/lib/libTTMLIRRuntime.so"
                  DESTINATION "${TTMLIR_INSTALL_PREFIX}/lib/")
         else()
-            message(FATAL_ERROR 
+            message(FATAL_ERROR
                 "libTTMLIRRuntime.so not found in ${TTMLIR_BUILD_DIR}/runtime/lib/\n"
                 "Please ensure tt-mlir was built with TTMLIR_ENABLE_RUNTIME=ON")
         endif()
     endif()
-    
+
     set(REQUIRED_LIBS
         "${TTMLIR_INSTALL_PREFIX}/lib/libTTMLIRCompiler.so"
         "${TTMLIR_INSTALL_PREFIX}/lib/libTTNNCompileSo.so"
@@ -72,11 +72,11 @@ if(TTMLIR_USE_EXTERNAL)
             message(FATAL_ERROR "Required library still missing after auto-install: ${lib}")
         endif()
     endforeach()
-    
+
     add_custom_target(tt-mlir
         COMMENT "Using external tt-mlir from ${TTMLIR_SOURCE_DIR}"
     )
-    
+
     message(STATUS "External tt-mlir validated successfully")
     message(STATUS "  Source: ${TTMLIR_SOURCE_DIR}")
     message(STATUS "  Build:  ${TTMLIR_BUILD_DIR}")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,34 +1,111 @@
 ### Build tt-mlir ###
 include(ExternalProject)
 
-set(METAL_LIB_DIR "${CMAKE_SOURCE_DIR}/third_party/tt-mlir/third_party/tt-metal/src/tt-metal/build/lib")
+option(TTMLIR_USE_EXTERNAL "Use an external pre-built tt-mlir instead of building from submodule" OFF)
 
-set(TTMLIR_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tt-mlir")
+if(DEFINED TTMLIR_SOURCE_DIR AND NOT TTMLIR_SOURCE_DIR STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/tt-mlir")
+    set(TTMLIR_USE_EXTERNAL ON)
+    message(STATUS "Using external tt-mlir from: ${TTMLIR_SOURCE_DIR}")
+else()
+    set(TTMLIR_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/tt-mlir")
+endif()
+
 set(TTMLIR_BUILD_DIR "${TTMLIR_SOURCE_DIR}/build")
 set(TTMLIR_INSTALL_PREFIX "${TTMLIR_BUILD_DIR}/install")
+set(METAL_LIB_DIR "${TTMLIR_SOURCE_DIR}/third_party/tt-metal/src/tt-metal/build/lib")
 
-ExternalProject_Add(
-    tt-mlir
-    SOURCE_DIR ${TTMLIR_SOURCE_DIR}
-    BINARY_DIR ${TTMLIR_BUILD_DIR} # for some reason BUILD_DIR for ExternalProject_Add doesn't exist, but they use BINARY_DIR instead
-    INSTALL_COMMAND ${CMAKE_COMMAND} --install ${TTMLIR_BUILD_DIR} --component SharedLib && ${CMAKE_COMMAND} --install ${TTMLIR_BUILD_DIR} --component TTNNStandalone
-    CMAKE_GENERATOR Ninja
-    CMAKE_ARGS
-        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
-        -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
-        -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
-        -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
-        -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
-        -DCMAKE_INSTALL_PREFIX=${TTMLIR_INSTALL_PREFIX}
-        -DTTMLIR_TOOLCHAIN_DIR=${TTMLIR_TOOLCHAIN_DIR}
-        -DTTMLIR_ENABLE_RUNTIME=ON
-        -DTTMLIR_ENABLE_RUNTIME_TESTS=ON  # used for emitc testing
-        -DTTMLIR_ENABLE_BINDINGS_PYTHON=OFF
-        -DTT_RUNTIME_DEBUG=${TTMLIR_RUNTIME_DEBUG}
-        -DMLIR_DIR=${TTMLIR_TOOLCHAIN_DIR}/lib/cmake/mlir
-        -DTTMLIR_ENABLE_OPMODEL=ON
-        -DTTMLIR_ENABLE_EXPLORER=OFF
-)
+if(TTMLIR_USE_EXTERNAL)    
+    if(NOT EXISTS "${TTMLIR_BUILD_DIR}")
+        message(FATAL_ERROR 
+            "External tt-mlir build directory not found: ${TTMLIR_BUILD_DIR}\n"
+            "Please ensure tt-mlir is built:\n"
+            "  cd ${TTMLIR_SOURCE_DIR}\n"
+            "  cmake --build build")
+    endif()
+
+    # Auto-install SharedLib component if needed
+    if(NOT EXISTS "${TTMLIR_INSTALL_PREFIX}/lib/libTTMLIRCompiler.so")
+        message(STATUS "Installing tt-mlir SharedLib component...")
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} --install ${TTMLIR_BUILD_DIR} --prefix ${TTMLIR_INSTALL_PREFIX} --component SharedLib
+            WORKING_DIRECTORY ${TTMLIR_SOURCE_DIR}
+            RESULT_VARIABLE INSTALL_RESULT
+        )
+        if(NOT INSTALL_RESULT EQUAL 0)
+            message(FATAL_ERROR "Failed to install tt-mlir SharedLib component")
+        endif()
+    endif()
+    
+    # Auto-install TTNNStandalone component if needed
+    if(NOT EXISTS "${TTMLIR_INSTALL_PREFIX}/lib/libTTNNCompileSo.so")
+        message(STATUS "Installing tt-mlir TTNNStandalone component...")
+        execute_process(
+            COMMAND ${CMAKE_COMMAND} --install ${TTMLIR_BUILD_DIR} --prefix ${TTMLIR_INSTALL_PREFIX} --component TTNNStandalone
+            WORKING_DIRECTORY ${TTMLIR_SOURCE_DIR}
+            RESULT_VARIABLE INSTALL_RESULT
+        )
+        if(NOT INSTALL_RESULT EQUAL 0)
+            message(FATAL_ERROR "Failed to install tt-mlir TTNNStandalone component")
+        endif()
+    endif()
+    
+    # Copy TTMLIRRuntime if not in install dir (it's not part of standard install components)
+    if(NOT EXISTS "${TTMLIR_INSTALL_PREFIX}/lib/libTTMLIRRuntime.so")
+        if(EXISTS "${TTMLIR_BUILD_DIR}/runtime/lib/libTTMLIRRuntime.so")
+            message(STATUS "Copying libTTMLIRRuntime.so to install directory...")
+            file(COPY "${TTMLIR_BUILD_DIR}/runtime/lib/libTTMLIRRuntime.so"
+                 DESTINATION "${TTMLIR_INSTALL_PREFIX}/lib/")
+        else()
+            message(FATAL_ERROR 
+                "libTTMLIRRuntime.so not found in ${TTMLIR_BUILD_DIR}/runtime/lib/\n"
+                "Please ensure tt-mlir was built with TTMLIR_ENABLE_RUNTIME=ON")
+        endif()
+    endif()
+    
+    set(REQUIRED_LIBS
+        "${TTMLIR_INSTALL_PREFIX}/lib/libTTMLIRCompiler.so"
+        "${TTMLIR_INSTALL_PREFIX}/lib/libTTNNCompileSo.so"
+        "${TTMLIR_INSTALL_PREFIX}/lib/libTTMLIRRuntime.so"
+    )
+    foreach(lib ${REQUIRED_LIBS})
+        if(NOT EXISTS ${lib})
+            message(FATAL_ERROR "Required library still missing after auto-install: ${lib}")
+        endif()
+    endforeach()
+    
+    add_custom_target(tt-mlir
+        COMMENT "Using external tt-mlir from ${TTMLIR_SOURCE_DIR}"
+    )
+    
+    message(STATUS "External tt-mlir validated successfully")
+    message(STATUS "  Source: ${TTMLIR_SOURCE_DIR}")
+    message(STATUS "  Build:  ${TTMLIR_BUILD_DIR}")
+    message(STATUS "  Install: ${TTMLIR_INSTALL_PREFIX}")
+else()
+    # Build tt-mlir from submodule (default behavior)
+    ExternalProject_Add(
+        tt-mlir
+        SOURCE_DIR ${TTMLIR_SOURCE_DIR}
+        BINARY_DIR ${TTMLIR_BUILD_DIR}
+        INSTALL_COMMAND ${CMAKE_COMMAND} --install ${TTMLIR_BUILD_DIR} --component SharedLib && ${CMAKE_COMMAND} --install ${TTMLIR_BUILD_DIR} --component TTNNStandalone
+        CMAKE_GENERATOR Ninja
+        CMAKE_ARGS
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+            -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+            -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+            -DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}
+            -DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}
+            -DCMAKE_INSTALL_PREFIX=${TTMLIR_INSTALL_PREFIX}
+            -DTTMLIR_TOOLCHAIN_DIR=${TTMLIR_TOOLCHAIN_DIR}
+            -DTTMLIR_ENABLE_RUNTIME=ON
+            -DTTMLIR_ENABLE_RUNTIME_TESTS=ON  # used for emitc testing
+            -DTTMLIR_ENABLE_BINDINGS_PYTHON=OFF
+            -DTT_RUNTIME_DEBUG=${TTMLIR_RUNTIME_DEBUG}
+            -DMLIR_DIR=${TTMLIR_TOOLCHAIN_DIR}/lib/cmake/mlir
+            -DTTMLIR_ENABLE_OPMODEL=ON
+            -DTTMLIR_ENABLE_EXPLORER=OFF
+    )
+endif()
 
 install(DIRECTORY ${TTMLIR_INSTALL_PREFIX}/ DESTINATION "${CMAKE_INSTALL_PREFIX}" USE_SOURCE_PERMISSIONS)
 


### PR DESCRIPTION
Enable tt-forge-fe to consume a pre-built external tt-mlir instead of requiring the tt-mlir submodule.
- Allow overriding tt-mlir location via TTMLIR_SOURCE_DIR (CMake, env, or cache).
- Update include/lib paths to derive from the resolved tt-mlir root.
- Add CMake logic to validate and auto-install required tt-mlir components when using an external build.
- Detect external tt-mlir in Python runtime to correctly set TT_METAL_RUNTIME_ROOT and source/wheel mode.
- Resolve tt-mlir and tt-metal commit SHAs from external sources in setup.py.

Default behavior (building tt-mlir from the submodule) remains unchanged.