### PR TITLE
Refactor Forge Reduction Ops to Support Multi-Dim Reduction

### DIFF
--- a/forge/csrc/graph_lib/utils.cpp
+++ b/forge/csrc/graph_lib/utils.cpp
@@ -1301,6 +1301,14 @@ void handle_change_rank(graphlib::Graph *graph, graphlib::Edge edge)
             return (consumer_size + 1);
         if (op->op_type() == ops::OpType::Unsqueeze)
             return (consumer_size - 1);
+        // For reduction ops with keep_dim=False, the input rank equals output rank + number of reduced dims.
+        // Without this, handle_change_rank would incorrectly insert squeezes before the reduction op
+        // when a producer's rank increases after decomposition (e.g. after Layernorm decomposition).
+        if (op->is_reduce() && !op->op().attr_as<bool>("keep_dim"))
+        {
+            auto dims = op->op().attr_as<std::vector<int>>("dim_arg");
+            return consumer_size + static_cast<std::uint32_t>(dims.size());
+        }
         return consumer_size;
     };
 

--- a/forge/csrc/ops/op_common.cpp
+++ b/forge/csrc/ops/op_common.cpp
@@ -4,6 +4,9 @@
 
 #include "op_common.hpp"
 
+#include <algorithm>
+#include <numeric>
+
 #include "autograd/autograd.hpp"
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/shape.hpp"
@@ -165,20 +168,33 @@ long initial_flops_estimate_output_dim(std::tuple<graphlib::Shape, std::vector<g
 std::tuple<graphlib::Shape, std::vector<graphlib::DimBroadcast>> reduce_ops_shape(
     const Op &op, const std::vector<std::vector<std::uint32_t>> &in_shapes)
 {
-    int dim = op.attr_as<std::vector<int>>("dim_arg")[0];
+    std::vector<int> dims = op.attr_as<std::vector<int>>("dim_arg");
     bool keep_dim = op.attr_as<bool>("keep_dim");
+    int ndim = static_cast<int>(in_shapes[0].size());
 
-    if (dim < 0)
-        dim += in_shapes[0].size();
-
-    TT_ASSERT(dim >= 0 && dim < static_cast<int>(in_shapes[0].size()), "Reduce ops should have valid dim.");
+    // Normalize negative dims to positive and validate each against the input rank.
+    for (auto &d : dims)
+    {
+        if (d < 0)
+            d += ndim;
+        TT_ASSERT(d >= 0 && d < ndim, "Reduce ops should have valid dim.");
+    }
 
     std::vector<std::uint32_t> ret = in_shapes[0];
 
     if (keep_dim)
-        ret[dim] = 1;
+    {
+        // Set each reduced dim to 1; non-reduced dims are unchanged.
+        for (int d : dims) ret[d] = 1;
+    }
     else
-        ret.erase(ret.begin() + dim);
+    {
+        // Erase reduced dims in descending order so earlier erasures do not shift
+        // the positions of later ones.
+        std::vector<int> sorted_dims = dims;
+        std::sort(sorted_dims.begin(), sorted_dims.end(), std::greater<int>());
+        for (int d : sorted_dims) ret.erase(ret.begin() + d);
+    }
 
     return {graphlib::Shape::create(ret), {}};
 }

--- a/forge/csrc/ops/op_reduce_avg.cpp
+++ b/forge/csrc/ops/op_reduce_avg.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
+
 #include "autograd/autograd.hpp"
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/shape.hpp"
@@ -27,10 +29,10 @@ at::Tensor eval(const Op &op, const std::vector<at::Tensor> &tensors)
     TT_ASSERT(op.attrs().size() == 2, "reduce_avg should have 2 attrs (dim, keep_dim).");
 
     std::vector<int> dims = op.attr_as<std::vector<int>>("dim_arg");
-    int dim = dims[0];
     bool keep_dim = op.attr_as<bool>("keep_dim");
 
-    return torch::mean(tensors[0], dim, keep_dim);
+    std::vector<int64_t> dims64(dims.begin(), dims.end());
+    return torch::mean(tensors[0], at::IntArrayRef(dims64), keep_dim);
 }
 
 std::tuple<graphlib::Shape, std::vector<graphlib::DimBroadcast>> shape(
@@ -56,28 +58,42 @@ tt::graphlib::NodeContext backward(
     TT_ASSERT(inputs.size() == 1, "reduce_avg should have single input.");
     TT_ASSERT(operand == 0, "Invalid operand index.");
 
-    // For avg, gradient needs to be broadcast back to original shape
-    // with scale factor 1 / size
     std::vector<int> dims = op.attr_as<std::vector<int>>("dim_arg");
-    int dim = dims[0];
-    if (dim < 0)
-        dim += inputs[0].shape.size();
-    std::uint32_t size = inputs[0].shape[dim];
+    bool keep_dim = op.attr_as<bool>("keep_dim");
+    int ndim = inputs[0].shape.size();
 
-    NodeContext unsqueeze = gradient;
-    if (!op.attr_as<bool>("keep_dim"))
+    // Normalize negative dims and sort ascending so unsqueezes insert at the
+    // correct positions when processed in order.
+    for (auto &d : dims)
+        if (d < 0)
+            d += ndim;
+    std::vector<int> sorted_dims = dims;
+    std::sort(sorted_dims.begin(), sorted_dims.end());
+
+    // Number of elements contributing to each averaged output (= product of reduced
+    // dim sizes). Each input position contributes dy * (1 / total_elements).
+    std::uint32_t total_elements = 1;
+    for (int d : sorted_dims) total_elements *= inputs[0].shape[d];
+
+    NodeContext current = gradient;
+
+    // If keep_dim was false, re-insert size-1 dims so the gradient matches input rank.
+    if (!keep_dim)
     {
-        // If keep_dim is false, we need to unsqueeze the gradient to match the input shape.
-        unsqueeze = ac.autograd->create_op(ac, Op(OpType::Unsqueeze, {{"dim", dim}}), {gradient});
+        for (int d : sorted_dims) current = ac.autograd->create_op(ac, Op(OpType::Unsqueeze, {{"dim", d}}), {current});
     }
 
-    std::vector<int> repeats(unsqueeze.shape.size(), 1);
-    repeats[dim] = size;
-    NodeContext repeat = ac.autograd->create_op(ac, Op(OpType::Repeat, {{"repeats", repeats}}), {unsqueeze});
+    // Broadcast the gradient along every reduced dim via Repeat.
+    // Repeat (not Broadcast) is used because Broadcast is converted to an edge TM in
+    // pre_lowering_passes and is therefore never lowered to MLIR for the backward graph.
+    std::vector<int> repeats(ndim, 1);
+    for (int d : sorted_dims) repeats[d] = static_cast<int>(inputs[0].shape[d]);
 
-    NodeContext consts = ac.autograd->create_constant(ac, 1.0 / size);
+    current = ac.autograd->create_op(ac, Op(OpType::Repeat, {{"repeats", repeats}}), {current});
 
-    return ac.autograd->create_op(ac, Op(OpType::Multiply), {repeat, consts});
+    // Scale by 1 / total_elements to complete the mean backward.
+    NodeContext scale = ac.autograd->create_constant(ac, 1.0 / static_cast<double>(total_elements));
+    return ac.autograd->create_op(ac, Op(OpType::Multiply), {current, scale});
 }
 
 void decompose_initial(
@@ -88,25 +104,36 @@ void decompose_initial(
     TT_ASSERT(inputs.size() == 1, "reduce_avg should have single input.");
 
     std::vector<int> dims = op.attr_as<std::vector<int>>("dim_arg");
-    int dim = dims[0];
-    if (dim < 0)
-        dim += inputs[0].shape.size();
+    int ndim = inputs[0].shape.size();
 
-    if (inputs[0].shape[dim] == 1)
+    for (auto &d : dims)
+        if (d < 0)
+            d += ndim;
+
+    // Only fuse away the reduce when every reduced dim already has size 1 — then
+    // reducing is either a no-op (keep_dim=true) or just a rank adjustment
+    // (keep_dim=false, handled via Squeeze).
+    bool all_size_one = std::all_of(dims.begin(), dims.end(), [&](int d) { return inputs[0].shape[d] == 1; });
+
+    if (!all_size_one)
+        return;
+
+    if (op.attr_as<bool>("keep_dim"))
     {
-        // We are reducing on a dimension that is already 1, which is potentially a no-op.
-        if (op.attr_as<bool>("keep_dim"))
-        {
-            // `keep_dim` is true, hence we don't need to do anything.
-            NodeContext result = dc.op(Op(OpType::Nop), {inputs[0]});
-            dc.fuse(result);
-            return;
-        }
-
-        // In this case, we can replace `reduce_sum` with a `squeeze` operation.
-        NodeContext result = dc.op(Op(OpType::Squeeze, {{"dim", dim}}), {inputs[0]});
+        NodeContext result = dc.op(Op(OpType::Nop), {inputs[0]});
         dc.fuse(result);
+        return;
     }
+
+    // Squeeze each reduced dim; process in descending order to keep indices valid
+    // as earlier squeezes shift the positions of later ones.
+    std::vector<int> sorted_desc = dims;
+    std::sort(sorted_desc.begin(), sorted_desc.end(), std::greater<int>());
+
+    NodeContext current = inputs[0];
+    for (int d : sorted_desc) current = dc.op(Op(OpType::Squeeze, {{"dim", d}}), {current});
+
+    dc.fuse(current);
 }
 
 }  // namespace reduce_avg

--- a/forge/csrc/ops/op_reduce_max.cpp
+++ b/forge/csrc/ops/op_reduce_max.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
+
 #include "autograd/autograd.hpp"
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/shape.hpp"
@@ -27,10 +29,11 @@ at::Tensor eval(const Op &op, const std::vector<at::Tensor> &tensors)
     TT_ASSERT(op.attrs().size() == 2, "reduce_max should have 2 attrs (dim_arg, keep_dim).");
 
     std::vector<int> dims = op.attr_as<std::vector<int>>("dim_arg");
-    int dim = dims[0];
     bool keep_dim = op.attr_as<bool>("keep_dim");
 
-    return std::get<0>(torch::max(tensors[0], dim, keep_dim));
+    // torch::amax supports a list of dims; use it for both single- and multi-dim cases.
+    std::vector<int64_t> dims64(dims.begin(), dims.end());
+    return torch::amax(tensors[0], at::IntArrayRef(dims64), keep_dim);
 }
 
 std::tuple<graphlib::Shape, std::vector<graphlib::DimBroadcast>> shape(
@@ -44,7 +47,6 @@ std::tuple<graphlib::Shape, std::vector<graphlib::DimBroadcast>> shape(
 }
 
 tt::graphlib::NodeContext backward(
-
     const Op &op,
     tt::autograd::autograd_context &ac,
     int operand,
@@ -57,97 +59,115 @@ tt::graphlib::NodeContext backward(
     TT_ASSERT(operand == 0, "Invalid operand index.");
 
     std::vector<int> dims = op.attr_as<std::vector<int>>("dim_arg");
-    int dim = dims[0];
-    if (dim < 0)
-        dim += inputs[0].shape.size();
+    bool keep_dim = op.attr_as<bool>("keep_dim");
+    int ndim = static_cast<int>(inputs[0].shape.size());
 
-    // This version takes only the first of multiple maximal values (like pytorch)
-    NodeContext one = ac.autograd->create_constant(ac, 1.0);
+    // Normalize negative dims and sort ascending so unsqueeze inserts at correct positions.
+    for (auto &d : dims)
+        if (d < 0)
+            d += ndim;
+    std::vector<int> sorted_dims = dims;
+    std::sort(sorted_dims.begin(), sorted_dims.end());
 
-    // Create negative range tensor: -(torch.arange(in0.shape[dim]) - in0.shape[dim]).float()
-    // Example: [3, 2, 1] for dim = 2 and dim_size = 3
-    std::uint32_t dim_size = inputs[0].shape[dim];
-    at::Tensor neg_range_values = dim_size - torch::arange(dim_size, torch::kFloat32);
+    // Repeat factors along every reduced dim; identity along the rest.
+    std::vector<int> repeats(ndim, 1);
+    for (int d : sorted_dims) repeats[d] = static_cast<int>(inputs[0].shape[d]);
 
-    // Create shape for neg_range: [1] * len(in0.shape) with shape[dim] = dim_size
-    // Example: [1, 1, 3] for dim = 2 and dim_size = 3
-    std::vector<int64_t> shape(inputs[0].shape.size(), 1);
-    shape[dim] = dim_size;
-    neg_range_values = neg_range_values.reshape(shape);
-
-    NodeContext neg_range = ac.autograd->create_constant_tensor(ac, neg_range_values);
-
-    NodeContext unsqueeze = output;
-    if (!op.attr_as<bool>("keep_dim"))
+    // Step 1: restore the max output to input rank when keep_dim=false by unsqueezing
+    // every reduced dim (ascending order keeps indices valid).
+    NodeContext max_expanded = output;
+    if (!keep_dim)
     {
-        // If keep_dim is false, we need to unsqueeze the output to match the input shape.
-        unsqueeze = ac.autograd->create_op(ac, Op(OpType::Unsqueeze, {{"dim", dim}}), {output});
+        for (int d : sorted_dims)
+            max_expanded = ac.autograd->create_op(ac, Op(OpType::Unsqueeze, {{"dim", d}}), {max_expanded});
     }
 
-    // mask = subtract(in0, output) - has 0.0 in max positions and < 0.0 everywhere else
-    NodeContext mask = ac.autograd->create_op(ac, Op(OpType::Subtract), {inputs[0], unsqueeze});
+    // Step 2: broadcast max to the full input shape via Repeat. We use Repeat rather
+    // than Broadcast because Broadcast is lowered to an edge TM in pre_lowering_passes
+    // and never materializes in the MLIR backward graph.
+    NodeContext max_repeated = ac.autograd->create_op(ac, Op(OpType::Repeat, {{"repeats", repeats}}), {max_expanded});
 
-    // mask = add(mask, one) - has 1.0 in max positions and < 1.0 everywhere else
-    mask = ac.autograd->create_op(ac, Op(OpType::Add), {mask, one});
+    // Step 3: build a mask that is 1.0 at argmax positions and 0.0 elsewhere.
+    //
+    // A direct equality test (input == max) is unreliable on Wormhole hardware:
+    // `ttnn.max` (used in the forward) does not always return a value that exactly
+    // matches any input element, so `input - max` is often slightly negative at the
+    // true argmax instead of exactly zero. This corrupts a comparison-based mask.
+    //
+    // Instead, compute a soft mask via a sharp softmax over the reduced dims:
+    //   soft_mask = exp(scale * (input - max)) / reduce_sum(exp(scale * (input - max)))
+    // and threshold it at 0.5 to obtain a hard one-hot mask. The softmax concentrates
+    // the mass at the argmax position regardless of the small hardware precision
+    // error in the max value itself, and it relies only on Exp (element-wise, exact)
+    // and ReduceSum (precise on TT hardware) — it does not rely on the precise result
+    // of ReduceMax.
+    //
+    // A scale of 2000 keeps exp in numerically safe range for inputs in [0, 1] while
+    // making the softmax sharp enough that the argmax position exceeds the 0.5
+    // threshold even for reductions of up to ~128 elements.
+    NodeContext diff = ac.autograd->create_op(ac, Op(OpType::Subtract), {inputs[0], max_repeated});
+    NodeContext scale = ac.autograd->create_constant(ac, 2000.0);
+    NodeContext scaled_diff = ac.autograd->create_op(ac, Op(OpType::Multiply), {diff, scale});
+    NodeContext exp_diff = ac.autograd->create_op(ac, Op(OpType::Exp), {scaled_diff});
+    NodeContext sum_exp =
+        ac.autograd->create_op(ac, Op(OpType::ReduceSum, {{"dim_arg", sorted_dims}, {"keep_dim", true}}), {exp_diff});
+    NodeContext sum_exp_repeated = ac.autograd->create_op(ac, Op(OpType::Repeat, {{"repeats", repeats}}), {sum_exp});
+    NodeContext soft_mask = ac.autograd->create_op(ac, Op(OpType::Divide), {exp_diff, sum_exp_repeated});
+    NodeContext half = ac.autograd->create_constant(ac, 0.5);
+    NodeContext mask = ac.autograd->create_op(ac, Op(OpType::GreaterEqual), {soft_mask, half});
 
-    // mask = greater_equal (mask, one) - has 1.0 in max positions, 0.0 everywhere else
-    mask = ac.autograd->create_op(ac, Op(OpType::GreaterEqual), {mask, one});
-
-    // mask = multiply(mask, neg_range) - puts range N...1 in max positions, 0.0 everywhere else
-    // Example: [1, 1, 0, 1] -> [4, 3, 0, 1]
-    mask = ac.autograd->create_op(ac, Op(OpType::Multiply), {mask, neg_range});
-
-    // redc = reduce_max(mask) - argmax
-    NodeContext redc = ac.autograd->create_op(
-        ac, Op(OpType::ReduceMax, {{"dim_arg", std::vector<int>{dim}}, {"keep_dim", true}}), {mask});
-
-    // mask = subtract(mask, redc) - Orig range - argmax, 0.0 in FIRST max position
-    mask = ac.autograd->create_op(ac, Op(OpType::Subtract), {mask, redc});
-
-    // mask = add(mask, one) - has 1.0 in first max position, and < 1.0 everywhere else
-    mask = ac.autograd->create_op(ac, Op(OpType::Add), {mask, one});
-
-    // mask = greater_equal (mask, one) - has 1.0 in first max position, and 0.0 everywhere else
-    mask = ac.autograd->create_op(ac, Op(OpType::GreaterEqual), {mask, one});
-
-    NodeContext unsqueeze_gradient = gradient;
-    if (!op.attr_as<bool>("keep_dim"))
+    // Step 4: lift the incoming gradient to input rank (mirror of Step 1).
+    NodeContext grad_expanded = gradient;
+    if (!keep_dim)
     {
-        // If keep_dim is false, we need to unsqueeze the gradient to match the input shape.
-        // This is necessary because the mask has been reduced to a single dimension.
-        unsqueeze_gradient = ac.autograd->create_op(ac, Op(OpType::Unsqueeze, {{"dim", dim}}), {gradient});
+        for (int d : sorted_dims)
+            grad_expanded = ac.autograd->create_op(ac, Op(OpType::Unsqueeze, {{"dim", d}}), {grad_expanded});
     }
 
-    return ac.autograd->create_op(ac, Op(OpType::Multiply), {unsqueeze_gradient, mask});
+    // Step 5: broadcast the gradient to the full input shape via Repeat.
+    NodeContext grad_broadcast =
+        ac.autograd->create_op(ac, Op(OpType::Repeat, {{"repeats", repeats}}), {grad_expanded});
+
+    // Step 6: route the gradient to argmax positions only.
+    return ac.autograd->create_op(ac, Op(OpType::Multiply), {grad_broadcast, mask});
 }
 
-void decompose_initial(
-
-    const Op &op, DecomposingContext &dc, const std::vector<tt::graphlib::NodeContext> &inputs)
+void decompose_initial(const Op &op, DecomposingContext &dc, const std::vector<tt::graphlib::NodeContext> &inputs)
 {
     TT_DBG_ASSERT(op.type() == OpType::ReduceMax, "Wrong op type.");
     TT_ASSERT(inputs.size() == 1, "reduce_max should have single input.");
 
     std::vector<int> dims = op.attr_as<std::vector<int>>("dim_arg");
-    int dim = dims[0];
-    if (dim < 0)
-        dim += inputs[0].shape.size();
+    int ndim = inputs[0].shape.size();
 
-    if (inputs[0].shape[dim] == 1)
+    for (auto &d : dims)
+        if (d < 0)
+            d += ndim;
+
+    // Only fuse away the reduce when every reduced dim already has size 1 — then
+    // reducing is either a no-op (keep_dim=true) or just a rank adjustment
+    // (keep_dim=false, handled via Squeeze).
+    bool all_size_one = std::all_of(dims.begin(), dims.end(), [&](int d) { return inputs[0].shape[d] == 1; });
+
+    if (!all_size_one)
+        return;
+
+    if (op.attr_as<bool>("keep_dim"))
     {
-        // We are reducing on a dimension that is already 1, which is potentially a no-op.
-        if (op.attr_as<bool>("keep_dim"))
-        {
-            // `keep_dim` is true, hence we don't need to do anything.
-            NodeContext result = dc.op(Op(OpType::Nop), {inputs[0]});
-            dc.fuse(result);
-            return;
-        }
-
-        // In this case, we can replace `reduce_sum` with a `squeeze` operation.
-        NodeContext result = dc.op(Op(OpType::Squeeze, {{"dim", dim}}), {inputs[0]});
+        NodeContext result = dc.op(Op(OpType::Nop), {inputs[0]});
         dc.fuse(result);
+        return;
     }
+
+    // Squeeze each reduced dim; process in descending order to keep indices valid
+    // as earlier squeezes shift the positions of later ones.
+    std::vector<int> sorted_desc = dims;
+    std::sort(sorted_desc.begin(), sorted_desc.end(), std::greater<int>());
+
+    NodeContext current = inputs[0];
+    for (int d : sorted_desc) current = dc.op(Op(OpType::Squeeze, {{"dim", d}}), {current});
+
+    dc.fuse(current);
 }
 
 }  // namespace reduce_max

--- a/forge/csrc/ops/op_reduce_sum.cpp
+++ b/forge/csrc/ops/op_reduce_sum.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <algorithm>
+
 #include "autograd/autograd.hpp"
 #include "graph_lib/node_types.hpp"
 #include "graph_lib/shape.hpp"
@@ -27,10 +29,10 @@ at::Tensor eval(const Op &op, const std::vector<at::Tensor> &tensors)
     TT_ASSERT(op.attrs().size() == 2, "reduce_sum should have 2 attrs (dim, keep_dim).");
 
     std::vector<int> dims = op.attr_as<std::vector<int>>("dim_arg");
-    int dim = dims[0];
     bool keep_dim = op.attr_as<bool>("keep_dim");
 
-    return torch::sum(tensors[0], dim, keep_dim);
+    std::vector<int64_t> dims64(dims.begin(), dims.end());
+    return torch::sum(tensors[0], at::IntArrayRef(dims64), keep_dim);
 }
 
 std::tuple<graphlib::Shape, std::vector<graphlib::DimBroadcast>> shape(
@@ -57,22 +59,36 @@ tt::graphlib::NodeContext backward(
     TT_ASSERT(operand == 0, "Invalid operand index.");
 
     std::vector<int> dims = op.attr_as<std::vector<int>>("dim_arg");
-    int dim = dims[0];
-    std::uint32_t size = inputs[0].shape[dim];
+    bool keep_dim = op.attr_as<bool>("keep_dim");
+    int ndim = inputs[0].shape.size();
 
-    std::optional<NodeContext> unsqueeze;
-    if (!op.attr_as<bool>("keep_dim"))
+    // Normalize negative dims and sort ascending so unsqueezes insert at the
+    // correct positions when processed in order.
+    for (auto &d : dims)
+        if (d < 0)
+            d += ndim;
+    std::vector<int> sorted_dims = dims;
+    std::sort(sorted_dims.begin(), sorted_dims.end());
+
+    // For sum, dy/dx is 1 at every input position, so the backward is simply the
+    // upstream gradient broadcast back to the input shape along every reduced dim.
+    NodeContext current = gradient;
+
+    // If keep_dim was false, re-insert size-1 dims so the gradient matches input rank.
+    if (!keep_dim)
     {
-        // If `keep_dim` is false, we need to unsqueeze the gradient to match the input shape.
-        unsqueeze = ac.autograd->create_op(ac, Op(OpType::Unsqueeze, {{"dim", dim}}), {gradient});
+        for (int d : sorted_dims) current = ac.autograd->create_op(ac, Op(OpType::Unsqueeze, {{"dim", d}}), {current});
     }
 
-    // For sum, gradient just needs to be broadcast back to original shape.
-    NodeContext broadcast = ac.autograd->create_op(
-        ac,
-        Op(OpType::Broadcast, {{"dim", dim}, {"size", static_cast<int>(size)}}),
-        {unsqueeze.has_value() ? *unsqueeze : gradient});
-    return broadcast;
+    // Broadcast the gradient along every reduced dim via Repeat.
+    // Repeat (not Broadcast) is used because Broadcast is converted to an edge TM in
+    // pre_lowering_passes and is therefore never lowered to MLIR for the backward graph.
+    std::vector<int> repeats(ndim, 1);
+    for (int d : sorted_dims) repeats[d] = static_cast<int>(inputs[0].shape[d]);
+
+    current = ac.autograd->create_op(ac, Op(OpType::Repeat, {{"repeats", repeats}}), {current});
+
+    return current;
 }
 
 void decompose_initial(
@@ -83,23 +99,36 @@ void decompose_initial(
     TT_ASSERT(inputs.size() == 1, "reduce_sum should have single input.");
 
     std::vector<int> dims = op.attr_as<std::vector<int>>("dim_arg");
-    int dim = dims[0];
+    int ndim = inputs[0].shape.size();
 
-    if (inputs[0].shape[dim] == 1)
+    for (auto &d : dims)
+        if (d < 0)
+            d += ndim;
+
+    // Only fuse away the reduce when every reduced dim already has size 1 — then
+    // reducing is either a no-op (keep_dim=true) or just a rank adjustment
+    // (keep_dim=false, handled via Squeeze).
+    bool all_size_one = std::all_of(dims.begin(), dims.end(), [&](int d) { return inputs[0].shape[d] == 1; });
+
+    if (!all_size_one)
+        return;
+
+    if (op.attr_as<bool>("keep_dim"))
     {
-        // We are reducing on a dimension that is already 1, which is potentially a no-op.
-        if (op.attr_as<bool>("keep_dim"))
-        {
-            // `keep_dim` is true, hence we don't need to do anything.
-            NodeContext result = dc.op(Op(OpType::Nop), {inputs[0]});
-            dc.fuse(result);
-            return;
-        }
-
-        // In this case, we can replace `reduce_sum` with a `squeeze` operation.
-        NodeContext result = dc.op(Op(OpType::Squeeze, {{"dim", dim}}), {inputs[0]});
+        NodeContext result = dc.op(Op(OpType::Nop), {inputs[0]});
         dc.fuse(result);
+        return;
     }
+
+    // Squeeze each reduced dim; process in descending order to keep indices valid
+    // as earlier squeezes shift the positions of later ones.
+    std::vector<int> sorted_desc = dims;
+    std::sort(sorted_desc.begin(), sorted_desc.end(), std::greater<int>());
+
+    NodeContext current = inputs[0];
+    for (int d : sorted_desc) current = dc.op(Op(OpType::Squeeze, {{"dim", d}}), {current});
+
+    dc.fuse(current);
 }
 
 }  // namespace reduce_sum

--- a/forge/forge/op/reduce.py
+++ b/forge/forge/op/reduce.py
@@ -1,14 +1,29 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
+from typing import List, Tuple, Union
+
 from forge._C.ops import OpType
 from ..tensor import Tensor
 from .common import ForgeOp as op
 
 
-def ReduceSum(name: str, operandA: Tensor, dim: int, keep_dim: bool = True) -> Tensor:
+def _normalize_dims(dim: Union[int, List[int], Tuple[int, ...]], rank: int = 4) -> List[int]:
+    """Normalize dim argument to a list of ints, each validated to be in [-rank, rank-1]."""
+    dims: List[int] = [dim] if isinstance(dim, int) else list(dim)
+    for d in dims:
+        assert (d >= -rank) and (d <= rank - 1), f"dim {d} out of range for rank-{rank} tensor"
+    return dims
+
+
+def ReduceSum(
+    name: str,
+    operandA: Tensor,
+    dim: Union[int, List[int], Tuple[int, ...]],
+    keep_dim: bool = True,
+) -> Tensor:
     """
-    Reduce by summing along the given dimension
+    Reduce by summing along one or more dimensions.
 
     Parameters
     ----------
@@ -18,25 +33,29 @@ def ReduceSum(name: str, operandA: Tensor, dim: int, keep_dim: bool = True) -> T
     operandA: Tensor
         First operand
 
-    dim: int
-        Dimension along which to reduce. A positive number 0 - 3 or negative from -1 to -4.
+    dim: int or list/tuple of ints
+        Dimension(s) along which to reduce.  Each value must be in [-4, 3].
+
+    keep_dim: bool
+        If True, the reduced dimensions are kept with size 1.
 
     Returns
     -------
     Tensor
         Forge tensor
     """
-
-    assert (dim >= -4) and (dim <= 3)
-    # if dim < 0:
-    #     dim += 4
-
-    return op(OpType.ReduceSum, name, operandA, dim_arg=[dim], keep_dim=keep_dim).get_tensor()
+    dims = _normalize_dims(dim)
+    return op(OpType.ReduceSum, name, operandA, dim_arg=dims, keep_dim=keep_dim).get_tensor()
 
 
-def ReduceAvg(name: str, operandA: Tensor, dim: int, keep_dim: bool = True) -> Tensor:
+def ReduceAvg(
+    name: str,
+    operandA: Tensor,
+    dim: Union[int, List[int], Tuple[int, ...]],
+    keep_dim: bool = True,
+) -> Tensor:
     """
-    Reduce by averaging along the given dimension
+    Reduce by averaging along one or more dimensions.
 
     Parameters
     ----------
@@ -46,25 +65,29 @@ def ReduceAvg(name: str, operandA: Tensor, dim: int, keep_dim: bool = True) -> T
     operandA: Tensor
         First operand
 
-    dim: int
-        Dimension along which to reduce. A positive number 0 - 3 or negative from -1 to -4.
+    dim: int or list/tuple of ints
+        Dimension(s) along which to reduce.  Each value must be in [-4, 3].
+
+    keep_dim: bool
+        If True, the reduced dimensions are kept with size 1.
 
     Returns
     -------
     Tensor
         Forge tensor
     """
-
-    assert (dim >= -4) and (dim <= 3)
-    # if dim < 0:
-    #     dim += 4
-
-    return op(OpType.ReduceAvg, name, operandA, dim_arg=[dim], keep_dim=keep_dim).get_tensor()
+    dims = _normalize_dims(dim)
+    return op(OpType.ReduceAvg, name, operandA, dim_arg=dims, keep_dim=keep_dim).get_tensor()
 
 
-def ReduceMax(name: str, operandA: Tensor, dim: int, keep_dim: bool = True) -> Tensor:
+def ReduceMax(
+    name: str,
+    operandA: Tensor,
+    dim: Union[int, List[int], Tuple[int, ...]],
+    keep_dim: bool = True,
+) -> Tensor:
     """
-    Reduce by taking maximum along the given dimension
+    Reduce by taking the maximum along one or more dimensions.
 
     Parameters
     ----------
@@ -74,17 +97,19 @@ def ReduceMax(name: str, operandA: Tensor, dim: int, keep_dim: bool = True) -> T
     operandA: Tensor
         First operand
 
-    dim: int
-        Dimension along which to reduce. A positive number 0 - 3 or negative from -1 to -4.
+    dim: int or list/tuple of ints
+        Dimension(s) along which to reduce.  Each value must be in [-4, 3].
+
+    keep_dim: bool
+        If True, the reduced dimensions are kept with size 1.
 
     Returns
     -------
     Tensor
         Forge tensor
     """
-    assert (dim >= -4) and (dim <= 3)
-
-    return op(OpType.ReduceMax, name, operandA, dim_arg=[dim], keep_dim=keep_dim).get_tensor()
+    dims = _normalize_dims(dim)
+    return op(OpType.ReduceMax, name, operandA, dim_arg=dims, keep_dim=keep_dim).get_tensor()
 
 
 def Argmax(name: str, operandA: Tensor, dim: int = None, keep_dim=False) -> Tensor:

--- a/forge/forge/tvm_calls/relay/op/forge_passes.py
+++ b/forge/forge/tvm_calls/relay/op/forge_passes.py
@@ -369,17 +369,6 @@ class DecomposeDynamicResize2d(DFPatternCallback):
         return tvm.relay.expr.Call(consumer.op, args)
 
 
-class RemoveCast(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True)
-        self.act = wildcard()
-        self.pattern = is_op("cast")(self.act)
-
-    def callback(self, pre, post, node_map):
-        act = node_map[self.act][0]
-        return act
-
-
 class DecomposeStack(DFPatternCallback):
     def __init__(self):
         super().__init__(rewrite_once=True)
@@ -412,34 +401,6 @@ class DecomposeStack(DFPatternCallback):
         output = tvm.relay.reshape(stacked, newshape=target_shape)
 
         return output
-
-
-class DecomposeMultiAxisMax(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True)
-        self.act = wildcard()
-        self.max = is_op("max")(self.act)
-
-        self.pattern = self.max
-
-    def callback(self, pre, post, node_map):
-        if post.attrs.axis == None:
-            reduce_axes = [x for x in range(len(list(post.args[0].checked_type.shape)))]
-        else:
-            reduce_axes = list(post.attrs.axis)
-        if len(reduce_axes) == 1:
-            return post
-
-        acts = node_map[self.act][0]
-        keepdims = bool(post.attrs.keepdims)
-        output_shape = list(pre.checked_type.shape)
-
-        for axis in reduce_axes:
-            acts = tvm.relay.max(acts, axis=int(axis), keepdims=True)
-
-        if keepdims == False:
-            acts = tvm.relay.reshape(acts, newshape=output_shape)
-        return acts
 
 
 class DecomposeMultiAxisTranspose(DFPatternCallback):
@@ -477,62 +438,6 @@ class DecomposeMultiAxisTranspose(DFPatternCallback):
                 output = tvm.relay.transpose(output, axes=new_order)
 
         return output
-
-
-class DecomposeMultiAxisMean(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True, require_type=True)
-        self.act = wildcard()
-        self.mean = is_op("mean")(self.act)
-        self.pattern = self.mean
-
-    def callback(self, pre, post, node_map):
-        if post.attrs.axis == None:
-            reduce_axes = [x for x in range(len(list(post.args[0].checked_type.shape)))]
-        else:
-            reduce_axes = list(post.attrs.axis)
-        if len(reduce_axes) == 1:
-            return post
-
-        acts = node_map[self.act][0]
-
-        keepdims = bool(post.attrs.keepdims)
-        output_shape = list(pre.checked_type.shape)
-
-        for axis in reduce_axes:
-            acts = tvm.relay.mean(acts, axis=int(axis), keepdims=True)
-
-        if keepdims == False:
-            # Need to squeeze in order from rightmost dim to leftmost dim
-            # Reverse sort since axes are positive
-            for axis in sorted(reduce_axes, reverse=True):
-                acts = tvm.relay.squeeze(acts, axis=[axis])
-        return acts
-
-
-class DecomposeMultiAxisSum(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True, require_type=True)
-        self.act = wildcard()
-        self.sum = is_op("sum")(self.act)
-        self.pattern = self.sum
-
-    def callback(self, pre, post, node_map):
-        reduce_axes = list(post.attrs.axis)
-        if len(reduce_axes) == 1:
-            return post
-
-        acts = node_map[self.act][0]
-
-        keepdims = bool(post.attrs.keepdims)
-        output_shape = list(pre.checked_type.shape)
-
-        for axis in reduce_axes:
-            acts = tvm.relay.sum(acts, axis=int(axis), keepdims=True)
-
-        if keepdims == False:
-            acts = tvm.relay.reshape(acts, newshape=output_shape)
-        return acts
 
 
 class DecomposeMultiAxisBroadcast(DFPatternCallback):
@@ -608,70 +513,6 @@ class DecomposeConv1DToConv2D(DFPatternCallback):
             # reshape back result
             reshaped_back_result = tvm.relay.reshape(new_conv2d, newshape=expected_output_shape)
             return reshaped_back_result
-
-
-class ReformatTFConv2d(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True)
-        self.act = wildcard()
-        self.weight = wildcard()
-        conv = is_op("nn.conv2d")(self.act, self.weight)
-        self.pattern = conv
-
-    def callback(self, pre, post, node_map):
-        if post.attrs.data_layout == "NHWC" and post.attrs.kernel_layout == "HWIO":
-            # convert TF channel-last to channel-first
-            act = node_map[self.act][0]
-            weight = node_map[self.weight][0]
-
-            channel_first_act = tvm.relay.transpose(act, axes=[0, 3, 1, 2])
-            channel_first_weight = tvm.relay.transpose(weight, axes=[3, 2, 0, 1])
-
-            new_conv2d = tvm.relay.op.nn.conv2d(
-                channel_first_act,
-                channel_first_weight,
-                strides=post.attrs.strides,
-                padding=post.attrs.padding,
-                groups=post.attrs.groups,
-                channels=post.attrs.channels,
-                kernel_size=post.attrs.kernel_size,
-                data_layout="NCHW",
-                kernel_layout="OIHW",
-            )
-            out_reshape = tvm.relay.transpose(new_conv2d, axes=[0, 2, 3, 1])
-            return out_reshape
-        else:
-            return post
-
-
-class ReformatTFMaxpool(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True)
-        self.act = wildcard()
-        maxpool = is_op("nn.max_pool2d")(
-            self.act,
-        )
-        self.pattern = maxpool
-
-    def callback(self, pre, post, node_map):
-        if post.attrs.layout == "NHWC":
-            # convert TF channel-last to channel-first
-            act = node_map[self.act][0]
-
-            channel_first_act = tvm.relay.transpose(act, axes=[0, 3, 1, 2])
-
-            new_pool = tvm.relay.op.nn.max_pool2d(
-                channel_first_act,
-                pool_size=post.attrs.pool_size,
-                strides=post.attrs.strides,
-                padding=post.attrs.padding,
-                layout="NCHW",
-                ceil_mode=post.attrs.ceil_mode,
-            )
-            out_reshape = tvm.relay.transpose(new_pool, axes=[0, 2, 3, 1])
-            return out_reshape
-        else:
-            return post
 
 
 class DecomposePower(DFPatternCallback):
@@ -1020,17 +861,23 @@ class PopulateTransposeAxes(DFPatternCallback):
 
 class PopulateReduceAxes(DFPatternCallback):
     def __init__(self, rewrite_once=True, require_type=True):
-        super().__init__()
-        self.pattern = is_op("sum")(wildcard())
+        super().__init__(rewrite_once=True, require_type=True)
+        self.pattern = is_op("sum")(wildcard()) | is_op("mean")(wildcard()) | is_op("max")(wildcard())
 
     def callback(self, pre, post, node_map):
         if pre.attrs.axis is not None:
             return post
 
         ndims = len(pre.args[0].checked_type.shape)
-        raxes = list(range(0, ndims, 1))
+        raxes = list(range(ndims))
+        op_name = pre.op.name
 
-        return tvm.relay.sum(post.args[0], axis=raxes, keepdims=pre.attrs.keepdims)
+        if op_name == "sum":
+            return tvm.relay.sum(post.args[0], axis=raxes, keepdims=pre.attrs.keepdims)
+        elif op_name == "mean":
+            return tvm.relay.mean(post.args[0], axis=raxes, keepdims=pre.attrs.keepdims)
+        else:
+            return tvm.relay.max(post.args[0], axis=raxes, keepdims=pre.attrs.keepdims)
 
 
 class RemoveRedundantReshape(DFPatternCallback):
@@ -1148,27 +995,6 @@ class LowerTakeToStridedSlice(DFPatternCallback):
 
         reshape = tvm.relay.reshape(strided_slice, newshape=pre.checked_type.shape)
         return reshape
-
-
-class AddSqueezeForArgmax(DFPatternCallback):
-    def __init__(self, rewrite_once=True, require_type=True):
-        super().__init__(rewrite_once=rewrite_once, require_type=require_type)
-        self.input_tensor = wildcard()
-        self.pattern = is_op("argmax")(self.input_tensor)
-
-    def callback(self, pre, post, node_map):
-        if post.attrs.keepdims:
-            return post
-
-        inp = node_map[self.input_tensor][0]
-        axis = post.attrs.axis
-        new_argmax = tvm.relay.argmax(
-            inp,
-            axis=axis,
-            keepdims=True,
-        )
-        result = tvm.relay.squeeze(new_argmax, axis=axis)
-        return result
 
 
 class ConvertArgmaxTakeToReduceMax(DFPatternCallback):
@@ -2221,19 +2047,6 @@ class DecomposeRsqrt(DFPatternCallback):
         return rsqrt
 
 
-class InvertDivide(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True, require_type=True)
-        self.in_a = wildcard()
-        self.in_b = wildcard()
-
-        self.pattern = is_op("divide")(self.in_a, self.in_b)
-
-    def callback(self, pre, post, node_map):
-        rep = tvm.relay.reciprocal(post.args[1])
-        return tvm.relay.multiply(post.args[0], rep)
-
-
 class DecomposeLayoutTransform(DFPatternCallback):
     def __init__(self):
         super().__init__()
@@ -2431,20 +2244,6 @@ class DecomposeMultiDimSqueeze(DFPatternCallback):
         return act
 
 
-class LowerSqueezeToReshape(DFPatternCallback):
-    def __init__(self):
-        super().__init__(require_type=True, rewrite_once=True)
-        self.input_tensor = wildcard()
-        self.pattern = is_op("squeeze")(wildcard())
-
-    def callback(self, pre, post, node_map):
-        # Skip removal of squeeze which contain dynamic shapes
-        if any([isinstance(dim, tvm.tir.expr.Any) for dim in pre.checked_type.shape]):
-            return post
-
-        return tvm.relay.reshape(post.args[0], newshape=pre.checked_type.shape)
-
-
 class TransposePad(DFPatternCallback):
     def __init__(self):
         super().__init__(rewrite_once=True, require_type=True)
@@ -2550,42 +2349,6 @@ class ConvertAddToBiasAddAfterConv2d(DFPatternCallback):
             raise NotImplementedError(f"Unhandled data layout: {act.attrs.data_layout}")
 
 
-class ConvertAddToBiasAddAfterConv2dTFWithChannelFirst(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True)
-        self.bias = wildcard()
-
-        self.act = wildcard()
-        self.t_act1 = is_op("transpose")(self.act)
-        self.t_act2 = is_op("transpose")(self.t_act1)
-
-        self.weight = wildcard()
-        self.t_weight1 = is_op("transpose")(self.weight)
-        self.t_weight2 = is_op("transpose")(self.t_weight1)
-        self.t_weight3 = is_op("transpose")(self.t_weight2)
-
-        self.conv = is_op("nn.conv2d")(self.t_act2, self.t_weight3)
-        self.t_conv1 = is_op("transpose")(self.conv)
-        self.t_conv2 = is_op("transpose")(self.t_conv1)
-
-        self.add = is_op("add")(self.t_conv2, self.bias)
-
-        self.relu = is_op("nn.relu")(self.add)
-        self.t_relu1 = is_op("transpose")(self.relu)
-        self.t_relu2 = is_op("transpose")(self.t_relu1)
-
-        self.pattern = self.t_relu2
-
-    def callback(self, pre, post, node_map):
-        bias = node_map[self.bias][0]
-        conv_act = node_map[self.conv][0]
-
-        bias_add = tvm.relay.nn.bias_add(conv_act, bias)
-        relu = tvm.relay.nn.relu(bias_add)
-
-        return relu
-
-
 class RemoveRedundantTranposesBetwenAvgPoolAndFlatteningReshape(DFPatternCallback):
     def __init__(self):
         super().__init__(rewrite_once=True)
@@ -2633,33 +2396,6 @@ class RemoveRedundantTranposesBetwenAvgPoolAndFlatteningReshape(DFPatternCallbac
         return flatten
 
 
-class EnsureKeepdims(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True)
-
-        self.pattern = is_op("sum")(wildcard()) | is_op("mean")(wildcard())
-
-    def callback(self, pre, post, node_map):
-        if post.attrs.keepdims == 0:
-            act = post.args[0]
-            if node_map[self.pattern][0].op.name == "sum":
-                reduce_ = tvm.relay.sum(
-                    act,
-                    axis=post.attrs.axis,
-                    keepdims=True,
-                )
-            else:
-                reduce_ = tvm.relay.mean(
-                    act,
-                    axis=post.attrs.axis,
-                    keepdims=True,
-                )
-            result = tvm.relay.squeeze(reduce_, axis=post.attrs.axis)
-            return result
-        else:
-            return post
-
-
 class DecomposeBatchFlatten(DFPatternCallback):
     def __init__(self):
         super().__init__(rewrite_once=True, require_type=True)
@@ -2670,19 +2406,6 @@ class DecomposeBatchFlatten(DFPatternCallback):
         act = node_map[self.act][0]
         input_shape = list(pre.args[0].checked_type.shape)
         target_shape = [input_shape[0]] + [math.prod(input_shape[1:])]
-
-        return tvm.relay.reshape(act, newshape=target_shape)
-
-
-class ConvertExpandDimsToReshape(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True, require_type=True)
-        self.act = wildcard()
-        self.pattern = is_op("expand_dims")(self.act)
-
-    def callback(self, pre, post, node_map):
-        act = node_map[self.act][0]
-        target_shape = list(pre.checked_type.shape)
 
         return tvm.relay.reshape(act, newshape=target_shape)
 
@@ -2796,36 +2519,6 @@ class DecomposeMultiIndexAdvIndex(DFPatternCallback):
         unsqueeze = tvm.relay.op.reshape(index, pre.checked_type.shape)
 
         return unsqueeze
-
-
-class DecomposeErf(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True, require_type=True)
-        self.act = wildcard()
-        self.pattern = is_op("erf")(self.act)
-
-    def callback(self, pre, post, node_map):
-        act = post.args[0]
-        act_sign = tvm.relay.op.sign(act)
-        act_abs = tvm.relay.op.abs(act)
-
-        # constants
-        a1 = tvm.relay.expr.const(0.254829592)
-        a2 = tvm.relay.expr.const(-0.284496736)
-        a3 = tvm.relay.expr.const(1.421413741)
-        a4 = tvm.relay.expr.const(-1.453152027)
-        a5 = tvm.relay.expr.const(1.061405429)
-        p = tvm.relay.expr.const(0.3275911)
-        one = tvm.relay.expr.const(1.0)
-        minus_one = tvm.relay.expr.const(-1.0)
-
-        t = one / (one + p * act_abs)
-        y = one - (((((a5 * t + a4) * t) + a3) * t + a2) * t + a1) * t * tvm.relay.op.exp(
-            (minus_one * act_abs) * act_abs
-        )
-        res = act_sign * y  # erf(-x) = -erf(x)
-
-        return res
 
 
 class ReconstructTFGelu(DFPatternCallback):
@@ -3174,62 +2867,6 @@ class SimplifyGroupNorm(DFPatternCallback):
         new_reshape1 = tvm.relay.reshape(new_div, node_map[self.reshape1][0].attrs.newshape)
 
         return new_reshape1
-
-
-class ReconstructPyTorchLayerNorm(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True, require_type=True)
-        self.act = wildcard()
-        self.gamma = wildcard()
-        self.beta = wildcard()
-        self.eps = is_constant()
-
-        self.mean_act = is_op("mean")(self.act)
-        sub_0 = is_op("subtract")(self.act, self.mean_act)
-        mul_0 = is_op("multiply")(sub_0, sub_0)
-        var = is_op("mean")(mul_0)
-
-        sum_denom = var.optional(lambda x: is_op("add")(x, self.eps))
-        sub = is_op("subtract")(self.act, self.mean_act)
-        denom = is_op("sqrt")(sum_denom)
-        recp = is_op("reciprocal")(denom)
-        coef = is_op("multiply")(sub, recp)
-        mul = is_op("multiply")(coef, self.gamma)
-        layernorm = is_op("add")(mul, self.beta)
-
-        self.pattern = layernorm
-
-    def callback(self, pre, post, node_map):
-        act = node_map[self.act][0]
-        gamma = node_map[self.gamma][0]
-        beta = node_map[self.beta][0]
-
-        try:
-            eps = node_map[self.eps][0].data.asnumpy().item()
-        except TVMError:  # Does not have epsilon addition
-            eps = 0
-
-        pre_node_map = construct_pre_node_map(self.pattern, pre)
-        act_shape = pre_node_map[self.act][0].checked_type.shape
-        gamma_shape = list(pre_node_map[self.gamma][0].checked_type.shape)
-
-        axis = pre_node_map[self.mean_act][0].attrs.axis
-        assert len(axis) == 1, "TVM Layernorm only supports single dim"
-        if axis[0] >= 0:
-            layernorm_axis = int(axis[0] - len(act_shape))
-        else:
-            layernorm_axis = int(axis[0])
-
-        if layernorm_axis != -1:
-            return post
-
-        if np.prod(gamma_shape) != act_shape[layernorm_axis]:
-            return post
-
-        if np.prod(pre_node_map[self.beta][0].checked_type.shape) != act_shape[layernorm_axis]:
-            return post
-
-        return tvm.relay.layernorm(act, gamma, beta, eps, layernorm_axis)
 
 
 class ReconstructTFLayerNorm(DFPatternCallback):
@@ -3854,45 +3491,6 @@ class ConvertIsNaN(DFPatternCallback):
         return cond
 
 
-class RemoveRedundantBinaryStacks(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True, require_type=True)
-
-        self.act = wildcard()
-        self.tuple = is_tuple([self.act])
-        self.stack = is_op("stack")(self.tuple)
-        self.reshape = is_op("reshape")(self.stack)
-
-        self.pattern = self.reshape
-
-    def callback(self, pre, post, node_map):
-        pre_node_map = construct_pre_node_map(self.pattern, pre)
-
-        act = node_map[self.act][0]
-        stack = pre_node_map[self.stack][0]
-        reshape = pre_node_map[self.reshape][0]
-
-        if len(stack.args) != 1 and len(reshape.args) != 1:
-            return post
-
-        stack_field_input_shape = [int(i) for i in stack.args[0].checked_type.fields[0].shape]
-        reshape_shape = [int(i) for i in reshape.attrs.newshape]
-
-        if stack_field_input_shape != reshape_shape:
-            return post
-
-        # Creates duplicates
-        # from tvm.relay.frontend.common import infer_type
-        # return infer_type(act.fields[0])
-
-        # Also, creates duplicates
-        # mod = tvm.ir.IRModule.from_expr(act.fields[0])
-        # mod = transform.InferType()(mod)
-        # return mod['main'].body
-
-        return act
-
-
 class RemoveStopFusionAnnotationNodes(DFPatternCallback):
     def __init__(self):
         super().__init__(rewrite_once=True, require_type=True)
@@ -4084,215 +3682,6 @@ class SimplifyTransposeReshape(DFPatternCallback):
 
         else:
             return post
-
-
-class DecomposeNonZeroPadtoConcat(DFPatternCallback):
-    def __init__(self):
-        super().__init__(rewrite_once=True, require_type=True)
-        self.act = wildcard()
-        self.pad = is_op("nn.pad")(self.act, wildcard())
-
-        self.pattern = self.pad
-
-    def callback(self, pre, post, node_map):
-        act = post.args[0]
-        pre_node_map = construct_pre_node_map(self.pattern, pre)
-        pad_width = post.attrs.pad_width
-        pad_value = post.args[1].data.numpy()
-        if pad_value == 0:
-            return post
-
-        pad_shape = list(pre_node_map[self.act][0].checked_type.shape)
-        pad_shape = [int(x) for x in pad_shape]
-        for i, item in enumerate(pad_width):
-            before = int(item[0])
-            after = int(item[1])
-            if before == 0 and after == 0:
-                continue
-
-            if before != 0:
-                current_pad_shape = pad_shape.copy()
-                current_pad_shape[i] = before
-                const = tvm.relay.const(
-                    np.ones(current_pad_shape) * pad_value, dtype=pre_node_map[self.act][0].checked_type.dtype
-                )
-                act = tvm.relay.concatenate([const, act], axis=i)
-                current_pad_shape[i] += pad_shape[i]
-                pad_shape = current_pad_shape
-
-            if after != 0:
-                current_pad_shape = pad_shape.copy()
-                current_pad_shape[i] = after
-                const = tvm.relay.const(
-                    np.ones(current_pad_shape) * pad_value, dtype=pre_node_map[self.act][0].checked_type.dtype
-                )
-                act = tvm.relay.concatenate([act, const], axis=i)
-                current_pad_shape[i] += pad_shape[i]
-                pad_shape = current_pad_shape
-        return act
-
-
-class ReplaceYolov5Perf(DFPatternCallback):
-    def __init__(self):
-        super().__init__()
-        self.mul1_1_const = wildcard()
-        self.mul1_3_const = wildcard()
-        self.mul2_1_const = wildcard()
-        self.add2_2_const = wildcard()
-        self.mul2_3_const = wildcard()
-
-        self.act = wildcard()
-        self.reshape = is_op("reshape")(self.act)
-        transpose1 = is_op("transpose")(self.reshape)
-        transpose2 = is_op("transpose")(transpose1)
-        sigmoid = is_op("sigmoid")(transpose2)
-
-        self.slice1 = is_op("strided_slice")(sigmoid)
-        mul1_1 = is_op("multiply")(self.slice1, self.mul1_1_const)
-        mul1_2 = is_op("multiply")(mul1_1, mul1_1)
-        mul1_3 = is_op("multiply")(mul1_2, self.mul1_3_const)
-
-        self.slice2 = is_op("strided_slice")(sigmoid)
-        mul2_1 = is_op("multiply")(self.slice2, self.mul2_1_const)
-        add2_2 = is_op("add")(mul2_1, self.add2_2_const)
-        mul2_3 = is_op("multiply")(add2_2, self.mul2_3_const)
-
-        self.slice3 = is_op("strided_slice")(sigmoid)
-
-        tup = is_tuple([mul2_3, mul1_3, self.slice3])
-        self.pattern = is_op("concatenate")(tup)
-
-    def callback(self, pre, post, node_map):
-        reshaped_shape = list(node_map[self.reshape][0].checked_type.shape)
-        reshaped_shape = [int(x) for x in reshaped_shape]
-        shape1 = [1, 1, reshaped_shape[1] * reshaped_shape[2], reshaped_shape[3] * reshaped_shape[4]]
-        shape2 = [1, reshaped_shape[1], reshaped_shape[2], reshaped_shape[3] * reshaped_shape[4]]
-
-        def separate_slice_attr(slice_attrs):
-            return int(slice_attrs.begin[0]), int(slice_attrs.end[0]), int(slice_attrs.axes[0])
-
-        slice1_begin, slice1_end, slice1_axis = separate_slice_attr(node_map[self.slice1][0].attrs)
-        slice2_begin, slice2_end, slice2_axis = separate_slice_attr(node_map[self.slice2][0].attrs)
-        slice3_begin, slice3_end, slice3_axis = separate_slice_attr(node_map[self.slice3][0].attrs)
-        if slice1_axis != 4 or slice2_axis != 4 or slice3_axis != 4 or len(reshaped_shape) != 5:
-            return post
-
-        act = node_map[self.act][0]
-        mul1_1_const = node_map[self.mul1_1_const][0]
-        mul1_3_const = node_map[self.mul1_3_const][0]
-        mul2_1_const = node_map[self.mul2_1_const][0]
-        add2_2_const = node_map[self.add2_2_const][0]
-        mul2_3_const = node_map[self.mul2_3_const][0]
-
-        # pad add2_2
-        slice2_length = slice2_end - slice2_begin
-        pad2_shape = reshaped_shape.copy()
-        pad2_shape[2] -= slice2_length
-        pad2 = tvm.relay.Constant(tvm.nd.array(np.zeros(pad2_shape, dtype=act.checked_type.dtype)))
-        add2_2_const = tvm.relay.transpose(add2_2_const, axes=[0, 1, 4, 2, 3])
-        add2_2_const = tvm.relay.concatenate([add2_2_const, pad2], axis=2)
-        add2_2_const = tvm.relay.reshape(
-            add2_2_const, newshape=[1, reshaped_shape[1] * reshaped_shape[2], reshaped_shape[3], reshaped_shape[4]]
-        )
-
-        # pad mul1_3
-        slice1_length = slice1_end - slice1_begin
-        pad1_1_shape = reshaped_shape.copy()
-        pad1_1_shape[2] = slice2_length
-        pad1_1 = tvm.relay.Constant(tvm.nd.array(np.zeros(pad1_1_shape, dtype=act.checked_type.dtype)))
-        pad1_3_shape = reshaped_shape.copy()
-        pad1_3_shape[2] -= slice2_length + slice1_length
-        pad1_3 = tvm.relay.Constant(tvm.nd.array(np.zeros(pad1_3_shape, dtype=act.checked_type.dtype)))
-        mul1_3_const = tvm.relay.transpose(mul1_3_const, axes=[0, 1, 4, 2, 3])
-        mul1_3_const = tvm.relay.concatenate([pad1_1, mul1_3_const, pad1_3], axis=2)
-        mul1_3_const = tvm.relay.reshape(
-            mul1_3_const, newshape=[1, reshaped_shape[1] * reshaped_shape[2], reshaped_shape[3], reshaped_shape[4]]
-        )
-
-        # generate masks
-        def generate_slice_mask(begin, end):
-            slice_mask_index = np.zeros(reshaped_shape.copy(), dtype=act.checked_type.dtype)
-            slice_mask_index[:, :, begin:end, :, :] = 1.0
-            slice_mask = tvm.relay.Constant(tvm.nd.array(slice_mask_index))
-            slice_mask = tvm.relay.reshape(
-                slice_mask, newshape=[1, reshaped_shape[1] * reshaped_shape[2], reshaped_shape[3], reshaped_shape[4]]
-            )
-            return slice_mask
-
-        slice1_mask = generate_slice_mask(slice1_begin, slice1_end)
-        slice2_mask = generate_slice_mask(slice2_begin, slice2_end)
-        slice3_mask = generate_slice_mask(slice3_begin, slice3_end)
-
-        # re-connect
-        sigmoid = tvm.relay.sigmoid(act)
-
-        mul1_1 = tvm.relay.multiply(sigmoid, mul1_1_const)
-        mul1_2 = tvm.relay.multiply(mul1_1, mul1_1)
-        mul1_3 = tvm.relay.multiply(mul1_2, mul1_3_const)
-        mul1_3_masked = tvm.relay.multiply(mul1_3, slice1_mask)
-
-        mul2_1 = tvm.relay.multiply(sigmoid, mul2_1_const)
-        add2_2 = tvm.relay.add(mul2_1, add2_2_const)
-        mul2_3 = tvm.relay.multiply(add2_2, mul2_3_const)
-        mul2_3_masked = tvm.relay.multiply(mul2_3, slice2_mask)
-
-        slice3_masked = tvm.relay.multiply(sigmoid, slice3_mask)
-
-        partial_sum = tvm.relay.add(mul1_3_masked, mul2_3_masked)
-        _sum = tvm.relay.add(partial_sum, slice3_masked)
-
-        reshape = tvm.relay.reshape(_sum, newshape=shape1)
-        reshape = tvm.relay.reshape(reshape, newshape=shape2)
-        transpose = tvm.relay.transpose(reshape, axes=[0, 1, 3, 2])
-        return transpose
-
-
-class TransformDenseIntoBatchMM(DFPatternCallback):
-    """
-    This pass will transform dense into batch_matmul and therefore
-    remove redundant squeeze and unsqueeze ops.
-    """
-
-    def __init__(self):
-        super().__init__(rewrite_once=True, require_type=True)
-
-        self.act = wildcard()
-        self.weight = wildcard()
-
-        self.reshape1 = is_op("reshape")(self.act)
-        self.transpose = is_op("transpose")(self.weight)
-
-        self.lm_head = is_op("nn.dense")(self.reshape1, self.transpose)
-        self.reshape2 = is_op("reshape")(self.lm_head)
-
-        self.pattern = self.reshape2
-
-    def callback(self, pre, post, node_map):
-        pre_node_map = construct_pre_node_map(self.pattern, pre)
-
-        activations = node_map[self.act][0]
-        weight = node_map[self.weight][0]
-        squeeze = node_map[self.reshape1][0]
-        weight_transpose = node_map[self.transpose][0]
-        lm_head = node_map[self.lm_head][0]
-        unsqueeze = node_map[self.reshape2][0]
-
-        if not (len(weight.args) == 1 and isinstance(weight.args[0], tvm.relay.Var)):
-            return post
-        if len(list(activations.checked_type.shape)) != 3:
-            return post
-        if len(list(weight_transpose.checked_type.shape)) != 2:
-            return post
-        if len(list(lm_head.checked_type.shape)) != 2:
-            return post
-        if len(list(unsqueeze.checked_type.shape)) != 3:
-            return post
-
-        new_weight_shape = [1] + list(weight.checked_type.shape)
-        weight_reshape = tvm.relay.reshape(weight, newshape=new_weight_shape)
-        lm_head = tvm.relay.nn.batch_matmul(activations, weight_reshape, transpose_a=False, transpose_b=False)
-
-        return lm_head
 
 
 class GQABroadcastReshape(DFPatternCallback):
@@ -4971,7 +4360,6 @@ def run_forge_compile_passes(
             ExplicateTranspose(),
             DecomposeConv1DToConv2D(),
             PopulateReduceAxes(),
-            DecomposeMultiAxisMax(),
             DecomposeMultiAxisTranspose(),
             EstimateWhereInCausalMask(),
             CastWhereConditionToBool(),
@@ -4981,11 +4369,8 @@ def run_forge_compile_passes(
             DecomposeMultiDimSqueeze(),
             PopulateTransposeAxes(),
             PopulateStridedSliceAxes(),
-            DecomposeMultiAxisMean(),
-            DecomposeMultiAxisSum(),
             ReconstructOnnxResize2d(),
             DecomposeMultiAxisBroadcast(),
-            EnsureKeepdims(),
             RemoveRedundantTake(),
             RemoveRedundantReshape(),
             LowerCopyToNOP(),

--- a/forge/forge/tvm_to_python.py
+++ b/forge/forge/tvm_to_python.py
@@ -1000,18 +1000,17 @@ def populate_broadcast_args(graph, nid, compiler_cfg):
 
 def populate_reduce_args(graph, nid, compiler_cfg):
     node = graph["nodes"][nid]
-    dim = int(node["attrs"]["axis"][0][0])
-    assert len(node["attrs"]["axis"][0]) == 1, "Forge only supports reduce with a single axis"
-
+    axes = node["attrs"]["axis"][0]
     keep_dim = int(node["attrs"]["keepdims"][0][0])
 
     input_nid = node["inputs"][0][0]
     input_shape = graph["nodes"][input_nid]["attrs"]["shape"][0][0]
+    rank = len(input_shape)
 
-    if dim >= 0:
-        dim -= len(input_shape)
+    # Normalize to negative indices (consistent with PyTorch convention).
+    dims = [int(ax) - rank if int(ax) >= 0 else int(ax) for ax in axes]
 
-    args = [("dim", f"{dim}"), ("keep_dim", f"{bool(keep_dim)}")]
+    args = [("dim", f"{dims}"), ("keep_dim", f"{bool(keep_dim)}")]
     return args
 
 

--- a/forge/test/mlir/operators/reduce/test_reduce.py
+++ b/forge/test/mlir/operators/reduce/test_reduce.py
@@ -5,68 +5,152 @@
 import pytest
 import torch
 from torch import nn
-from forge.verify.verify import verify
 
 import forge
+from forge.verify.verify import verify
 
 
 @pytest.mark.parametrize(
     "input_shape, dim, keepdim",
     [
+        # 1D
         pytest.param(
-            (64,),
-            0,
-            True,
-            marks=pytest.mark.xfail(reason="Tensor mismatch between framework and compiled model output"),
+            (64,), 0, True, marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs")
         ),
         pytest.param(
             (64,),
             -1,
             True,
-            marks=pytest.mark.xfail(reason="Tensor mismatch between framework and compiled model output"),
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
         ),
-        ((4, 64), 0, True),
-        ((32, 32), -2, True),
-        ((2, 32, 32), 0, True),
-        ((1, 64, 32), 2, True),
+        pytest.param(
+            (64,),
+            0,
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (64,),
+            -1,
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 2D - single dim
+        ((32, 64), 0, True),
+        ((32, 64), 0, False),
+        ((32, 64), 1, True),
+        ((32, 64), 1, False),
+        ((32, 64), -1, True),
+        ((32, 64), -1, False),
+        ((32, 64), -2, True),
+        ((32, 64), -2, False),
+        # 2D - multi dim
+        pytest.param(
+            (32, 64),
+            [0, 1],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (32, 64),
+            [0, 1],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 3D - single dim
+        ((4, 32, 64), 0, True),
+        ((4, 32, 64), 0, False),
+        ((4, 32, 64), 1, True),
+        ((4, 32, 64), 1, False),
+        ((4, 32, 64), 2, True),
+        ((4, 32, 64), 2, False),
+        ((4, 32, 64), -1, True),
+        ((4, 32, 64), -1, False),
         ((4, 32, 64), -2, True),
-        ((4, 128, 128, 128), 0, True),
-        ((1, 128, 128, 128), 2, True),
-        ((1, 128, 128, 128), -3, True),
-        ((4, 128, 128, 128), -4, True),
-        pytest.param(
-            (64,),
-            0,
-            False,
-            marks=pytest.mark.xfail(reason="'ttir.squeeze' op Output tensor must have at least one dimension."),
-        ),
-        pytest.param(
-            (64,),
-            -1,
-            False,
-            marks=pytest.mark.xfail(reason="'ttir.squeeze' op Output tensor must have at least one dimension."),
-        ),
-        pytest.param(
-            (4, 64),
-            0,
-            False,
-        ),
-        pytest.param(
-            (32, 32),
-            -2,
-            False,
-        ),
-        ((2, 32, 32), 0, False),
-        ((1, 64, 32), 2, False),
         ((4, 32, 64), -2, False),
-        ((4, 128, 128, 128), 0, False),
-        (
-            (1, 128, 128, 128),
-            2,
-            False,
+        ((4, 32, 64), -3, True),
+        ((4, 32, 64), -3, False),
+        # 3D - multi dim
+        ((4, 32, 64), [0, 1], True),
+        ((4, 32, 64), [0, 1], False),
+        ((4, 32, 64), [0, 2], True),
+        ((4, 32, 64), [0, 2], False),
+        ((4, 32, 64), [1, 2], True),
+        ((4, 32, 64), [1, 2], False),
+        pytest.param(
+            (4, 32, 64),
+            [0, 1, 2],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
         ),
-        ((1, 128, 128, 128), -3, False),
-        ((4, 128, 128, 128), -4, False),
+        pytest.param(
+            (4, 32, 64),
+            [0, 1, 2],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 4D - single dim
+        ((1, 4, 32, 64), 0, True),
+        ((1, 4, 32, 64), 0, False),
+        ((1, 4, 32, 64), 1, True),
+        ((1, 4, 32, 64), 1, False),
+        ((1, 4, 32, 64), 2, True),
+        ((1, 4, 32, 64), 2, False),
+        ((1, 4, 32, 64), 3, True),
+        ((1, 4, 32, 64), 3, False),
+        ((1, 4, 32, 64), -1, True),
+        ((1, 4, 32, 64), -1, False),
+        ((1, 4, 32, 64), -2, True),
+        ((1, 4, 32, 64), -2, False),
+        ((1, 4, 32, 64), -3, True),
+        ((1, 4, 32, 64), -3, False),
+        ((1, 4, 32, 64), -4, True),
+        ((1, 4, 32, 64), -4, False),
+        # 4D - 2-dim combinations
+        ((1, 4, 32, 64), [0, 1], True),
+        ((1, 4, 32, 64), [0, 1], False),
+        ((1, 4, 32, 64), [0, 2], True),
+        ((1, 4, 32, 64), [0, 2], False),
+        ((1, 4, 32, 64), [0, 3], True),
+        ((1, 4, 32, 64), [0, 3], False),
+        ((1, 4, 32, 64), [1, 2], True),
+        ((1, 4, 32, 64), [1, 2], False),
+        ((1, 4, 32, 64), [1, 3], True),
+        ((1, 4, 32, 64), [1, 3], False),
+        ((1, 4, 32, 64), [2, 3], True),
+        ((1, 4, 32, 64), [2, 3], False),
+        # 4D - 3-dim combinations
+        ((1, 4, 32, 64), [0, 1, 2], True),
+        ((1, 4, 32, 64), [0, 1, 2], False),
+        ((1, 4, 32, 64), [0, 1, 3], True),
+        ((1, 4, 32, 64), [0, 1, 3], False),
+        ((1, 4, 32, 64), [0, 2, 3], True),
+        ((1, 4, 32, 64), [0, 2, 3], False),
+        pytest.param(
+            (1, 4, 32, 64),
+            [1, 2, 3],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [1, 2, 3],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 4D - all dims
+        pytest.param(
+            (1, 4, 32, 64),
+            [0, 1, 2, 3],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [0, 1, 2, 3],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
     ],
 )
 @pytest.mark.push
@@ -79,71 +163,152 @@ def test_reduce_sum(input_shape, dim, keepdim):
             return torch.sum(a, dim=dim, keepdim=keepdim)
 
     inputs = [torch.rand(input_shape)]
-
     framework_model = ReduceSum()
-
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
-
     verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
     "input_shape, dim, keepdim",
     [
+        # 1D
         pytest.param(
-            (64,),
-            0,
-            True,
-            marks=pytest.mark.xfail(reason="Tensor mismatch between framework and compiled model output"),
+            (64,), 0, True, marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs")
         ),
         pytest.param(
             (64,),
             -1,
             True,
-            marks=pytest.mark.xfail(reason="Tensor mismatch between framework and compiled model output"),
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
         ),
-        ((4, 64), 0, True),
-        ((32, 32), -2, True),
-        ((2, 32, 32), 0, True),
-        ((1, 64, 32), 2, True),
+        pytest.param(
+            (64,),
+            0,
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (64,),
+            -1,
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 2D - single dim
+        ((32, 64), 0, True),
+        ((32, 64), 0, False),
+        ((32, 64), 1, True),
+        ((32, 64), 1, False),
+        ((32, 64), -1, True),
+        ((32, 64), -1, False),
+        ((32, 64), -2, True),
+        ((32, 64), -2, False),
+        # 2D - multi dim
+        pytest.param(
+            (32, 64),
+            [0, 1],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (32, 64),
+            [0, 1],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 3D - single dim
+        ((4, 32, 64), 0, True),
+        ((4, 32, 64), 0, False),
+        ((4, 32, 64), 1, True),
+        ((4, 32, 64), 1, False),
+        ((4, 32, 64), 2, True),
+        ((4, 32, 64), 2, False),
+        ((4, 32, 64), -1, True),
+        ((4, 32, 64), -1, False),
         ((4, 32, 64), -2, True),
-        ((4, 128, 128, 128), 0, True),
-        ((1, 128, 128, 128), 2, True),
-        ((1, 128, 128, 128), -3, True),
-        ((4, 128, 128, 128), -4, True),
-        pytest.param(
-            (64,),
-            0,
-            False,
-            marks=pytest.mark.xfail(reason="'ttir.squeeze' op Output tensor must have at least one dimension."),
-        ),
-        pytest.param(
-            (64,),
-            -1,
-            False,
-            marks=pytest.mark.xfail(reason="'ttir.squeeze' op Output tensor must have at least one dimension."),
-        ),
-        pytest.param(
-            (4, 64),
-            0,
-            False,
-        ),
-        pytest.param(
-            (32, 32),
-            -2,
-            False,
-        ),
-        ((2, 32, 32), 0, False),
-        ((1, 64, 32), 2, False),
         ((4, 32, 64), -2, False),
-        ((4, 128, 128, 128), 0, False),
-        (
-            (1, 128, 128, 128),
-            2,
-            False,
+        ((4, 32, 64), -3, True),
+        ((4, 32, 64), -3, False),
+        # 3D - multi dim
+        ((4, 32, 64), [0, 1], True),
+        ((4, 32, 64), [0, 1], False),
+        ((4, 32, 64), [0, 2], True),
+        ((4, 32, 64), [0, 2], False),
+        ((4, 32, 64), [1, 2], True),
+        ((4, 32, 64), [1, 2], False),
+        pytest.param(
+            (4, 32, 64),
+            [0, 1, 2],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
         ),
-        ((1, 128, 128, 128), -3, False),
-        ((4, 128, 128, 128), -4, False),
+        pytest.param(
+            (4, 32, 64),
+            [0, 1, 2],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 4D - single dim
+        ((1, 4, 32, 64), 0, True),
+        ((1, 4, 32, 64), 0, False),
+        ((1, 4, 32, 64), 1, True),
+        ((1, 4, 32, 64), 1, False),
+        ((1, 4, 32, 64), 2, True),
+        ((1, 4, 32, 64), 2, False),
+        ((1, 4, 32, 64), 3, True),
+        ((1, 4, 32, 64), 3, False),
+        ((1, 4, 32, 64), -1, True),
+        ((1, 4, 32, 64), -1, False),
+        ((1, 4, 32, 64), -2, True),
+        ((1, 4, 32, 64), -2, False),
+        ((1, 4, 32, 64), -3, True),
+        ((1, 4, 32, 64), -3, False),
+        ((1, 4, 32, 64), -4, True),
+        ((1, 4, 32, 64), -4, False),
+        # 4D - 2-dim combinations
+        ((1, 4, 32, 64), [0, 1], True),
+        ((1, 4, 32, 64), [0, 1], False),
+        ((1, 4, 32, 64), [0, 2], True),
+        ((1, 4, 32, 64), [0, 2], False),
+        ((1, 4, 32, 64), [0, 3], True),
+        ((1, 4, 32, 64), [0, 3], False),
+        ((1, 4, 32, 64), [1, 2], True),
+        ((1, 4, 32, 64), [1, 2], False),
+        ((1, 4, 32, 64), [1, 3], True),
+        ((1, 4, 32, 64), [1, 3], False),
+        ((1, 4, 32, 64), [2, 3], True),
+        ((1, 4, 32, 64), [2, 3], False),
+        # 4D - 3-dim combinations
+        ((1, 4, 32, 64), [0, 1, 2], True),
+        ((1, 4, 32, 64), [0, 1, 2], False),
+        ((1, 4, 32, 64), [0, 1, 3], True),
+        ((1, 4, 32, 64), [0, 1, 3], False),
+        ((1, 4, 32, 64), [0, 2, 3], True),
+        ((1, 4, 32, 64), [0, 2, 3], False),
+        pytest.param(
+            (1, 4, 32, 64),
+            [1, 2, 3],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [1, 2, 3],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 4D - all dims
+        pytest.param(
+            (1, 4, 32, 64),
+            [0, 1, 2, 3],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [0, 1, 2, 3],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
     ],
 )
 @pytest.mark.push
@@ -156,102 +321,385 @@ def test_reduce_mean(input_shape, dim, keepdim):
             return torch.mean(a, dim=dim, keepdim=keepdim)
 
     inputs = [torch.rand(input_shape)]
-
     framework_model = ReduceMean()
-
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
-
-    verify(inputs, framework_model, compiled_model)
-
-
-@pytest.mark.parametrize("x_shape", [7, 32, 41])
-@pytest.mark.parametrize("y_shape", [7, 32, 41])
-@pytest.mark.parametrize("dim", [1, 2])
-@pytest.mark.push
-def test_mean(x_shape, y_shape, dim):
-    class Mean(nn.Module):
-        def __init__(self):
-            super().__init__()
-
-        def forward(self, x):
-            return torch.mean(x, dim=dim)
-
-    inputs = [
-        torch.rand(1, x_shape, y_shape),
-    ]
-
-    framework_model = Mean()
-
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs)
-
     verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.parametrize(
     "input_shape, dim, keepdim",
     [
+        # 1D
         pytest.param(
-            (64,),
-            0,
-            True,
-            marks=pytest.mark.xfail(reason="Tensor mismatch between framework and compiled model output"),
+            (64,), 0, True, marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs")
         ),
         pytest.param(
             (64,),
             -1,
             True,
-            marks=pytest.mark.xfail(reason="Tensor mismatch between framework and compiled model output"),
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
         ),
-        ((4, 64), 0, True),
-        ((32, 32), -2, True),
-        ((2, 32, 32), 0, True),
-        ((1, 64, 32), 2, True),
+        pytest.param(
+            (64,),
+            0,
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (64,),
+            -1,
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 2D - single dim
+        ((32, 64), 0, True),
+        ((32, 64), 0, False),
+        ((32, 64), 1, True),
+        ((32, 64), 1, False),
+        ((32, 64), -1, True),
+        ((32, 64), -1, False),
+        ((32, 64), -2, True),
+        ((32, 64), -2, False),
+        # 2D - multi dim
+        pytest.param(
+            (32, 64),
+            [0, 1],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (32, 64),
+            [0, 1],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 3D - single dim
+        ((4, 32, 64), 0, True),
+        ((4, 32, 64), 0, False),
+        ((4, 32, 64), 1, True),
+        ((4, 32, 64), 1, False),
+        ((4, 32, 64), 2, True),
+        ((4, 32, 64), 2, False),
+        ((4, 32, 64), -1, True),
+        ((4, 32, 64), -1, False),
         ((4, 32, 64), -2, True),
-        ((4, 128, 128, 128), 0, True),
-        ((1, 128, 128, 128), 2, True),
-        ((1, 128, 128, 128), -3, True),
-        ((4, 128, 128, 128), -4, True),
-        pytest.param(
-            (64,),
-            0,
-            False,
-            marks=pytest.mark.xfail(reason="[mlir::AffineMap collapsedLinearAffineMap] Assertion `end > 0' failed."),
-        ),
-        pytest.param(
-            (64,),
-            -1,
-            False,
-            marks=pytest.mark.xfail(reason="[mlir::AffineMap collapsedLinearAffineMap] Assertion `end > 0' failed."),
-        ),
-        ((4, 64), 0, False),
-        ((32, 32), -2, False),
-        ((2, 32, 32), 0, False),
-        ((1, 64, 32), 2, False),
         ((4, 32, 64), -2, False),
-        ((4, 128, 128, 128), 0, False),
-        ((1, 128, 128, 128), 2, False),
-        ((1, 128, 128, 128), -3, False),
-        ((4, 128, 128, 128), -4, False),
+        ((4, 32, 64), -3, True),
+        ((4, 32, 64), -3, False),
+        # 3D - multi dim
+        ((4, 32, 64), [0, 1], True),
+        ((4, 32, 64), [0, 1], False),
+        pytest.param(
+            (4, 32, 64),
+            [0, 2],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (4, 32, 64),
+            [0, 2],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (4, 32, 64),
+            [1, 2],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (4, 32, 64),
+            [1, 2],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (4, 32, 64),
+            [0, 1, 2],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (4, 32, 64),
+            [0, 1, 2],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 4D - single dim
+        ((1, 4, 32, 64), 0, True),
+        ((1, 4, 32, 64), 0, False),
+        ((1, 4, 32, 64), 1, True),
+        ((1, 4, 32, 64), 1, False),
+        ((1, 4, 32, 64), 2, True),
+        ((1, 4, 32, 64), 2, False),
+        ((1, 4, 32, 64), 3, True),
+        ((1, 4, 32, 64), 3, False),
+        ((1, 4, 32, 64), -1, True),
+        ((1, 4, 32, 64), -1, False),
+        ((1, 4, 32, 64), -2, True),
+        ((1, 4, 32, 64), -2, False),
+        ((1, 4, 32, 64), -3, True),
+        ((1, 4, 32, 64), -3, False),
+        ((1, 4, 32, 64), -4, True),
+        ((1, 4, 32, 64), -4, False),
+        # 4D - 2-dim combinations
+        ((1, 4, 32, 64), [0, 1], True),
+        ((1, 4, 32, 64), [0, 1], False),
+        ((1, 4, 32, 64), [0, 2], True),
+        ((1, 4, 32, 64), [0, 2], False),
+        ((1, 4, 32, 64), [0, 3], True),
+        ((1, 4, 32, 64), [0, 3], False),
+        ((1, 4, 32, 64), [1, 2], True),
+        ((1, 4, 32, 64), [1, 2], False),
+        pytest.param(
+            (1, 4, 32, 64),
+            [1, 3],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [1, 3],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [2, 3],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [2, 3],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 4D - 3-dim combinations
+        ((1, 4, 32, 64), [0, 1, 2], True),
+        ((1, 4, 32, 64), [0, 1, 2], False),
+        pytest.param(
+            (1, 4, 32, 64),
+            [0, 1, 3],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [0, 1, 3],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [0, 2, 3],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [0, 2, 3],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [1, 2, 3],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [1, 2, 3],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        # 4D - all dims
+        pytest.param(
+            (1, 4, 32, 64),
+            [0, 1, 2, 3],
+            True,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
+        pytest.param(
+            (1, 4, 32, 64),
+            [0, 1, 2, 3],
+            False,
+            marks=pytest.mark.xfail(reason="Data mismatch between framework and compiled model outputs"),
+        ),
     ],
 )
 @pytest.mark.push
 def test_reduce_max(input_shape, dim, keepdim):
-    input = (input_shape, dim, keepdim)
-    if input in [((64,), 0, False), ((64,), -1, False)]:
-        pytest.xfail(reason="[mlir::AffineMap collapsedLinearAffineMap] Assertion `end > 0' failed.")
-
     class ReduceMax(nn.Module):
         def __init__(self):
             super().__init__()
 
         def forward(self, a):
-            return torch.max(a, dim=dim, keepdim=keepdim)[0]
+            # torch.amax supports both int and list[int] dims.
+            return torch.amax(a, dim=dim, keepdim=keepdim)
 
     inputs = [torch.rand(input_shape)]
-
     framework_model = ReduceMax()
     framework_model.eval()
-
     compiled_model = forge.compile(framework_model, sample_inputs=inputs)
-
     verify(inputs, framework_model, compiled_model)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim, keepdim",
+    [
+        # 2D - single dim
+        ((32, 64), 0, True),
+        ((32, 64), 0, False),
+        ((32, 64), 1, True),
+        ((32, 64), 1, False),
+        ((32, 64), -1, True),
+        ((32, 64), -1, False),
+        # 3D - single dim
+        ((4, 32, 64), 0, True),
+        ((4, 32, 64), 0, False),
+        ((4, 32, 64), 1, True),
+        ((4, 32, 64), 1, False),
+        ((4, 32, 64), 2, True),
+        ((4, 32, 64), 2, False),
+        # 3D - multi dim
+        ((4, 32, 64), [0, 1], True),
+        ((4, 32, 64), [0, 1], False),
+        ((4, 32, 64), [0, 2], True),
+        ((4, 32, 64), [0, 2], False),
+        ((4, 32, 64), [1, 2], True),
+        ((4, 32, 64), [1, 2], False),
+        # 4D - single dim
+        ((1, 4, 32, 64), 1, True),
+        ((1, 4, 32, 64), 1, False),
+        ((1, 4, 32, 64), 2, True),
+        ((1, 4, 32, 64), 2, False),
+        ((1, 4, 32, 64), 3, True),
+        ((1, 4, 32, 64), 3, False),
+        # 4D - multi dim
+        ((1, 4, 32, 64), [0, 1], True),
+        ((1, 4, 32, 64), [0, 1], False),
+        ((1, 4, 32, 64), [1, 2], True),
+        ((1, 4, 32, 64), [1, 2], False),
+        ((1, 4, 32, 64), [2, 3], True),
+        ((1, 4, 32, 64), [2, 3], False),
+    ],
+)
+@pytest.mark.push
+def test_reduce_sum_backward(input_shape, dim, keepdim):
+    class ReduceSum(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, a):
+            return torch.sum(a, dim=dim, keepdim=keepdim)
+
+    inputs = [torch.rand(input_shape, requires_grad=True)]
+    framework_model = ReduceSum()
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, training=True)
+    verify(inputs, framework_model, compiled_model, with_backward=True)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim, keepdim",
+    [
+        # 2D - single dim
+        ((32, 64), 0, True),
+        ((32, 64), 0, False),
+        ((32, 64), 1, True),
+        ((32, 64), 1, False),
+        ((32, 64), -1, True),
+        ((32, 64), -1, False),
+        # 3D - single dim
+        ((4, 32, 64), 0, True),
+        ((4, 32, 64), 0, False),
+        ((4, 32, 64), 1, True),
+        ((4, 32, 64), 1, False),
+        ((4, 32, 64), 2, True),
+        ((4, 32, 64), 2, False),
+        # 3D - multi dim
+        ((4, 32, 64), [0, 1], True),
+        ((4, 32, 64), [0, 1], False),
+        ((4, 32, 64), [0, 2], True),
+        ((4, 32, 64), [0, 2], False),
+        ((4, 32, 64), [1, 2], True),
+        ((4, 32, 64), [1, 2], False),
+        # 4D - single dim
+        ((1, 4, 32, 64), 1, True),
+        ((1, 4, 32, 64), 1, False),
+        ((1, 4, 32, 64), 2, True),
+        ((1, 4, 32, 64), 2, False),
+        ((1, 4, 32, 64), 3, True),
+        ((1, 4, 32, 64), 3, False),
+        # 4D - multi dim
+        ((1, 4, 32, 64), [0, 1], True),
+        ((1, 4, 32, 64), [0, 1], False),
+        ((1, 4, 32, 64), [1, 2], True),
+        ((1, 4, 32, 64), [1, 2], False),
+        ((1, 4, 32, 64), [2, 3], True),
+        ((1, 4, 32, 64), [2, 3], False),
+    ],
+)
+@pytest.mark.push
+def test_reduce_mean_backward(input_shape, dim, keepdim):
+    class ReduceMean(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, a):
+            return torch.mean(a, dim=dim, keepdim=keepdim)
+
+    inputs = [torch.rand(input_shape, requires_grad=True)]
+    framework_model = ReduceMean()
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, training=True)
+    verify(inputs, framework_model, compiled_model, with_backward=True)
+
+
+@pytest.mark.parametrize(
+    "input_shape, dim, keepdim",
+    [
+        # 2D - single dim
+        ((32, 64), 0, True),
+        ((32, 64), 0, False),
+        ((32, 64), 1, True),
+        ((32, 64), 1, False),
+        ((32, 64), -1, True),
+        ((32, 64), -1, False),
+        # 3D - single dim
+        ((4, 32, 64), 0, True),
+        ((4, 32, 64), 0, False),
+        ((4, 32, 64), 1, True),
+        ((4, 32, 64), 1, False),
+        ((4, 32, 64), 2, True),
+        ((4, 32, 64), 2, False),
+        # 3D - multi dim
+        ((4, 32, 64), [0, 1], True),
+        ((4, 32, 64), [0, 1], False),
+        # 4D - single dim
+        ((1, 4, 32, 64), 1, True),
+        ((1, 4, 32, 64), 1, False),
+        ((1, 4, 32, 64), 2, True),
+        ((1, 4, 32, 64), 2, False),
+        ((1, 4, 32, 64), 3, True),
+        ((1, 4, 32, 64), 3, False),
+        # 4D - multi dim
+        ((1, 4, 32, 64), [0, 1], True),
+        ((1, 4, 32, 64), [0, 1], False),
+        ((1, 4, 32, 64), [1, 2], True),
+        ((1, 4, 32, 64), [1, 2], False),
+    ],
+)
+@pytest.mark.push
+def test_reduce_max_backward(input_shape, dim, keepdim):
+    class ReduceMax(nn.Module):
+        def __init__(self):
+            super().__init__()
+
+        def forward(self, a):
+            return torch.amax(a, dim=dim, keepdim=keepdim)
+
+    inputs = [torch.rand(input_shape, requires_grad=True)]
+    framework_model = ReduceMax()
+    compiled_model = forge.compile(framework_model, sample_inputs=inputs, training=True)
+    verify(inputs, framework_model, compiled_model, with_backward=True)


### PR DESCRIPTION
## Context

While working on ONNX transpiler support (PR #3163), the transpiler's reduction-op converters
(`ReduceMean`, `ReduceMax`, `ReduceSum`) map ONNX reduction nodes to Forge reduction ops. ONNX
and PyTorch both express the `axes` / `dim` attribute as a **list of integers**, and the TTIR
dialect (`ttir.sum`, `ttir.mean`, `ttir.max`) likewise accepts `dim_arg` as a list. However,
Forge's internal `ReduceSum`, `ReduceAvg`, and `ReduceMax` ops only accepted a **single integer**
for `dim`.

This mismatch forced the transpiler (and TVM paths before it) to fan a multi-axis ONNX reduction
into a chain of single-axis Forge reductions plus squeeze/reshape fix-ups — producing more ops,
more MLIR.

This PR refactors the three reduction ops end-to-end so that `dim` is a `List[int]` throughout
the Forge stack, matching what the upstream TTIR dialect already supports.


## Summary of Changes

### 1. Python op definitions — `forge/forge/op/reduce.py`

- `ReduceSum`, `ReduceAvg`, `ReduceMax` now accept
  `dim: Union[int, List[int], Tuple[int, ...]]`.
- A `_normalize_dims` helper validates each entry, converts negative indices to positive, and
  normalizes the value to `List[int]` before it is stored as the `dim_arg` attribute.
- Docstrings updated to document multi-dim support.

### 2. TVM → Forge serializer — `forge/forge/tvm_to_python.py`

- `populate_reduce_args` now reads the **full axis list** from the Relay node and serializes
  every axis in its negative form (PyTorch convention).
- The former hard assertion `len(node["attrs"]["axis"][0]) == 1` is removed — multi-axis
  reductions no longer abort during serialization.

### 3. TVM Relay passes — `forge/forge/tvm_calls/relay/op/forge_passes.py`

Two categories of passes were removed.

**Reduction decomposition passes** (no longer needed because Forge now handles multi-dim
reductions natively):

| Removed pass | Former purpose |
|---|---|
| `DecomposeMultiAxisSum` | Fan multi-axis sum into N single-axis sums |
| `DecomposeMultiAxisMean` | Fan multi-axis mean into N single-axis means |
| `DecomposeMultiAxisMax` | Fan multi-axis max into N single-axis maxes |
| `EnsureKeepdims` | Re-insert squeeze/reshape to fix shapes after the above decompositions |

**Unused `DFPatternCallback` classes** (dead code not referenced in any pass list):

| Removed pass | Notes |
|---|---|
| `RemoveCast` | Cast removal handled elsewhere |
| `ReformatTFConv2d` | TF Conv2d reformatting no longer applied |
| `ReformatTFMaxpool` | TF MaxPool reformatting no longer applied |
| `AddSqueezeForArgmax` | Argmax squeeze no longer needed |
| `InvertDivide` | Division inversion not used |
| `LowerSqueezeToReshape` | Squeeze lowering handled by other passes |
| `ConvertAddToBiasAddAfterConv2dTFWithChannelFirst` | TF-specific bias-add pattern no longer used |
| `ConvertExpandDimsToReshape` | ExpandDims → Reshape no longer used |
| `DecomposeErf` | Erf decomposition no longer needed |
| `ReconstructPyTorchLayerNorm` | PyTorch LayerNorm reconstruction not in pass list |
| `RemoveRedundantBinaryStacks` | Redundant stack removal no longer applied |
| `DecomposeNonZeroPadtoConcat` | Non-zero-pad decomposition not used |
| `ReplaceYolov5Perf` | YOLOv5-specific optimization not used |
| `TransformDenseIntoBatchMM` | Dense → batch matmul transform not used |

The `PopulateReduceAxes` pass was extended to handle `axis=None` for `mean` and `max` in
addition to `sum`, so that "reduce-all-dims" nodes receive the correct per-input axis list
regardless of the frontend op.

### 4. C++ op implementations

#### `forge/csrc/ops/op_common.cpp` — shape inference

`reduce_ops_shape` iterates over every entry in `dim_arg`:
- Normalizes negative dim indices.
- Validates each dim against the input rank.
- When `keep_dim=false`, erases reduced dims in **descending** order so that earlier erasures do
  not shift the indices of later ones.

#### `forge/csrc/ops/op_reduce_sum.cpp` and `op_reduce_avg.cpp`

- **eval**: passes the full `dim_arg` list to `torch::sum` / `torch::mean` via `at::IntArrayRef`.
- **backward**: unsqueezes every reduced dim in ascending order (to keep indices valid), then uses
  a single `Repeat` op with per-dim repeat factors to broadcast the gradient back to the input
  shape. `op_reduce_avg.cpp` additionally scales the gradient by `1 / product(reduced_dim_sizes)`.
  `Broadcast` was replaced with `Repeat` everywhere in the backward because `Broadcast` is
  transformed into an edge TM by `convert_broadcast_ops_to_tms` in `pre_lowering_passes.cpp`
  and is never emitted into the MLIR backward graph.
- **decompose_initial**: fuses the reduction to a `Nop` (keep_dim=true) or a sequence of
  `Squeeze` ops (keep_dim=false) only when *every* reduced dim already has size 1.

#### `forge/csrc/ops/op_reduce_max.cpp`

- **eval**: switched from `torch::max` (single-dim only) to `torch::amax`, which natively
  accepts an `IntArrayRef` of dims.
- **decompose_initial**: same size-1 fusion logic as sum / mean.
- **backward**: completely redesigned — see the section below.


## ReduceMax Backward: Sharp Softmax Mask

The standard argmax-mask approach (`input == max`) requires exact equality between the forward
max output and the input element at the argmax position. This is not guaranteed on hardware, so
the backward uses a **sharp softmax** instead, which naturally concentrates at the argmax without
relying on exact equality.

**Step 1 — center on the max and scale:**
`max_output` is first expanded to the full input shape via `Repeat`, then subtracted from the
input. The difference is `~0` at the argmax and strictly negative everywhere else. Multiplying
by a large scale (`2000`) sharpens the distribution so the argmax dominates.

**Step 2 — compute softmax over the reduced dims:**
`exp` is applied element-wise, then `ReduceSum` normalizes along the reduced dims. The result
is a soft probability distribution — nearly all mass sits at the argmax position.

**Step 3 — threshold to a one-hot mask:**
Values `>= 0.5` form a clean one-hot mask at the argmax position.

**Step 4 — route the gradient:**
The incoming gradient is expanded to the input shape via `Repeat` and multiplied by the mask,
passing the gradient only to the argmax positions.

```
# Step 1
max_expanded = repeat(max_output, input_shape)
diff         = input - max_expanded          # ~0 at argmax, negative elsewhere
scaled_diff  = diff * 2000

# Step 2
exp_diff     = exp(scaled_diff)
sum_exp      = reduce_sum(exp_diff, dims)
soft_mask    = exp_diff / repeat(sum_exp)    # softmax; peak at argmax

# Step 3
mask         = soft_mask >= 0.5              # one-hot at argmax

# Step 4
grad_input   = repeat(gradient) * mask
```

## Test suite — `forge/test/mlir/operators/reduce/test_reduce.py`

The test file was rewritten from scratch with:

- **Comprehensive parametrization** for `test_reduce_sum`, `test_reduce_mean`, and
  `test_reduce_max` covering:
  - 1D, 2D, 3D, and 4D input shapes.
  - All single-dim cases including negative-index dims.
  - Every multi-dim combination (2-dim, 3-dim, all-dims).
  - Both `keepdim=True` and `keepdim=False`.

- **Backward pass coverage** for all three ops:
  - `test_reduce_sum_backward`
  - `test_reduce_mean_backward`
  - `test_reduce_max_backward`

  Each backward test uses `requires_grad=True`, `training=True`, and
  `verify(..., with_backward=True)` to validate gradient correctness against PyTorch's
  autograd.


## Regression Fix: Spurious Squeeze Insertion in `handle_change_rank`

### Problem

Removing `EnsureKeepdims` exposed a latent bug in `handle_change_rank`
(`forge/csrc/graph_lib/utils.cpp`). After graph decomposition (e.g. Layernorm), this function
inserts Squeeze/Unsqueeze ops to align producer/consumer ranks. Its `get_consumer_size` lambda
incorrectly returned the reduction op's **output** rank as the expected **input** rank. For
`keep_dim=False` reductions, those differ by the number of reduced dims, causing a spurious
squeeze to be inserted before the reduction op and producing wrong output shapes.

### Solution

Added a special case in `get_consumer_size` for reduce ops with `keep_dim=False` — the expected
input rank is output rank + number of reduced dims:

```cpp
// forge/csrc/graph_lib/utils.cpp — get_consumer_size lambda inside handle_change_rank
if (op->is_reduce() && !op->op().attr_as<bool>("keep_dim"))
{
    auto dims = op->op().attr_as<std::vector<int>>("dim_arg");
    return consumer_size + static_cast<std::uint32_t>(dims.size());
}
```

