### PR TITLE
Remove xfail markers for passing nightly tests

### DIFF
--- a/forge/test/models/onnx/vision/beit/test_beit_onnx.py
+++ b/forge/test/models/onnx/vision/beit/test_beit_onnx.py
@@ -19,10 +19,7 @@ import onnx
 
 variants = [
     pytest.param("microsoft/beit-base-patch16-224", marks=[pytest.mark.xfail]),
-    pytest.param(
-        "microsoft/beit-large-patch16-224",
-        marks=[pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-forge-onnx/issues/2969")],
-    ),
+    pytest.param("microsoft/beit-large-patch16-224"),
 ]
 
 

--- a/forge/test/models/onnx/vision/mgp_str_base/test_mgp_str_base_onnx.py
+++ b/forge/test/models/onnx/vision/mgp_str_base/test_mgp_str_base_onnx.py
@@ -34,7 +34,6 @@ class Wrapper(torch.nn.Module):
         return self.model(inputs)[0]
 
 
-@pytest.mark.xfail(reason="https://github.com/tenstorrent/tt-forge-onnx/issues/2969")
 @pytest.mark.nightly
 @pytest.mark.parametrize(
     "variant",

--- a/forge/test/models/onnx/vision/mlp_mixer/test_mlp_mixer_onnx.py
+++ b/forge/test/models/onnx/vision/mlp_mixer/test_mlp_mixer_onnx.py
@@ -27,28 +27,13 @@ from test.models.models_utils import print_cls_results
 from test.utils import download_model
 
 varaints = [
-    pytest.param(
-        "mixer_b16_224",
-        marks=[pytest.mark.xfail],
-    ),
-    pytest.param(
-        "mixer_b16_224_in21k",
-        marks=[pytest.mark.xfail],
-    ),
+    pytest.param("mixer_b16_224"),
+    pytest.param("mixer_b16_224_in21k"),
     pytest.param("mixer_b16_224_miil"),
-    pytest.param(
-        "mixer_b16_224_miil_in21k",
-        marks=[pytest.mark.xfail],
-    ),
+    pytest.param("mixer_b16_224_miil_in21k"),
     pytest.param("mixer_b32_224"),
-    pytest.param(
-        "mixer_l16_224",
-        marks=[pytest.mark.xfail],
-    ),
-    pytest.param(
-        "mixer_l16_224_in21k",
-        marks=[pytest.mark.xfail],
-    ),
+    pytest.param("mixer_l16_224"),
+    pytest.param("mixer_l16_224_in21k"),
     pytest.param("mixer_l32_224"),
     pytest.param(
         "mixer_s16_224",


### PR DESCRIPTION
## Summary

Three model tests that were previously marked as `xfail` are now passing in the nightly pipeline (run [25329851626](https://github.com/tenstorrent/tt-forge-onnx/actions/runs/25329851626)). This PR removes the `xfail` markers so they are treated as expected passes and no longer cause job failures.

## XPASS Tests

### MLP Mixer — `forge/test/models/onnx/vision/mlp_mixer/test_mlp_mixer_onnx.py`

| Test | Variant |
|---|---|
| `test_mlp_mixer_timm_onnx` | `mixer_b16_224` |
| `test_mlp_mixer_timm_onnx` | `mixer_b16_224_in21k` |
| `test_mlp_mixer_timm_onnx` | `mixer_b16_224_miil_in21k` |
| `test_mlp_mixer_timm_onnx` | `mixer_l16_224` |
| `test_mlp_mixer_timm_onnx` | `mixer_l16_224_in21k` |

### BEiT — `forge/test/models/onnx/vision/beit/test_beit_onnx.py`

| Test | Variant |
|---|---|
| `test_beit_onnx` | `microsoft/beit-large-patch16-224` |

### MGP-STR Base — `forge/test/models/onnx/vision/mgp_str_base/test_mgp_str_base_onnx.py`

| Test | Variant |
|---|---|
| `test_mgp_scene_text_recognition_onnx` | `alibaba-damo/mgp-str-base` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)