### PR TITLE
Fix: Wheel Installation Failures on Python 3.12

### DIFF
--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -28,7 +28,7 @@ pyinstrument>=4.1.1
 scipy>=1.8.0
 tensorflow==2.19.0
 tensorboard==2.19.0
-tf2onnx==1.15.1
+tf2onnx==1.17.0
 transformers==4.52.4
 # To avoid warning during the import
 requests==2.28.2

--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -36,6 +36,9 @@ tflite==2.10.0
 ultralytics==8.3.91
 paddlepaddle==2.6.2
 paddlenlp==2.8.1
+# paddle2onnx>=2.1.0 marks onnxoptimizer as python_version < "3.12" so it is
+# not pulled in on Python 3.12, avoiding a source build that fails with newer CMake
+paddle2onnx==2.1.0
 aistudio-sdk==0.2.6
 pytorch_forecasting
 patool

--- a/env/core_requirements.txt
+++ b/env/core_requirements.txt
@@ -1,4 +1,7 @@
 setuptools>=61
+# grpcio-tools>=1.60.0 avoids building 1.48.2 from source on Python 3.12 (no cp312 wheel exists for 1.48.2)
+# orbax-checkpoint pulls grpcio-tools with no version constraint, so uv resolves to the oldest version otherwise
+grpcio-tools>=1.60.0
 # This is needed to avoid issue https://yyz-gitlab.local.tenstorrent.com/devops/devops/-/issues/95
 # jax requires any version of optax which requires any version of chex which in turn
 # requires jax>=0.4.6 which conflicts with our jax == 0.3.16

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.uv.extra-build-dependencies]
-grpcio-tools = ["setuptools"]
-
 [project]
 name = "tt_forge_onnx"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,9 @@
 requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.uv.extra-build-dependencies]
+grpcio-tools = ["setuptools"]
+
 [project]
 name = "tt_forge_onnx"
 readme = "README.md"


### PR DESCRIPTION
## Summary

CI test jobs were failing at wheel installation due to three transitive dependencies that either had no pre-built Python 3.12 wheel or conflicting version constraints. Fixed by pinning `grpcio-tools>=1.60.0`, upgrading `tf2onnx` to `1.17.0`, and pinning `paddle2onnx==2.1.0`.



## Problem 1 — grpcio-tools 1.48.2 fails to build on Python 3.12

**Dependency chain:**
```
tt-forge-onnx → flax==0.12.0 → orbax-checkpoint==0.11.37 → grpcio-tools
```

`orbax-checkpoint==0.11.37` declares `grpcio-tools` with no version constraint, so `uv` picks the oldest compatible version (`1.48.2`). That version has no pre-built Python 3.12 wheel, so `uv` builds it from source. Its `setup.py` imports `pkg_resources` (part of `setuptools`) without declaring it as a build dependency, causing the build to fail:

```
ModuleNotFoundError: No module named 'pkg_resources'
```

**Fix:** Added `grpcio-tools>=1.60.0` to `core_requirements.txt`. Versions `>=1.60.0` ship a pre-built `cp312` wheel, so no source build is needed.



## Problem 2 — grpcio-tools>=1.60.0 conflicts with tf2onnx==1.15.1 via protobuf

Forcing a newer `grpcio-tools` exposed a version conflict:

```
grpcio-tools>=1.60.0  →  requires protobuf>=4.21.6
tf2onnx==1.15.1       →  requires protobuf~=3.20  (<3.21)
```

**Fix:** Upgraded `tf2onnx` from `1.15.1` to `1.17.0`. In `1.17.0` the protobuf constraint was relaxed from `~=3.20` to `>=3.20` (no upper bound), resolving the conflict.



## Problem 3 — onnxoptimizer 0.3.13 fails to build on Python 3.12

**Dependency chain:**
```
paddlenlp==2.8.1 → paddle2onnx==2.0.1 → onnxoptimizer==0.3.13
```

`onnxoptimizer==0.3.13` has no pre-built Python 3.12 wheel, so `uv` builds it from source. Its bundled `third_party/onnx/CMakeLists.txt` declares a `cmake_minimum_required` version below 3.5, which newer CMake no longer supports:

```
CMake Error at third_party/onnx/CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

**Fix:** Pinned `paddle2onnx==2.1.0`. That version gates the `onnxoptimizer` dependency with `python_version < "3.12"`, so it is never installed on Python 3.12. `paddlenlp==2.8.1` has no version constraint on `paddle2onnx`, so the pin is compatible.
