### PR TITLE
Fix dla model loading issue and track tt_forge_models

### DIFF
--- a/forge/test/models/onnx/vision/dla/test_dla.py
+++ b/forge/test/models/onnx/vision/dla/test_dla.py
@@ -27,10 +27,10 @@ variants = [
     ModelVariant.DLA60,
     pytest.param(ModelVariant.DLA60X, marks=pytest.mark.pr_models_regression),
     ModelVariant.DLA60X_C,
-    pytest.param(ModelVariant.DLA102),
-    pytest.param(ModelVariant.DLA102X),
+    ModelVariant.DLA102,
+    ModelVariant.DLA102X,
     ModelVariant.DLA102X2,
-    pytest.param(ModelVariant.DLA169),
+    ModelVariant.DLA169,
 ]
 
 
@@ -43,7 +43,7 @@ def test_dla_onnx(variant, tmp_path):
         model=ModelArch.DLA,
         variant=variant,
         task=Task.CV_IMAGE_ENCODING,
-        source=Source.TORCHVISION,
+        source=Source.TIMM,
     )
 
     # Load model and input using tt_forge_models
@@ -72,9 +72,6 @@ def test_dla_onnx(variant, tmp_path):
 
     # Compile
     compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
-
-    # Adjust verify config for known numerical sensitivity
-    verify_cfg = VerifyConfig()
 
     # Verify
     _, co_out = verify(inputs, framework_model, compiled_model)


### PR DESCRIPTION
## Summary

This PR fixes a model loading issue in the DLA  ONNX test suite and updates the `tt_forge_models` submodule to the latest commit.

**Changes:**

- **`forge/test/models/onnx/vision/dla/test_dla.py`**
  - Switched the model source from `TORCHVISION` to `TIMM` to correctly load DLA models, resolving the loading failure.
  - Removed unnecessary `pytest.param()` wrappers around `DLA102`, `DLA102X`, and `DLA169` variants (no marks were attached, so plain enum values are sufficient).
  - Removed a stale/redundant `VerifyConfig()` instantiation that was unused after cleanup.

- **`third_party/tt_forge_models`**
  - Updated the submodule pointer to the latest commit (`d1b7f61`) to track upstream changes in `tt_forge_models`.
