### PR TITLE
Enhance MLIRConfig with full TTIRToTTNN pipeline options and fix inference performance regression

### DIFF
--- a/forge/csrc/forge_bindings.cpp
+++ b/forge/csrc/forge_bindings.cpp
@@ -27,6 +27,7 @@ namespace py = pybind11;
 #include "passes/extract_unique_op_configuration.hpp"
 #include "passes/fracture.hpp"
 #include "passes/mlir_compiler.hpp"
+#include "passes/mlir_config.hpp"
 #include "passes/passes_utils.hpp"
 #include "passes/split_graph.hpp"
 #include "python_bindings_common.hpp"
@@ -169,8 +170,18 @@ PYBIND11_MODULE(_C, m)
 
     py::register_exception<UnsupportedHWOpsError>(m, "UnsupportedHWOpsError");
 
+    py::enum_<tt::passes::MemoryLayoutAnalysisPolicy>(m, "MemoryLayoutAnalysisPolicy")
+        .value("DFSharding", tt::passes::MemoryLayoutAnalysisPolicy::DFSharding)
+        .value("GreedyL1Interleaved", tt::passes::MemoryLayoutAnalysisPolicy::GreedyL1Interleaved)
+        .value("BFInterleaved", tt::passes::MemoryLayoutAnalysisPolicy::BFInterleaved)
+        .export_values();
+
     py::class_<tt::passes::MLIRConfig>(m, "MLIRConfig")
         .def(py::init<>())
+        .def(
+            "set_optimization_level",
+            [](tt::passes::MLIRConfig &self, int level) { return self.set_optimization_level(level); },
+            py::arg("level"))
         .def(
             "set_enable_consteval",
             [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_consteval(enable); },
@@ -184,13 +195,113 @@ PYBIND11_MODULE(_C, m)
             [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_memory_layout_analysis(enable); },
             py::arg("enable"))
         .def(
+            "set_memory_layout_analysis_policy",
+            [](tt::passes::MLIRConfig &self, tt::passes::MemoryLayoutAnalysisPolicy policy)
+            { return self.set_memory_layout_analysis_policy(policy); },
+            py::arg("policy"))
+        .def(
+            "set_enable_l1_interleaved_fallback_analysis",
+            [](tt::passes::MLIRConfig &self, bool enable)
+            { return self.set_enable_l1_interleaved_fallback_analysis(enable); },
+            py::arg("enable"))
+        .def(
+            "set_enable_memreconfig",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_memreconfig(enable); },
+            py::arg("enable"))
+        .def(
+            "set_max_legal_layouts",
+            [](tt::passes::MLIRConfig &self, int64_t max) { return self.set_max_legal_layouts(max); },
+            py::arg("max"))
+        .def(
+            "set_enable_row_major",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_row_major(enable); },
+            py::arg("enable"))
+        .def(
+            "set_compute_cfg_math_fidelity",
+            [](tt::passes::MLIRConfig &self, tt::MathFidelity fidelity)
+            { return self.set_compute_cfg_math_fidelity(fidelity); },
+            py::arg("fidelity"))
+        .def(
+            "set_compute_cfg_fp32_dest_acc_en",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_compute_cfg_fp32_dest_acc_en(enable); },
+            py::arg("enable"))
+        .def(
+            "set_experimental_weight_dtype",
+            [](tt::passes::MLIRConfig &self, tt::DataFormat dtype)
+            { return self.set_experimental_weight_dtype(dtype); },
+            py::arg("dtype"))
+        .def(
+            "set_enable_erase_inverse_ops",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_erase_inverse_ops(enable); },
+            py::arg("enable"))
+        .def(
+            "set_enable_implicit_broadcast_folding",
+            [](tt::passes::MLIRConfig &self, bool enable)
+            { return self.set_enable_implicit_broadcast_folding(enable); },
+            py::arg("enable"))
+        .def(
+            "set_enable_permute_matmul_fusion",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_permute_matmul_fusion(enable); },
+            py::arg("enable"))
+        .def(
+            "set_enable_dram_space_saving_optimization",
+            [](tt::passes::MLIRConfig &self, bool enable)
+            { return self.set_enable_dram_space_saving_optimization(enable); },
+            py::arg("enable"))
+        .def(
+            "set_enable_remove_dead_values",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_remove_dead_values(enable); },
+            py::arg("enable"))
+        .def(
+            "set_enable_cpu_hoisted_consteval",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_cpu_hoisted_consteval(enable); },
+            py::arg("enable"))
+        .def(
+            "set_enable_consteval_inputs_to_system_memory",
+            [](tt::passes::MLIRConfig &self, bool enable)
+            { return self.set_enable_consteval_inputs_to_system_memory(enable); },
+            py::arg("enable"))
+        .def(
             "set_enable_fusing",
             [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_fusing(enable); },
             py::arg("enable"))
         .def(
+            "set_enable_d2m_fusing",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_d2m_fusing(enable); },
+            py::arg("enable"))
+        .def(
             "set_enable_fusing_conv2d_with_multiply_pattern",
             [](tt::passes::MLIRConfig &self, bool enable)
-            { return self.set_fusing_conv2d_with_multiply_pattern(enable); },
+            { return self.set_enable_fusing_conv2d_with_multiply_pattern(enable); },
+            py::arg("enable"))
+        .def(
+            "set_enable_trace",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_trace(enable); },
+            py::arg("enable"))
+        .def(
+            "set_disable_workarounds",
+            [](tt::passes::MLIRConfig &self, bool disable) { return self.set_disable_workarounds(disable); },
+            py::arg("disable"))
+        .def(
+            "set_enable_layout_workaround",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_layout_workaround(enable); },
+            py::arg("enable"))
+        .def(
+            "set_enable_decomposition_workaround",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_decomposition_workaround(enable); },
+            py::arg("enable"))
+        .def(
+            "set_enable_ttnn_perf_metrics",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_ttnn_perf_metrics(enable); },
+            py::arg("enable"))
+        .def(
+            "set_ttnn_perf_metrics_output_file",
+            [](tt::passes::MLIRConfig &self, const std::string &path)
+            { return self.set_ttnn_perf_metrics_output_file(path); },
+            py::arg("path"))
+        .def(
+            "set_enable_ttnn_perf_metrics_verbose",
+            [](tt::passes::MLIRConfig &self, bool enable) { return self.set_enable_ttnn_perf_metrics_verbose(enable); },
             py::arg("enable"))
         .def(
             "set_custom_config",

--- a/forge/csrc/passes/mlir_compiler.cpp
+++ b/forge/csrc/passes/mlir_compiler.cpp
@@ -14,6 +14,7 @@
 #include "graph_lib/defines.hpp"
 #include "llvm/Support/raw_ostream.h"
 #include "lower_to_mlir.hpp"
+#include "mlir_config.hpp"
 #include "mlir_passes.hpp"
 #include "shared_utils/json_extension.hpp"
 
@@ -236,27 +237,6 @@ std::string run_mlir_compiler_to_shared_object(
     tt::ForgeGraphModule& module, const std::optional<MLIRConfig>& mlir_config)
 {
     return run_mlir_compiler_generic<MLIROutputKind::SharedObject>(module, mlir_config);
-}
-
-void to_json(::nlohmann::json& j, const MLIRConfig& p)
-{
-    j = nlohmann::json{
-        {"enable_consteval", p.enable_consteval},
-        {"enable_optimizer", p.enable_optimizer},
-        {"enable_memory_layout_analysis", p.enable_memory_layout_analysis},
-        {"enable_fusing", p.enable_fusing},
-        {"enable_fusing_conv2d_with_multiply_pattern", p.enable_fusing_conv2d_with_multiply_pattern},
-        {"custom_config", p.custom_config}};
-}
-
-void from_json(const ::nlohmann::json& j, MLIRConfig& p)
-{
-    j.at("enable_consteval").get_to(p.enable_consteval);
-    j.at("enable_optimizer").get_to(p.enable_optimizer);
-    j.at("enable_memory_layout_analysis").get_to(p.enable_memory_layout_analysis);
-    j.at("enable_fusing").get_to(p.enable_fusing);
-    j.at("enable_fusing_conv2d_with_multiply_pattern").get_to(p.enable_fusing_conv2d_with_multiply_pattern);
-    j.at("custom_config").get_to(p.custom_config);
 }
 
 }  // namespace tt::passes

--- a/forge/csrc/passes/mlir_compiler.hpp
+++ b/forge/csrc/passes/mlir_compiler.hpp
@@ -10,6 +10,7 @@
 #include <pybind11/pybind11.h>
 #pragma clang diagnostic pop
 
+#include "mlir_config.hpp"
 #include "nlohmann/json_fwd.hpp"
 #include "tt/runtime/types.h"
 
@@ -22,61 +23,6 @@ class ForgeGraphModule;
 
 namespace tt::passes
 {
-
-/// Struct to hold the configuration for the MLIR compiler.
-struct MLIRConfig
-{
-    std::optional<bool> enable_consteval = std::nullopt;
-    std::optional<bool> enable_optimizer = std::nullopt;
-    std::optional<bool> enable_memory_layout_analysis = std::nullopt;
-    std::optional<bool> enable_fusing = std::nullopt;
-    std::optional<bool> enable_fusing_conv2d_with_multiply_pattern = std::nullopt;
-
-    // Custom configuration string for the MLIR compiler.
-    std::string custom_config = "";
-
-    MLIRConfig& set_enable_consteval(bool enable)
-    {
-        enable_consteval = enable;
-        return *this;
-    }
-
-    MLIRConfig& set_enable_optimizer(bool enable)
-    {
-        enable_optimizer = enable;
-        return *this;
-    }
-
-    MLIRConfig& set_enable_memory_layout_analysis(bool enable)
-    {
-        enable_memory_layout_analysis = enable;
-        return *this;
-    }
-
-    MLIRConfig& set_enable_fusing(bool enable)
-    {
-        enable_fusing = enable;
-        return *this;
-    }
-
-    MLIRConfig& set_fusing_conv2d_with_multiply_pattern(bool enable)
-    {
-        enable_fusing_conv2d_with_multiply_pattern = enable;
-        return *this;
-    }
-
-    // Set custom configuration string for the MLIR compiler.
-    // This can be used to pass any additional configuration options to the MLIR compiler - not covered by the existing
-    // knobs.
-    MLIRConfig& set_custom_config(const std::string& config)
-    {
-        custom_config = config;
-        return *this;
-    }
-};
-
-void to_json(nlohmann::json& j, const MLIRConfig& p);
-void from_json(const nlohmann::json& j, MLIRConfig& p);
 
 /// Public API for running MLIR passes and generating binary.
 runtime::Binary run_mlir_compiler(

--- a/forge/csrc/passes/mlir_config.cpp
+++ b/forge/csrc/passes/mlir_config.cpp
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#include "mlir_config.hpp"
+
+#include <sstream>
+
+#include "nlohmann/json.hpp"
+#include "shared_utils/json_extension.hpp"
+
+namespace tt::passes
+{
+
+void to_json(nlohmann::json& j, MemoryLayoutAnalysisPolicy p) { j = to_pipeline_string(p); }
+
+void from_json(const nlohmann::json& j, MemoryLayoutAnalysisPolicy& p)
+{
+    p = memory_layout_policy_from_string(j.get<std::string>());
+}
+
+void to_json(::nlohmann::json& j, const MLIRConfig& p)
+{
+    const auto fidelity_val = [&]() -> nlohmann::json
+    {
+        if (!p.compute_cfg_math_fidelity.has_value())
+            return nullptr;
+        return to_pipeline_string(*p.compute_cfg_math_fidelity);
+    }();
+
+    const auto weight_dtype_val = [&]() -> nlohmann::json
+    {
+        if (!p.experimental_weight_dtype.has_value())
+            return nullptr;
+        return weight_dtype_to_pipeline_string(*p.experimental_weight_dtype);
+    }();
+
+    j = nlohmann::json{// Optimization level shorthand
+                       {"optimization_level", p.optimization_level},
+                       // Optimizer control
+                       {"enable_consteval", p.enable_consteval},
+                       {"enable_optimizer", p.enable_optimizer},
+                       {"enable_memory_layout_analysis", p.enable_memory_layout_analysis},
+                       // Memory layout options
+                       {"memory_layout_analysis_policy", p.memory_layout_analysis_policy},
+                       {"enable_l1_interleaved_fallback_analysis", p.enable_l1_interleaved_fallback_analysis},
+                       {"enable_memreconfig", p.enable_memreconfig},
+                       {"max_legal_layouts", p.max_legal_layouts},
+                       {"enable_row_major", p.enable_row_major},
+                       // Compute kernel configuration
+                       {"compute_cfg_math_fidelity", fidelity_val},
+                       {"compute_cfg_fp32_dest_acc_en", p.compute_cfg_fp32_dest_acc_en},
+                       // Data type / quantization options
+                       {"experimental_weight_dtype", weight_dtype_val},
+                       // Graph transformation passes
+                       {"enable_erase_inverse_ops", p.enable_erase_inverse_ops},
+                       {"enable_implicit_broadcast_folding", p.enable_implicit_broadcast_folding},
+                       {"enable_permute_matmul_fusion", p.enable_permute_matmul_fusion},
+                       {"enable_dram_space_saving_optimization", p.enable_dram_space_saving_optimization},
+                       {"enable_remove_dead_values", p.enable_remove_dead_values},
+                       // Const-eval options
+                       {"enable_cpu_hoisted_consteval", p.enable_cpu_hoisted_consteval},
+                       {"enable_consteval_inputs_to_system_memory", p.enable_consteval_inputs_to_system_memory},
+                       // Fusing passes
+                       {"enable_fusing", p.enable_fusing},
+                       {"enable_d2m_fusing", p.enable_d2m_fusing},
+                       {"enable_fusing_conv2d_with_multiply_pattern", p.enable_fusing_conv2d_with_multiply_pattern},
+                       // Execution options
+                       {"enable_trace", p.enable_trace},
+                       // Workaround passes
+                       {"disable_workarounds", p.disable_workarounds},
+                       {"enable_layout_workaround", p.enable_layout_workaround},
+                       {"enable_decomposition_workaround", p.enable_decomposition_workaround},
+                       // Performance metrics and diagnostics
+                       {"enable_ttnn_perf_metrics", p.enable_ttnn_perf_metrics},
+                       {"ttnn_perf_metrics_output_file", p.ttnn_perf_metrics_output_file},
+                       {"enable_ttnn_perf_metrics_verbose", p.enable_ttnn_perf_metrics_verbose},
+                       // Custom configuration passthrough
+                       {"custom_config", p.custom_config}};
+}
+
+void from_json(const ::nlohmann::json& j, MLIRConfig& p)
+{
+    // Optimization level shorthand
+    j.at("optimization_level").get_to(p.optimization_level);
+    // Optimizer control
+    j.at("enable_consteval").get_to(p.enable_consteval);
+    j.at("enable_optimizer").get_to(p.enable_optimizer);
+    j.at("enable_memory_layout_analysis").get_to(p.enable_memory_layout_analysis);
+    // Memory layout options
+    j.at("memory_layout_analysis_policy").get_to(p.memory_layout_analysis_policy);
+    j.at("enable_l1_interleaved_fallback_analysis").get_to(p.enable_l1_interleaved_fallback_analysis);
+    j.at("enable_memreconfig").get_to(p.enable_memreconfig);
+    j.at("max_legal_layouts").get_to(p.max_legal_layouts);
+    j.at("enable_row_major").get_to(p.enable_row_major);
+    // Compute kernel configuration
+    {
+        const auto& jf = j.at("compute_cfg_math_fidelity");
+        p.compute_cfg_math_fidelity =
+            jf.is_null() ? std::nullopt : std::make_optional(math_fidelity_from_string(jf.get<std::string>()));
+    }
+    j.at("compute_cfg_fp32_dest_acc_en").get_to(p.compute_cfg_fp32_dest_acc_en);
+    {
+        const auto& jd = j.at("experimental_weight_dtype");
+        p.experimental_weight_dtype =
+            jd.is_null() ? std::nullopt : std::make_optional(weight_dtype_from_string(jd.get<std::string>()));
+    }
+    // Graph transformation passes
+    j.at("enable_erase_inverse_ops").get_to(p.enable_erase_inverse_ops);
+    j.at("enable_implicit_broadcast_folding").get_to(p.enable_implicit_broadcast_folding);
+    j.at("enable_permute_matmul_fusion").get_to(p.enable_permute_matmul_fusion);
+    j.at("enable_dram_space_saving_optimization").get_to(p.enable_dram_space_saving_optimization);
+    j.at("enable_remove_dead_values").get_to(p.enable_remove_dead_values);
+    // Const-eval options
+    j.at("enable_cpu_hoisted_consteval").get_to(p.enable_cpu_hoisted_consteval);
+    j.at("enable_consteval_inputs_to_system_memory").get_to(p.enable_consteval_inputs_to_system_memory);
+    // Fusing passes
+    j.at("enable_fusing").get_to(p.enable_fusing);
+    j.at("enable_d2m_fusing").get_to(p.enable_d2m_fusing);
+    j.at("enable_fusing_conv2d_with_multiply_pattern").get_to(p.enable_fusing_conv2d_with_multiply_pattern);
+    // Execution options
+    j.at("enable_trace").get_to(p.enable_trace);
+    // Workaround passes
+    j.at("disable_workarounds").get_to(p.disable_workarounds);
+    j.at("enable_layout_workaround").get_to(p.enable_layout_workaround);
+    j.at("enable_decomposition_workaround").get_to(p.enable_decomposition_workaround);
+    // Performance metrics and diagnostics
+    j.at("enable_ttnn_perf_metrics").get_to(p.enable_ttnn_perf_metrics);
+    j.at("ttnn_perf_metrics_output_file").get_to(p.ttnn_perf_metrics_output_file);
+    j.at("enable_ttnn_perf_metrics_verbose").get_to(p.enable_ttnn_perf_metrics_verbose);
+    // Custom configuration passthrough
+    j.at("custom_config").get_to(p.custom_config);
+}
+
+std::string config_to_pipeline_options(const std::optional<MLIRConfig>& mlir_config)
+{
+    std::stringstream options;
+
+    if (!mlir_config.has_value())
+        return options.str();
+
+    // -----------------------------------------------------------------------
+    // Optimization level shorthand
+    // -----------------------------------------------------------------------
+    if (mlir_config->optimization_level.has_value())
+        options << " optimization-level=" << *mlir_config->optimization_level;
+
+    // -----------------------------------------------------------------------
+    // Optimizer control
+    // -----------------------------------------------------------------------
+    if (mlir_config->enable_consteval.has_value())
+        options << " enable-const-eval=" << *mlir_config->enable_consteval;
+    if (mlir_config->enable_optimizer.has_value())
+        options << " enable-optimizer=" << *mlir_config->enable_optimizer;
+    if (mlir_config->enable_memory_layout_analysis.has_value())
+        options << " memory-layout-analysis-enabled=" << *mlir_config->enable_memory_layout_analysis;
+
+    // -----------------------------------------------------------------------
+    // Memory layout options
+    // -----------------------------------------------------------------------
+    if (mlir_config->memory_layout_analysis_policy.has_value())
+        options << " memory-layout-analysis-policy=" << to_pipeline_string(*mlir_config->memory_layout_analysis_policy);
+    if (mlir_config->enable_l1_interleaved_fallback_analysis.has_value())
+        options << " l1-interleaved-fallback-analysis-enabled="
+                << *mlir_config->enable_l1_interleaved_fallback_analysis;
+    if (mlir_config->enable_memreconfig.has_value())
+        options << " memreconfig-enabled=" << *mlir_config->enable_memreconfig;
+    if (mlir_config->max_legal_layouts.has_value())
+        options << " max-legal-layouts=" << *mlir_config->max_legal_layouts;
+    if (mlir_config->enable_row_major.has_value())
+        options << " row-major-enabled=" << *mlir_config->enable_row_major;
+
+    // -----------------------------------------------------------------------
+    // Compute kernel configuration
+    // -----------------------------------------------------------------------
+    if (mlir_config->compute_cfg_math_fidelity.has_value())
+        options << " compute-cfg-math-fidelity=" << to_pipeline_string(*mlir_config->compute_cfg_math_fidelity);
+    if (mlir_config->compute_cfg_fp32_dest_acc_en.has_value())
+        options << " compute-cfg-fp32-dest-acc-en=" << *mlir_config->compute_cfg_fp32_dest_acc_en;
+
+    // -----------------------------------------------------------------------
+    // Data type / quantization options
+    // -----------------------------------------------------------------------
+    if (mlir_config->experimental_weight_dtype.has_value())
+        options << " experimental-weight-dtype="
+                << weight_dtype_to_pipeline_string(*mlir_config->experimental_weight_dtype);
+
+    // -----------------------------------------------------------------------
+    // Graph transformation passes
+    // -----------------------------------------------------------------------
+    if (mlir_config->enable_erase_inverse_ops.has_value())
+        options << " enable-erase-inverse-ops-pass=" << *mlir_config->enable_erase_inverse_ops;
+    if (mlir_config->enable_implicit_broadcast_folding.has_value())
+        options << " enable-implicit-broadcast-folding-pass=" << *mlir_config->enable_implicit_broadcast_folding;
+    if (mlir_config->enable_permute_matmul_fusion.has_value())
+        options << " enable-permute-matmul-fusion=" << *mlir_config->enable_permute_matmul_fusion;
+    if (mlir_config->enable_dram_space_saving_optimization.has_value())
+        options << " enable-dram-space-saving-optimization-pass="
+                << *mlir_config->enable_dram_space_saving_optimization;
+    if (mlir_config->enable_remove_dead_values.has_value())
+        options << " enable-remove-dead-values=" << *mlir_config->enable_remove_dead_values;
+
+    // -----------------------------------------------------------------------
+    // Const-eval options
+    // -----------------------------------------------------------------------
+    if (mlir_config->enable_cpu_hoisted_consteval.has_value())
+        options << " enable-cpu-hoisted-const-eval=" << *mlir_config->enable_cpu_hoisted_consteval;
+    if (mlir_config->enable_consteval_inputs_to_system_memory.has_value())
+        options << " enable-const-eval-inputs-to-system-memory="
+                << *mlir_config->enable_consteval_inputs_to_system_memory;
+
+    // -----------------------------------------------------------------------
+    // Fusing passes
+    // -----------------------------------------------------------------------
+    if (mlir_config->enable_fusing.has_value())
+        options << " enable-fusing-pass=" << *mlir_config->enable_fusing;
+    if (mlir_config->enable_d2m_fusing.has_value())
+        options << " enable-d2m-fusing-pass=" << *mlir_config->enable_d2m_fusing;
+    if (mlir_config->enable_fusing_conv2d_with_multiply_pattern.has_value())
+        options << " enable-fusing-conv2d-with-multiply-pattern="
+                << *mlir_config->enable_fusing_conv2d_with_multiply_pattern;
+
+    // -----------------------------------------------------------------------
+    // Execution options
+    // -----------------------------------------------------------------------
+    if (mlir_config->enable_trace.has_value())
+        options << " enable-trace=" << *mlir_config->enable_trace;
+
+    // -----------------------------------------------------------------------
+    // Workaround passes
+    // -----------------------------------------------------------------------
+    if (mlir_config->disable_workarounds.has_value())
+        options << " disable-workarounds=" << *mlir_config->disable_workarounds;
+    if (mlir_config->enable_layout_workaround.has_value())
+        options << " enable-layout-workaround-pass=" << *mlir_config->enable_layout_workaround;
+    if (mlir_config->enable_decomposition_workaround.has_value())
+        options << " enable-decomposition-workaround-pass=" << *mlir_config->enable_decomposition_workaround;
+
+    // -----------------------------------------------------------------------
+    // Performance metrics and diagnostics
+    // -----------------------------------------------------------------------
+    if (mlir_config->enable_ttnn_perf_metrics.has_value())
+        options << " ttnn-perf-metrics-enabled=" << *mlir_config->enable_ttnn_perf_metrics;
+    if (mlir_config->ttnn_perf_metrics_output_file.has_value() && !mlir_config->ttnn_perf_metrics_output_file->empty())
+        options << " ttnn-perf-metrics-output-file=" << *mlir_config->ttnn_perf_metrics_output_file;
+    if (mlir_config->enable_ttnn_perf_metrics_verbose.has_value())
+        options << " ttnn-perf-metrics-verbose-output-enabled=" << *mlir_config->enable_ttnn_perf_metrics_verbose;
+
+    // -----------------------------------------------------------------------
+    // Custom configuration passthrough
+    // -----------------------------------------------------------------------
+    if (!mlir_config->custom_config.empty())
+        options << " " << mlir_config->custom_config;
+
+    return options.str();
+}
+
+}  // namespace tt::passes

--- a/forge/csrc/passes/mlir_config.hpp
+++ b/forge/csrc/passes/mlir_config.hpp
@@ -1,0 +1,562 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+#include "lower_to_forge/common.hpp"
+#include "nlohmann/json_fwd.hpp"
+
+namespace tt::passes
+{
+
+// ============================================================================
+// MemoryLayoutAnalysisPolicy
+//
+// Maps to the `memory-layout-analysis-policy` option of
+// TTIRToTTNNDevicePipelineOptions (TTNNPipelines.h).
+//
+// Selects the search strategy used by the sharding analysis sub-pass of the
+// TTNNOptimizer when it searches for the best tensor memory layout across the
+// full compute graph.  The option only takes effect when both
+//   enable_optimizer = true
+//   enable_memory_layout_analysis = true
+// are set (or optimization_level >= 2).
+//
+// Pipeline option: memory-layout-analysis-policy   default: DFSharding
+// ============================================================================
+enum class MemoryLayoutAnalysisPolicy
+{
+    /// Depth-first data-flow driven sharding (pipeline default).
+    /// Propagates sharding decisions top-to-bottom through the dataflow graph.
+    DFSharding,
+
+    /// Greedy search that first promotes tensors to L1-interleaved layouts
+    /// before attempting block/height/width sharding.
+    GreedyL1Interleaved,
+
+    /// Breadth-first interleaved strategy.  Analyses all ops at a given depth
+    /// before moving deeper, favouring interleaved layouts throughout.
+    BFInterleaved,
+};
+
+/// Returns the pipeline option string for the given MemoryLayoutAnalysisPolicy.
+/// Throws std::invalid_argument for unknown values.
+inline std::string to_pipeline_string(MemoryLayoutAnalysisPolicy p)
+{
+    switch (p)
+    {
+        case MemoryLayoutAnalysisPolicy::DFSharding: return "DFSharding";
+        case MemoryLayoutAnalysisPolicy::GreedyL1Interleaved: return "GreedyL1Interleaved";
+        case MemoryLayoutAnalysisPolicy::BFInterleaved: return "BFInterleaved";
+    }
+    throw std::invalid_argument("Unknown MemoryLayoutAnalysisPolicy value");
+}
+
+/// Parses a pipeline option string back into a MemoryLayoutAnalysisPolicy.
+/// Throws std::invalid_argument for unknown strings.
+inline MemoryLayoutAnalysisPolicy memory_layout_policy_from_string(const std::string& s)
+{
+    if (s == "DFSharding")
+        return MemoryLayoutAnalysisPolicy::DFSharding;
+    if (s == "GreedyL1Interleaved")
+        return MemoryLayoutAnalysisPolicy::GreedyL1Interleaved;
+    if (s == "BFInterleaved")
+        return MemoryLayoutAnalysisPolicy::BFInterleaved;
+    throw std::invalid_argument("Unknown MemoryLayoutAnalysisPolicy string: " + s);
+}
+
+void to_json(nlohmann::json& j, MemoryLayoutAnalysisPolicy p);
+void from_json(const nlohmann::json& j, MemoryLayoutAnalysisPolicy& p);
+
+/// Converts tt::MathFidelity to the MLIR pipeline option string.
+/// MathFidelity::Invalid maps to "undefined" (backend-selected fidelity).
+inline std::string to_pipeline_string(tt::MathFidelity f)
+{
+    switch (f)
+    {
+        case tt::MathFidelity::LoFi: return "lofi";
+        case tt::MathFidelity::HiFi2: return "hifi2";
+        case tt::MathFidelity::HiFi3: return "hifi3";
+        case tt::MathFidelity::HiFi4: return "hifi4";
+        case tt::MathFidelity::Invalid: return "undefined";
+    }
+    throw std::invalid_argument("Unknown MathFidelity value");
+}
+
+/// Parses a math-fidelity pipeline string back into tt::MathFidelity.
+/// "undefined" maps to MathFidelity::Invalid.
+inline tt::MathFidelity math_fidelity_from_string(const std::string& s)
+{
+    if (s == "lofi")
+        return tt::MathFidelity::LoFi;
+    if (s == "hifi2")
+        return tt::MathFidelity::HiFi2;
+    if (s == "hifi3")
+        return tt::MathFidelity::HiFi3;
+    if (s == "hifi4")
+        return tt::MathFidelity::HiFi4;
+    if (s == "undefined")
+        return tt::MathFidelity::Invalid;
+    throw std::invalid_argument("Unknown MathFidelity pipeline string: " + s);
+}
+
+/// Converts a weight-dtype DataFormat value to the MLIR pipeline option string.
+/// Only DataFormat::Bfp8_b and DataFormat::Bfp4_b are accepted; all other
+/// values throw std::invalid_argument.
+inline std::string weight_dtype_to_pipeline_string(tt::DataFormat d)
+{
+    switch (d)
+    {
+        case tt::DataFormat::Bfp8_b: return "bfp_bf8";
+        case tt::DataFormat::Bfp4_b: return "bfp_bf4";
+        default:
+            throw std::invalid_argument(
+                "experimental_weight_dtype only accepts DataFormat::Bfp8_b or "
+                "DataFormat::Bfp4_b");
+    }
+}
+
+/// Parses a weight-dtype pipeline string back into a tt::DataFormat value.
+inline tt::DataFormat weight_dtype_from_string(const std::string& s)
+{
+    if (s == "bfp_bf8")
+        return tt::DataFormat::Bfp8_b;
+    if (s == "bfp_bf4")
+        return tt::DataFormat::Bfp4_b;
+    throw std::invalid_argument("Unknown weight dtype pipeline string: " + s);
+}
+
+// ============================================================================
+// MLIRConfig
+//
+// Typed configuration wrapper for TTIRToTTNNDevicePipelineOptions
+// (TTNNPipelines.h).  Used to pass compile-time options from Python / C++
+// callers through to the MLIR pipeline without requiring knowledge of the
+// internal MLIR option-string format.
+//
+// Each field is std::optional.  When left as std::nullopt, the option is
+// omitted from the pipeline string and the pipeline uses its built-in default
+// ============================================================================
+struct MLIRConfig
+{
+    // -------------------------------------------------------------------------
+    // Optimization level shorthand
+    // Pipeline option : optimization-level   default: 0
+    //
+    //  0 — All optimizer passes disabled. Fastest compile, baseline runtime.
+    //      Equivalent to: enable_optimizer=false, memory_layout_analysis=false.
+    //  1 — Optimizer on; Conv2d-multiply fusing on; sharding (MLA) off.
+    //      Equivalent to: enable_optimizer=true,
+    //                     enable_fusing_conv2d_with_multiply_pattern=true.
+    //  2 — All optimizer passes including sharding.  Longest compile, best
+    //      runtime.  Equivalent to level 1 + enable_memory_layout_analysis=true.
+    //
+    // -------------------------------------------------------------------------
+    std::optional<int> optimization_level = std::nullopt;
+
+    // -------------------------------------------------------------------------
+    // Optimizer control
+    // -------------------------------------------------------------------------
+
+    /// Pipeline option: enable-const-eval   default: true
+    /// Folds constant sub-graphs at compile time, eliminating redundant
+    /// on-device computation for weights and static inputs.
+    std::optional<bool> enable_consteval = std::nullopt;
+
+    /// Pipeline option: enable-optimizer   default: false
+    /// Master switch for the TTNNOptimizer pass.  When enabled, the compiler
+    /// determines the optimal Tensix core grid, sharding strategy, and memory
+    /// placement (L1 vs DRAM) for every operation.
+    /// Note: requires TTMLIR_ENABLE_OPMODEL=ON at build time.
+    /// Automatically enabled when optimization_level >= 1.
+    std::optional<bool> enable_optimizer = std::nullopt;
+
+    /// Pipeline option: memory-layout-analysis-enabled   default: false
+    /// Enables the sharding analysis sub-pass of the optimizer.  Searches the
+    /// full compute graph for the best L1-sharding layout for each tensor.
+    /// Requires enable_optimizer = true.
+    /// Automatically enabled when optimization_level >= 2.
+    std::optional<bool> enable_memory_layout_analysis = std::nullopt;
+
+    // -------------------------------------------------------------------------
+    // Memory layout options
+    // -------------------------------------------------------------------------
+
+    /// Pipeline option: memory-layout-analysis-policy   default: DFSharding
+    /// Selects the sharding search strategy used by the memory layout analysis
+    /// pass.
+    std::optional<MemoryLayoutAnalysisPolicy> memory_layout_analysis_policy = std::nullopt;
+
+    /// Pipeline option: l1-interleaved-fallback-analysis-enabled   default: false
+    /// Lightweight pass that promotes DRAM-interleaved tensors to L1-interleaved
+    /// when sufficient on-chip SRAM is available.  Works independently of the
+    /// full sharding analysis (enable_memory_layout_analysis not required).
+    std::optional<bool> enable_l1_interleaved_fallback_analysis = std::nullopt;
+
+    /// Pipeline option: memreconfig-enabled   default: true
+    /// Inserts ToLayout ops between operations whose output/input memory
+    /// layouts are incompatible.  Disable only for debugging — may produce
+    /// incorrect results when off.
+    std::optional<bool> enable_memreconfig = std::nullopt;
+
+    /// Pipeline option: max-legal-layouts   default: 8
+    /// Maximum number of sharded layout candidates the optimizer generates and
+    /// evaluates per operation during legal layout analysis.
+    std::optional<int64_t> max_legal_layouts = std::nullopt;
+
+    /// Pipeline option: row-major-enabled   default: false
+    /// Includes row-major layout as a candidate during legal layout analysis.
+    /// Can improve ops that run faster in row-major; increases the search space.
+    std::optional<bool> enable_row_major = std::nullopt;
+
+    // -------------------------------------------------------------------------
+    // Compute kernel configuration
+    // -------------------------------------------------------------------------
+
+    /// Pipeline option: compute-cfg-math-fidelity   default: hifi4
+    /// Arithmetic fidelity for all Tensix compute kernels that expose a
+    /// ComputeKernelConfig.  Uses the canonical tt::MathFidelity enum from
+    /// lower_to_forge/common.hpp.
+    ///
+    ///   MathFidelity::LoFi    — lowest precision, fastest throughput
+    ///   MathFidelity::HiFi2   — good accuracy/speed trade-off
+    ///   MathFidelity::HiFi3   — high accuracy
+    ///   MathFidelity::HiFi4   — highest accuracy (pipeline default)
+    ///   MathFidelity::Invalid — let the backend choose ("undefined")
+    std::optional<tt::MathFidelity> compute_cfg_math_fidelity = std::nullopt;
+
+    /// Pipeline option: compute-cfg-fp32-dest-acc-en   default: true
+    /// When true, intermediate sums are accumulated in FP32 before being
+    /// written back to the output tensor.  Setting false uses the native
+    /// accumulator width (typically the same as the input dtype), which is
+    /// faster at the cost of slightly lower precision on FP16/BF16 workloads.
+    std::optional<bool> compute_cfg_fp32_dest_acc_en = std::nullopt;
+
+    // -------------------------------------------------------------------------
+    // Data type / quantization options
+    // -------------------------------------------------------------------------
+
+    /// Pipeline option: experimental-weight-dtype   default: none (nullopt)
+    /// Experimental: converts weight tensors in matmul / linear operations to a
+    /// reduced-precision block-floating-point format, reducing DRAM bandwidth.
+    /// Uses tt::DataFormat from lower_to_forge/common.hpp.
+    ///
+    ///   DataFormat::Bfp8_b — BFP BFloat8 (8-bit mantissa)
+    ///   DataFormat::Bfp4_b — BFP BFloat4 (4-bit mantissa)
+    ///   std::nullopt        — no conversion (pipeline default "none")
+    ///
+    /// Only DataFormat::Bfp8_b and DataFormat::Bfp4_b are accepted; all other
+    /// DataFormat values are rejected by set_experimental_weight_dtype().
+    std::optional<tt::DataFormat> experimental_weight_dtype = std::nullopt;
+
+    // -------------------------------------------------------------------------
+    // Graph transformation passes
+    // -------------------------------------------------------------------------
+
+    /// Pipeline option: enable-erase-inverse-ops-pass   default: true
+    /// Cancels pairs of inverse operations, reducing unnecessary data movement.
+    std::optional<bool> enable_erase_inverse_ops = std::nullopt;
+
+    /// Pipeline option: enable-implicit-broadcast-folding-pass   default: true
+    /// Folds implicit broadcast operations into downstream consumers,
+    /// eliminating standalone broadcast ops where possible.
+    std::optional<bool> enable_implicit_broadcast_folding = std::nullopt;
+
+    /// Pipeline option: enable-permute-matmul-fusion   default: false
+    /// Fuses permute / transpose operations into adjacent matmul operations
+    /// so that no separate transpose kernel is dispatched.
+    std::optional<bool> enable_permute_matmul_fusion = std::nullopt;
+
+    /// Pipeline option: enable-dram-space-saving-optimization-pass   default: false
+    /// Reduces peak DRAM memory usage by safely reusing buffers across ops
+    /// whose live ranges do not overlap.
+    std::optional<bool> enable_dram_space_saving_optimization = std::nullopt;
+
+    /// Pipeline option: enable-remove-dead-values   default: false
+    /// Eliminates dead (unused) values and their producers from the compute
+    /// graph, reducing both compile time and runtime overhead.
+    /// Note: this pass can significantly increase peak memory consumption
+    /// during compilation; disabled by default for this reason.
+    std::optional<bool> enable_remove_dead_values = std::nullopt;
+
+    // -------------------------------------------------------------------------
+    // Const-eval (constant folding) options
+    // -------------------------------------------------------------------------
+
+    /// Pipeline option: enable-cpu-hoisted-const-eval   default: true
+    /// Hoists constant sub-graphs to CPU execution, folding them at compile
+    /// time rather than dispatching them to device at every inference call.
+    std::optional<bool> enable_cpu_hoisted_consteval = std::nullopt;
+
+    /// Pipeline option: enable-const-eval-inputs-to-system-memory   default: true
+    /// Stores the output of const-eval sub-graphs in system (host) memory
+    /// instead of device DRAM.  Disable if device DRAM capacity is not a
+    /// bottleneck and lower host-to-device latency is preferred.
+    std::optional<bool> enable_consteval_inputs_to_system_memory = std::nullopt;
+
+    // -------------------------------------------------------------------------
+    // Fusing passes
+    // -------------------------------------------------------------------------
+
+    /// Pipeline option: enable-fusing-pass   default: true
+    /// Master switch for the general op-fusion pass.
+    std::optional<bool> enable_fusing = std::nullopt;
+
+    /// Pipeline option: enable-fusing-conv2d-with-multiply-pattern   default: false
+    /// Fuses Conv2d with a subsequent elementwise multiply (e.g. channel
+    /// scaling or batch-norm weight fold).  Automatically enabled at
+    /// optimization_level >= 1.
+    std::optional<bool> enable_fusing_conv2d_with_multiply_pattern = std::nullopt;
+
+    /// Pipeline option: enable-d2m-fusing-pass   default: false
+    /// Fuses device-to-memory (D2M) data movement operations into adjacent
+    /// compute kernels where possible.
+    std::optional<bool> enable_d2m_fusing = std::nullopt;
+
+    // -------------------------------------------------------------------------
+    // Execution options
+    // -------------------------------------------------------------------------
+
+    /// Pipeline option: enable-trace   default: false
+    /// Enables TTNN program tracing.  The first inference call captures the
+    /// compute graph; subsequent calls replay the captured trace, reducing
+    /// host-side dispatch overhead for repeated inference.
+    std::optional<bool> enable_trace = std::nullopt;
+
+    // -------------------------------------------------------------------------
+    // Workaround passes
+    // -------------------------------------------------------------------------
+
+    /// Pipeline option: disable-workarounds   default: false
+    /// Disables all hardware compatibility workaround passes in one flag.
+    /// Use only for debugging; likely to produce incorrect results on real
+    /// Tenstorrent hardware.
+    std::optional<bool> disable_workarounds = std::nullopt;
+
+    /// Pipeline option: enable-layout-workaround-pass   default: true
+    /// Inserts layout conversion ops required for operations whose expected
+    /// input layout differs from their producer's output layout.
+    /// Automatically overridden to false when enable_optimizer = true.
+    std::optional<bool> enable_layout_workaround = std::nullopt;
+
+    /// Pipeline option: enable-decomposition-workaround-pass   default: true
+    /// Decomposes compound ops that are not natively supported on the target
+    /// hardware into sequences of supported primitives.
+    std::optional<bool> enable_decomposition_workaround = std::nullopt;
+
+    // -------------------------------------------------------------------------
+    // Performance metrics and diagnostics
+    // -------------------------------------------------------------------------
+
+    /// Pipeline option: ttnn-perf-metrics-enabled   default: false
+    /// Instruments the compiled program to collect per-op TTNN performance
+    /// counters (cycles, bandwidth, compute utilisation).
+    std::optional<bool> enable_ttnn_perf_metrics = std::nullopt;
+
+    /// Pipeline option: ttnn-perf-metrics-output-file   default: ""
+    /// Path to the file where the TTNN performance report is written.
+    /// When empty, the pipeline generates a filename based on the module or
+    /// function name under the "perf_metrics" directory.
+    /// Only meaningful when enable_ttnn_perf_metrics = true.
+    std::optional<std::string> ttnn_perf_metrics_output_file = std::nullopt;
+
+    /// Pipeline option: ttnn-perf-metrics-verbose-output-enabled   default: true
+    /// Enables verbose mode in the TTNN performance metrics report, including
+    /// per-operation details.
+    std::optional<bool> enable_ttnn_perf_metrics_verbose = std::nullopt;
+
+    // -------------------------------------------------------------------------
+    // Custom configuration passthrough
+    //
+    // Any pipeline option not covered by the typed fields above can be supplied
+    // as a raw, space-separated option string.  This string is appended verbatim
+    // to the generated pipeline option string and takes precedence over any
+    // conflicting structured field.
+    // -------------------------------------------------------------------------
+    std::string custom_config = "";
+
+    MLIRConfig& set_optimization_level(int level)
+    {
+        if (level < 0 || level > 2)
+            throw std::out_of_range("optimization_level must be 0, 1, or 2");
+        optimization_level = level;
+        return *this;
+    }
+
+    // Optimizer control
+    MLIRConfig& set_enable_consteval(bool v)
+    {
+        enable_consteval = v;
+        return *this;
+    }
+    MLIRConfig& set_enable_optimizer(bool v)
+    {
+        enable_optimizer = v;
+        return *this;
+    }
+    MLIRConfig& set_enable_memory_layout_analysis(bool v)
+    {
+        enable_memory_layout_analysis = v;
+        return *this;
+    }
+
+    // Memory layout options
+    MLIRConfig& set_memory_layout_analysis_policy(MemoryLayoutAnalysisPolicy p)
+    {
+        memory_layout_analysis_policy = p;
+        return *this;
+    }
+    MLIRConfig& set_enable_l1_interleaved_fallback_analysis(bool v)
+    {
+        enable_l1_interleaved_fallback_analysis = v;
+        return *this;
+    }
+    MLIRConfig& set_enable_memreconfig(bool v)
+    {
+        enable_memreconfig = v;
+        return *this;
+    }
+
+    MLIRConfig& set_max_legal_layouts(int64_t max)
+    {
+        if (max <= 0)
+            throw std::out_of_range("max_legal_layouts must be greater than 0");
+        max_legal_layouts = max;
+        return *this;
+    }
+    MLIRConfig& set_enable_row_major(bool v)
+    {
+        enable_row_major = v;
+        return *this;
+    }
+
+    MLIRConfig& set_compute_cfg_math_fidelity(tt::MathFidelity f)
+    {
+        compute_cfg_math_fidelity = f;
+        return *this;
+    }
+    MLIRConfig& set_compute_cfg_fp32_dest_acc_en(bool v)
+    {
+        compute_cfg_fp32_dest_acc_en = v;
+        return *this;
+    }
+
+    MLIRConfig& set_experimental_weight_dtype(tt::DataFormat d)
+    {
+        if (d != tt::DataFormat::Bfp8_b && d != tt::DataFormat::Bfp4_b)
+            throw std::invalid_argument(
+                "experimental_weight_dtype only accepts "
+                "DataFormat::Bfp8_b or DataFormat::Bfp4_b");
+        experimental_weight_dtype = d;
+        return *this;
+    }
+
+    MLIRConfig& set_enable_erase_inverse_ops(bool v)
+    {
+        enable_erase_inverse_ops = v;
+        return *this;
+    }
+    MLIRConfig& set_enable_implicit_broadcast_folding(bool v)
+    {
+        enable_implicit_broadcast_folding = v;
+        return *this;
+    }
+    MLIRConfig& set_enable_permute_matmul_fusion(bool v)
+    {
+        enable_permute_matmul_fusion = v;
+        return *this;
+    }
+    MLIRConfig& set_enable_dram_space_saving_optimization(bool v)
+    {
+        enable_dram_space_saving_optimization = v;
+        return *this;
+    }
+    MLIRConfig& set_enable_remove_dead_values(bool v)
+    {
+        enable_remove_dead_values = v;
+        return *this;
+    }
+
+    MLIRConfig& set_enable_cpu_hoisted_consteval(bool v)
+    {
+        enable_cpu_hoisted_consteval = v;
+        return *this;
+    }
+    MLIRConfig& set_enable_consteval_inputs_to_system_memory(bool v)
+    {
+        enable_consteval_inputs_to_system_memory = v;
+        return *this;
+    }
+
+    MLIRConfig& set_enable_fusing(bool v)
+    {
+        enable_fusing = v;
+        return *this;
+    }
+    MLIRConfig& set_enable_d2m_fusing(bool v)
+    {
+        enable_d2m_fusing = v;
+        return *this;
+    }
+    MLIRConfig& set_enable_fusing_conv2d_with_multiply_pattern(bool v)
+    {
+        enable_fusing_conv2d_with_multiply_pattern = v;
+        return *this;
+    }
+
+    MLIRConfig& set_enable_trace(bool v)
+    {
+        enable_trace = v;
+        return *this;
+    }
+
+    MLIRConfig& set_disable_workarounds(bool v)
+    {
+        disable_workarounds = v;
+        return *this;
+    }
+    MLIRConfig& set_enable_layout_workaround(bool v)
+    {
+        enable_layout_workaround = v;
+        return *this;
+    }
+    MLIRConfig& set_enable_decomposition_workaround(bool v)
+    {
+        enable_decomposition_workaround = v;
+        return *this;
+    }
+
+    MLIRConfig& set_enable_ttnn_perf_metrics(bool v)
+    {
+        enable_ttnn_perf_metrics = v;
+        return *this;
+    }
+    MLIRConfig& set_ttnn_perf_metrics_output_file(const std::string& path)
+    {
+        ttnn_perf_metrics_output_file = path;
+        return *this;
+    }
+    MLIRConfig& set_enable_ttnn_perf_metrics_verbose(bool v)
+    {
+        enable_ttnn_perf_metrics_verbose = v;
+        return *this;
+    }
+
+    MLIRConfig& set_custom_config(const std::string& config)
+    {
+        custom_config = config;
+        return *this;
+    }
+};
+
+void to_json(nlohmann::json& j, const MLIRConfig& p);
+void from_json(const nlohmann::json& j, MLIRConfig& p);
+
+std::string config_to_pipeline_options(const std::optional<MLIRConfig>& mlir_config);
+
+}  // namespace tt::passes

--- a/forge/csrc/passes/mlir_passes.cpp
+++ b/forge/csrc/passes/mlir_passes.cpp
@@ -8,6 +8,7 @@
 
 // Forge headers
 #include "mlir_compiler.hpp"
+#include "mlir_config.hpp"
 #include "utils/logger.hpp"
 
 // MLIR headers
@@ -40,43 +41,6 @@ void register_mlir_passes()
     (void)_;
 }
 
-std::string config_to_pipeline_options(const std::optional<MLIRConfig> &mlir_config)
-{
-    std::stringstream options{""};
-
-    // Convert the MLIRConfig to a string of pipeline options.
-    // If the config is not set, return an empty string.
-    if (mlir_config.has_value())
-    {
-        // Add all specified configs to the options string.
-        if (mlir_config->enable_consteval.has_value())
-        {
-            options << " enable-const-eval=" << *mlir_config->enable_consteval;
-        }
-        if (mlir_config->enable_optimizer.has_value())
-        {
-            options << " enable-optimizer=" << *mlir_config->enable_optimizer;
-        }
-        if (mlir_config->enable_memory_layout_analysis.has_value())
-        {
-            options << " memory-layout-analysis-enabled=" << *mlir_config->enable_memory_layout_analysis;
-        }
-        if (mlir_config->enable_fusing.has_value())
-        {
-            options << " enable-fusing-pass=" << *mlir_config->enable_fusing;
-        }
-        if (mlir_config->enable_fusing_conv2d_with_multiply_pattern.has_value())
-        {
-            options << " enable-fusing-conv2d-with-multiply-pattern="
-                    << *mlir_config->enable_fusing_conv2d_with_multiply_pattern;
-        }
-        // Add custom configuration options.
-        options << " " << mlir_config->custom_config;
-    }
-
-    return options.str();
-}
-
 template <MLIROutputKind output>
 void run_mlir_passes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module, const std::optional<MLIRConfig> &mlir_config)
 {
@@ -89,7 +53,7 @@ void run_mlir_passes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module, const std::
     // Get the pipeline info for the wanted pipeline.
     static_assert(
         output == MLIROutputKind::Flatbuffer || output == MLIROutputKind::Cpp || output == MLIROutputKind::SharedObject,
-        "Handling only Flatbuffer and Cpp output correctly.");
+        "Unsupported MLIROutputKind: only Flatbuffer, Cpp, and SharedObject are handled.");
 
     const char *pipeline_name;
     if constexpr (output == MLIROutputKind::Flatbuffer)
@@ -114,7 +78,6 @@ void run_mlir_passes(mlir::OwningOpRef<mlir::ModuleOp> &mlir_module, const std::
         return mlir::failure();
     };
 
-    // Pipeline options are empty for now.
     std::string options{config_to_pipeline_options(mlir_config)};
 
     // Add target-dylib flag for SharedObject output

--- a/forge/csrc/runtime/tensor.hpp
+++ b/forge/csrc/runtime/tensor.hpp
@@ -134,6 +134,16 @@ class TensorImpl : public std::enable_shared_from_this<TensorImpl>
                 host_storage->data_ptr(), desc.shape, desc.stride, desc.itemsize, desc.dataType);
         }
 
+        // Skip the toLayout call when the tensor is already in the target layout.
+        // This is the common case for persistent inputs (weights/parameters) on repeated inference
+        // calls — they are moved to device once and stay in the correct layout across runs.
+        // For training scenarios where layout must change between programs, hasLayout returns false
+        // and the conversion proceeds correctly.
+        if (tt::runtime::hasLayout(rt_tensor.value(), layout))
+        {
+            return;
+        }
+
         auto device = TTSystem::get_system().devices[device_id];
         rt_tensor = tt::runtime::toLayout(rt_tensor.value(), *device->rt_device, layout);
     }


### PR DESCRIPTION
Fixes https://github.com/tenstorrent/tt-forge-onnx/issues/3241

## Summary

- Expanded `MLIRConfig` from 5 options to 30+ typed options, exposing nearly all `TTIRToTTNNDevicePipelineOptions` from `tt-mlir`
- Extracted `MLIRConfig` into dedicated files (`mlir_config.hpp` / `mlir_config.cpp`), decoupling it from `mlir_compiler.hpp`
- Fixed inference performance regression on persistent inputs caused by unconditional `toLayout` calls introduced in #3226, restoring ResNet-50 ONNX benchmark from ~55ms  back to ~4.48ms 

## Problem Description

### 1. Limited MLIRConfig coverage

The existing `MLIRConfig` only exposed 5 pipeline options:

| Option | Pipeline flag |
|---|---|
| `enable_consteval` | `enable-const-eval` |
| `enable_optimizer` | `enable-optimizer` |
| `enable_memory_layout_analysis` | `memory-layout-analysis-enabled` |
| `enable_fusing` | `enable-fusing-pass` |
| `enable_fusing_conv2d_with_multiply_pattern` | `enable-fusing-conv2d-with-multiply-pattern` |

Users who needed to tune other TTIR→TTNN pipeline knobs — math fidelity, trace mode, L1-interleaved fallback, sharding policy, dead-value removal, etc. — had to use the raw `custom_config` string, which is error-prone, lacks validation, and provides no discoverability.

The full set of options available in `TTIRToTTNNDevicePipelineOptions` ([TTNNPipelines.h](https://github.com/tenstorrent/tt-mlir/blob/main/include/ttmlir/Dialect/TTNN/Pipelines/TTNNPipelines.h)) was left unexposed.

### 2. Inference performance regression on repeated runs

Commit f035fb84 (#3226, "Fix input tensor layout mismatch") removed the `if (!on_device())` guard in `state.cpp` to fix training scenarios where tensors flow across independently compiled programs (forward → backward → optimizer) with different layout requirements.

However, this caused **every** input — including persistent inputs (weights/parameters) already on-device in the correct layout — to unconditionally go through `tt::runtime::toLayout()` on **every** `run_program` call. The runtime's `toLayout()` has no built-in early-exit: even when source and target layouts are identical.

For ResNet-50 with ~100+ persistent weight tensors, this added ~50ms of redundant overhead per inference call:

| Metric | Before #3226 | After #3226 |
|---|---|---|
| Inference time (H2D + run + D2H) | **4.48 ± 0.15 ms** | ~55 ms |

## What's Changed

### New files: `mlir_config.hpp` / `mlir_config.cpp`

Extracted `MLIRConfig` into its own translation unit with comprehensive typed coverage of `TTIRToTTNNDevicePipelineOptions`:

<details>
<summary><b>Full option list (30+ fields across 10 categories)</b></summary>

| Category | Field | Pipeline option | Default |
|---|---|---|---|
| **Optimization** | `optimization_level` | `optimization-level` | 0 |
| **Optimizer** | `enable_consteval` | `enable-const-eval` | true |
| | `enable_optimizer` | `enable-optimizer` | false |
| | `enable_memory_layout_analysis` | `memory-layout-analysis-enabled` | false |
| **Memory layout** | `memory_layout_analysis_policy` | `memory-layout-analysis-policy` | DFSharding |
| | `enable_l1_interleaved_fallback_analysis` | `l1-interleaved-fallback-analysis-enabled` | false |
| | `enable_memreconfig` | `memreconfig-enabled` | true |
| | `max_legal_layouts` | `max-legal-layouts` | 8 |
| | `enable_row_major` | `row-major-enabled` | false |
| **Compute kernel** | `compute_cfg_math_fidelity` | `compute-cfg-math-fidelity` | hifi4 |
| | `compute_cfg_fp32_dest_acc_en` | `compute-cfg-fp32-dest-acc-en` | true |
| **Data type** | `experimental_weight_dtype` | `experimental-weight-dtype` | none |
| **Graph transforms** | `enable_erase_inverse_ops` | `enable-erase-inverse-ops-pass` | true |
| | `enable_implicit_broadcast_folding` | `enable-implicit-broadcast-folding-pass` | true |
| | `enable_permute_matmul_fusion` | `enable-permute-matmul-fusion` | false |
| | `enable_dram_space_saving_optimization` | `enable-dram-space-saving-optimization-pass` | false |
| | `enable_remove_dead_values` | `enable-remove-dead-values` | false |
| **Const-eval** | `enable_cpu_hoisted_consteval` | `enable-cpu-hoisted-const-eval` | true |
| | `enable_consteval_inputs_to_system_memory` | `enable-const-eval-inputs-to-system-memory` | true |
| **Fusing** | `enable_fusing` | `enable-fusing-pass` | true |
| | `enable_d2m_fusing` | `enable-d2m-fusing-pass` | false |
| | `enable_fusing_conv2d_with_multiply_pattern` | `enable-fusing-conv2d-with-multiply-pattern` | false |
| **Execution** | `enable_trace` | `enable-trace` | false |
| **Workarounds** | `disable_workarounds` | `disable-workarounds` | false |
| | `enable_layout_workaround` | `enable-layout-workaround-pass` | true |
| | `enable_decomposition_workaround` | `enable-decomposition-workaround-pass` | true |
| **Perf metrics** | `enable_ttnn_perf_metrics` | `ttnn-perf-metrics-enabled` | false |
| | `ttnn_perf_metrics_output_file` | `ttnn-perf-metrics-output-file` | "" |
| | `enable_ttnn_perf_metrics_verbose` | `ttnn-perf-metrics-verbose-output-enabled` | true |

</details>

Design choices:
- All fields are `std::optional` — when unset (`std::nullopt`), the option is omitted from the pipeline string and the MLIR pipeline uses its built-in default
- Input validation on construction (e.g., `optimization_level` must be 0–2, `experimental_weight_dtype` only accepts `Bfp8_b` / `Bfp4_b`, `max_legal_layouts` must be > 0)
- Full JSON round-trip serialization (`to_json` / `from_json`) for all fields

### `mlir_compiler.hpp` / `mlir_compiler.cpp`

- Moved `MLIRConfig` struct, JSON serialization, and pipeline-string generation out to `mlir_config.hpp`/`.cpp`
- Removed inlined `to_json`/`from_json` for the old 5-field config

### `mlir_passes.cpp`

- Removed old `config_to_pipeline_options()` implementation (replaced by the comprehensive version in `mlir_config.cpp`)

### `forge_bindings.cpp`

- Exposed `MemoryLayoutAnalysisPolicy` enum to Python with all three values
- Registered all 30+ `MLIRConfig` setter methods in pybind11 bindings
- Fixed naming inconsistency: `set_fusing_conv2d_with_multiply_pattern` → `set_enable_fusing_conv2d_with_multiply_pattern`

### `tensor.hpp` — performance fix

Added a `tt::runtime::hasLayout()` early-exit check in `TensorImpl::to_layout()` before the expensive `tt::runtime::toLayout()` call:

```cpp
if (tt::runtime::hasLayout(rt_tensor.value(), layout))
{
    return;  // already in the target layout — skip
}
```

This is a finer-grained guard than the original `if (!on_device())` that was removed in #3226:

| Guard | Inference (repeated runs) | Training (cross-program tensor flow) |
|---|---|---|
| Old: `if (!on_device())` | Fast — skips if on device | **Broken** — skips even when layout mismatches |
| #3226: no guard | **Slow** — always converts | Correct — always converts |
| This PR: `if (hasLayout(...))` | **Fast** — skips when layout matches | **Correct** — converts when layout differs |

`hasLayout()` compares the full `LayoutDesc` (storage type, layout mode, data type, memory config) via `operator==`. It returns `false` whenever the tensor needs any transition — host↔device, TILE↔ROW_MAJOR, or memory config change — so the training cases fixed by #3226 remain correct.

**Result:** ResNet-50 ONNX benchmark inference restored to **~4.48 ± 0.15 ms** and **~221 FPS**.
