### PR TITLE
Remove Grayskull Architecture Support

### DIFF
--- a/forge/csrc/backend_api/arch_type.cpp
+++ b/forge/csrc/backend_api/arch_type.cpp
@@ -13,7 +13,6 @@ std::string to_string_arch(ARCH arch)
 {
     switch (arch)
     {
-        case ARCH::GRAYSKULL: return "GRAYSKULL";
         case ARCH::WORMHOLE_B0: return "WORMHOLE_B0";
         case ARCH::BLACKHOLE: return "BLACKHOLE";
         default: throw std::runtime_error("Unsupported ARCH enum: " + std::to_string(static_cast<int>(arch)));
@@ -25,11 +24,7 @@ std::string to_string_arch_lower(ARCH arch) { return tt::utils::to_lower_string(
 ARCH to_arch_type(const std::string& arch_string)
 {
     std::string arch_string_lower = tt::utils::to_upper_string(arch_string);
-    if (arch_string_lower == "GRAYSKULL")
-    {
-        return ARCH::GRAYSKULL;
-    }
-    else if (arch_string_lower == "WORMHOLE_B0")
+    if (arch_string_lower == "WORMHOLE_B0")
     {
         return ARCH::WORMHOLE_B0;
     }

--- a/forge/csrc/backend_api/arch_type.hpp
+++ b/forge/csrc/backend_api/arch_type.hpp
@@ -10,7 +10,6 @@ namespace tt
 enum class ARCH
 {
     JAWBRIDGE = 0,
-    GRAYSKULL = 1,
     WORMHOLE = 2,
     WORMHOLE_B0 = 3,
     BLACKHOLE = 4,

--- a/forge/csrc/backend_api/device_config.hpp
+++ b/forge/csrc/backend_api/device_config.hpp
@@ -221,9 +221,6 @@ struct DeviceConfig
     // we temporarily treat it as equivalent to the Wormhole_b0 architecture.
     inline bool is_wormhole_b0() const { return arch == ARCH::WORMHOLE_B0 || is_blackhole(); }
 
-    // Get if the device is a grayskull
-    inline bool is_grayskull() const { return arch == ARCH::GRAYSKULL; }
-
     template <typename T>
     T get(std::string const& param, const bool system_level_command) const;
     void load_system_level_params();
@@ -265,7 +262,7 @@ struct DeviceConfig
     std::uint32_t get_dram_num_subchannels() const
     {
         // TODO - get from backend, but backend needs to add it
-        return is_grayskull() ? 1 : 3;
+        return 3;
     }
     std::uint32_t get_dram_channel_capacity() const { return get<std::uint32_t>("dram-channel_capacity", false); }
     std::size_t get_dram_bandwidth_per_block_theoretical() const
@@ -291,7 +288,7 @@ struct DeviceConfig
     CoreCoord get_dram_core_coord(std::uint32_t channel, std::uint32_t subchannel) const
     {
         // Emulation device has only one dram channel
-        if (is_grayskull() || this->backend_type == "emulation")
+        if (this->backend_type == "emulation")
         {
             return get<CoreCoord>("dram-core_xy_chan" + std::to_string(channel), false);
         }
@@ -399,7 +396,7 @@ struct DeviceConfig
         return ret;
     }
 
-    bool supports_fp32_accumulation() const { return not is_grayskull(); }
+    bool supports_fp32_accumulation() const { return true; }
     bool supports_stochastic_rounding() const { return is_wormhole_b0(); }
     std::unordered_map<std::uint32_t, std::set<std::uint32_t>> get_chip_connections() const
     {

--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -53,7 +53,6 @@ PYBIND11_MODULE(_C, m)
 
     py::enum_<tt::ARCH>(m, "Arch")
         .value("JAWBRIDGE", tt::ARCH::JAWBRIDGE)
-        .value("GRAYSKULL", tt::ARCH::GRAYSKULL)
         .value("WORMHOLE", tt::ARCH::WORMHOLE)
         .value("WORMHOLE_B0", tt::ARCH::WORMHOLE_B0)
         .value("BLACKHOLE", tt::ARCH::BLACKHOLE)

--- a/forge/csrc/passes/dataformat.cpp
+++ b/forge/csrc/passes/dataformat.cpp
@@ -210,12 +210,11 @@ void cast_and_resolve_input_data_formats(
 // Fix illegal situations
 //
 // Current rules:
-// 1. On Grayskull, the output can convert from a to b exponent for FP16, or when writing out FP32. On Wormhole,
-//    BFP* formats can also convert from a to b when packing.
+// 1. On Wormhole, BFP* formats can convert from a to b when packing.
 // 2. Intermediate format is currently only used for matmul, but for non-matmul we should follow the rule that
 //    intermed df == output df
 // 3. Matmul is a special case where operand 1, intermed df, and output df must all match
-// 4. Acc_df must match math format on Grayskull, but can be either math format or FP32 on Wormhole
+// 4. Acc_df can be either math format or FP32 on Wormhole
 // 5. Untilize op can't be in Bfp* formats
 //
 // When fixing, try not to change formats that were specifically overriden by the user

--- a/forge/csrc/runtime/tt_device.cpp
+++ b/forge/csrc/runtime/tt_device.cpp
@@ -37,7 +37,6 @@ TTSystem detect_available_devices()
 
         switch (chip_desc->arch())
         {
-            case target::Arch::Grayskull: arch = ARCH::GRAYSKULL; break;
             case target::Arch::Wormhole_b0: arch = ARCH::WORMHOLE_B0; break;
             case target::Arch::Blackhole: arch = ARCH::BLACKHOLE; break;
             default: log_fatal(LogTTDevice, "Unknown chip type {}", target::EnumNameArch(chip_desc->arch()));

--- a/forge/csrc/shared_utils/placement_printer.hpp
+++ b/forge/csrc/shared_utils/placement_printer.hpp
@@ -17,7 +17,6 @@ class PlacementPrinter
    public:
     enum class DeviceType
     {
-        Grayskull,
         Wormhole
     };
 
@@ -30,10 +29,6 @@ class PlacementPrinter
 
         switch (device)
         {
-            case DeviceType::Grayskull:
-                this->height = 10;
-                this->width = 12;
-                break;
             case DeviceType::Wormhole:
                 this->height = 10;
                 this->width = 8;

--- a/forge/test/conftest.py
+++ b/forge/test/conftest.py
@@ -315,7 +315,7 @@ def pytest_addoption(parser):
         "--versim", action="store_true", default=False, help="run versim tests"
     )
     parser.addoption(
-        "--arch", action="store", default="grayskull", help="run tests on different arch"
+        "--arch", action="store", default="wormhole_b0", help="run tests on different arch"
     )
     parser.addoption(
         "--microbatch-size", action="store", default=8,
@@ -473,7 +473,7 @@ def pytest_generate_tests(metafunc):
 
     if "_test_device_not_implemented" in metafunc.fixturenames:
         # if "test_device" in metafunc.fixturenames:
-        names = ["Golden", "Model", "Versim", "Emulation", "Grayskull", "Wormhole_B0", "Blackhole"]
+        names = ["Golden", "Model", "Versim", "Emulation", "Wormhole_B0", "Blackhole"]
 
         # Set device-mode for the test
         compile_only = metafunc.config.getoption("--compile-only")


### PR DESCRIPTION
## Problem

In the tt-mlir repository, Grayskull architecture support was removed as part of the upcoming [tt-metal to tt-mlir uplift ](https://github.com/tenstorrent/tt-mlir/pull/6916). This removal causes compilation failures in the tt-forge-onnx CI pipeline when building against the updated tt-mlir.

The build error occurs because `tt-forge-onnx` still references `target::Arch::Grayskull` from tt-mlir, which no longer exists in the updated API.

**Build Error:**
```
error: no member named 'Grayskull' in 'tt::target::Arch'
    case target::Arch::Grayskull: arch = ARCH::GRAYSKULL; break;
```

## Solution

This PR removes all Grayskull architecture references from the tt-forge-onnx codebase to align with the updated tt-mlir.

Tested the tt-forge-onnx on-pr workflow in upcoming [tt-metal to tt-mlir uplift ](https://github.com/tenstorrent/tt-mlir/pull/6916) and validated - https://github.com/tenstorrent/tt-forge-onnx/actions/runs/21746682123


