### PR TITLE
Fix imagenet-1k dataset loading issue

### DIFF
--- a/forge/test/models/models_utils.py
+++ b/forge/test/models/models_utils.py
@@ -388,7 +388,7 @@ def Gemma2DecoderLayer_patched_forward(
 def preprocess_inputs():
 
     # Load Input
-    dataset = load_dataset("imagenet-1k", split="validation", streaming=True)
+    dataset = load_dataset("ILSVRC/imagenet-1k", split="validation", streaming=True)
     input_image = next(iter(dataset.skip(10)))["image"]
 
     # Prepare input

--- a/forge/test/models/onnx/vision/autoencoder/test_autoencoder_onnx.py
+++ b/forge/test/models/onnx/vision/autoencoder/test_autoencoder_onnx.py
@@ -53,8 +53,8 @@ def test_linear_ae_pytorch(forge_tmp_path):
     )
 
     # Load sample from MNIST dataset
-    dataset = load_dataset("mnist")
-    sample = dataset["train"][0]["image"]
+    dataset = load_dataset("ylecun/mnist", split="train")
+    sample = dataset[0]["image"]
     sample_tensor = transform(sample).squeeze(0)
 
     inputs = [sample_tensor]

--- a/forge/test/models/onnx/vision/efficientnet/test_efficientnet.py
+++ b/forge/test/models/onnx/vision/efficientnet/test_efficientnet.py
@@ -49,7 +49,7 @@ def test_efficientnet_onnx(variant, forge_tmp_path):
     model = timm.create_model(variant, pretrained=True)
 
     # Load the inputs
-    dataset = load_dataset("imagenet-1k", split="validation", streaming=True)
+    dataset = load_dataset("ILSVRC/imagenet-1k", split="validation", streaming=True)
     img = next(iter(dataset.skip(10)))["image"]
     inputs = load_inputs(img, model)
     onnx_path = f"{forge_tmp_path}/efficientnet.onnx"

--- a/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
+++ b/forge/test/models/onnx/vision/mobilenetv2/test_mobilenetv2.py
@@ -41,7 +41,7 @@ def test_mobilenetv2_onnx(variant, forge_tmp_path):
     model = timm.create_model(variant, pretrained=True)
 
     # Load the inputs
-    dataset = load_dataset("imagenet-1k", split="validation", streaming=True)
+    dataset = load_dataset("ILSVRC/imagenet-1k", split="validation", streaming=True)
     img = next(iter(dataset.skip(10)))["image"]
     inputs = load_inputs(img, model)
     onnx_path = f"{forge_tmp_path}/mobilenetv2.onnx"

--- a/forge/test/models/pytorch/vision/dla/model_utils/utils.py
+++ b/forge/test/models/pytorch/vision/dla/model_utils/utils.py
@@ -15,7 +15,7 @@ def load_dla_model(variant):
     func = getattr(dla_model, variant)
 
     # Load data sample
-    dataset = load_dataset("imagenet-1k", split="validation", streaming=True)
+    dataset = load_dataset("ILSVRC/imagenet-1k", split="validation", streaming=True)
     image = next(iter(dataset))["image"]
 
     # Preprocessing

--- a/forge/test/models/pytorch/vision/ghostnet/model_utils/utils.py
+++ b/forge/test/models/pytorch/vision/ghostnet/model_utils/utils.py
@@ -18,7 +18,7 @@ def load_ghostnet_model(variant):
     framework_model.eval()
 
     # Prepare input
-    dataset = load_dataset("imagenet-1k", split="validation", streaming=True)
+    dataset = load_dataset("ILSVRC/imagenet-1k", split="validation", streaming=True)
     img = next(iter(dataset.skip(10)))["image"]
     data_config = resolve_data_config({}, model=framework_model)
     transforms = create_transform(**data_config, is_training=False)


### PR DESCRIPTION
## Summary

This PR fixes dataset loading failures across multiple vision model tests by updating incorrect dataset identifiers to their correct Hugging Face Hub names:
- ImageNet-1k: Changed from `"imagenet-1k"` to `"ILSVRC/imagenet-1k"`
- MNIST: Changed from `"mnist"` to `"ylecun/mnist"`

## Problem

Multiple vision model tests were failing when attempting to load datasets from Hugging Face Hub due to incorrect dataset identifiers:

1. **ImageNet-1k**: Tests were using `"imagenet-1k"` which is not a valid dataset name on Hugging Face Hub, causing failures with:
   ```
   FileNotFoundError: Dataset 'imagenet-1k' doesn't exist on the Hub
   ```

2. **MNIST**: The autoencoder test was using `"mnist"` which is not a valid dataset name on Hugging Face Hub, causing failures with:
   ```
   FileNotFoundError: Dataset 'mnist' doesn't exist on the Hub
   ```

## Solution

Updated all instances of incorrect dataset names to use the correct Hugging Face Hub identifiers:

1. **ImageNet-1k**: Changed `load_dataset("imagenet-1k", split="validation", streaming=True)` to `load_dataset("ILSVRC/imagenet-1k", split="validation", streaming=True)` across all affected files in `forge/test/models/models_utils.py`.

2. **MNIST**: Changed `load_dataset("mnist", split="train")` to `load_dataset("ylecun/mnist", split="train")` in `forge/test/models/onnx/vision/autoencoder/test_autoencoder_onnx.py`.

This ensures the code references the official dataset repositories on Hugging Face Hub:
- `ILSVRC/imagenet-1k` for the ImageNet-1k validation dataset
- `ylecun/mnist` for the MNIST dataset (Yann LeCun's official repository).
