### PR TITLE
docs(nav): add Galaxy systems and Cloud-Native Support to top nav

### DIFF
--- a/docs/source/_templates/layout.html
+++ b/docs/source/_templates/layout.html
@@ -32,6 +32,7 @@
           <a href="https://docs.tenstorrent.com/tt-mlir/" target="_blank" rel="noopener">TT-MLIR</a>
           <a href="https://docs.tenstorrent.com/tt-xla/" target="_blank" rel="noopener">TT-XLA</a>
           <a href="https://docs.tenstorrent.com/tt-metal/latest/tt-metalium/" target="_blank" rel="noopener">TT-Metalium</a>
+          <a href="https://docs.tenstorrent.com/cloud-native-support/" target="_blank" rel="noopener">Cloud-Native Support</a>
         </div>
       </li>
       <li class="has-dropdown">
@@ -41,10 +42,12 @@
           <a href="{{ _home }}aibs/blackhole/index.html">Blackhole™ PCIe Cards</a>
           <a href="{{ _home }}systems/quietbox/quietbox-bh/index.html">TT-QuietBox</a>
           <a href="{{ _home }}systems/quietbox/quietbox-bh-2/index.html">TT-QuietBox 2</a>
+          <a href="{{ _home }}systems/galaxy-blackhole/index.html">Galaxy™ (Blackhole)</a>
           <span class="tt-nav-dropdown-label">Wormhole</span>
           <a href="{{ _home }}aibs/wormhole/index.html">Wormhole™ PCIe Cards</a>
           <a href="{{ _home }}systems/quietbox/quietbox-wh/index.html">TT-QuietBox</a>
           <a href="{{ _home }}systems/t3000/index.html">TT-LoudBox™</a>
+          <a href="{{ _home }}systems/galaxy-wormhole/index.html">Galaxy™ (Wormhole)</a>
         </div>
       </li>
       <li class="has-dropdown">


### PR DESCRIPTION
## What

Adds three top-navbar entries that exist on the main docs site (`tenstorrent/tenstorrent.github.io`) but were missing here:

- **Software** → Cloud-Native Support
- **Hardware / Blackhole** → Galaxy™ (Blackhole)
- **Hardware / Wormhole** → Galaxy™ (Wormhole)

## Why

`layout.html` is duplicated per repo rather than shared as a package, so the navbar drifts. This brings the menu back in sync with the canonical version so users see the same navigation on every docs subsite.

## Notes

Additive only — no existing entries were changed, moved, or removed. Template-only change, no build or CI impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)