### PR TITLE
Ignore broken symlinks on setup.py during wheel build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -97,6 +97,17 @@ class CMakeBuild(build_ext):
         self.spawn(["cmake", "--build", str(build_dir)])
         self.spawn(["cmake", "--install", str(build_dir)])
 
+        _remove_broken_symlinks(install_dir)
+
+
+def _remove_broken_symlinks(root: Path) -> None:
+    """Remove broken symlinks that would cause wheel packaging to fail."""
+    for path in root.rglob("*"):
+        if path.is_symlink() and not path.exists():
+            rel = path.relative_to(root)
+            print(f"Removing broken symlink: {rel}")
+            path.unlink()
+
 
 with open("README.md", "r") as f:
     long_description = f.read()


### PR DESCRIPTION
### Ticket
https://github.com/tenstorrent/tt-mlir/pull/6643

### Problem description
tt-metal -> tt-mlir uplift introduces a chance in tt-metals third party tt-umd with a new file that consist of a "broken" symlink, when building the tt-forge-onnx wheel it tries to copy the broken symlink and fails after not being able to find the file.

### What's changed
Added a function to remove/ignore broken symlinks

### Checklist
- [x] New/Existing tests provide coverage for changes
