### PR TITLE
Refactor Onnx tests:Set2

### DIFF
--- a/forge/test/models/onnx/multimodal/oft/test_oft_onnx.py
+++ b/forge/test/models/onnx/multimodal/oft/test_oft_onnx.py
@@ -4,10 +4,9 @@
 import pytest
 
 import forge
-from forge.verify.verify import verify
-
-from test.models.onnx.multimodal.oft.model_utils.oft_utils import get_inputs, get_models
+from third_party.tt_forge_models.oft_stable_diffusion.text_to_image.onnx import ModelLoader
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
+from forge.verify.verify import verify
 
 
 @pytest.mark.parametrize("variant", ["runwayml/stable-diffusion-v1-5"])
@@ -24,9 +23,10 @@ def test_oft(forge_tmp_path, variant):
 
     pytest.xfail(reason="Segmentation Fault")
 
-    # Load model and inputs
-    pipe, inputs = get_inputs(model=variant)
-    onnx_model, framework_model = get_models(inputs, forge_tmp_path, pipe)
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = list(loader.load_inputs())
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     compiled_model = forge.compile(
@@ -36,4 +36,8 @@ def test_oft(forge_tmp_path, variant):
     )
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/vision/deit/test_deit_onnx.py
+++ b/forge/test/models/onnx/vision/deit/test_deit_onnx.py
@@ -2,9 +2,6 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-import torch
-from datasets import load_dataset
-from transformers import AutoFeatureExtractor, ViTForImageClassification
 
 import forge
 from forge.forge_property_utils import (
@@ -16,15 +13,14 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
-from test.utils import download_model
-import onnx
+from third_party.tt_forge_models.deit.image_classification.onnx import ModelLoader, ModelVariant
 from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 
 variants = [
-    pytest.param("facebook/deit-base-patch16-224", marks=pytest.mark.pr_models_regression),
-    "facebook/deit-small-patch16-224",
-    "facebook/deit-tiny-patch16-224",
+    pytest.param(ModelVariant.BASE, marks=pytest.mark.pr_models_regression),
+    pytest.param(ModelVariant.SMALL),
+    pytest.param(ModelVariant.TINY),
 ]
 
 
@@ -36,36 +32,22 @@ def test_deit_onnx(variant, forge_tmp_path):
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.DEIT,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_IMAGE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
     )
 
-    # Load model
-    image_processor = download_model(AutoFeatureExtractor.from_pretrained, variant)
-    torch_model = download_model(ViTForImageClassification.from_pretrained, variant, return_dict=False)
-    torch_model.eval()
-
-    # Prepare input
-    dataset = load_dataset("huggingface/cats-image")
-    image_1 = dataset["test"]["image"][0]
-    img_tensor = image_processor(image_1, return_tensors="pt").pixel_values
-    inputs = [img_tensor]
-
-    # Export model to ONNX
-    onnx_path = f'{forge_tmp_path}/{variant.split("/")[-1].replace("-", "_")}.onnx'
-    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
-
-    # Load framework model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Compile model
     compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
 
     pcc = 0.99
-    if variant == "facebook/deit-base-patch16-224":
+    if variant == ModelVariant.BASE:
         pcc = 0.96
 
     # Model Verification and Inference
@@ -77,6 +59,4 @@ def test_deit_onnx(variant, forge_tmp_path):
     )
 
     # Post processing
-    logits = co_out[0]
-    predicted_class_idx = logits.argmax(-1).item()
-    print("Predicted class: ", torch_model.config.id2label[predicted_class_idx])
+    loader.output_postprocess(co_out=co_out)

--- a/forge/test/models/onnx/vision/detr/test_detr.py
+++ b/forge/test/models/onnx/vision/detr/test_detr.py
@@ -11,9 +11,15 @@ import forge
 import torch
 import onnx
 from forge.verify.verify import verify
-from test.utils import download_model
+from third_party.tt_forge_models.detr.object_detection.onnx import (
+    ModelLoader as DetrObjectDetectionOnnxLoader,
+    ModelVariant as DetrObjectDetectionOnnxVariant,
+)
+from third_party.tt_forge_models.detr.segmentation.onnx import (
+    ModelLoader as DetrSegmentationOnnxLoader,
+    ModelVariant as DetrSegmentationOnnxVariant,
+)
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
-from test.models.models_utils import preprocess_input_data
 from third_party.tt_forge_models.tools.utils import get_file
 from PIL import Image
 import numpy as np
@@ -22,32 +28,21 @@ from torchvision import transforms
 
 @pytest.mark.nightly
 @pytest.mark.xfail
-@pytest.mark.parametrize("variant", ["facebook/detr-resnet-50"])
+@pytest.mark.parametrize("variant", [DetrObjectDetectionOnnxVariant.RESNET_50])
 def test_detr_detection_onnx(variant, forge_tmp_path):
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.DETR,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_OBJECT_DETECTION,
         source=Source.HUGGINGFACE,
     )
 
     # Load the model
-    framework_model = download_model(DetrForObjectDetection.from_pretrained, variant, return_dict=False)
-    framework_model.eval()
-
-    # Prepare input
-    input_batch = preprocess_input_data()
-    inputs = [input_batch]
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/detr_obj_det.onnx"
-    torch.onnx.export(framework_model, (inputs[0]), onnx_path, opset_version=17)
-
-    # Load ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    loader = DetrObjectDetectionOnnxLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile framework model
@@ -59,32 +54,21 @@ def test_detr_detection_onnx(variant, forge_tmp_path):
 
 @pytest.mark.nightly
 @pytest.mark.xfail
-@pytest.mark.parametrize("variant", ["facebook/detr-resnet-50-panoptic"])
+@pytest.mark.parametrize("variant", [DetrSegmentationOnnxVariant.RESNET_50_PANOPTIC])
 def test_detr_segmentation_onnx(variant, forge_tmp_path):
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.DETR,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_IMAGE_SEGMENTATION,
         source=Source.HUGGINGFACE,
     )
 
     # Load the model
-    framework_model = download_model(DetrForSegmentation.from_pretrained, variant, return_dict=False)
-    framework_model.eval()
-
-    # Prepare input
-    input_batch = preprocess_input_data()
-    inputs = [input_batch]
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/detr_semseg.onnx"
-    torch.onnx.export(framework_model, (inputs[0]), onnx_path, opset_version=17)
-
-    # Load ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    loader = DetrSegmentationOnnxLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile framework model

--- a/forge/test/models/onnx/vision/dla/test_dla.py
+++ b/forge/test/models/onnx/vision/dla/test_dla.py
@@ -2,12 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import torch
-import os
-from third_party.tt_forge_models.dla.pytorch import ModelLoader, ModelVariant
-import onnx
 
 import forge
+from third_party.tt_forge_models.dla.image_classification.onnx import ModelLoader, ModelVariant
+
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -15,8 +13,6 @@ from forge.forge_property_utils import (
     Task,
     record_model_properties,
 )
-from forge.verify.config import VerifyConfig
-from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
 
@@ -36,45 +32,30 @@ variants = [
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
-def test_dla_onnx(variant, tmp_path):
+def test_dla_onnx(variant, forge_tmp_path):
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.DLA,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_IMAGE_ENCODING,
         source=Source.TIMM,
     )
 
-    # Load model and input using tt_forge_models
+    # Load model and input
     loader = ModelLoader(variant=variant)
-    torch_model = loader.load_model()
-    input_tensor = loader.load_inputs()
-    inputs = [input_tensor]
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
+    framework_model = forge.OnnxModule(module_name, onnx_model)
 
-    # Export ONNX
-    onnx_path = tmp_path / f"{variant}_exported.onnx"
-    if not os.path.exists(onnx_path):
-        torch.onnx.export(
-            torch_model,
-            input_tensor,
-            onnx_path,
-            input_names=["input"],
-            output_names=["output"],
-            opset_version=18,
-            dynamic_axes={"input": {0: "batch"}, "output": {0: "batch"}},
-        )
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
 
-    # Load exported ONNX model
-    model_name = f"onnx_dla_{variant}"
-    onnx_model = onnx.load(str(onnx_path))
-    framework_model = forge.OnnxModule(model_name, onnx_model)
+    # Model Verification and Inference
+    _, co_out = verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )
 
-    # Compile
-    compiled_model = forge.compile(framework_model, sample_inputs=inputs, module_name=module_name)
-
-    # Verify
-    _, co_out = verify(inputs, framework_model, compiled_model)
-
-    # Post-processing
     loader.print_cls_results(co_out)

--- a/forge/test/models/onnx/vision/ghostnet/test_ghostnet_onnx.py
+++ b/forge/test/models/onnx/vision/ghostnet/test_ghostnet_onnx.py
@@ -3,7 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
+
 import forge
+from third_party.tt_forge_models.ghostnet.image_classification.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -13,11 +15,10 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
-from test.models.onnx.vision.ghostnet.model_utils.utils import load_ghostnet_model, post_processing
-import onnx
-import torch
-
-variants = [pytest.param("ghostnet_100", marks=pytest.mark.pr_models_regression), "ghostnet_100.in1k"]
+variants = [
+    pytest.param(ModelVariant.GHOSTNET_100, marks=pytest.mark.pr_models_regression),
+    ModelVariant.GHOSTNET_100_IN1K,
+]
 
 
 @pytest.mark.nightly
@@ -27,21 +28,15 @@ def test_ghostnet_onnx(variant, forge_tmp_path):
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.GHOSTNET,
-        variant=variant,
+        variant=variant.value,
         source=Source.TIMM,
         task=Task.CV_IMAGE_CLASSIFICATION,
     )
 
-    # Load the model and input
-    torch_model, inputs = load_ghostnet_model(variant)
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/{variant.replace('.', '_')}.onnx"
-    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
-
-    # Load framework model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Compile model
@@ -54,5 +49,4 @@ def test_ghostnet_onnx(variant, forge_tmp_path):
         compiled_model,
     )
 
-    # Post processing
-    post_processing(co_out)
+    loader.print_cls_results(co_out)

--- a/forge/test/models/onnx/vision/glpn_kitti/test_glpn_kitti_onnx.py
+++ b/forge/test/models/onnx/vision/glpn_kitti/test_glpn_kitti_onnx.py
@@ -2,10 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-import torch
-import onnx
 
 import forge
+from third_party.tt_forge_models.glpn_kitti.image_classification.onnx import ModelLoader
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -14,11 +13,6 @@ from forge.forge_property_utils import (
     record_model_properties,
 )
 from forge.verify.verify import verify
-
-from test.models.onnx.vision.glpn_kitti.model_utils.utils import (
-    load_input,
-    load_model,
-)
 
 
 @pytest.mark.out_of_memory
@@ -32,7 +26,6 @@ from test.models.onnx.vision.glpn_kitti.model_utils.utils import (
     ],
 )
 def test_glpn_kitti(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
@@ -44,23 +37,17 @@ def test_glpn_kitti(variant, forge_tmp_path):
     pytest.xfail(reason="Requires multi-chip support")
 
     # Load model and input
-    framework_model = load_model(variant)
-    inputs = load_input(variant)
-    inputs = [inputs[0]]
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/linear_ae.onnx"
-    torch.onnx.export(
-        framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
-    )
-
-    # Load ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    loader = ModelLoader()
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
-    # Forge compile framework model
-    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
 
     # Model Verification
-    verify(inputs, framework_model, compiled_model)
+    verify(
+        inputs,
+        framework_model,
+        compiled_model,
+    )

--- a/forge/test/models/onnx/vision/hrnet/test_hrnet_onnx.py
+++ b/forge/test/models/onnx/vision/hrnet/test_hrnet_onnx.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import torch
-from pytorchcv.model_provider import get_model as ptcv_get_model
 
 import forge
+from third_party.tt_forge_models.hrnet.image_classification.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -14,56 +13,43 @@ from forge.forge_property_utils import (
     Task,
     record_model_properties,
 )
-
-from test.models.models_utils import print_cls_results, preprocess_inputs
-from test.utils import download_model
-import onnx
-from forge.verify.verify import verify
 from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
+from forge.verify.verify import verify
+
+from test.models.models_utils import print_cls_results
 
 variants = [
-    pytest.param("hrnet_w18_small_v1", marks=pytest.mark.pr_models_regression),
-    "hrnet_w18_small_v2",
-    "hrnetv2_w18",
-    "hrnetv2_w30",
-    "hrnetv2_w44",
-    "hrnetv2_w48",
-    "hrnetv2_w64",
+    pytest.param(ModelVariant.HRNET_W18_SMALL_V1_OSMR, marks=pytest.mark.pr_models_regression),
+    ModelVariant.HRNET_W18_SMALL_V2_OSMR,
+    ModelVariant.HRNETV2_W18_OSMR,
+    ModelVariant.HRNETV2_W30_OSMR,
+    ModelVariant.HRNETV2_W44_OSMR,
+    ModelVariant.HRNETV2_W48_OSMR,
+    ModelVariant.HRNETV2_W64_OSMR,
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_hrnet_onnx(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.HRNET,
-        variant=variant,
+        variant=variant.value,
         source=Source.OSMR,
         task=Task.CV_IMAGE_CLASSIFICATION,
     )
 
-    # Load the model
-    torch_model = download_model(ptcv_get_model, variant, pretrained=True)
-    torch_model.eval()
-
-    # Load input
-    inputs = preprocess_inputs()
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/{variant}.onnx"
-    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
-
-    # Load framework model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     pcc = 0.99
-    if variant in ["hrnetv2_w64", "hrnetv2_w44"]:
+    if variant in (ModelVariant.HRNETV2_W64_OSMR, ModelVariant.HRNETV2_W44_OSMR):
         pcc = 0.95
 
     # Compile model
@@ -77,5 +63,4 @@ def test_hrnet_onnx(variant, forge_tmp_path):
         VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)),
     )
 
-    # Run model on sample data and print results
     print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/onnx/vision/inception/test_inception_v4_onnx.py
+++ b/forge/test/models/onnx/vision/inception/test_inception_v4_onnx.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 ## Inception V4
 import pytest
-import torch
-import onnx
 
 import forge
+from third_party.tt_forge_models.inception.image_classification.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -16,26 +15,15 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
-from test.models.onnx.vision.inception.model_utils.model_utils import (
-    preprocess_timm_model,
-)
-from test.utils import download_model
 from test.models.models_utils import print_cls_results
-
-
-def generate_model_inceptionV4_imgcls_timm_pytorch(variant):
-    # Load model & Preprocess image
-    framework_model, img_tensor = download_model(preprocess_timm_model, variant)
-    return framework_model, [img_tensor]
-
 
 variants = [
     pytest.param(
-        "inception_v4",
+        ModelVariant.INCEPTION_V4,
         marks=pytest.mark.pr_models_regression,
     ),
     pytest.param(
-        "inception_v4.tf_in1k",
+        ModelVariant.INCEPTION_V4_TF_IN1K,
     ),
 ]
 
@@ -43,44 +31,25 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_inception_v4_timm_onnx(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.INCEPTION,
-        variant=variant,
+        variant=variant.value,
         source=Source.TIMM,
         task=Task.CV_IMAGE_CLASSIFICATION,
     )
 
-    # Load model + input
-    framework_model, inputs = generate_model_inceptionV4_imgcls_timm_pytorch(variant)
-
-    # Export to ONNX
-    onnx_path = f"{forge_tmp_path}/{variant}_inception_v4.onnx"
-    torch.onnx.export(
-        framework_model,
-        inputs[0],
-        onnx_path,
-        opset_version=17,
-        input_names=["input"],
-        output_names=["output"],
-    )
-
-    # Load and verify ONNX
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
-    # Forge compile ONNX model
-    compiled_model = forge.compile(
-        onnx_model,
-        sample_inputs=inputs,
-        module_name=module_name,
-    )
+    # Compile model
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
 
     # Model Verification
     fw_out, co_out = verify(inputs, framework_model, compiled_model)
 
-    # Run model on sample data and print results
     print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/onnx/vision/mgp_str_base/test_mgp_str_base_onnx.py
+++ b/forge/test/models/onnx/vision/mgp_str_base/test_mgp_str_base_onnx.py
@@ -4,10 +4,9 @@
 
 # From: https://huggingface.co/alibaba-damo/mgp-str-base
 import pytest
-import torch
-import onnx
 
 import forge
+from third_party.tt_forge_models.mgp_str_base.image_classification.onnx import ModelLoader
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -19,20 +18,6 @@ from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 from forge.verify.verify import verify
 
-from test.models.onnx.vision.mgp_str_base.model_utils.utils import (
-    load_input,
-    load_model,
-)
-
-
-class Wrapper(torch.nn.Module):
-    def __init__(self, model):
-        super().__init__()
-        self.model = model
-
-    def forward(self, inputs):
-        return self.model(inputs)[0]
-
 
 @pytest.mark.nightly
 @pytest.mark.parametrize(
@@ -42,7 +27,6 @@ class Wrapper(torch.nn.Module):
     ],
 )
 def test_mgp_scene_text_recognition_onnx(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
@@ -52,35 +36,21 @@ def test_mgp_scene_text_recognition_onnx(variant, forge_tmp_path):
         task=Task.CV_IMAGE_ENCODING,
     )
 
-    # Load model and wrap
-    framework_model = load_model(variant)
-    framework_model = Wrapper(framework_model).eval()
-
-    # Load input
-    inputs, processor = load_input(variant)
-    inputs = [inputs[0]]
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/mgp_str_base.onnx"
-    torch.onnx.export(
-        framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
-    )
-
-    # Load and check ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = ModelLoader()
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile ONNX model
-    compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
 
     # Model Verification
     _, co_out = verify(
         inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.95))
     )
 
-    # Post-processing
     output = (co_out[0], co_out[1], co_out[2])
-    generated_text = processor.batch_decode(output)["generated_text"]
+    generated_text = loader.torch_loader.processor.batch_decode(output)["generated_text"]
 
     print(f"Generated text: {generated_text}")

--- a/forge/test/models/onnx/vision/mlp_mixer/test_mlp_mixer_onnx.py
+++ b/forge/test/models/onnx/vision/mlp_mixer/test_mlp_mixer_onnx.py
@@ -2,16 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-import timm
-import torch
-import onnx
-from loguru import logger
-from PIL import Image
-from third_party.tt_forge_models.tools.utils import get_file
-from timm.data import resolve_data_config
-from timm.data.transforms_factory import create_transform
 
 import forge
+from third_party.tt_forge_models.mlp_mixer.image_classification.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -23,25 +16,37 @@ from forge.verify.verify import verify
 from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 
-from test.models.models_utils import print_cls_results
-from test.utils import download_model
-
 varaints = [
-    pytest.param("mixer_b16_224"),
-    pytest.param("mixer_b16_224_in21k"),
-    pytest.param("mixer_b16_224_miil"),
-    pytest.param("mixer_b16_224_miil_in21k"),
-    pytest.param("mixer_b32_224"),
-    pytest.param("mixer_l16_224"),
-    pytest.param("mixer_l16_224_in21k"),
-    pytest.param("mixer_l32_224"),
     pytest.param(
-        "mixer_s16_224",
+        ModelVariant.MIXER_B16_224,
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(
+        ModelVariant.MIXER_B16_224_IN21K,
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(ModelVariant.MIXER_B16_224_MIIL),
+    pytest.param(
+        ModelVariant.MIXER_B16_224_MIIL_IN21K,
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(ModelVariant.MIXER_B32_224),
+    pytest.param(
+        ModelVariant.MIXER_L16_224,
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(
+        ModelVariant.MIXER_L16_224_IN21K,
+        marks=[pytest.mark.xfail],
+    ),
+    pytest.param(ModelVariant.MIXER_L32_224),
+    pytest.param(
+        ModelVariant.MIXER_S16_224,
         marks=pytest.mark.pr_models_regression,
     ),
-    pytest.param("mixer_s32_224"),
+    pytest.param(ModelVariant.MIXER_S32_224),
     pytest.param(
-        "mixer_b16_224.goog_in21k",
+        ModelVariant.MIXER_B16_224_GOOG_IN21K,
         marks=[pytest.mark.xfail],
     ),
 ]
@@ -50,69 +55,24 @@ varaints = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", varaints)
 def test_mlp_mixer_timm_onnx(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.MLPMIXER,
-        variant=variant,
+        variant=variant.value,
         source=Source.TIMM,
         task=Task.CV_IMAGE_CLASSIFICATION,
     )
 
-    load_pretrained_weights = True
-    if variant in ["mixer_s32_224", "mixer_s16_224", "mixer_b32_224", "mixer_l32_224"]:
-        load_pretrained_weights = False
-
-    framework_model = download_model(timm.create_model, variant, pretrained=load_pretrained_weights)
-    config = resolve_data_config({}, model=framework_model)
-    transform = create_transform(**config)
-
-    try:
-        if variant in [
-            "mixer_b16_224_in21k",
-            "mixer_b16_224_miil_in21k",
-            "mixer_l16_224_in21k",
-            "mixer_b16_224.goog_in21k",
-        ]:
-            input_image = get_file(
-                "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/beignets-task-guide.png"
-            )
-            use_1k_labels = False
-        else:
-            input_image = get_file(
-                "https://images.rawpixel.com/image_1300/cHJpdmF0ZS9sci9pbWFnZXMvd2Vic2l0ZS8yMDIyLTA1L3BkMTA2LTA0Ny1jaGltXzEuanBn.jpg"
-            )
-            use_1k_labels = True
-        image = Image.open(str(input_image)).convert("RGB")
-    except:
-        logger.warning(
-            "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
-        )
-        image = torch.rand(1, 3, 256, 256)
-    pixel_values = transform(image).unsqueeze(0)
-
-    inputs = [pixel_values]
-    pcc = 0.99
-    if variant == "mixer_b16_224_miil":
-        pcc = 0.95
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/{variant}_mlpmixer.onnx"
-    torch.onnx.export(
-        framework_model,
-        inputs[0],
-        onnx_path,
-        opset_version=17,
-        input_names=["input"],
-        output_names=["output"],
-        keep_initializers_as_inputs=True,
-    )
-
-    # Load and verify ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
+
+    pcc = 0.99
+    if variant == ModelVariant.MIXER_B16_224_MIIL:
+        pcc = 0.95
 
     # Forge compile ONNX model
     compiled_model = forge.compile(
@@ -126,5 +86,4 @@ def test_mlp_mixer_timm_onnx(variant, forge_tmp_path):
         inputs, framework_model, compiled_model, VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc))
     )
 
-    # Print classification results
-    print_cls_results(fw_out[0], co_out[0], use_1k_labels=use_1k_labels)
+    loader.print_cls_results(co_out)

--- a/forge/test/models/onnx/vision/mnist/test_mnist_onnx.py
+++ b/forge/test/models/onnx/vision/mnist/test_mnist_onnx.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import torch
-import onnx
 
 import forge
+from third_party.tt_forge_models.mnist.image_classification.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -18,40 +18,24 @@ from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 
 from test.models.models_utils import print_cls_results
-from test.models.onnx.vision.mnist.model_utils.utils import load_input, load_model
 
 
 @pytest.mark.pr_models_regression
 @pytest.mark.nightly
 def test_mnist(forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.MNIST,
+        variant=ModelVariant.CNN_DROPOUT.value,
         source=Source.GITHUB,
         task=Task.CV_IMAGE_CLASSIFICATION,
     )
 
-    # Load model and input
-    framework_model = load_model()
-    inputs = load_input()
-    inputs = [inputs[0]]
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/mnist.onnx"
-    torch.onnx.export(
-        framework_model,
-        inputs[0],
-        onnx_path,
-        opset_version=17,
-        input_names=["input"],
-        output_names=["output"],
-    )
-
-    # Load and check ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input (float32: bfloat16 tensors cannot be converted to NumPy in forge.compile's ONNX path)
+    loader = ModelLoader(variant=ModelVariant.CNN_DROPOUT)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path, dtype_override=torch.float32)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Set data format override
@@ -74,5 +58,4 @@ def test_mnist(forge_tmp_path):
         verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=0.98)),
     )
 
-    # Post Processing
     print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/onnx/vision/monodepth2/test_monodepth2_onnx.py
+++ b/forge/test/models/onnx/vision/monodepth2/test_monodepth2_onnx.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import torch
-import onnx
 
 import forge
+from third_party.tt_forge_models.monodepth2.image_classification.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -14,73 +13,49 @@ from forge.forge_property_utils import (
     Task,
     record_model_properties,
 )
-from forge.verify.verify import VerifyConfig, verify
+from forge.verify.verify import verify
+from forge.verify.config import VerifyConfig
 from forge.verify.value_checkers import AutomaticValueChecker
 
-from test.models.onnx.vision.monodepth2.model_utils.utils import (
-    download_model,
-    load_input,
-    load_model,
-    postprocess_and_save_disparity_map,
-)
-
 variants = [
-    pytest.param("mono_640x192"),
-    pytest.param("stereo_640x192"),
-    pytest.param("mono+stereo_640x192", marks=pytest.mark.pr_models_regression),
-    pytest.param("mono_no_pt_640x192"),
-    pytest.param("stereo_no_pt_640x192"),
-    pytest.param("mono+stereo_no_pt_640x192"),
-    pytest.param("mono_1024x320"),
-    pytest.param("stereo_1024x320"),
-    pytest.param("mono+stereo_1024x320"),
+    pytest.param(ModelVariant.MONO_640X192),
+    pytest.param(ModelVariant.STEREO_640X192),
+    pytest.param(ModelVariant.MONO_STEREO_640X192, marks=pytest.mark.pr_models_regression),
+    pytest.param(ModelVariant.MONO_NO_PT_640X192),
+    pytest.param(ModelVariant.STEREO_NO_PT_640X192),
+    pytest.param(ModelVariant.MONO_STEREO_NO_PT_640X192),
+    pytest.param(ModelVariant.MONO_1024X320),
+    pytest.param(ModelVariant.STEREO_1024X320),
+    pytest.param(ModelVariant.MONO_STEREO_1024X320),
 ]
 
 
 @pytest.mark.parametrize("variant", variants)
 @pytest.mark.nightly
 def test_monodepth2(variant, forge_tmp_path):
-
     pcc = 0.99
-    if variant in [
-        "mono_640x192",
-        "stereo_640x192",
-        "mono+stereo_640x192",
-        "mono_no_pt_640x192",
-        "stereo_no_pt_640x192",
-    ]:
+    if variant in (
+        ModelVariant.MONO_640X192,
+        ModelVariant.STEREO_640X192,
+        ModelVariant.MONO_STEREO_640X192,
+        ModelVariant.MONO_NO_PT_640X192,
+        ModelVariant.STEREO_NO_PT_640X192,
+    ):
         pcc = 0.95
 
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.MONODEPTH2,
-        variant=variant,
+        variant=variant.value,
         source=Source.TORCHVISION,
         task=Task.CV_DEPTH_ESTIMATION,
     )
 
-    # prepare model and input
-    download_model(variant)
-    framework_model, height, width = load_model(variant)
-    input_tensor, original_width, original_height = load_input(height, width)
-
-    inputs = [input_tensor]
-
-    # Export to ONNX
-    onnx_path = f"{forge_tmp_path}/{variant}_monodepth2.onnx"
-    torch.onnx.export(
-        framework_model,
-        inputs[0],
-        onnx_path,
-        opset_version=17,
-        input_names=["input"],
-        output_names=["output"],
-    )
-
-    # Load and check ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile ONNX model
@@ -97,5 +72,4 @@ def test_monodepth2(variant, forge_tmp_path):
         verify_cfg=VerifyConfig(value_checker=AutomaticValueChecker(pcc=pcc)),
     )
 
-    # Post-process and save result
-    postprocess_and_save_disparity_map(co_out, original_height, original_width, variant)
+    loader.torch_loader.postprocess_and_save_disparity_map(co_out, str(forge_tmp_path))


### PR DESCRIPTION
### Ticket
Fixes [#3231](https://github.com/tenstorrent/tt-forge-onnx/issues/3231)

### Problem description

- Standardize all model and input loading in tt-forge-onnx to use the tt-forge-models repository (e.g. third_party/tt_forge_models)

### What's changed
This PR modifies the onnx test files to load model and inputs from third party/tt_forge_models.

- Deit
- Detr (Object Detection and Segmentation)
- Dla
- Ghostnet
- Glpn Kitti
- Hrnet
- Inception
- Mgp str base
- Mlp mixer
- Mnist
- Monodepth2
- Oft 

### Checklist
- [x] Verify successful model and input loading by running ort.

### Logs
[set2_logs.zip](https://github.com/user-attachments/files/27592096/set2_logs.zip)