### PR TITLE
[skip ci] Fix typos and corrections in docs

### DIFF
--- a/docs/src/dev_notes/verification.md
+++ b/docs/src/dev_notes/verification.md
@@ -98,7 +98,7 @@ For this checker you can set:
 # default behavior
 verify(inputs, framework_model, compiled_model)
 # this will result same as the default behavior
-verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker())
+verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker()))
 # setting pcc and rtol
 verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95, rtol=1e-03)))
 ```
@@ -133,7 +133,7 @@ For this checker you can set:
 **Examples of usage:**
 ```python
 # setting full checker with default values
-verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=FullValueChecker())
+verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=FullValueChecker()))
 # setting full checker with custom values
 verify(inputs, framework_model, compiled_model, VerifyConfig(value_checker=FullValueChecker(pcc=0.95, rtol=1e-03)))
 ```

--- a/docs/src/getting_started_build_from_source.md
+++ b/docs/src/getting_started_build_from_source.md
@@ -37,7 +37,7 @@ tt-smi
 You should see the Tenstorrent System Management Interface. It allows you to view real-time stats, diagnostics, and health info about your Tenstorrent device.
 
 ## Prerequisites
-The prerequisites for building TT-Forge-ONNX from souce are:
+The prerequisites for building TT-Forge-ONNX from source are:
 
 * Clang 17
 * Ninja
@@ -149,7 +149,7 @@ This is a one off step to build the toolchain and create a virtual environment f
 1. First, it's required to create toolchain directories. The proposed example creates directories using the default paths. You can change the paths if you want to use different locations (see the [Useful Build Environment Variables](#useful-build-environment-variables) section below).
 
 ```bash
-# FFE related toolchain (dafault path)
+# FFE related toolchain (default path)
 sudo mkdir -p /opt/ttforge-toolchain
 sudo chown -R $USER /opt/ttforge-toolchain
 

--- a/docs/src/getting_started_docker.md
+++ b/docs/src/getting_started_docker.md
@@ -43,7 +43,7 @@ You should see the Tenstorrent System Management Interface. It allows you to vie
 
 ![TT-SMI](./imgs/tt_smi.png)
 
-5. You can now deactivate the virtual environment.
+6. You can now deactivate the virtual environment.
 
 ## Setting up the Docker Container
 


### PR DESCRIPTION
- Fixed typos in `getting_started_build_from_source.md`
- Fixed duplicate step numbering in `getting_started_docker.md`
- Fixed missing closing parentheses in code examples in `dev_notes/verification.md`
