### PR TITLE
docs: add Tenstorrent top navbar menu

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -1,5 +1,99 @@
 {%- extends "!layout.html" %}
 
+{#── Top navbar injected before the RTD grid ─────────────────────#}
+{%- block extrabody %}
+{%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}
+{%- set _root_doc = root_doc|default(master_doc) %}
+{%- set _home = "https://docs.tenstorrent.com/" %}
+<nav class="tt-top-nav" role="navigation" aria-label="Top navigation">
+  <div class="tt-top-nav-left">
+    <a href="{{ _home }}" class="tt-nav-logo">
+      <img src="https://docs.tenstorrent.com/_static/logotype.png" alt="Tenstorrent" />
+      <span>DOCUMENTATION</span>
+    </a>
+    <ul class="tt-nav-links">
+      <li class="has-dropdown">
+        <a href="{{ _home }}#get-started">Get Started</a>
+        <div class="tt-nav-dropdown">
+          <a href="{{ _home }}getting-started/tt-software-stack.html">Overview</a>
+          <a href="{{ _home }}getting-started/README.html">Installing Tenstorrent Software</a>
+          <a href="{{ _home }}getting-started/manual-software-install.html">Manual Installation</a>
+          <a href="{{ _home }}getting-started/vLLM-servers.html">Deploy LLMs</a>
+          <a href="https://docs.tenstorrent.com/tt-vscode-toolkit/" target="_blank" rel="noopener">Learn by Building</a>
+        </div>
+      </li>
+      <li class="has-dropdown">
+        <a href="{{ _home }}#software">Software</a>
+        <div class="tt-nav-dropdown">
+          <a href="{{ _home }}forge/index.html">TT-Forge</a>
+          <a href="https://docs.tenstorrent.com/tt-forge-onnx/" target="_blank" rel="noopener">TT-Forge-ONNX</a>
+          <a href="https://docs.tenstorrent.com/tt-metal/latest/ttnn/" target="_blank" rel="noopener">TT-NN</a>
+          <a href="https://docs.tenstorrent.com/tt-lang/" target="_blank" rel="noopener">TT-Lang</a>
+          <a href="https://docs.tenstorrent.com/tt-mlir/" target="_blank" rel="noopener">TT-MLIR</a>
+          <a href="https://docs.tenstorrent.com/tt-xla/" target="_blank" rel="noopener">TT-XLA</a>
+          <a href="https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/" target="_blank" rel="noopener">TT-Metalium</a>
+        </div>
+      </li>
+      <li class="has-dropdown">
+        <a href="{{ _home }}#hardware">Hardware</a>
+        <div class="tt-nav-dropdown">
+          <span class="tt-nav-dropdown-label">Blackhole</span>
+          <a href="{{ _home }}aibs/blackhole/index.html">Blackhole™ PCIe Cards</a>
+          <a href="{{ _home }}systems/quietbox/quietbox-bh/index.html">TT-QuietBox</a>
+          <a href="{{ _home }}systems/quietbox/quietbox-bh-2/index.html">TT-QuietBox 2</a>
+          <span class="tt-nav-dropdown-label">Wormhole</span>
+          <a href="{{ _home }}aibs/wormhole/index.html">Wormhole™ PCIe Cards</a>
+          <a href="{{ _home }}systems/quietbox/quietbox-wh/index.html">TT-QuietBox</a>
+          <a href="{{ _home }}systems/t3000/index.html">TT-LoudBox™</a>
+        </div>
+      </li>
+      <li class="has-dropdown">
+        <a href="{{ _home }}#tools">Tools</a>
+        <div class="tt-nav-dropdown">
+          <a href="https://github.com/tenstorrent/tt-inference-server" target="_blank" rel="noopener">TT-Inference-Server</a>
+          <a href="https://github.com/tenstorrent/tt-studio" target="_blank" rel="noopener">TT-Studio</a>
+          <a href="https://github.com/tenstorrent/tt-smi" target="_blank" rel="noopener">TT-SMI</a>
+          <a href="https://docs.tenstorrent.com/tt-toplike/" target="_blank" rel="noopener">TT-Toplike</a>
+          <a href="https://docs.tenstorrent.com/ttnn-visualizer/" target="_blank" rel="noopener">TT-NN Visualizer</a>
+          <a href="https://github.com/tenstorrent/tt-topology" target="_blank" rel="noopener">TT-Topology</a>
+          <a href="https://docs.tenstorrent.com/tt-vscode-toolkit" target="_blank" rel="noopener">TT-VSCode-Toolkit</a>
+          <a href="https://docs.tenstorrent.com/tt-blacksmith/" target="_blank" rel="noopener">TT-Blacksmith</a>
+        </div>
+      </li>
+      <li class="has-dropdown">
+        <a href="{{ _home }}#resources">Resources</a>
+        <div class="tt-nav-dropdown">
+          <a href="https://tenstorrent.atlassian.net/servicedesk/customer/portal/1" target="_blank" rel="noopener">Request Support</a>
+          <a href="https://tenstorrent.com/developers" target="_blank" rel="noopener">Developer Hub</a>
+          <a href="https://discord.com/invite/tenstorrent" target="_blank" rel="noopener">Join our Discord</a>
+          <a href="https://tenstorrent.com/faq" target="_blank" rel="noopener">FAQ</a>
+        </div>
+      </li>
+    </ul>
+  </div>
+  <div class="tt-top-nav-right">
+    <button type="button" class="tt-nav-search-form tt-search-trigger" aria-label="Search docs" aria-haspopup="dialog">
+      <svg class="tt-search-glyph" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+        <circle cx="7" cy="7" r="4.5" stroke="currentColor" stroke-width="1.4"/>
+        <path d="M11 11l3.5 3.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+      </svg>
+      <span class="tt-nav-search-placeholder">Search</span>
+      <kbd class="tt-nav-search-kbd">⌘K</kbd>
+    </button>
+    <div class="tt-nav-actions">
+      <a href="https://docs.tenstorrent.com/tt-awesome/" class="tt-nav-btn-cta" target="_blank" rel="noopener">Explore</a>
+      <a href="https://github.com/tenstorrent" class="tt-nav-btn-github" target="_blank" rel="noopener">
+        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+        GitHub
+      </a>
+    </div>
+    <i data-toggle="wy-nav-top" class="fa fa-bars tt-nav-hamburger" aria-hidden="true"></i>
+  </div>
+</nav>
+{%- endblock %}
+
 {#── Sidebar: logo, project name ─────────────────────────────────#}
 {%- block sidebartitle %}
 {%- set _logo_url = logo_url|default(pathto('_static/' + (logo or ""), 1)) %}


### PR DESCRIPTION
## What

Adds the shared **Tenstorrent top navbar** to the docs, matching [tt-xla](https://docs.tenstorrent.com/tt-xla/) and [tt-mlir](https://docs.tenstorrent.com/tt-mlir/).

> ⛓️ **Stacked PR (2/3).** Base is `docs/sphinx-migration` (#3381). Review/merge that first; the diff here is navbar-only.

## Changes
- Inject the navbar via the Sphinx `extrabody` block in `_templates/layout.html`:
  - Tenstorrent logo + `DOCUMENTATION` wordmark linking to the docs home.
  - Dropdown menus: **Get Started**, **Software**, **Hardware**, **Tools**, **Resources**.
  - **Software** dropdown lists **TT-Forge-ONNX** alongside TT-Forge, TT-NN, TT-Lang, TT-MLIR, TT-XLA, TT-Metalium.
  - Search trigger button (`⌘K`) and **Explore** / **GitHub** actions + mobile hamburger.
- Styling comes from the shared `tt_theme.css` wired in the base PR — no per-project CSS.

## Notes
- The search button opens the search modal added in the next PR (`docs/opensearch-kapa`); until then it is a no-op.

## Verification
`make -C docs html` builds cleanly with `-W`; navbar markup (`tt-top-nav`) and the TT-Forge-ONNX menu entry are present in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)