### PR TITLE
removed reference to "mac_requirements.txt"

### DIFF
--- a/env/create_venv.sh
+++ b/env/create_venv.sh
@@ -22,19 +22,10 @@ if [[ -z "$CURRENT_SOURCE_DIR" ]]; then
     exit 1
 fi
 
-# Torch requires a specific version of wheel to be installed
-# which depends on the platform
-if [[ "$OSTYPE" == "darwin"* ]]; then
-    REQUIREMENTS_FILE="$CURRENT_SOURCE_DIR/mac_requirements.txt"
-else
-    # TODO test on linux
-    REQUIREMENTS_FILE="$CURRENT_SOURCE_DIR/linux_requirements.txt"
-fi
-
 $TTFORGE_PYTHON_VERSION -m venv $TTFORGE_VENV_DIR
 unset LD_PRELOAD
 source $TTFORGE_VENV_DIR/bin/activate
 python -m pip install --upgrade pip
 pip3 install wheel==0.37.1
 pip3 install setuptools==78.1.0
-pip3 install -r $REQUIREMENTS_FILE -f https://download.pytorch.org/whl/cpu/torch_stable.html
+pip3 install -r "$CURRENT_SOURCE_DIR/linux_requirements.txt" -f https://download.pytorch.org/whl/cpu/torch_stable.html


### PR DESCRIPTION
### Ticket
na

### Problem description
"mac_requirements.txt" has been removed as part of this [pr](https://github.com/tenstorrent/tt-forge-onnx/pull/1544/files)

also, according to [this](https://github.com/tenstorrent/tt-forge-onnx/pull/1544#issuecomment-2884029861) comment macos is not considered officially supported

### What's changed
only removed reference to "mac_requirements.txt" in "create_venv.sh"

### Checklist
~- [ ] New/Existing tests provide coverage for changes~ - na
