### PR TITLE
Fix sparse-checkout cone mode and upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/benchmark-sub.yml
+++ b/.github/workflows/benchmark-sub.yml
@@ -95,8 +95,9 @@ jobs:
       - name: Git safe dir
         run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             .github/workflows/
             env/

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -24,7 +24,7 @@ jobs:
       MDBOOK_VERSION: v0.4.36
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
           fetch-depth: 0 # Fetch all history and tags
           clean: true

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -34,7 +34,7 @@ jobs:
         shell: bash
         run: sudo chown ubuntu:ubuntu -R $(pwd)
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: 'tenstorrent/tt-forge-onnx'
           submodules: recursive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
         git config --system --add safe.directory ${{ steps.strings.outputs.work-dir }}
         chown -R root:root ${{ steps.strings.outputs.work-dir }}
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         repository: 'tenstorrent/tt-forge-onnx'
         submodules: recursive
@@ -198,7 +198,7 @@ jobs:
           git config --system --add safe.directory ${{ steps.strings.outputs.work-dir }}
           chown -R root:root ${{ steps.strings.outputs.work-dir }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           repository: 'tenstorrent/tt-forge-onnx'
           submodules: recursive

--- a/.github/workflows/call-uplift-submodule.yml
+++ b/.github/workflows/call-uplift-submodule.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
           fetch-depth: 0  # Fetch all history and tags

--- a/.github/workflows/issue-last-updated.yml
+++ b/.github/workflows/issue-last-updated.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
       - uses: tenstorrent/tt-forge/.github/actions/issue-last-updated@main
         with:
           issue_number: ${{ github.event.issue.number }}

--- a/.github/workflows/model-analysis.yml
+++ b/.github/workflows/model-analysis.yml
@@ -265,7 +265,7 @@ jobs:
       - name: Git safe dir
         run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .github/download-artifacts.sh
@@ -426,7 +426,7 @@ jobs:
       - name: Git safe dir
         run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
             submodules: recursive
             fetch-depth: 0 # Fetch all history and tags

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
         with:
           python-version: '3.12'

--- a/.github/workflows/spdx.yml
+++ b/.github/workflows/spdx.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
     - uses: enarx/spdx@master
       with:
         licenses: Apache-2.0

--- a/.github/workflows/test-model-analysis-sub.yml
+++ b/.github/workflows/test-model-analysis-sub.yml
@@ -113,8 +113,9 @@ jobs:
       - name: Git safe dir
         run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             .github/workflows/
             env/

--- a/.github/workflows/test-sub.yml
+++ b/.github/workflows/test-sub.yml
@@ -124,8 +124,9 @@ jobs:
       - name: Git safe dir
         run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             .github/workflows/
             env/

--- a/.github/workflows/test-verbose.yml
+++ b/.github/workflows/test-verbose.yml
@@ -121,8 +121,9 @@ jobs:
       - name: Git safe dir
         run: git config --global --add safe.directory ${{ steps.strings.outputs.work-dir }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
+          sparse-checkout-cone-mode: false
           sparse-checkout: |
             .github/workflows/
             env/

--- a/.github/workflows/update-test-durations.yml
+++ b/.github/workflows/update-test-durations.yml
@@ -16,7 +16,7 @@ jobs:
   update_test_durations:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           # ref: main


### PR DESCRIPTION
## Summary

`actions/checkout` defaults to `sparse-checkout-cone-mode: true`. In cone mode Git treats every entry as a directory and rejects plain files, causing the checkout step to fail immediately with exit code 128. The sparse-checkout lists in four workflow files include root-level files (`pytest.ini`, `conftest.py`, `.test_durations`, `.test_list`) that are not directories, triggering this error and blocking all downstream test steps.

## Failure

```
[command]/usr/bin/git sparse-checkougt set .github/workflows/ env/ forge/test pytest.ini conftest.py .test_durations
fatal: 'pytest.ini' is not a directory; to treat it as a directory anyway, rerun with --skip-checks
##[error]The process '/usr/bin/git' failed with exit code 128
```

## Pipeline Link

https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25090644045/job/73517954145?pr=3287

## Solution

Added `sparse-checkout-cone-mode: false` to all four affected checkout steps. Non-cone mode uses gitignore-style patterns and correctly handles individual files alongside directories.

Also upgraded `actions/checkout` from `v5` to `v6` (latest stable: `v6.0.2`) across all workflow files.

**Files changed:**
- `.github/workflows/test-sub.yml`
- `.github/workflows/test-verbose.yml`
- `.github/workflows/benchmark-sub.yml`
- `.github/workflows/test-model-analysis-sub.yml`
- All remaining workflow files (`pre-commit.yml`, `build.yml`, `build-image.yml`, `build-docs.yml`, `spdx.yml`, `model-analysis.yml`, `call-uplift-submodule.yml`, `issue-last-updated.yml`, `update-test-durations.yml`)