### PR TITLE
Refactor Onnx tests:Set3

### DIFF
--- a/forge/test/models/onnx/audio/test_whisper_large.py
+++ b/forge/test/models/onnx/audio/test_whisper_large.py
@@ -2,66 +2,34 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-import torch
-from datasets import load_dataset
-from transformers import AutoFeatureExtractor, WhisperModel
-
-import forge
-from forge.forge_property_utils import Framework, ModelArch, Source, Task, record_model_properties
-from forge.verify.verify import verify
-
-from test.utils import download_model
 import onnx
 
-
-class Wrapper(torch.nn.Module):
-    def __init__(self, model):
-        super().__init__()
-        self.model = model
-
-    def forward(self, input_features, decoder_input_ids):
-        inputs = {"input_features": input_features, "decoder_input_ids": decoder_input_ids}
-        output = self.model(**inputs)
-        return output
-
-
-variants = ["openai/whisper-large-v3"]
+import forge
+from third_party.tt_forge_models.whisper.audio_classification.onnx import ModelLoader, ModelVariant
+from forge.forge_property_utils import Framework, ModelArch, Source, Task, record_model_properties
+from forge.verify.verify import verify
 
 
 @pytest.mark.skip_model_analysis
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
-def test_whisper_large_v3_onnx(variant, tmp_path):
-
+def test_whisper_large_v3_onnx(forge_tmp_path, variant=ModelVariant.WHISPER_LARGE_V3):
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.WHISPER,
-        variant=variant,
+        variant=variant.value,
         task=Task.NLP_CAUSAL_LM,
         source=Source.HUGGINGFACE,
     )
 
     pytest.xfail(reason="Requires multi-chip support")
 
-    # Load Model and feature extractor
-    model = download_model(WhisperModel.from_pretrained, variant, return_dict=False)
-    torch_model = Wrapper(model)
-    feature_extractor = download_model(AutoFeatureExtractor.from_pretrained, variant)
-
-    # prepare input
-    ds = load_dataset("hf-internal-testing/librispeech_asr_dummy", "clean", split="validation")
-    input_audio = feature_extractor(ds[0]["audio"]["array"], return_tensors="pt")
-    input_features = input_audio.input_features
-    decoder_input_ids = torch.tensor([[1, 1]]) * model.config.decoder_start_token_id
-    inputs = [input_features, decoder_input_ids]
-
-    # Export model to ONNX
-    onnx_path = f"{tmp_path}/whisper_v3.onnx"
-    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
-
-    # Load framework model
-    onnx_model = onnx.load(onnx_path)
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
+    prep = loader.torch_loader._variant_config.pretrained_model_name
+    onnx_path = f"{forge_tmp_path}/{prep}.onnx"
 
     # passing model file instead of model proto due to size of the model(>2GB) - #https://github.com/onnx/onnx/issues/3775#issuecomment-943416925
     onnx.checker.check_model(onnx_path)
@@ -71,7 +39,7 @@ def test_whisper_large_v3_onnx(variant, tmp_path):
     compiled_model = forge.compile(framework_model, inputs, module_name=module_name)
 
     # Model Verification and inference
-    _, cout = verify(
+    verify(
         inputs,
         framework_model,
         compiled_model,

--- a/forge/test/models/onnx/audio/test_whisper_onnx.py
+++ b/forge/test/models/onnx/audio/test_whisper_onnx.py
@@ -3,11 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import torch
-import onnx
-from transformers import AutoProcessor, WhisperConfig, WhisperForConditionalGeneration
 
 import forge
+from third_party.tt_forge_models.whisper.audio_classification.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -17,107 +15,59 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
-from test.utils import download_model
-
-
-class Wrapper(torch.nn.Module):
-    def __init__(self, model):
-        super().__init__()
-        self.model = model
-
-    def forward(self, input_features, decoder_input_ids):
-        inputs = {"input_features": input_features, "decoder_input_ids": decoder_input_ids}
-        output = self.model(**inputs)
-        return output.logits
-
 
 variants = [
     pytest.param(
-        "openai/whisper-tiny",
+        ModelVariant.WHISPER_TINY,
         marks=[
             pytest.mark.pr_models_regression,
             pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-mlir/issues/6937"),
         ],
     ),
     pytest.param(
-        "openai/whisper-base",
+        ModelVariant.WHISPER_BASE,
         marks=[
             pytest.mark.pr_models_regression,
             pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-mlir/issues/6937"),
         ],
     ),
     pytest.param(
-        "openai/whisper-small",
+        ModelVariant.WHISPER_SMALL,
         marks=[
             pytest.mark.pr_models_regression,
             pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-mlir/issues/6937"),
         ],
     ),
-    pytest.param("openai/whisper-medium", marks=pytest.mark.xfail),
-    pytest.param("openai/whisper-large", marks=pytest.mark.xfail),
+    pytest.param(ModelVariant.WHISPER_MEDIUM, marks=pytest.mark.xfail),
+    pytest.param(ModelVariant.WHISPER_LARGE, marks=pytest.mark.xfail),
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_whisper_onnx(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.WHISPER,
-        variant=variant,
+        variant=variant.value,
         task=Task.AUDIO_SPEECH_RECOGNITION,
         source=Source.HUGGINGFACE,
     )
 
-    if variant == "openai/whisper-medium":
+    if variant == ModelVariant.WHISPER_MEDIUM:
         pytest.xfail(reason="Skipping the test because it takes longer time to run")
-    elif variant == "openai/whisper-large":
+    elif variant == ModelVariant.WHISPER_LARGE:
         pytest.xfail(reason="https://github.com/tenstorrent/tt-forge-onnx/issues/2767")
 
-    # Load model (with tokenizer and feature extractor)
-    processor = download_model(AutoProcessor.from_pretrained, variant)
-    model_config = WhisperConfig.from_pretrained(variant)
-    model = download_model(
-        WhisperForConditionalGeneration.from_pretrained,
-        variant,
-        config=model_config,
-    )
-    model.config.use_cache = False
-
-    # Load and preprocess sample audio
-    sample = torch.load("forge/test/models/files/samples/audio/1272-128104-0000.pt", weights_only=False)
-    sample_audio = sample["audio"]["array"]
-
-    inputs = processor(sample_audio, return_tensors="pt")
-    input_features = inputs.input_features
-
-    # Get decoder inputs
-    decoder_start_token_tensor = torch.tensor(model.generation_config.decoder_start_token_id, dtype=torch.long)
-    decoder_input_ids = torch.ones((1, 1), dtype=torch.long) * decoder_start_token_tensor
-
-    inputs = [input_features, decoder_input_ids]
-
-    torch_model = Wrapper(model)
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
-    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
-
-    # Load framework model
-    onnx_model = onnx.load(onnx_path)
-    if variant in ["openai/whisper-medium", "openai/whisper-large"]:
-        onnx.checker.check_model(onnx_path)
-        framework_model = forge.OnnxModule(module_name, onnx_model, onnx_path)
-        model = framework_model
-    else:
-        onnx.checker.check_model(onnx_model)
-        framework_model = forge.OnnxModule(module_name, onnx_model)
-        model = onnx_model
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
+    framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Compile model
-    compiled_model = forge.compile(model, inputs, module_name=module_name)
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
 
     # Model Verification and Inference
     verify(

--- a/forge/test/models/onnx/multimodal/vilt/test_vilt_onnx.py
+++ b/forge/test/models/onnx/multimodal/vilt/test_vilt_onnx.py
@@ -2,8 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-import torch
 
+import forge
+from third_party.tt_forge_models.vilt.question_answering.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -11,73 +12,25 @@ from forge.forge_property_utils import (
     Task,
     record_model_properties,
 )
-
-import forge
-import onnx
 from forge.verify.verify import verify
-from PIL import Image
-from third_party.tt_forge_models.tools.utils import get_file
-from transformers import (
-    ViltConfig,
-    ViltForQuestionAnswering,
-    ViltProcessor,
-)
-from test.models.onnx.multimodal.vilt.model_utils.model import (
-    ViLtEmbeddingWrapper,
-    ViltModelWrapper,
-)
-from test.utils import download_model
-
-text1 = "How many cats are there?"
-
-
-def get_image():
-    input_image = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-    return Image.open(str(input_image))
-
-
-def generate_model_vilt_question_answering_hf_pytorch(variant):
-
-    # Set model configurations
-    config = ViltConfig.from_pretrained(variant)
-    config_dict = config.to_dict()
-    config_dict["return_dict"] = False
-    config = ViltConfig(**config_dict)
-
-    # Load model and processor from HuggingFace
-    processor = download_model(ViltProcessor.from_pretrained, variant)
-    model = download_model(ViltForQuestionAnswering.from_pretrained, variant, config=config)
-    model.eval()
-    encoding = processor(get_image(), text1, return_tensors="pt")
-
-    # Wrapper
-    text_vision_embedding_model = ViLtEmbeddingWrapper(model)
-    vilt_model = ViltModelWrapper(model, task=Task.NLP_QA.short)
-    embedding_output, attention_mask = text_vision_embedding_model(**encoding)
-    return vilt_model, [embedding_output.detach().cpu(), attention_mask.detach().cpu().to(torch.float32)], model
-
-
-variants = ["dandelin/vilt-b32-finetuned-vqa"]
 
 
 @pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-forge-onnx/issues/2969")
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants, ids=variants)
-def test_vilt_question_answering_onnx(variant, forge_tmp_path):
-
+def test_vilt_question_answering_onnx(forge_tmp_path, variant=ModelVariant.VQA):
     # Record Forge Property
     module_name = record_model_properties(
-        framework=Framework.ONNX, model=ModelArch.VILT, variant=variant, task=Task.NLP_QA, source=Source.HUGGINGFACE
+        framework=Framework.ONNX,
+        model=ModelArch.VILT,
+        variant=variant.value,
+        task=Task.NLP_QA,
+        source=Source.HUGGINGFACE,
     )
-    torch_model, inputs, model = generate_model_vilt_question_answering_hf_pytorch(variant)
 
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
-    torch.onnx.export(torch_model, (inputs[0], inputs[1]), onnx_path, opset_version=17)
-
-    # Load framework model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Compile model
@@ -90,7 +43,6 @@ def test_vilt_question_answering_onnx(variant, forge_tmp_path):
         compiled_model,
     )
 
-    # Post processing
     logits = co_out[0]
     idx = logits.argmax(-1).item()
-    print(f"Predicted answer: {model.config.id2label[idx]}")
+    print(f"Predicted answer: {loader.torch_loader.model.config.id2label[idx]}")

--- a/forge/test/models/onnx/vision/perceiverio/test_perceiverio_onnx.py
+++ b/forge/test/models/onnx/vision/perceiverio/test_perceiverio_onnx.py
@@ -2,19 +2,9 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-import torch
-import onnx
-from loguru import logger
-from PIL import Image
-from third_party.tt_forge_models.tools.utils import get_file
-from transformers import (
-    AutoImageProcessor,
-    PerceiverForImageClassificationConvProcessing,
-    PerceiverForImageClassificationFourier,
-    PerceiverForImageClassificationLearned,
-)
 
 import forge
+from third_party.tt_forge_models.perceiverio_vision.image_classification.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -23,38 +13,21 @@ from forge.forge_property_utils import (
     record_model_properties,
 )
 from forge.verify.verify import verify
+
 from test.models.models_utils import print_cls_results
-
-
-def get_sample_data(model_name):
-    image_processor = AutoImageProcessor.from_pretrained(model_name)
-    try:
-        input_image = get_file("http://images.cocodataset.org/val2017/000000039769.jpg")
-        image = Image.open(str(input_image))
-        pixel_values = image_processor(images=image, return_tensors="pt").pixel_values
-    except:
-        logger.warning(
-            "Failed to download the image file, replacing input with random tensor. Please check if the URL is up to date"
-        )
-        height = image_processor.to_dict()["size"]["height"]
-        width = image_processor.to_dict()["size"]["width"]
-        pixel_values = torch.rand(1, 3, height, width).to(torch.float32)
-    return pixel_values
-
 
 variants = [
     pytest.param(
-        "deepmind/vision-perceiver-conv", marks=pytest.mark.pr_models_regression, id="deepmind/vision-perceiver-conv"
+        ModelVariant.VISION_PERCEIVER_CONV,
+        marks=pytest.mark.pr_models_regression,
     ),
     pytest.param(
-        "deepmind/vision-perceiver-learned",
+        ModelVariant.VISION_PERCEIVER_LEARNED,
         marks=pytest.mark.xfail,
-        id="deepmind/vision-perceiver-learned",
     ),
     pytest.param(
-        "deepmind/vision-perceiver-fourier",
+        ModelVariant.VISION_PERCEIVER_FOURIER,
         marks=pytest.mark.xfail,
-        id="deepmind/vision-perceiver-fourier",
     ),
 ]
 
@@ -62,51 +35,21 @@ variants = [
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_perceiverio_for_image_classification_onnx(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.PERCEIVERIO,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_IMAGE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
     )
-    if variant == "deepmind/vision-perceiver-learned":
+    if variant == ModelVariant.VISION_PERCEIVER_LEARNED:
         pytest.xfail(reason="Segmentation Fault")
 
-    # Sample Image
-    pixel_values = get_sample_data(variant)
-
-    # Load the model from HuggingFace
-    if variant == "deepmind/vision-perceiver-learned":
-        framework_model = PerceiverForImageClassificationLearned.from_pretrained(variant, return_dict=False)
-
-    elif variant == "deepmind/vision-perceiver-conv":
-        framework_model = PerceiverForImageClassificationConvProcessing.from_pretrained(variant, return_dict=False)
-
-    elif variant == "deepmind/vision-perceiver-fourier":
-        framework_model = PerceiverForImageClassificationFourier.from_pretrained(variant, return_dict=False)
-
-    else:
-        logger.info(f"The model {variant} is not supported")
-
-    framework_model.eval()
-    inputs = [pixel_values]
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/{variant.replace('/', '_')}_perceiver.onnx"
-    torch.onnx.export(
-        framework_model,
-        pixel_values,
-        onnx_path,
-        opset_version=17,
-        input_names=["input"],
-        output_names=["output"],
-    )
-
-    # Load ONNX model and check
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile ONNX model
@@ -123,5 +66,4 @@ def test_perceiverio_for_image_classification_onnx(variant, forge_tmp_path):
         compiled_model,
     )
 
-    # Post processing
     print_cls_results(fw_out[0], co_out[0])

--- a/forge/test/models/onnx/vision/regnet/test_regnet_onnx.py
+++ b/forge/test/models/onnx/vision/regnet/test_regnet_onnx.py
@@ -3,12 +3,9 @@
 
 import pytest
 import torch
-import onnx
-from pathlib import Path
-
-from third_party.tt_forge_models.regnet.pytorch import ModelLoader, ModelVariant
 
 import forge
+from third_party.tt_forge_models.regnet.image_classification.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -36,45 +33,22 @@ def test_regnet_img_classification_onnx(variant, forge_tmp_path):
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.REGNET,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_IMAGE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
     )
 
-    # Load model and input using tt_forge_models
+    # Load model and input
     loader = ModelLoader(variant=variant)
-    torch_model = loader.load_model(dtype_override=torch.float32)
-    input_tensor = loader.load_inputs(dtype_override=torch.float32)
-    inputs = [input_tensor]
-
-    # Export ONNX model from PyTorch
-    onnx_path = Path(forge_tmp_path) / f"{variant.value}_exported.onnx"
-    if not onnx_path.exists():
-        torch.onnx.export(
-            torch_model,
-            input_tensor,
-            onnx_path,
-            input_names=["input"],
-            output_names=["output"],
-            opset_version=18,
-            dynamic_axes={"input": {0: "batch"}, "output": {0: "batch"}},
-        )
-
-    # Load ONNX model properly
-    model_name = f"onnx_regnet_{variant.value}"
-    onnx_model = onnx.load(str(onnx_path))
-    onnx.checker.check_model(onnx_model)
-    framework_model = forge.OnnxModule(model_name, onnx_model)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs(dtype_override=torch.float32)
+    framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile
-    compiled_model = forge.compile(
-        framework_model,
-        sample_inputs=inputs,
-        module_name=module_name,
-    )
+    compiled_model = forge.compile(onnx_model, inputs, module_name=module_name)
 
     # Verify
     _, co_out = verify(inputs, framework_model, compiled_model)
 
     # Post-processing
-    loader.output_postprocess(co_out)
+    loader.torch_loader.output_postprocess(co_out)

--- a/forge/test/models/onnx/vision/resnext/test_resnext_onnx.py
+++ b/forge/test/models/onnx/vision/resnext/test_resnext_onnx.py
@@ -3,10 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-import torch
-from pytorchcv.model_provider import get_model as ptcv_get_model
 
 import forge
+from third_party.tt_forge_models.resnext.image_classification.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -16,47 +15,30 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
-from test.models.onnx.vision.resnext.model_utils.utils import (
-    get_image_tensor,
-    post_processing,
-)
-from test.utils import download_model
-import onnx
-
 variants = [
-    pytest.param("resnext14_32x4d", marks=pytest.mark.pr_models_regression),
-    "resnext26_32x4d",
-    "resnext50_32x4d",
-    "resnext101_64x4d",
+    pytest.param(ModelVariant.RESNEXT14_32X4D_OSMR, marks=pytest.mark.pr_models_regression),
+    ModelVariant.RESNEXT26_32X4D_OSMR,
+    ModelVariant.RESNEXT50_32X4D_OSMR,
+    ModelVariant.RESNEXT101_64X4D_OSMR,
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_resnext_onnx(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.RESNEXT,
         source=Source.OSMR,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_IMAGE_CLASSIFICATION,
     )
 
-    # Load the model and prepare input data
-    torch_model = download_model(ptcv_get_model, variant, pretrained=True)
-    torch_model.eval()
-    input_batch = get_image_tensor()
-    inputs = [input_batch]
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/{variant}.onnx"
-    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
-
-    # Load framework model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inputs = loader.load_inputs()
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Compile model
@@ -69,5 +51,4 @@ def test_resnext_onnx(variant, forge_tmp_path):
         compiled_model,
     )
 
-    # Post processing
-    post_processing(co_out)
+    loader.print_cls_results(co_out)

--- a/forge/test/models/onnx/vision/retinanet/test_retinanet_onnx.py
+++ b/forge/test/models/onnx/vision/retinanet/test_retinanet_onnx.py
@@ -1,16 +1,12 @@
 # SPDX-FileCopyrightText: © 2024 Tenstorrent AI ULC
 
 # SPDX-License-Identifier: Apache-2.0
-import os
-import shutil
-import zipfile
 
 import pytest
-import requests
 import torch
-import onnx
 
 import forge
+from third_party.tt_forge_models.retinanet.object_detection.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -19,84 +15,42 @@ from forge.forge_property_utils import (
     record_model_properties,
 )
 from forge.verify.verify import verify
-from test.models.onnx.vision.retinanet.model_utils.model_utils import img_preprocess
-from test.models.onnx.vision.retinanet.model_utils.model import Model
 
 variants = [
-    "retinanet_rn18fpn",
-    "retinanet_rn34fpn",
-    "retinanet_rn50fpn",
-    "retinanet_rn101fpn",
-    "retinanet_rn152fpn",
+    ModelVariant.RETINANET_RN18FPN,
+    ModelVariant.RETINANET_RN34FPN,
+    ModelVariant.RETINANET_RN50FPN,
+    ModelVariant.RETINANET_RN101FPN,
+    ModelVariant.RETINANET_RN152FPN,
 ]
 
 
 @pytest.mark.nightly
 @pytest.mark.parametrize("variant", variants)
 def test_retinanet(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.RETINANET,
-        variant=variant,
+        variant=variant.value,
         source=Source.HUGGINGFACE,
         task=Task.CV_OBJECT_DETECTION,
     )
 
-    # Prepare model
-    url = f"https://github.com/NVIDIA/retinanet-examples/releases/download/19.04/{variant}.zip"
-    local_zip_path = f"{variant}.zip"
+    loader = ModelLoader(variant=variant)
+    try:
+        onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+        inp = loader.load_inputs()
+        inputs = [inp] if isinstance(inp, torch.Tensor) else inp
+        framework_model = forge.OnnxModule(module_name, onnx_model)
 
-    response = requests.get(url)
-    with open(local_zip_path, "wb") as f:
-        f.write(response.content)
+        compiled_model = forge.compile(
+            onnx_model,
+            sample_inputs=inputs,
+            module_name=module_name,
+        )
 
-    # Unzip the file
-    with zipfile.ZipFile(local_zip_path, "r") as zip_ref:
-        zip_ref.extractall(".")
-
-    # Find the path of the .pth file
-    extracted_path = f"{variant}"
-    checkpoint_path = ""
-    for root, _, files in os.walk(extracted_path):
-        for file in files:
-            if file.endswith(".pth"):
-                checkpoint_path = os.path.join(root, file)
-
-    framework_model = Model.load(checkpoint_path)
-    framework_model.eval()
-
-    # Prepare input
-    input_batch = img_preprocess()
-    inputs = [input_batch]
-
-    # Export to ONNX
-    onnx_path = f"{forge_tmp_path}/{variant}_retinanet.onnx"
-    torch.onnx.export(
-        framework_model,
-        inputs[0],
-        onnx_path,
-        opset_version=17,
-        input_names=["input"],
-        output_names=["output"],
-    )
-
-    # Load and check ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
-    framework_model = forge.OnnxModule(module_name, onnx_model)
-
-    # Forge compile ONNX model
-    compiled_model = forge.compile(
-        onnx_model,
-        sample_inputs=inputs,
-        module_name=module_name,
-    )
-
-    # Verify model correctness
-    verify(inputs, framework_model, compiled_model)
-
-    # Cleanup
-    shutil.rmtree(extracted_path)
-    os.remove(local_zip_path)
+        verify(inputs, framework_model, compiled_model)
+    finally:
+        if getattr(loader, "torch_loader", None) is not None:
+            loader.torch_loader.cleanup()

--- a/forge/test/models/onnx/vision/segformer/test_segformer.py
+++ b/forge/test/models/onnx/vision/segformer/test_segformer.py
@@ -2,56 +2,54 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-import forge
-from transformers import AutoImageProcessor
 import pytest
-import onnx
 import torch
+
+import forge
+from third_party.tt_forge_models.segformer.image_classification.onnx import (
+    ModelLoader as SegformerImgClsOnnxLoader,
+    ModelVariant as SegformerImgClsVariant,
+)
+from third_party.tt_forge_models.segformer.semantic_segmentation.onnx import (
+    ModelLoader as SegformerSemSegOnnxLoader,
+    ModelVariant as SegformerSemSegVariant,
+)
 from forge.verify.verify import verify
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
-from transformers import SegformerForSemanticSegmentation, SegformerForImageClassification
-from test.models.models_utils import get_sample_data
-from test.utils import download_model
 
 variants_img_classification = [
-    pytest.param("nvidia/mit-b0", marks=pytest.mark.pr_models_regression),
-    pytest.param("nvidia/mit-b2"),
-    pytest.param("nvidia/mit-b3", marks=pytest.mark.xfail),
-    pytest.param("nvidia/mit-b4", marks=pytest.mark.xfail),
-    pytest.param("nvidia/mit-b5", marks=pytest.mark.xfail),
+    pytest.param(SegformerImgClsVariant.MIT_B0, marks=pytest.mark.pr_models_regression),
+    pytest.param(SegformerImgClsVariant.MIT_B2),
+    pytest.param(SegformerImgClsVariant.MIT_B3, marks=pytest.mark.xfail),
+    pytest.param(SegformerImgClsVariant.MIT_B4, marks=pytest.mark.xfail),
+    pytest.param(SegformerImgClsVariant.MIT_B5, marks=pytest.mark.xfail),
 ]
 
 
 @pytest.mark.parametrize("variant", variants_img_classification)
 @pytest.mark.nightly
 def test_segformer_image_classification_onnx(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.SEGFORMER,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_IMAGE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
     )
 
-    if variant in ["nvidia/mit-b3", "nvidia/mit-b4", "nvidia/mit-b5"]:
+    if variant in (
+        SegformerImgClsVariant.MIT_B3,
+        SegformerImgClsVariant.MIT_B4,
+        SegformerImgClsVariant.MIT_B5,
+    ):
         pytest.xfail(reason="Fatal Python error: Aborted")
 
-    # Load the model from HuggingFace
-    torch_model = download_model(SegformerForImageClassification.from_pretrained, variant, return_dict=False)
-    torch_model.eval()
-
-    # prepare input
-    inputs = get_sample_data(variant)
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/segformer_" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
-    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
-
-    # Load framework model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = SegformerImgClsOnnxLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inp = loader.load_inputs()
+    inputs = [inp] if isinstance(inp, torch.Tensor) else inp
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Set data format override
@@ -71,45 +69,35 @@ def test_segformer_image_classification_onnx(variant, forge_tmp_path):
     # Post processing
     logits = co_out[0]
     predicted_label = logits.argmax(-1).item()
-    print("Predicted class: ", torch_model.config.id2label[predicted_label])
+    print("Predicted class: ", loader.torch_loader.model.config.id2label[predicted_label])
 
 
 variants_semseg = [
-    pytest.param("nvidia/segformer-b0-finetuned-ade-512-512", marks=pytest.mark.pr_models_regression),
-    "nvidia/segformer-b1-finetuned-ade-512-512",
-    pytest.param("nvidia/segformer-b2-finetuned-ade-512-512"),
-    pytest.param("nvidia/segformer-b3-finetuned-ade-512-512"),
-    pytest.param("nvidia/segformer-b4-finetuned-ade-512-512"),
+    pytest.param(SegformerSemSegVariant.B0_FINETUNED, marks=pytest.mark.pr_models_regression),
+    SegformerSemSegVariant.B1_FINETUNED,
+    pytest.param(SegformerSemSegVariant.B2_FINETUNED),
+    pytest.param(SegformerSemSegVariant.B3_FINETUNED),
+    pytest.param(SegformerSemSegVariant.B4_FINETUNED),
 ]
 
 
 @pytest.mark.parametrize("variant", variants_semseg)
 @pytest.mark.nightly
 def test_segformer_semantic_segmentation_onnx(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.SEGFORMER,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_IMAGE_SEGMENTATION,
         source=Source.HUGGINGFACE,
     )
 
-    # Load the model from HuggingFace
-    torch_model = download_model(SegformerForSemanticSegmentation.from_pretrained, variant, return_dict=False)
-    torch_model.eval()
-
-    # prepare input
-    inputs = get_sample_data(variant)
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/" + str(variant).split("/")[-1].replace("-", "_") + ".onnx"
-    torch.onnx.export(torch_model, inputs[0], onnx_path, opset_version=17)
-
-    # Load framework model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = SegformerSemSegOnnxLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inp = loader.load_inputs()
+    inputs = [inp] if isinstance(inp, torch.Tensor) else inp
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Compile model

--- a/forge/test/models/onnx/vision/ssd300_resnet50/test_ssd300_resnet50_onnx.py
+++ b/forge/test/models/onnx/vision/ssd300_resnet50/test_ssd300_resnet50_onnx.py
@@ -2,7 +2,10 @@
 
 # SPDX-License-Identifier: Apache-2.0
 import pytest
+import torch
+
 import forge
+from third_party.tt_forge_models.ssd300_resnet50.object_detection.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -12,14 +15,6 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
-from test.models.onnx.vision.ssd300_resnet50.model_utils.utils import (
-    load_ssd300_torch_model,
-    load_ssd300_inputs,
-)
-from test.models.onnx.vision.vision_utils.utils import (
-    load_onnx_with_fallback,
-)
-
 
 @pytest.mark.pr_models_regression
 @pytest.mark.nightly
@@ -28,21 +23,16 @@ def test_pytorch_ssd300_resnet50(forge_tmp_path):
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.SSD300RESNET50,
+        variant=ModelVariant.BASE.value,
         source=Source.TORCH_HUB,
         task=Task.CV_IMAGE_CLASSIFICATION,
     )
 
-    # Prepare input
-    inputs = load_ssd300_inputs()
-
-    # Load ONNX model
-    onnx_model = load_onnx_with_fallback(
-        torch_model_loader=load_ssd300_torch_model,
-        s3_onnx_path="test_files/onnx/ssd300_resnet50/ssd300_resnet50.onnx",
-        onnx_filename="ssd300_resnet50.onnx",
-        forge_tmp_path=forge_tmp_path,
-        inputs=inputs,
-    )
+    # Load model and input
+    loader = ModelLoader(variant=ModelVariant.BASE)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inp = loader.load_inputs()
+    inputs = [inp] if isinstance(inp, torch.Tensor) else inp
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile

--- a/forge/test/models/onnx/vision/ssd300_vgg16/test_ssd300_vgg16_onnx.py
+++ b/forge/test/models/onnx/vision/ssd300_vgg16/test_ssd300_vgg16_onnx.py
@@ -4,9 +4,9 @@
 
 import pytest
 import torch
-import onnx
 
 import forge
+from third_party.tt_forge_models.ssd300_vgg16.object_detection.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -16,48 +16,25 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
-from test.models.onnx.vision.ssd300_vgg16.model_utils.model_utils import SSDWrapper
-from test.models.onnx.vision.vision_utils.utils import load_vision_model_and_input
-
-variants_with_weights = {
-    "ssd300_vgg16": "SSD300_VGG16_Weights",
-}
-
 
 @pytest.mark.nightly
 @pytest.mark.xfail
-@pytest.mark.parametrize("variant", variants_with_weights.keys())
+@pytest.mark.parametrize("variant", [ModelVariant.BASE])
 def test_ssd300_vgg16(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.SSD300VGG16,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_IMAGE_CLASSIFICATION,
         source=Source.TORCHVISION,
     )
 
     # Load model and input
-    weight_name = variants_with_weights[variant]
-    framework_model, inputs = load_vision_model_and_input(variant, "detection", weight_name)
-    model = SSDWrapper(framework_model)
-    inputs = [inputs[0]]
-
-    # Export to ONNX
-    onnx_path = f"{forge_tmp_path}/{variant}_ssd.onnx"
-    torch.onnx.export(
-        model,
-        inputs[0],
-        onnx_path,
-        opset_version=17,
-        input_names=["input"],
-        output_names=["bbox_regression", "cls_logits", "features"],
-    )
-
-    # Load ONNX
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inp = loader.load_inputs()
+    inputs = [inp] if isinstance(inp, torch.Tensor) else inp
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Compile with Forge

--- a/forge/test/models/onnx/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3_onnx.py
+++ b/forge/test/models/onnx/vision/ssdlite320_mobilenetv3/test_ssdlite320_mobilenetv3_onnx.py
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import torch
-import onnx
 
 import forge
+from third_party.tt_forge_models.ssdlite320_mobilenetv3.object_detection.onnx import ModelLoader, ModelVariant
 from forge.forge_property_utils import (
     Framework,
     ModelArch,
@@ -15,23 +15,16 @@ from forge.forge_property_utils import (
 )
 from forge.verify.verify import verify
 
-from test.models.onnx.vision.vision_utils.utils import load_vision_model_and_input
-
-variants_with_weights = {
-    "ssdlite320_mobilenet_v3_large": "SSDLite320_MobileNet_V3_Large_Weights",
-}
-
 
 @pytest.mark.pr_models_regression
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", variants_with_weights.keys())
+@pytest.mark.parametrize("variant", [ModelVariant.SSDLITE320_MOBILENET_V3_LARGE])
 def test_ssdlite320_mobilenetv3(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.SSDLITE320MOBILENETV3,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_IMAGE_CLASSIFICATION,
         source=Source.TORCHVISION,
     )
@@ -39,33 +32,18 @@ def test_ssdlite320_mobilenetv3(variant, forge_tmp_path):
     pytest.xfail(reason="Fatal Python error: Segmentation fault")
 
     # Load model and input
-    weight_name = variants_with_weights[variant]
-    framework_model, inputs = load_vision_model_and_input(variant, "detection", weight_name)
-    inputs = [inputs[0]]
-
-    # STEP 3: Export to ONNX
-    onnx_path = f"{forge_tmp_path}/{variant}.onnx"
-    torch.onnx.export(
-        framework_model,
-        inputs[0],
-        onnx_path,
-        opset_version=17,
-        input_names=["input"],
-        output_names=["bbox_regression", "cls_logits", "features"],
-        dynamic_axes={"input": {0: "batch_size"}},
-    )
-
-    # STEP 4: Load ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inp = loader.load_inputs()
+    inputs = [inp] if isinstance(inp, torch.Tensor) else inp
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
-    # STEP 5: Compile with Forge
+    # Compile with Forge
     compiled_model = forge.compile(
         onnx_model,
         sample_inputs=inputs,
         module_name=module_name,
     )
 
-    # STEP 6: Verify
+    # Verify
     verify(inputs, framework_model, compiled_model)

--- a/forge/test/models/onnx/vision/swin/test_swin.py
+++ b/forge/test/models/onnx/vision/swin/test_swin.py
@@ -2,127 +2,95 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 import pytest
-from transformers import (
-    Swinv2ForMaskedImageModeling,
-    Swinv2ForImageClassification,
-    Swinv2Model,
-    ViTImageProcessor,
-)
-import onnx
 import torch
-import forge
 
-from test.models.onnx.vision.swin.model_utils.image_utils import load_image
-from test.models.onnx.vision.vision_utils.utils import load_vision_model_and_input
+import forge
+from third_party.tt_forge_models.swin.image_classification.onnx import (
+    ModelLoader as SwinImgClsOnnxLoader,
+    ModelVariant as SwinImgClsOnnxVariant,
+)
+from third_party.tt_forge_models.swin.masked_image_modeling.onnx import (
+    ModelLoader as SwinMimOnnxLoader,
+    ModelVariant as SwinMimOnnxVariant,
+)
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
+from forge.verify.verify import verify
 
 
 @pytest.mark.nightly
 @pytest.mark.xfail
-@pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
+@pytest.mark.parametrize("variant", [SwinImgClsOnnxVariant.SWINV2_TINY_HF])
 def test_swin_v2_tiny_image_classification_onnx(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.SWIN,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_IMAGE_CLASSIFICATION,
         source=Source.HUGGINGFACE,
     )
     pytest.xfail(reason="Segmentation Fault")
 
-    # Load the model
-    framework_model = Swinv2ForImageClassification.from_pretrained(variant)
-    framework_model.eval()
-
-    # Prepare input data
-    feature_extractor = ViTImageProcessor.from_pretrained(variant)
-    inputs = load_image(feature_extractor)
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/swin_v2_obj_cls.onnx"
-    torch.onnx.export(
-        framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
-    )
-
-    # Load ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = SwinImgClsOnnxLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inp = loader.load_inputs()
+    inputs = [inp] if isinstance(inp, torch.Tensor) else inp
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile framework model
     compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
+
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.pr_models_regression
 @pytest.mark.nightly
-@pytest.mark.parametrize("variant", ["microsoft/swinv2-tiny-patch4-window8-256"])
+@pytest.mark.parametrize("variant", [SwinMimOnnxVariant.SWINV2_TINY])
 def test_swin_v2_tiny_masked_onnx(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.SWIN,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_MASKED_IMAGE_MODELING,
         source=Source.HUGGINGFACE,
     )
 
-    # Load the model
-    framework_model = Swinv2ForMaskedImageModeling.from_pretrained(variant)
-    framework_model.eval()
-
-    # Prepare input data
-    feature_extractor = ViTImageProcessor.from_pretrained(variant)
-    inputs = load_image(feature_extractor)
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/swin_v2_tiny_masked.onnx"
-    torch.onnx.export(
-        framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
-    )
-
-    # Load ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = SwinMimOnnxLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inp = loader.load_inputs()
+    inputs = [inp] if isinstance(inp, torch.Tensor) else inp
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile framework model
     compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
 
-
-variants_with_weights = {"swin_v2_t": "Swin_V2_T_Weights"}
+    verify(inputs, framework_model, compiled_model)
 
 
 @pytest.mark.nightly
 @pytest.mark.xfail
-@pytest.mark.parametrize("variant", ["swin_v2_t"])
+@pytest.mark.parametrize("variant", [SwinImgClsOnnxVariant.SWIN_V2_T])
 def test_swin_torchvision(variant, forge_tmp_path):
-
     # Record Forge Property
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.SWIN,
-        variant=variant,
+        variant=variant.value,
         task=Task.CV_IMAGE_CLASSIFICATION,
         source=Source.TORCHVISION,
     )
 
     # Load model and input
-    weight_name = variants_with_weights[variant]
-    framework_model, inputs = load_vision_model_and_input(variant, "classification", weight_name)
-
-    # Export model to ONNX
-    onnx_path = f"{forge_tmp_path}/swin_v2_torchvision.onnx"
-    torch.onnx.export(
-        framework_model, inputs[0], onnx_path, opset_version=17, input_names=["input"], output_names=["output"]
-    )
-
-    # Load ONNX model
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    loader = SwinImgClsOnnxLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inp = loader.load_inputs()
+    inputs = [inp] if isinstance(inp, torch.Tensor) else inp
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile framework model
     compiled_model = forge.compile(onnx_model, sample_inputs=inputs, module_name=module_name)
+
+    verify(inputs, framework_model, compiled_model)

--- a/forge/test/models/onnx/vision/unet/test_unet.py
+++ b/forge/test/models/onnx/vision/unet/test_unet.py
@@ -3,52 +3,30 @@
 # SPDX-License-Identifier: Apache-2.0
 import pytest
 import torch
-import numpy as np
+
 import forge
-import onnx
+from third_party.tt_forge_models.unet.image_segmentation.onnx import ModelLoader, ModelVariant
 from forge.verify.verify import verify
 from forge.forge_property_utils import Framework, Source, Task, ModelArch, record_model_properties
-from test.models.onnx.vision.unet.model_utils.utils import load_inputs
-from test.utils import download_model
 
 
 @pytest.mark.nightly
-def test_unet_onnx(forge_tmp_path):
-
+@pytest.mark.parametrize("variant", [ModelVariant.TORCHHUB_BRAIN_UNET])
+def test_unet_onnx(variant, forge_tmp_path):
     # Build Module Name
     module_name = record_model_properties(
         framework=Framework.ONNX,
         model=ModelArch.UNET,
-        variant="base",
+        variant=variant.value,
         source=Source.TORCH_HUB,
         task=Task.CV_IMAGE_SEGMENTATION,
     )
 
-    # Load the torch model
-    # trust_repo=True bypasses GitHub API validation that triggers rate limit (403) in CI/shared envs
-    torch_model = download_model(
-        torch.hub.load,
-        "mateuszbuda/brain-segmentation-pytorch",
-        "unet",
-        in_channels=3,
-        out_channels=1,
-        init_features=32,
-        pretrained=True,
-        trust_repo=True,
-    )
-    torch_model.eval()
-
-    # Load the inputs
-    url, filename = (
-        "https://github.com/mateuszbuda/brain-segmentation-pytorch/raw/master/assets/TCGA_CS_4944.png",
-        "TCGA_CS_4944.png",
-    )
-    inputs = load_inputs(url, filename)
-
-    onnx_path = f"{forge_tmp_path}/unet.onnx"
-    torch.onnx.export(torch_model, inputs[0], onnx_path)
-    onnx_model = onnx.load(onnx_path)
-    onnx.checker.check_model(onnx_model)
+    # Load model and input
+    loader = ModelLoader(variant=variant)
+    onnx_model = loader.load_model(onnx_tmp_path=forge_tmp_path)
+    inp = loader.load_inputs()
+    inputs = [inp] if isinstance(inp, torch.Tensor) else inp
     framework_model = forge.OnnxModule(module_name, onnx_model)
 
     # Forge compile framework model


### PR DESCRIPTION
### Ticket
Fixes [#3273](https://github.com/tenstorrent/tt-forge-onnx/issues/3273)

### Problem description

- Standardize all model and input loading in tt-forge-onnx to use the tt-forge-models repository (e.g. third_party/tt_forge_models)

### What's changed
This PR modifies the onnx test files to load model and inputs from third party/tt_forge_models.:

- Retinanet
- Segformer (Image Classification and Segmentation)
- Ssd300_resnet50
- Ssd300_vgg16
- Ssdlite320_mobilenetv3
- Swin
- Unet
- Perceiverio
- Regnet
- Resnext
- Vilt
- Whisper

### Checklist
- [x] Verify successful model and input loading by running ort.

### Logs
[set3_logs.zip](https://github.com/user-attachments/files/27596924/set3_logs.zip)