### PR TITLE
Fix libtt-umd changes

### DIFF
--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -31,8 +31,8 @@ transformers==4.52.4
 requests==2.28.2
 tflite==2.10.0
 ultralytics==8.3.91
-paddlepaddle
-paddlenlp
+paddlepaddle==2.6.2
+paddlenlp==2.8.1
 aistudio-sdk==0.2.6
 pytorch_forecasting
 patool

--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -31,8 +31,8 @@ transformers==4.52.4
 requests==2.28.2
 tflite==2.10.0
 ultralytics==8.3.91
-paddlepaddle==2.6.2
-paddlenlp==2.8.1
+paddlepaddle
+paddlenlp
 aistudio-sdk==0.2.6
 pytorch_forecasting
 patool

--- a/setup.py
+++ b/setup.py
@@ -112,10 +112,18 @@ def _prune_bloat_from_wheel(install_dir: str) -> None:
     _remove_bloat_dir(install_dir / "lib" / "pkgconfig")
     _remove_bloat_dir(install_dir / "include")
     _remove_bloat_dir(install_dir / "tt-metal" / ".cpmcache")
+    _fix_file(install_dir / "lib" / "libtt-umd.so.0", "$ORIGIN:$ORIGIN/lib")
     _remove_bloat_file(install_dir / "lib" / "libtt-umd.so")
     _remove_bloat_file(install_dir / "lib" / "libtt-umd.so.0.*")
-    adjust_rpath(install_dir / "lib" / "libtt-umd.so.0", "$ORIGIN:$ORIGIN/lib")
     _strip_shared_objects(install_dir)
+
+
+def _fix_file(file_path: Path) -> None:
+    if file_path.is_symlink():
+        target = file_path.resolve()
+        file_path.unlink()
+        shutil.copy2(target, file_path)
+    adjust_rpath(file_path, "$ORIGIN:$ORIGIN/lib")
 
 
 def _remove_broken_symlinks(root: Path) -> None:

--- a/setup.py
+++ b/setup.py
@@ -112,18 +112,18 @@ def _prune_bloat_from_wheel(install_dir: str) -> None:
     _remove_bloat_dir(install_dir / "lib" / "pkgconfig")
     _remove_bloat_dir(install_dir / "include")
     _remove_bloat_dir(install_dir / "tt-metal" / ".cpmcache")
-    _fix_file(install_dir / "lib" / "libtt-umd.so.0")
+    _fix_file(install_dir / "lib" / "libtt-umd.so.0", install_dir)
     _remove_bloat_file(install_dir / "lib" / "libtt-umd.so")
     _remove_bloat_file(install_dir / "lib" / "libtt-umd.so.0.*")
     _strip_shared_objects(install_dir)
 
 
-def _fix_file(file_path: Path) -> None:
+def _fix_file(file_path: Path, install_dir: Path) -> None:
     if file_path.is_symlink():
         target = file_path.resolve()
         file_path.unlink()
         shutil.copy2(target, file_path)
-    adjust_rpath(file_path, "$ORIGIN:$ORIGIN/lib")
+    adjust_rpath(file_path, "$ORIGIN:$ORIGIN/lib", install_dir)
 
 
 def _remove_broken_symlinks(root: Path) -> None:
@@ -183,7 +183,7 @@ def _remove_bloat_file(file_path: Path) -> None:
             file_path.unlink()
 
 
-def adjust_rpath(so_file: str, new_rpath: str) -> None:
+def adjust_rpath(so_file: str, new_rpath: str, install_dir: Path) -> None:
     """Adjust rpath of a .so file using patchelf."""
     patchelf_path = shutil.which("patchelf")
     if patchelf_path is None:
@@ -263,7 +263,7 @@ def _add_so_dependencies(install_dir: Path) -> None:
                     shutil.copy2(dep, dest_path)
                     # adjust_rpath(dest_path, "$ORIGIN/../lib:$ORIGIN")
                     copied_libs.add(dest_path)
-                    adjust_rpath(str(dest_path), "$ORIGIN:$ORIGIN/lib")
+                    adjust_rpath(str(dest_path), "$ORIGIN:$ORIGIN/lib", install_dir)
             else:
                 print(f"Skipping standard/our library dependency: {dep}")
 

--- a/setup.py
+++ b/setup.py
@@ -112,6 +112,9 @@ def _prune_bloat_from_wheel(install_dir: str) -> None:
     _remove_bloat_dir(install_dir / "lib" / "pkgconfig")
     _remove_bloat_dir(install_dir / "include")
     _remove_bloat_dir(install_dir / "tt-metal" / ".cpmcache")
+    _remove_bloat_file(install_dir / "lib" / "libtt-umd.so")
+    _remove_bloat_file(install_dir / "lib" / "libtt-umd.so.0.*")
+    adjust_rpath(install_dir / "lib" / "libtt-umd.so.0", "$ORIGIN:$ORIGIN/lib")
     _strip_shared_objects(install_dir)
 
 
@@ -157,6 +160,36 @@ def _remove_bloat_dir(dir_path: Path) -> None:
         shutil.rmtree(dir_path)
 
 
+def _remove_bloat_file(file_path: Path) -> None:
+    # Handle wildcard patterns
+    if "*" in file_path.as_posix():
+        parent = file_path.parent
+        pattern = file_path.name
+        for matched_file in parent.glob(pattern):
+            if matched_file.is_file():
+                print(f"Removing bloat file: {matched_file}")
+                matched_file.unlink()
+    else:
+        if file_path.exists() and file_path.is_file():
+            print(f"Removing bloat file: {file_path}")
+            file_path.unlink()
+
+
+def adjust_rpath(so_file: str, new_rpath: str) -> None:
+    """Adjust rpath of a .so file using patchelf."""
+    patchelf_path = shutil.which("patchelf")
+    if patchelf_path is None:
+        print("patchelf not found; skipping rpath adjustment")
+        return
+
+    try:
+        subprocess.run([patchelf_path, "--set-rpath", new_rpath, so_file], check=True)
+        rel = Path(so_file).relative_to(install_dir)
+        print(f"Adjusted rpath: {rel}")
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(f"Failed to adjust rpath for {so_file}: {exc}")
+
+
 def _add_so_dependencies(install_dir: Path) -> None:
     """Copy non-standard .so dependencies into install_dir/lib and adjust rpath."""
 
@@ -197,20 +230,6 @@ def _add_so_dependencies(install_dir: Path) -> None:
         except (subprocess.CalledProcessError, FileNotFoundError):
             print(f"{so_path} is NOT a standard library.")
         return False
-
-    def adjust_rpath(so_file: str, new_rpath: str) -> None:
-        """Adjust rpath of a .so file using patchelf."""
-        patchelf_path = shutil.which("patchelf")
-        if patchelf_path is None:
-            print("patchelf not found; skipping rpath adjustment")
-            return
-
-        try:
-            subprocess.run([patchelf_path, "--set-rpath", new_rpath, so_file], check=True)
-            rel = Path(so_file).relative_to(install_dir)
-            print(f"Adjusted rpath: {rel}")
-        except subprocess.CalledProcessError as exc:
-            raise RuntimeError(f"Failed to adjust rpath for {so_file}: {exc}")
 
     def collect_libs(lib_dir: Path) -> set[str]:
         all_libs = set()

--- a/setup.py
+++ b/setup.py
@@ -212,33 +212,36 @@ def _add_so_dependencies(install_dir: Path) -> None:
         except subprocess.CalledProcessError as exc:
             raise RuntimeError(f"Failed to adjust rpath for {so_file}: {exc}")
 
-    lib_dir = install_dir / "lib"
-    all_libs = set()
-    copied_libs = set()
-    for so_file in install_dir.rglob("*.so*"):
-        if so_file.is_symlink() or not so_file.is_file():
-            continue
+    def collect_and_add_libs(lib_dir: Path) -> None:
+        all_libs = set()
+        copied_libs = set()
+        for so_file in install_dir.rglob("*.so*"):
+            if so_file.is_symlink() or not so_file.is_file():
+                continue
 
-        all_libs.update(get_so_dependencies(str(so_file)))
+            all_libs.update(get_so_dependencies(str(so_file)))
 
-    print(f"Total dependencies found: {len(all_libs)}")
-    print(all_libs)
-    for dep in all_libs:
-        dep_path = Path(dep).resolve()
-        if dep_path.parts[:-1] != install_dir.parts and not is_standard_library(dep):
-            dep_path = Path(dep)
-            dest_path = lib_dir / dep_path.name
-            if not dest_path.exists():
-                print(f"Copying dependency {dep} to {dest_path}...")
-                shutil.copy2(dep, dest_path)
-                # adjust_rpath(dest_path, "$ORIGIN/../lib:$ORIGIN")
-                copied_libs.add(dest_path)
-                adjust_rpath(str(dest_path), "$ORIGIN:$ORIGIN/../lib")
-        else:
-            print(f"Skipping standard/our library dependency: {dep}")
+        print(f"Total dependencies found: {len(all_libs)}")
+        print(all_libs)
+        for dep in all_libs:
+            dep_path = Path(dep).resolve()
+            if dep_path.parts[:-1] != install_dir.parts and not is_standard_library(dep):
+                dep_path = Path(dep)
+                dest_path = lib_dir / dep_path.name
+                if not dest_path.exists():
+                    print(f"Copying dependency {dep} to {dest_path}...")
+                    shutil.copy2(dep, dest_path)
+                    # adjust_rpath(dest_path, "$ORIGIN/../lib:$ORIGIN")
+                    copied_libs.add(dest_path)
+                    adjust_rpath(str(dest_path), "$ORIGIN:$ORIGIN/../lib")
+            else:
+                print(f"Skipping standard/our library dependency: {dep}")
 
-    print(f"Copied dependencies {len(copied_libs)}:")
-    print(copied_libs)
+        print(f"Copied dependencies {len(copied_libs)}:")
+        print(copied_libs)
+
+    collect_and_add_libs(install_dir)
+    collect_and_add_libs(install_dir / "lib")
 
 
 with open("README.md", "r") as f:

--- a/setup.py
+++ b/setup.py
@@ -270,11 +270,31 @@ def _add_so_dependencies(install_dir: Path) -> None:
         print(f"Copied dependencies {len(copied_libs)}:")
         print(copied_libs)
 
+    def get_full_paths(lib_names: Set[str]) -> Set[str]:
+        """Convert library names to their full paths using ldconfig or system search."""
+        full_paths = set()
+        try:
+            output = subprocess.check_output(["ldconfig", "-p"], text=True)
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pass
+        for lib_name in lib_names:
+            for line in output.splitlines():
+                if lib_name in line:
+                    parts = line.split("=>")
+                    if len(parts) > 1:
+                        path = parts[1].strip()
+                        if path:
+                            full_paths.add(path)
+                            break
+        return full_paths
+
     alllibs = collect_libs(install_dir)
     alllibs.update(collect_libs(install_dir / "lib"))
 
-    additional_libs = set(  # Add any known additional dependencies that might not be picked up by ldd
-        ["libgomp.so.1"]  # PaddlePaddle requires libgomp
+    additional_libs = get_full_paths(
+        set(  # Add any known additional dependencies that might not be picked up by ldd
+            ["libgomp.so.1"]  # PaddlePaddle requires libgomp
+        )
     )
     alllibs.update(additional_libs)
     copy_libs(install_dir / "lib", alllibs)

--- a/setup.py
+++ b/setup.py
@@ -212,9 +212,8 @@ def _add_so_dependencies(install_dir: Path) -> None:
         except subprocess.CalledProcessError as exc:
             raise RuntimeError(f"Failed to adjust rpath for {so_file}: {exc}")
 
-    def collect_and_add_libs(lib_dir: Path) -> None:
+    def collect_libs(lib_dir: Path) -> set[str]:
         all_libs = set()
-        copied_libs = set()
         for so_file in install_dir.rglob("*.so*"):
             if so_file.is_symlink() or not so_file.is_file():
                 continue
@@ -223,6 +222,10 @@ def _add_so_dependencies(install_dir: Path) -> None:
 
         print(f"Total dependencies found: {len(all_libs)}")
         print(all_libs)
+        return all_libs
+
+    def copy_libs(lib_dir: Path, all_libs: Set[str]) -> None:
+        copied_libs = set()
         for dep in all_libs:
             dep_path = Path(dep).resolve()
             if dep_path.parts[:-1] != install_dir.parts and not is_standard_library(dep):
@@ -233,15 +236,16 @@ def _add_so_dependencies(install_dir: Path) -> None:
                     shutil.copy2(dep, dest_path)
                     # adjust_rpath(dest_path, "$ORIGIN/../lib:$ORIGIN")
                     copied_libs.add(dest_path)
-                    adjust_rpath(str(dest_path), "$ORIGIN:$ORIGIN/../lib")
+                    adjust_rpath(str(dest_path), "$ORIGIN:$ORIGIN/lib")
             else:
                 print(f"Skipping standard/our library dependency: {dep}")
 
         print(f"Copied dependencies {len(copied_libs)}:")
         print(copied_libs)
 
-    collect_and_add_libs(install_dir)
-    collect_and_add_libs(install_dir / "lib")
+    alllibs = collect_libs(install_dir)
+    alllibs.update(collect_libs(install_dir / "lib"))
+    copy_libs(install_dir / "lib", alllibs)
 
 
 with open("README.md", "r") as f:

--- a/setup.py
+++ b/setup.py
@@ -272,6 +272,11 @@ def _add_so_dependencies(install_dir: Path) -> None:
 
     alllibs = collect_libs(install_dir)
     alllibs.update(collect_libs(install_dir / "lib"))
+
+    additional_libs = set(  # Add any known additional dependencies that might not be picked up by ldd
+        ["libgomp.so.1"]  # PaddlePaddle requires libgomp
+    )
+    alllibs.update(additional_libs)
     copy_libs(install_dir / "lib", alllibs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -273,10 +273,7 @@ def _add_so_dependencies(install_dir: Path) -> None:
     def get_full_paths(lib_names: Set[str]) -> Set[str]:
         """Convert library names to their full paths using ldconfig or system search."""
         full_paths = set()
-        try:
-            output = subprocess.check_output(["ldconfig", "-p"], text=True)
-        except (subprocess.CalledProcessError, FileNotFoundError):
-            pass
+        output = subprocess.check_output(["ldconfig", "-p"], text=True)
         for lib_name in lib_names:
             for line in output.splitlines():
                 if lib_name in line:
@@ -290,13 +287,6 @@ def _add_so_dependencies(install_dir: Path) -> None:
 
     alllibs = collect_libs(install_dir)
     alllibs.update(collect_libs(install_dir / "lib"))
-
-    additional_libs = get_full_paths(
-        set(  # Add any known additional dependencies that might not be picked up by ldd
-            ["libgomp.so.1"]  # PaddlePaddle requires libgomp
-        )
-    )
-    alllibs.update(additional_libs)
     copy_libs(install_dir / "lib", alllibs)
 
 

--- a/setup.py
+++ b/setup.py
@@ -112,7 +112,7 @@ def _prune_bloat_from_wheel(install_dir: str) -> None:
     _remove_bloat_dir(install_dir / "lib" / "pkgconfig")
     _remove_bloat_dir(install_dir / "include")
     _remove_bloat_dir(install_dir / "tt-metal" / ".cpmcache")
-    _fix_file(install_dir / "lib" / "libtt-umd.so.0", "$ORIGIN:$ORIGIN/lib")
+    _fix_file(install_dir / "lib" / "libtt-umd.so.0")
     _remove_bloat_file(install_dir / "lib" / "libtt-umd.so")
     _remove_bloat_file(install_dir / "lib" / "libtt-umd.so.0.*")
     _strip_shared_objects(install_dir)


### PR DESCRIPTION
### Ticket

### Problem description
After installing the wheel libatomic.so is missing

### What's changed
The problem is with changes in tt-umd - instead of expected one libtt-umd.so there is also libtt-umd.so.0 and libtt-umd.so.0.70.0. The former is real lib, others are just symlinks. Metal uses libtt-umd.so.0 and due to wheel design (symlinks are not supported) three (same) library files are embedded in the wheel but their rpath is not correctly set.
During wheel build, symlink is resolved, two libs are removed, so only one needed lib remains, and its rpath is correctly set. 

### Checklist
- [ ] New/Existing tests provide coverage for changes
