### PR TITLE
verify/config: fix _set_global_verify_config writing to wrong global variable

### DIFF
--- a/forge/forge/verify/config.py
+++ b/forge/forge/verify/config.py
@@ -231,8 +231,8 @@ def _clear_global_verify_config():
 
 
 def _set_global_verify_config(config: DeprecatedVerifyConfig):
-    global g_compiler_config
-    g_compiler_config = config
+    global g_verify_config
+    g_verify_config = config
 
 
 class VerifyTensorMetadata(Enum):


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`_set_global_verify_config` declared `global g_compiler_config` instead of
`global g_verify_config`. In Python, declaring a non-existent name in a
`global` statement is legal — it silently creates an orphan module-level
binding that nothing ever reads. As a result, calling
`_set_global_verify_config(config)` had no effect on `g_verify_config`, so
any subsequent call to `_get_global_verify_config()` would return the
original default `DeprecatedVerifyConfig()` instead of the config that was
passed in. This is a copy-paste mistake, as the sibling functions
`_get_global_verify_config` and `_clear_global_verify_config` both correctly
reference `g_verify_config`.

### What's changed
Replaced `global g_compiler_config` and `g_compiler_config = config` with
`global g_verify_config` and `g_verify_config = config` inside
`_set_global_verify_config` in `forge/forge/verify/config.py`.

This makes the setter consistent with the getter and the clear function,
ensuring that callers who set the global verify config actually have their
config respected downstream (e.g. in `tvm_to_python.py` which reads it via
`_get_global_verify_config()`). No API changes, no new dependencies.

### Checklist
- [ ] New/Existing tests provide coverage for changes