### PR TITLE
 Fix permission error in submodule uplift reusable workflow

### DIFF
--- a/.github/workflows/call-uplift-submodule.yml
+++ b/.github/workflows/call-uplift-submodule.yml
@@ -24,10 +24,6 @@ on:
         required: true
         type: string
 
-permissions:
-  packages: write
-  checks: write
-
 jobs:
   uplift-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Removes the top-level `permissions` block (`checks: write`, `packages: write`) from `call-uplift-submodule.yml`.

## Problem

The `nightly-uplift-mlir.yml` caller workflow was failing at startup with:

> Error calling workflow: The workflow is requesting 'checks: write, packages: write', but is only allowed 'checks: none, packages: read'.

GitHub enforces that a reusable workflow (`workflow_call`) cannot request permissions beyond what the calling workflow's token allows. The `schedule`/`workflow_dispatch` triggers run under a restricted default token, so the elevated permissions declared in the reusable workflow were rejected before any job could run.

## Fix

Removed the unnecessary `permissions` block from `call-uplift-submodule.yml`. All write operations in the reusable workflow already use explicit PAT secrets (`GH_TOKEN`, `GH_APPROVE_TOKEN`) rather than the default `GITHUB_TOKEN`, so no elevated `GITHUB_TOKEN` permissions are needed.

## Related

- Failing run: https://github.com/tenstorrent/tt-forge-onnx/actions/runs/24661400564