### PR TITLE
Fix missing system libraries  (libgomp1, libmpc3) 

### DIFF
--- a/.github/Dockerfile.release-ubuntu
+++ b/.github/Dockerfile.release-ubuntu
@@ -21,7 +21,9 @@ RUN apt-get update && \
         jq \
         unzip \
         ca-certificates \
-        software-properties-common && \
+        software-properties-common \
+        libatomic1 \
+        libgomp1 && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/.github/Dockerfile.release-ubuntu
+++ b/.github/Dockerfile.release-ubuntu
@@ -22,8 +22,8 @@ RUN apt-get update && \
         unzip \
         ca-certificates \
         software-properties-common \
-        libatomic1 \
-        libgomp1 && \
+        libgomp1 \
+        libmpc3 && \
     add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -56,7 +56,16 @@ This section walks you through downloading and installing a wheel. You can insta
 
 1. Make sure you have Python 3.12 installed and you are in an active Python 3.12 virtual environment. This walkthrough uses the same environment you activated to look at TT-SMI in the [Configuring Hardware](#configuring-hardware) section.
 
-2. For this walkthrough, TT-Forge-ONNX is used. You need to install the **tt_forge_onnx** and **tt_tvm** wheels:
+2. Install the required system runtime libraries on Ubuntu 24.04:
+
+```bash
+sudo apt-get install -y libgomp1 libmpc3
+```
+
+- `libgomp1` — OpenMP runtime (`libgomp.so.1`), required by PaddlePaddle's `libpaddle.so`.
+- `libmpc3` — GNU MPC library (`libmpc.so.3`), required by the sfpi RISC-V GCC compiler bundled in the wheel.
+
+3. For this walkthrough, TT-Forge-ONNX is used. You need to install the **tt_forge_onnx** and **tt_tvm** wheels:
 
 ```bash
 # Install uv if you don't have it yet
@@ -66,7 +75,7 @@ uv pip install tt_forge_onnx --extra-index-url https://pypi.eng.aws.tenstorrent.
 uv pip install tt_tvm --extra-index-url https://pypi.eng.aws.tenstorrent.com/
 ```
 
-3. To test that everything is running correctly, try an example model. You can use nano or another text editor to paste this code into a file named **forge_example.py** and then run it from the terminal. You should still have your virtual environment running after installing the wheel when running this example:
+4. To test that everything is running correctly, try an example model. You can use nano or another text editor to paste this code into a file named **forge_example.py** and then run it from the terminal. You should still have your virtual environment running after installing the wheel when running this example:
 
 ```python
 import numpy as np
@@ -93,7 +102,7 @@ output = compiled_model(x, y)
 print("Output:", output)
 ```
 
-4. You have now set up the latest wheel for TT-Forge-ONNX, and can run any models you want inside your virtual environment.
+5. You have now set up the latest wheel for TT-Forge-ONNX, and can run any models you want inside your virtual environment.
 
 ## Other Set up Options
 If you want to keep your environment completely separate in a Docker container, or you want to develop TT-Forge-ONNX further, this section links you to the pages with those options:


### PR DESCRIPTION
Follow-up fix to #3290

## Failure

```
# PaddlePaddle failing to import libpaddle
ImportError: libgomp.so.1: cannot open shared object file: No such file or directory
```
Pipeline: https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25085223350/job/73517481689

```
# sfpi RISC-V GCC compiler (cc1plus) failing to compile firmware kernels
cc1plus: error while loading shared libraries: libmpc.so.3: cannot open shared object file: No such file or directory
```
Pipeline:  https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25085223350/job/73517481607

## Solution

Added `libgomp1` and `libmpc3` to the `apt-get install` step in `Dockerfile.release-ubuntu`. These are runtime system dependencies that are missing from the minimal Ubuntu 24.04 base image and cannot be auto-bundled into the wheel:

- `libgomp1` — provides `libgomp.so.1` (OpenMP runtime), required by PaddlePaddle's `libpaddle.so`
- `libmpc3` — provides `libmpc.so.3` (GNU MPC library), required by the sfpi GCC 15.1.0 `cc1plus` binary bundled in the wheel

## Note
Validated by triggering pipeline: https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25093014172 and now all the release demo tests are passing 