### PR TITLE
Update model and ops tests with issues details

### DIFF
--- a/forge/test/mlir/mnist/training/test_training.py
+++ b/forge/test/mlir/mnist/training/test_training.py
@@ -624,6 +624,9 @@ def test_e2e_device(dtype):
     if dtype == torch.bfloat16:
         data_format_override = DataFormat.Float16_b
         compiler_cfg.default_df_override = data_format_override
+
+        # Issue: https://github.com/tenstorrent/tt-mlir/issues/6915
+        # Once the issue is fixed, CPU Hoisted Const Eval should be enabled
         compiler_cfg.mlir_config = forge.config.MLIRConfig().set_custom_config("enable-cpu-hoisted-const-eval=false")
 
     verify_cfg = DeprecatedVerifyConfig()

--- a/forge/test/mlir/test_optimizers.py
+++ b/forge/test/mlir/test_optimizers.py
@@ -153,6 +153,8 @@ def test_adam(shape, betas, weight_decay):
         golden_model.parameters(), lr=learning_rate, eps=eps, betas=betas, weight_decay=weight_decay
     )
 
+    # Issue: https://github.com/tenstorrent/tt-mlir/issues/6915
+    # Once the issue is fixed, CPU Hoisted Const Eval should be enabled
     mlir_config = forge.config.MLIRConfig()
     mlir_config.set_custom_config("enable-cpu-hoisted-const-eval=false")
 

--- a/forge/test/models/onnx/audio/test_whisper_onnx.py
+++ b/forge/test/models/onnx/audio/test_whisper_onnx.py
@@ -36,13 +36,23 @@ variants = [
         "openai/whisper-tiny",
         marks=[
             pytest.mark.pr_models_regression,
-            pytest.mark.xfail(
-                reason="Runtime Error: CB page size 384 should be greater than the config tensor page size 776"
-            ),
+            pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-mlir/issues/6937"),
         ],
     ),
-    "openai/whisper-base",
-    "openai/whisper-small",
+    pytest.param(
+        "openai/whisper-base",
+        marks=[
+            pytest.mark.pr_models_regression,
+            pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-mlir/issues/6937"),
+        ],
+    ),
+    pytest.param(
+        "openai/whisper-small",
+        marks=[
+            pytest.mark.pr_models_regression,
+            pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-mlir/issues/6937"),
+        ],
+    ),
     pytest.param("openai/whisper-medium", marks=pytest.mark.xfail),
     pytest.param("openai/whisper-large", marks=pytest.mark.xfail),
 ]

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v6_onnx.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v6_onnx.py
@@ -95,6 +95,8 @@ def test_yolo_v6_pytorch(variant, forge_tmp_path):
     onnx.checker.check_model(onnx_model)
     onnx_module = forge.OnnxModule(module_name, onnx_model)
 
+    # Issue: https://github.com/tenstorrent/tt-mlir/issues/6915
+    # Once the issue is fixed, CPU Hoisted Const Eval should be enabled
     mlir_config = forge.config.MLIRConfig()
     mlir_config.set_custom_config("enable-cpu-hoisted-const-eval=false")
 

--- a/forge/test/models/onnx/vision/yolo/test_yolo_v9_onnx.py
+++ b/forge/test/models/onnx/vision/yolo/test_yolo_v9_onnx.py
@@ -57,6 +57,8 @@ def test_yolov9(forge_tmp_path):
     onnx.checker.check_model(onnx_model)
     onnx_module = forge.OnnxModule(module_name, onnx_model)
 
+    # Issue: https://github.com/tenstorrent/tt-mlir/issues/6915
+    # Once the issue is fixed, CPU Hoisted Const Eval should be enabled
     mlir_config = forge.config.MLIRConfig()
     mlir_config.set_custom_config("enable-cpu-hoisted-const-eval=false")
 


### PR DESCRIPTION
### Summary

1. The **whisper onnx model** test was failing with `CB page size 384 should be greater than the config tensor page size 776` and created issue in tt-mlir(https://github.com/tenstorrent/tt-mlir/issues/6937), so updating the xfail reason with issue link.

2. In tt-mlir recently CPU Hosit const eval was enabled by default due to which some of the test are failing and issue was filed in tt-mlir(https://github.com/tenstorrent/tt-mlir/issues/6937), so updating it with issue link as comment 