### PR TITLE
Boolean Input Handling and Add Verbose Output Feature for Test Workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,12 +52,17 @@ on:
         description: 'Filter specific tests (comma separated)'
         required: false
         type: string
+      enable-verbose-output:
+        description: 'Enable verbose pytest output (-svv flag). Shows print statements and detailed test execution information'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   packages: write
   checks: write
 
-run-name: "Test (Mark: ${{ inputs.test_mark }} - ${{ inputs.sh-runner && format('{0}-shared', inputs.runs-on) || (inputs.runs-on) }} - ${{ inputs.test_group_cnt }} - Run ID: ${{ inputs.workflow_runners }} - MLIR Override: ${{ inputs.mlir_override }} - Tests to Filter: ${{ inputs.tests_to_filter }})"
+run-name: "Test (Mark: ${{ inputs.test_mark }} - ${{ inputs.sh-runner && format('{0}-shared', inputs.runs-on) || (inputs.runs-on) }} - ${{ inputs.test_group_cnt }} - Run ID: ${{ inputs.workflow_runners }} - MLIR Override: ${{ inputs.mlir_override }} - Tests to Filter: ${{ inputs.tests_to_filter }}) - Verbose Output: ${{ inputs.enable-verbose-output }}"
 
 jobs:
 
@@ -76,9 +81,10 @@ jobs:
           echo "- Workflow Runners (Run ID): ${{ inputs.workflow_runners }}" >> $GITHUB_STEP_SUMMARY
           echo "- MLIR Override: ${{ inputs.mlir_override }}" >> $GITHUB_STEP_SUMMARY
           echo "- Tests to Filter: ${{ inputs.tests_to_filter }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Verbose Output: ${{ inputs.enable-verbose-output }}" >> $GITHUB_STEP_SUMMARY
       - name: Save inputs to file
         run: |
-          echo '{ "branch_name": "${{ github.ref_name }}", "test_mark": "${{ inputs.test_mark }}", "runs-on": "${{ inputs.runs-on }}", "sh-runner": "$${{ inputs.sh-runner }}", "test_group_cnt": "${{ inputs.test_group_cnt }}", "on-crash": "${{ inputs.on-crash }}", "workflow_runners": "${{ inputs.workflow_runners }}", "mlir_override": "${{ inputs.mlir_override }}", "tests_to_filter": "${{ inputs.tests_to_filter }}" }' > inputs.json
+          echo '{ "branch_name": "${{ github.ref_name }}", "test_mark": "${{ inputs.test_mark }}", "runs-on": "${{ inputs.runs-on }}", "sh-runner": "$${{ inputs.sh-runner }}", "test_group_cnt": "${{ inputs.test_group_cnt }}", "on-crash": "${{ inputs.on-crash }}", "workflow_runners": "${{ inputs.workflow_runners }}", "mlir_override": "${{ inputs.mlir_override }}", "tests_to_filter": "${{ inputs.tests_to_filter }}", "enable-verbose-output": "${{ inputs.enable-verbose-output }}" }' > inputs.json
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -157,3 +163,4 @@ jobs:
       tests_to_filter: ${{ needs.set-inputs.outputs.tests_to_filter }}
       run_id: ${{ needs.set-inputs.outputs.run_id }}
       continue-on-crash: ${{ needs.set-inputs.outputs.continue_on_crash == 'true' }}
+      enable-verbose-output: ${{ inputs.enable-verbose-output }}


### PR DESCRIPTION
## Summary

Fixed the workflow validation error that occurred when passing the `continue-on-crash` boolean value to the reusable workflow. The issue was caused by GitHub Actions not properly handling boolean expressions in job outputs when passed to reusable workflow inputs. Additionally, added a new `enable-verbose-output` input parameter to allow users to enable verbose pytest output for better debugging.

## Issue

The workflow was failing with the following error:
```
evaluate reusable workflow inputs: .github/workflows/test.yml (Line: 154, Col: 26): Unexpected value 'false'
```

The issue occurred when passing the `continue-on-crash` boolean value to the reusable workflow `test-sub.yml`. The workflow was attempting to pass a boolean expression directly from a job output:
```yaml
continue_on_crash: ${{ inputs.on-crash == 'Continue' }}
```

GitHub Actions doesn't properly handle boolean expressions in job outputs when they're passed to reusable workflow inputs, causing the validation error.

## Solution

Fixed the boolean value handling by setting the value in the step output as a string (`'true'` or `'false'`) in the bash script , and then converting it back to a boolean when passing to the reusable workflow using `== 'true'`. This ensures the reusable workflow receives the expected boolean type.