### PR TITLE
Replace scikit-image with pillow

### DIFF
--- a/env/linux_requirements.txt
+++ b/env/linux_requirements.txt
@@ -9,7 +9,7 @@ pytest-xdist==2.5.0
 pytorchcv==0.0.67
 pytest-split
 seaborn
-scikit-image==0.20.0 # For DenseNet 121 HF XRay model
+Pillow>=10.0.0 # For image processing (DenseNet 121 HF XRay model, SSD300)
 segmentation_models_pytorch==0.4.0
 timm==1.0.9
 # The CPU versions of torch and torch visions are used due to their size being

--- a/forge/test/models/onnx/vision/ssd300_resnet50/model_utils/image_utils.py
+++ b/forge/test/models/onnx/vision/ssd300_resnet50/model_utils/image_utils.py
@@ -2,13 +2,14 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import numpy as np
-import skimage
+from PIL import Image
 
 
 def load_image(image_path):
     """Code from Loading_Pretrained_Models.ipynb - a Caffe2 tutorial"""
     mean, std = 128, 128
-    img = skimage.img_as_float(skimage.io.imread(image_path))
+    img = Image.open(image_path)
+    img = np.array(img).astype(np.float32) / 255.0  # Convert to float [0, 1]
     if len(img.shape) == 2:
         img = np.array([img, img, img]).swapaxes(0, 2)
     return img
@@ -17,17 +18,23 @@ def load_image(image_path):
 def rescale(img, input_height, input_width):
     """Code from Loading_Pretrained_Models.ipynb - a Caffe2 tutorial"""
     aspect = img.shape[1] / float(img.shape[0])
+    # Convert to PIL Image for resizing
+    img_pil = Image.fromarray((img * 255).astype(np.uint8))
+
     if aspect > 1:
         # landscape orientation - wide image
         res = int(aspect * input_height)
-        imgScaled = skimage.transform.resize(img, (input_width, res))
-    if aspect < 1:
+        # PIL resize takes (width, height), skimage takes (height, width)
+        imgScaled = img_pil.resize((res, input_width), Image.BILINEAR)
+    elif aspect < 1:
         # portrait orientation - tall image
         res = int(input_width / aspect)
-        imgScaled = skimage.transform.resize(img, (res, input_height))
-    if aspect == 1:
-        imgScaled = skimage.transform.resize(img, (input_width, input_height))
-    return imgScaled
+        imgScaled = img_pil.resize((input_height, res), Image.BILINEAR)
+    else:
+        imgScaled = img_pil.resize((input_height, input_width), Image.BILINEAR)
+
+    # Convert back to float numpy array [0, 1]
+    return np.array(imgScaled).astype(np.float32) / 255.0
 
 
 def crop_center(img, cropx, cropy):

--- a/forge/test/models/onnx/vision/ssd300_resnet50/model_utils/image_utils.py
+++ b/forge/test/models/onnx/vision/ssd300_resnet50/model_utils/image_utils.py
@@ -8,10 +8,8 @@ from PIL import Image
 def load_image(image_path):
     """Code from Loading_Pretrained_Models.ipynb - a Caffe2 tutorial"""
     mean, std = 128, 128
-    img = Image.open(image_path)
+    img = Image.open(image_path).convert("RGB")
     img = np.array(img).astype(np.float32) / 255.0  # Convert to float [0, 1]
-    if len(img.shape) == 2:
-        img = np.array([img, img, img]).swapaxes(0, 2)
     return img
 
 
@@ -25,13 +23,13 @@ def rescale(img, input_height, input_width):
         # landscape orientation - wide image
         res = int(aspect * input_height)
         # PIL resize takes (width, height), skimage takes (height, width)
-        imgScaled = img_pil.resize((res, input_width), Image.BILINEAR)
+        imgScaled = img_pil.resize((res, input_width), Image.Resampling.BILINEAR)
     elif aspect < 1:
         # portrait orientation - tall image
         res = int(input_width / aspect)
-        imgScaled = img_pil.resize((input_height, res), Image.BILINEAR)
+        imgScaled = img_pil.resize((input_height, res), Image.Resampling.BILINEAR)
     else:
-        imgScaled = img_pil.resize((input_height, input_width), Image.BILINEAR)
+        imgScaled = img_pil.resize((input_height, input_width), Image.Resampling.BILINEAR)
 
     # Convert back to float numpy array [0, 1]
     return np.array(imgScaled).astype(np.float32) / 255.0


### PR DESCRIPTION
### Ticket


### Problem description
With ubuntu 24.04 and python 3.12 scikit-image requirement needs build tools to build scikit while pip install

### What's changed
Remove scikit-image with pillow

### Checklist
- [ ] New/Existing tests provide coverage for changes
